### PR TITLE
fix: correctly return binaries analysis

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -181,7 +181,7 @@ function parseAnalysisResults(analysisJson) {
     targetOS: analysisJson.osRelease,
     type: depType,
     depInfosList: analysisResult.Analysis,
-    binaries: analysisJson.binaries,
+    binaries: analysisJson.binaries.Analysis,
   };
 }
 


### PR DESCRIPTION
A little difficult to explain the precise reason for this change, but
currently the Snyk CLI has hacks in place to work around the different
format being returned for the binary results. The CLI shouldn't need
this level of knowledge / handling about the type of results.
