### PR TITLE
fix: better error when no permissions talking to docker

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,9 +49,20 @@ function handleCommonErrors(error, targetImage) {
     throw new Error('Cannot connect to the Docker daemon. Is the docker'
     + ' daemon running?')
   }
-  if ((error.indexOf('Error loading image from docker engine') !== -1) ||
-      (error.indexOf('Error performing image analysis') !== -1)) {
-    throw new Error('Docker image was not found: ' + targetImage)
+  var ERROR_LOADING_IMAGE_STR = 'Error loading image from docker engine:';
+  if (error.indexOf(ERROR_LOADING_IMAGE_STR) !== -1) {
+    if (error.indexOf('reference does not exist') !== -1) {
+      throw new Error(
+        `Docker image was not found locally: ${targetImage}`);
+    }
+    if (error.indexOf('permission denied while trying to connect') !== -1) {
+      var errString = error.split(ERROR_LOADING_IMAGE_STR)[1];
+      errString = (errString || '').slice(0, -2); // remove trailing \"
+      throw new Error(
+        'Permission denied connecting to docker daemon. ' +
+        'Please make sure user has the required permissions. ' +
+        'Error string: ' + errString);
+    }
   }
   if (error.indexOf('Error getting docker client:') !== -1) {
     throw new Error('Failed getting docker client')

--- a/test/system.test.js
+++ b/test/system.test.js
@@ -59,7 +59,7 @@ test('fetches analyzer only if doesnt exist', function (t) {
 
 test('inspect an image that doesnt exist', function (t) {
   return plugin.inspect('not-here:latest').catch((err) => {
-    t.match(err.message, 'Docker image was not found:');
+    t.match(err.message, 'Docker image was not found locally:');
     t.pass('failed as expected');
   })
 });


### PR DESCRIPTION
Example for an error that will printed in the case of no permissions:
```
Permission denied connecting to docker daemon. Please make sure user has the required permissions. Error string:  Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.22/images/get?names=hello-world%3Alatest: dial unix /var/run/docker.sock: connect: permission denied
```

Previously it would print:
```
Docker image was not found: ubuntu:18.04
```
