### PR TITLE
fix: show better message when no Linux packages are detected

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,8 +113,10 @@ function parseAnalysisResults(analysisOut) {
     return res.Analysis && res.Analysis.length > 0;
   })[0];
 
-  // TODO: if analysisResult is undefined -
-  //  throw a nice error, or report 0 deps
+  if (!analysisResult) {
+    throw new Error(
+      'Failed to detect a supported Linux package manager (deb/rpm/apk)');
+  }
 
   var depType;
   switch (analysisResult.AnalyzeType) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "snyk-docker-analyzer": {
-    "version": "1.5.1"
+    "version": "1.5.2"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",

--- a/test/system.test.js
+++ b/test/system.test.js
@@ -64,6 +64,25 @@ test('inspect an image that doesnt exist', function (t) {
   })
 });
 
+test('inspect an image with an unsupported pkg manager', function (t) {
+  const imgName = 'base/archlinux';
+  const imgTag = '2018.06.01';
+  const img = imgName + ':' + imgTag;
+
+  return dockerPull(t, img)
+    .then(function () {
+      return plugin.inspect(img);
+    })
+    .then(function () {
+      t.fail('should have failed');
+    })
+    .catch(function (err) {
+      t.match(err.message,
+        'Failed to detect a supported Linux package manager (deb/rpm/apk)',
+        'error msg is correct');
+    })
+});
+
 test('inspect nginx:1.13.10', function (t) {
   const imgName = 'nginx';
   const imgTag = '1.13.10';


### PR DESCRIPTION
before that fix, we would get a `TypeError` trying to access fields of `undefined`

