### PR TITLE
feat: return scanned image ID in metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ function inspect(root, targetFile, options) {
         name: 'snyk-docker-plugin',
         runtime: result[0],
         packageManager: result[1].packageManager,
+        dockerImageId: result[1].imageId,
       };
       var package = result[1].package;
       return {
@@ -75,6 +76,7 @@ function getDependencies(analyzerBinaryPath, targetImage) {
     return {
       package: package,
       packageManager: result.type,
+      imageId: result.imageId,
     };
   })
   .catch(function (error) {
@@ -115,9 +117,10 @@ function parseAnalysisResults(analysisOut) {
   }
 
   return {
+    imageId: analysisJson.imageID,
+    targetOS: analysisJson.osRelease,
     type: depType,
     depInfosList: analysisResult.Analysis,
-    targetOS: analysisJson.osRelease,
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "snyk-docker-analyzer": {
-    "version": "1.3.1"
+    "version": "1.4.0"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",

--- a/test/system.test.js
+++ b/test/system.test.js
@@ -76,6 +76,7 @@ test('inspect nginx:1.13.10', function (t) {
       const pkg = res.package;
 
       t.equal(plugin.name, 'snyk-docker-plugin', 'name');
+      t.equal(plugin.dockerImageId.length, 'sha256:'.length + 64)
       t.equal(plugin.packageManager, 'deb', 'returns deb package manager');
 
       t.match(pkg, {
@@ -172,6 +173,7 @@ test('inspect redis:3.2.11-alpine', function (t) {
       const pkg = res.package;
 
       t.equal(plugin.name, 'snyk-docker-plugin', 'name');
+      t.equal(plugin.dockerImageId.length, 'sha256:'.length + 64)
       t.equal(plugin.packageManager, 'apk', 'returns apk package manager');
 
       t.match(pkg, {
@@ -218,6 +220,7 @@ test('inspect centos', function (t) {
       const pkg = res.package;
 
       t.equal(plugin.name, 'snyk-docker-plugin', 'name');
+      t.equal(plugin.dockerImageId.length, 'sha256:'.length + 64)
       t.equal(plugin.packageManager, 'rpm', 'returns rpm package manager');
 
       t.match(pkg, {


### PR DESCRIPTION
returned by analyzer since https://github.com/snyk/snyk-docker-analyzer/pull/15