### PR TITLE
fix: remove docker analyzer progress bar

### DIFF
--- a/lib/fetch-snyk-docker-analyzer.js
+++ b/lib/fetch-snyk-docker-analyzer.js
@@ -56,22 +56,7 @@ function fetch() {
             return;
           }
 
-          if (ciInfo.isCI) {
-            console.log(`downloading ${getBinaryName()} ...`);
-          } else {
-            const total = parseInt(res.headers['content-length'], 10);
-            bar = new ProgressBar(`downloading ${getBinaryName()} [:bar] :rate/Kbps :percent :etas remaining`, { // jscs:ignore maximumLineLength
-              complete: '=',
-              incomplete: '.',
-              width: 20,
-              total: total / 1000,
-            });
-          }
-        })
-        .on('data', function (chunk) {
-          if (bar) {
-            bar.tick(chunk.length / 1000);
-          }
+          console.log(`downloading ${getBinaryName()} ...`);
         })
         .on('error', function (err) {
           reject(err);
@@ -82,6 +67,7 @@ function fetch() {
           reject(err);
         })
         .on('finish', function () {
+          console.log(`finished ${getBinaryName()} ...`);
           fs.renameSync(localPath + '.part', localPath);
           const CHMOD_WITH_EXEC = 0755;
           fs.chmodSync(localPath, CHMOD_WITH_EXEC);


### PR DESCRIPTION
The problems occurs when the plugin trying to download the analyzer.
 There are 2 parallel progress bars:
* The downloading
* The regular "Analyzing docker dependencies for...."

Running them together make some problem.

I tried adding the following code but it still writes the "Analyzing docker dependencies for...." at the end of every line:

`var COLUMNS = process.stdout.columns || 100;
process.stderr.cursorTo = function (column) { 
process.stderr.write("\u001b[" + column + "D");
};
`