### PR TITLE
fix: parsing oracle linux name

### DIFF
--- a/lib/analyzer/os-release-detector.ts
+++ b/lib/analyzer/os-release-detector.ts
@@ -37,7 +37,7 @@ async function detect(targetImage: string): Promise<OSRelease> {
   }
 
   // Oracle Linux identifies itself as "ol"
-  if (osRelease.name === 'ol') {
+  if (osRelease.name.trim() === 'ol') {
     osRelease.name = 'oracle';
   }
 
@@ -125,5 +125,6 @@ async function tryOracleRelease(docker: Docker): Promise<OSRelease|null> {
   }
   const name = idRes[1].replace(/"/g, '').toLowerCase();
   const version = versionRes[1].replace(/"/g, '');
+
   return { name, version };
 }


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix bug - for oracle:6 images like `oraclelinux:6`, the `OS.name` is 'ol ' and not 'ol'