### PR TITLE
fix: handle common errors from the analyser properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var subProcess = require('./sub-process');
 var fetchSnykDockerAnalyzer = require('./fetch-snyk-docker-analyzer');
+var debug = require('debug')('snyk');
 
 module.exports = {
   inspect: inspect,
@@ -40,6 +41,26 @@ function getMetaData() {
   });
 }
 
+function handleCommonErrors(error, targetImage) {
+  if (error.indexOf('command not found') !== -1) {
+    throw new Error('Snyk docker CLI was not found')
+  }
+  if (error.indexOf('Cannot connect to the Docker daemon') !== -1) {
+    throw new Error('Cannot connect to the Docker daemon. Is the docker'
+    + ' daemon running?')
+  }
+  if ((error.indexOf('Error loading image from docker engine') !== -1) ||
+      (error.indexOf('Error performing image analysis') !== -1)) {
+    throw new Error('Docker image was not found: ' + targetImage)
+  }
+  if (error.indexOf('Error getting docker client:') !== -1) {
+    throw new Error('Failed getting docker client')
+  }
+  if (error.indexOf('Error processing image:') !== -1) {
+    throw new Error('Failed processing image:' + targetImage)
+  }
+}
+
 function getDependencies(analyzerBinaryPath, targetImage) {
   return subProcess.execute(
     analyzerBinaryPath,
@@ -51,9 +72,8 @@ function getDependencies(analyzerBinaryPath, targetImage) {
   })
   .catch(function (error) {
     if (typeof error === 'string') {
-      if (error.indexOf('command not found') !== -1) {
-        throw new Error('Snyk docker CLI wasn\'t found')
-      }
+      debug(`Error while running analyser: '${error}'`);
+      handleCommonErrors(error, targetImage);
       errorMsg = error;
       errorMatch = /msg="(.*)"/g.exec(errorMsg)
       if (errorMatch) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "nock": "^9.2.3",
     "semantic-release": "^6.3.6",
     "tap": "^11.1.3",
+    "debug": "^3.1.0",
     "tap-only": "0.0.5"
   },
   "dependencies": {

--- a/test/system.test.js
+++ b/test/system.test.js
@@ -58,7 +58,7 @@ test('fetches analyzer only if doesnt exist', function (t) {
 
 test('inspect an image that doesnt exist', function (t) {
   return plugin.inspect('not-here:latest').catch((err) => {
-    t.match(err.message, 'does not exist');
+    t.match(err.message, 'Docker image was not found:');
     t.pass('failed as expected');
   })
 });


### PR DESCRIPTION
Change common errors from the analyser. like:

> Error processing image: Error loading image from docker engine: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

was changed to:
> Cannot connect to the Docker daemon. Is the docker daemon running?