### PR TITLE
feat: change dockerOSRelease to targetOS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ function getDependencies(analyzerBinaryPath, targetImage) {
   .then(function (output) {
     result = parseAnalysisResults(output);
     return buildTree(
-      targetImage, result.type, result.depInfosList, result.osRelease);
+      targetImage, result.type, result.depInfosList, result.targetOS);
   })
   .then(function (package) {
     return {
@@ -117,11 +117,11 @@ function parseAnalysisResults(analysisOut) {
   return {
     type: depType,
     depInfosList: analysisResult.Analysis,
-    osRelease: analysisJson.osRelease,
+    targetOS: analysisJson.osRelease,
   }
 }
 
-function buildTree(targetImage, depType, depInfosList, osRelease) {
+function buildTree(targetImage, depType, depInfosList, targetOS) {
   var targetSplit = targetImage.split(':');
   var imageName = targetSplit[0];
   var imageVersion = targetSplit[1] ? targetSplit[1] : 'latest';
@@ -129,7 +129,7 @@ function buildTree(targetImage, depType, depInfosList, osRelease) {
   var root = {
     name: imageName,
     version: imageVersion,
-    dockerOSRelease: osRelease,
+    targetOS: targetOS,
     packageFormatVersion: depType + ':0.0.1',
     dependencies: {},
   };

--- a/test/system.test.js
+++ b/test/system.test.js
@@ -82,7 +82,7 @@ test('inspect nginx:1.13.10', function (t) {
         name: imgName,
         version: imgTag,
         packageFormatVersion: 'deb:0.0.1',
-        dockerOSRelease: {
+        targetOS: {
           name: 'debian',
           version: '9',
         },
@@ -178,7 +178,7 @@ test('inspect redis:3.2.11-alpine', function (t) {
         name: imgName,
         version: imgTag,
         packageFormatVersion: 'apk:0.0.1',
-        dockerOSRelease: {
+        targetOS: {
           name: 'alpine',
           version: '3.7.0',
         },
@@ -224,7 +224,7 @@ test('inspect centos', function (t) {
         name: imgName,
         version: imgTag,
         packageFormatVersion: 'rpm:0.0.1',
-        dockerOSRelease: {
+        targetOS: {
           name: 'centos',
           version: '7',
         },


### PR DESCRIPTION
- aligns `targetOS` with `targetFile`
- `dockerOSRelease` is too docker specific
- not marking as `BREAKING` as we are still in pre-beta