### PR TITLE
 feat: create full dependency trees for DEB 

### DIFF
--- a/lib/fetch-snyk-docker-analyzer.js
+++ b/lib/fetch-snyk-docker-analyzer.js
@@ -7,7 +7,7 @@ const pkgInfo = require('../package.json')
 
 module.exports = fetch
 
-const version = pkgInfo['snyk-docker-analyzer']['version'];
+const version = pkgInfo['snyk-docker-analyzer'].version;
 
 function getBinaryName() {
   const arch = os.arch();

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,8 +65,9 @@ function getDependencies(analyzerBinaryPath, targetImage) {
     buildArgs(targetImage)
   )
   .then(function (output) {
-    scanResults = JSON.parse(output);
-    return convertDependecies(targetImage, scanResults);
+    result = parseAnalysisResults(output);
+    return buildTree(
+      targetImage, result.type, result.depInfosList, result.osRelease);
   })
   .catch(function (error) {
     if (typeof error === 'string') {
@@ -84,51 +85,190 @@ function getDependencies(analyzerBinaryPath, targetImage) {
   })
 }
 
-function convertDependecies(targetImage, scanResults) {
+function parseAnalysisResults(analysisOut) {
+  var analysisJson = JSON.parse(analysisOut);
+
+  var analysisResult = analysisJson.results.filter(function (res) {
+    return res.Analysis && res.Analysis.length > 0;
+  })[0];
+
+  // TODO: if analysisResult is undefined -
+  //  throw a nice error, or report 0 deps
+
+  var depType;
+  switch (analysisResult.AnalyzeType) {
+    case 'Apt': {
+      depType = 'deb';
+      break;
+    }
+    default: {
+      depType = analysisResult.AnalyzeType.toLowerCase()
+    }
+  }
+
+  return {
+    type: depType,
+    depInfosList: analysisResult.Analysis,
+    osRelease: analysisJson.osRelease,
+  }
+}
+
+function buildTree(targetImage, depType, depInfosList, osRelease) {
   var targetSplit = targetImage.split(':');
   var imageName = targetSplit[0];
   var imageVersion = targetSplit[1] ? targetSplit[1] : 'latest';
 
-  var analysisResults = scanResults.results.filter(function (res) {
-    return res.Analysis && res.Analysis.length > 0;
-  })[0];
-
-  var pkgType;
-  switch (analysisResults.AnalyzeType) {
-    case 'Apt': {
-      pkgType = 'deb';
-      break;
-    }
-    default: {
-      pkgType = analysisResults.AnalyzeType.toLowerCase()
-    }
-  }
   var root = {
     name: imageName,
     version: imageVersion,
-    dockerOSRelease: scanResults.osRelease,
-    packageFormatVersion: pkgType + ':0.0.1',
+    dockerOSRelease: osRelease,
+    packageFormatVersion: depType + ':0.0.1',
+    dependencies: {},
   };
 
-  var pkgs = analysisResults['Analysis'];
-
-  root.dependencies = pkgs.reduce(function (acc, pkg) {
-    if (!pkg['Source']) {
-      name = pkg['Name'];
-    } else {
-      name = pkg['Source'] + '/' + pkg['Name'];
-    }
-    version = pkg['Version'];
-
-    acc[name] = {
-      name: name,
-      version: version,
-      dependencies: {},
-    }
+  var depsMap = depInfosList.reduce(function (acc, depInfo) {
+    var name = depInfo.Name;
+    acc[name] = depInfo;
     return acc;
   }, {});
 
+  var virtualDepsMap = depInfosList.reduce(function (acc, depInfo) {
+    var providesNames = depInfo.Provides || [];
+    providesNames.forEach(function (name) {
+      acc[name] = depInfo;
+    });
+    return acc;
+  }, {});
+
+  var depsCounts = {};
+  depInfosList.forEach(function (depInfo) {
+    countDepsRecursive(
+      depInfo.Name, new Set(), depsMap, virtualDepsMap, depsCounts);
+  });
+  var DEP_FREQ_THRESHOLD = 100;
+  var tooFrequentDepNames = Object.keys(depsCounts)
+    .filter(function (depName) {
+      return depsCounts[depName] > DEP_FREQ_THRESHOLD;
+    });
+
+  var attachDeps = function (depInfos) {
+    var depNamesToSkip = new Set(tooFrequentDepNames);
+    depInfos.forEach(function (depInfo) {
+      var subtree = buildTreeRecurisve(
+        depInfo.Name, new Set(), depsMap, virtualDepsMap, depNamesToSkip);
+      if (subtree) {
+        root.dependencies[subtree.name] = subtree;
+      }
+    })
+  };
+
+  // attach (as direct deps) pkgs not marked auto-installed:
+  var manuallyInstalledDeps = depInfosList.filter(function (depInfo) {
+    return !depInfo.AutoInstalled;
+  })
+  attachDeps(manuallyInstalledDeps);
+
+  // attach (as direct deps) pkgs marked as auto-insatalled,
+  //  but not dependant upon:
+  var notVisitedDeps = depInfosList.filter(function (depInfo) {
+    var depName = depInfo.Name;
+    return !(depsMap[depName]._visited);
+  })
+  attachDeps(notVisitedDeps);
+
+  // group all the "too frequest" deps under a meta package:
+  if (tooFrequentDepNames.length > 0) {
+    var tooFrequentDeps = tooFrequentDepNames.map(function (name) {
+      return depsMap[name];
+    });
+
+    var metaSubtree = {
+      name: 'meta-common-packages',
+      version: 'meta',
+      dependencies: {},
+    };
+
+    tooFrequentDeps.forEach(function (depInfo) {
+      var pkg = {
+        name: depFullName(depInfo),
+        version: depInfo.Version,
+      };
+      metaSubtree.dependencies[pkg.name] = pkg;
+    });
+
+    root.dependencies[metaSubtree.name] = metaSubtree;
+  }
+
   return root;
+}
+
+function buildTreeRecurisve(
+    depName, ancestors, depsMap, virtualDepsMap, depNamesToSkip) {
+  var depInfo = depsMap[depName] || virtualDepsMap[depName];
+  if (!depInfo) {
+    return null;
+  }
+
+  // "realName" as the argument depName might be a virtual pkg
+  var realName = depInfo.Name;
+  var fullName = depFullName(depInfo);
+  if (ancestors.has(fullName) || depNamesToSkip.has(realName)) {
+    return null;
+  }
+
+  depInfo._visited = true;
+
+  const tree = {
+    name: fullName,
+    version: depInfo.Version,
+  };
+
+  var newAncestors = (new Set(ancestors)).add(fullName);
+
+  var deps = depInfo.Deps || {};
+  Object.keys(deps).forEach(function (depName) {
+    var subTree = buildTreeRecurisve(
+      depName, newAncestors, depsMap, virtualDepsMap, depNamesToSkip);
+    if (subTree) {
+      if (!tree.dependencies) {
+        tree.dependencies = {};
+      }
+      tree.dependencies[subTree.name] = subTree;
+    }
+  });
+
+  return tree;
+}
+
+function countDepsRecursive(
+    depName, ancestors, depsMap, virtualDepsMap, depCounts) {
+  var depInfo = depsMap[depName] || virtualDepsMap[depName];
+  if (!depInfo) {
+    return;
+  }
+
+  // "realName" as the argument depName might be a virtual pkg
+  var realName = depInfo.Name;
+  if (ancestors.has(realName)) {
+    return;
+  }
+
+  depCounts[realName] = (depCounts[realName] || 0) + 1;
+
+  var newAncestors = (new Set(ancestors)).add(realName);
+  var deps = depInfo.Deps || {};
+  Object.keys(deps).forEach(function (depName) {
+    countDepsRecursive(
+      depName, newAncestors, depsMap, virtualDepsMap, depCounts);
+  });
+}
+
+function depFullName(depInfo) {
+  var fullName = depInfo.Name;
+  if (depInfo.Source) {
+    fullName = depInfo.Source + '/' + fullName;
+  }
+  return fullName;
 }
 
 function buildArgs(targetImage) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "snyk-docker-analyzer": {
-    "version": "1.2.1"
+    "version": "1.3.1"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR uses the Apt/Deb dependency info returned from the analyzer (https://github.com/snyk/snyk-docker-analyzer/pull/12) to create a dependency tree for DEB packages.

The current recursive tree structure used creates huge payloads (e.g. 21MB for the official `node:8` docker image), so to reduce it and to make backend's life easier we count the occurrences of dependencies in the tree, and all deps that appear more than 100 times are grouped instead only once under a meta package we call "meta-common-packages"