### PR TITLE
chore: .npmignore the bin/ fodler (analyzer binary)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .github
 .jscsrc
 .travis.yml
+appveyor.yml
 test/
 bin/


### PR DESCRIPTION
verified it works with `npm pack`:
```
npm notice === Tarball Contents ===
npm notice 853B  package.json
npm notice 2B    .nvmrc
npm notice 117B  .snyk
npm notice 550B  LICENSE
npm notice 352B  README.md
npm notice 2.2kB lib/fetch-snyk-docker-analyzer.js
npm notice 3.5kB lib/index.js
npm notice 685B  lib/sub-process.js
```