### PR TITLE
feat: improve error msg on failure to analyze the image

### DIFF
--- a/lib/analyzer/index.ts
+++ b/lib/analyzer/index.ts
@@ -3,6 +3,7 @@ import * as imageIdDetector from './image-id-detector';
 import * as apkAnalyzer from './apk-analyzer';
 import * as aptAnalyzer from './apt-analyzer';
 import * as rpmAnalyzer from './rpm-analyzer';
+const debug = require('debug')('snyk');
 
 export {
   analyze,
@@ -16,7 +17,10 @@ function analyze(targetImage: string) {
       apkAnalyzer.analyze(targetImage),
       aptAnalyzer.analyze(targetImage),
       rpmAnalyzer.analyze(targetImage),
-    ]),
+    ]).catch((err) => {
+      debug(`Error while running analyzer: '${err}'`);
+      throw new Error('Failed to detect installed OS packages');
+    }),
   ])
   .then(res => ({
     imageId: res[0],


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
In case we fail to analyse the image, we want to have a proper error msg to the user.
For example, on `busybox` - there is no proper PM, but the binaries of `rpm` + `dpkg` do exist, so we try to run `rpm` and get an usage error

#### What are the relevant tickets?
https://snyksec.atlassian.net/secure/RapidBoard.jspa?rapidView=56&modal=detail&selectedIssue=SC-6675
