### PR TITLE
fix: don't scan the image name for issues

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -139,7 +139,8 @@ function buildTree(targetImage, depType, depInfosList, targetOS) {
   const imageVersion = targetSplit[1] ? targetSplit[1] : 'latest';
 
   const root = {
-    name: imageName,
+    // don't use the real image name to avoid scanning it as an issue
+    name: 'docker-image|' + imageName,
     version: imageVersion,
     targetOS,
     packageFormatVersion: depType + ':0.0.1',

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -62,7 +62,7 @@ test('inspect nginx:1.13.10', t => {
       t.equal(plugin.packageManager, 'deb', 'returns deb package manager');
 
       t.match(pkg, {
-        name: imgName,
+        name: 'docker-image|' + imgName,
         version: imgTag,
         packageFormatVersion: 'deb:0.0.1',
         targetOS: {
@@ -176,7 +176,7 @@ test('inspect redis:3.2.11-alpine', t => {
       t.equal(plugin.packageManager, 'apk', 'returns apk package manager');
 
       t.match(pkg, {
-        name: imgName,
+        name: 'docker-image|' + imgName,
         version: imgTag,
         packageFormatVersion: 'apk:0.0.1',
         targetOS: {
@@ -233,7 +233,7 @@ test('inspect centos', t => {
       t.equal(plugin.packageManager, 'rpm', 'returns rpm package manager');
 
       t.match(pkg, {
-        name: imgName,
+        name: 'docker-image|' + imgName,
         version: imgTag,
         packageFormatVersion: 'rpm:0.0.1',
         targetOS: {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

When we scan for docker images we want to avoid scanning
the image name as an issue.

The image name can have any name it would like and we don't
want to treat it as a package.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
