### PR TITLE
Spike: prune duplicate subtrees

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,22 +148,10 @@ function buildTree(targetImage, depType, depInfosList, osRelease) {
     return acc;
   }, {});
 
-  var depsCounts = {};
-  depInfosList.forEach(function (depInfo) {
-    countDepsRecursive(
-      depInfo.Name, new Set(), depsMap, virtualDepsMap, depsCounts);
-  });
-  var DEP_FREQ_THRESHOLD = 100;
-  var tooFrequentDepNames = Object.keys(depsCounts)
-    .filter(function (depName) {
-      return depsCounts[depName] > DEP_FREQ_THRESHOLD;
-    });
-
   var attachDeps = function (depInfos) {
-    var depNamesToSkip = new Set(tooFrequentDepNames);
     depInfos.forEach(function (depInfo) {
       var subtree = buildTreeRecurisve(
-        depInfo.Name, new Set(), depsMap, virtualDepsMap, depNamesToSkip);
+        depInfo.Name, new Set(), depsMap, virtualDepsMap);
       if (subtree) {
         root.dependencies[subtree.name] = subtree;
       }
@@ -184,43 +172,18 @@ function buildTree(targetImage, depType, depInfosList, osRelease) {
   })
   attachDeps(notVisitedDeps);
 
-  // group all the "too frequest" deps under a meta package:
-  if (tooFrequentDepNames.length > 0) {
-    var tooFrequentDeps = tooFrequentDepNames.map(function (name) {
-      return depsMap[name];
-    });
-
-    var metaSubtree = {
-      name: 'meta-common-packages',
-      version: 'meta',
-      dependencies: {},
-    };
-
-    tooFrequentDeps.forEach(function (depInfo) {
-      var pkg = {
-        name: depFullName(depInfo),
-        version: depInfo.Version,
-      };
-      metaSubtree.dependencies[pkg.name] = pkg;
-    });
-
-    root.dependencies[metaSubtree.name] = metaSubtree;
-  }
-
   return root;
 }
 
 function buildTreeRecurisve(
-    depName, ancestors, depsMap, virtualDepsMap, depNamesToSkip) {
+    depName, ancestors, depsMap, virtualDepsMap) {
   var depInfo = depsMap[depName] || virtualDepsMap[depName];
   if (!depInfo) {
     return null;
   }
 
-  // "realName" as the argument depName might be a virtual pkg
-  var realName = depInfo.Name;
   var fullName = depFullName(depInfo);
-  if (ancestors.has(fullName) || depNamesToSkip.has(realName)) {
+  if (ancestors.has(fullName)) {
     return null;
   }
 
@@ -229,6 +192,7 @@ function buildTreeRecurisve(
     version: depInfo.Version,
   };
 
+  //TODO: if we do this we can avoid tracking ancestors
   if (depInfo._visited) {
     return tree;
   }
@@ -239,7 +203,7 @@ function buildTreeRecurisve(
   var deps = depInfo.Deps || {};
   Object.keys(deps).forEach(function (depName) {
     var subTree = buildTreeRecurisve(
-      depName, newAncestors, depsMap, virtualDepsMap, depNamesToSkip);
+      depName, newAncestors, depsMap, virtualDepsMap);
     if (subTree) {
       if (!tree.dependencies) {
         tree.dependencies = {};
@@ -249,29 +213,6 @@ function buildTreeRecurisve(
   });
 
   return tree;
-}
-
-function countDepsRecursive(
-    depName, ancestors, depsMap, virtualDepsMap, depCounts) {
-  var depInfo = depsMap[depName] || virtualDepsMap[depName];
-  if (!depInfo) {
-    return;
-  }
-
-  // "realName" as the argument depName might be a virtual pkg
-  var realName = depInfo.Name;
-  if (ancestors.has(realName)) {
-    return;
-  }
-
-  depCounts[realName] = (depCounts[realName] || 0) + 1;
-
-  var newAncestors = (new Set(ancestors)).add(realName);
-  var deps = depInfo.Deps || {};
-  Object.keys(deps).forEach(function (depName) {
-    countDepsRecursive(
-      depName, newAncestors, depsMap, virtualDepsMap, depCounts);
-  });
 }
 
 function depFullName(depInfo) {


### PR DESCRIPTION
A package might appear multiple times in the tree - but only once it will also have dependencies. This way there is no "information loss"
TODO: probably same should be done with cycles to avoid the information loss