### PR TITLE
Feat: prune duplicate subtrees

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -224,12 +224,15 @@ function buildTreeRecurisve(
     return null;
   }
 
-  depInfo._visited = true;
-
   const tree = {
     name: fullName,
     version: depInfo.Version,
   };
+
+  if (depInfo._visited) {
+    return tree;
+  }
+  depInfo._visited = true;
 
   var newAncestors = (new Set(ancestors)).add(fullName);
 

--- a/test/system.test.js
+++ b/test/system.test.js
@@ -119,11 +119,6 @@ test('inspect nginx:1.13.10', function (t) {
             },
             nginx: {
               version: '1.13.10-1~stretch',
-              dependencies: {
-                'lsb/lsb-base': {
-                  version: '9.20161125',
-                },
-              },
             },
           },
         },
@@ -134,17 +129,16 @@ test('inspect nginx:1.13.10', function (t) {
           // a package marked as "Auto-Installed", but not dependant upon:
           name: 'shadow/login',
           version: '1:4.4-4.1',
-        },
-        'gnupg2/gpgv': {
-          // a package marked as "Auto-Installed", but not dependant upon:
-          version: '2.1.18-8~deb9u1',
           dependencies: {
-            libgcrypt20: {
-              version: '1.7.6-2+deb9u2',
+            'pam/libpam-runtime': {
+              version: '1.1.8-3.6',
             },
           },
         },
       }, 'regular deps seem ok');
+
+      t.false(deps['nginx-module-xslt'].dependencies.nginx.dependencies,
+        'nginx-module-xslt -> ngxinx has do deps')
 
       const commonDeps = deps['meta-common-packages'].dependencies;
       t.equal(Object.keys(commonDeps).length, 19,


### PR DESCRIPTION
A package might appear multiple times in the tree - but only once it will also have dependencies. This way there is no "information loss".

This drastically decreases the tree size. 

Still not sure it's a good solution as this "hides" information from the user, for example maybe an important direct dependency has a a transitive with a vuln, but we won't show this path if it was already traversed elsewhere.




