### PR TITLE
fix: bump analyzer to get correct image IDs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -117,7 +117,7 @@ function parseAnalysisResults(analysisOut) {
   }
 
   return {
-    imageId: analysisJson.imageID,
+    imageId: analysisJson.imageId,
     targetOS: analysisJson.osRelease,
     type: depType,
     depInfosList: analysisResult.Analysis,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "snyk-docker-analyzer": {
-    "version": "1.4.0"
+    "version": "1.4.1"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",


### PR DESCRIPTION
analyzer PR: https://github.com/snyk/snyk-docker-analyzer/pull/17

also improved the tests to actually call `docker inspect` and compare the plugin result