### PR TITLE
Parse image name with registry when a port is specified

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -133,10 +133,19 @@ function parseAnalysisResults(analysisJson) {
   };
 }
 
+function parseImageName(imageName) {
+  const slashSplit = imageName.split('/');
+  const colonSplit = imageName.split(':');
+
+  const name = slashSplit[1]
+      ? `${slashSplit[0]}/${slashSplit[1]}`
+      : imageName.split(':')[0];
+  const version = colonSplit[colonSplit.length - 1];
+  return [name, version];
+}
+
 function buildTree(targetImage, depType, depInfosList, targetOS) {
-  const targetSplit = targetImage.split(':');
-  const imageName = targetSplit[0];
-  const imageVersion = targetSplit[1] ? targetSplit[1] : 'latest';
+  const [imageName, imageVersion] = parseImageName(targetImage);
 
   const root = {
     // don't use the real image name to avoid scanning it as an issue

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -208,6 +208,44 @@ test('inspect redis:3.2.11-alpine', t => {
     });
 });
 
+test('inspect image with registry name ' +
+  'localhost:5000/redis:3.2.11-alpine', t => {
+  const imgName = 'redis';
+  const imgTag = '3.2.11-alpine';
+  const img = imgName + ':' + imgTag;
+  const dockerFileLocation = getDockerfileFixturePath('redis');
+
+  const registryAndImgName = 'localhost:5000' + '/' + imgName;
+  const registryAndImg = registryAndImgName + ':' + imgTag;
+
+  return dockerPull(t, img)
+    .then(() => {
+      return dockerTag(t, img, registryAndImg);
+    })
+    .then(() => {
+      return dockerGetImageId(t, registryAndImg);
+    })
+    .then(() => {
+      return plugin.inspect(registryAndImg, dockerFileLocation);
+    })
+    .then((res) => {
+      const pkg = res.package;
+
+      t.match(pkg, {
+        name: 'docker-image|' + registryAndImgName,
+        version: imgTag,
+        packageFormatVersion: 'apk:0.0.1',
+        targetOS: {
+          name: 'alpine',
+          version: '3.7.0',
+        },
+        docker: {
+          baseImage: 'alpine:3.7',
+        },
+      }, 'root pkg');
+    });
+});
+
 test('inspect centos', t => {
   const imgName = 'centos';
   const imgTag = '7.4.1708';
@@ -275,6 +313,11 @@ test('inspect centos', t => {
 function dockerPull(t, name) {
   t.comment('pulling ' + name);
   return subProcess.execute('docker', ['image', 'pull', name]);
+}
+
+function dockerTag(t, fromName, toName) {
+  t.comment('re-tagging ' + fromName + ' as ' + toName);
+  return subProcess.execute('docker', ['tag', fromName, toName]);
 }
 
 function dockerGetImageId(t, name) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

If using a registry with a specific port. i.e. the default of 5000, then the current parsing results in
```json5
{
  name: `docker-image|{registryName},
  version: `${registryPort}:${imageName}:${imageTag},
  ...
}
```

Instead we parse out any forward slashes and then parse the registry explicitly if it exists, resulting in:

```
docker-image|registryName/imageName
```

e.g

```
docker-image|localhost:5000/redis
```


#### Where should the reviewer start?

`system.test.js` to view the expectation.

#### How should this be manually tested?

Likely unnecessary here as the existing tests pass.

#### Any background context you want to provide?

We use a private internal registry with a specific port, `nexus.in.ft.com:5000`.

#### What are the relevant tickets?

Not raised.

#### Screenshots

n/a

#### Additional questions