### PR TITLE
fix: improve analyzer download console logs

### DIFF
--- a/lib/fetch-snyk-docker-analyzer.js
+++ b/lib/fetch-snyk-docker-analyzer.js
@@ -32,7 +32,7 @@ function getBinaryLocalPath() {
 function fetch() {
   return new Promise((resolve, reject) => {
     try {
-      const localPath = getBinaryLocalPath()
+      const localPath = getBinaryLocalPath();
       if (fs.existsSync(localPath)) {
         return resolve(localPath);
       }
@@ -54,7 +54,8 @@ function fetch() {
             return;
           }
 
-          console.log(`downloading ${getBinaryName()} ...`);
+          console.log(
+            `Downloading ${getBinaryName()} to ${path.dirname(getBinaryLocalPath())} ...`); // jscs:ignore maximumLineLength
         })
         .on('error', function (err) {
           reject(err);
@@ -65,7 +66,8 @@ function fetch() {
           reject(err);
         })
         .on('finish', function () {
-          console.log(`\t=> download complete.`);
+          // padding log() with some whitespaces to not mix with the CLI spinner
+          console.log(`  => download complete.` + ' '.repeat(50));
           fs.renameSync(localPath + '.part', localPath);
           const CHMOD_WITH_EXEC = 0755;
           fs.chmodSync(localPath, CHMOD_WITH_EXEC);

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ function getDependencies(analyzerBinaryPath, targetImage) {
   })
   .catch(function (error) {
     if (typeof error === 'string') {
-      debug(`Error while running analyser: '${error}'`);
+      debug(`Error while running analyzer: '${error}'`);
       handleCommonErrors(error, targetImage);
       errorMsg = error;
       errorMatch = /msg="(.*)"/g.exec(errorMsg)


### PR DESCRIPTION
print the download path, and add some padding to play nicer with the CLI
spinner.