### PR TITLE
feat: add non-direct dependencies for rpm analyzer

### DIFF
--- a/lib/analyzer/rpm-analyzer.ts
+++ b/lib/analyzer/rpm-analyzer.ts
@@ -1,6 +1,9 @@
 import { Docker } from '../docker';
 import { AnalyzerPkg } from './types';
 
+const DELIM: string = '\t';
+const NO_PKG: string = 'no package provides ';
+
 export {
   analyze,
 };
@@ -15,12 +18,14 @@ async function analyze(targetImage: string) {
 }
 
 function getPackages(targetImage: string) {
+  // information can be found at:
+  // git log --all --grep='feat: add non-direct dependencies for rpm analyzer'
   return new Docker(targetImage).run('rpm', [
     '--nodigest',
     '--nosignature',
-    '-qa',
+    '-qaR',
     '--qf',
-    '"%{NAME}\t%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\t%{SIZE}\n"',
+    '"%{NAME}' + DELIM + '%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\n"',
   ])
     .catch(stderr => {
       if (typeof stderr === 'string' && stderr.indexOf('not found') >= 0) {
@@ -28,28 +33,72 @@ function getPackages(targetImage: string) {
       }
       throw new Error(stderr);
     })
-    .then(parseOutput);
+    .then(stdout => {
+      if (!stdout) {
+        return [];
+      }
+      return parseRequirements(targetImage, stdout);
+    });
 }
 
-function parseOutput(text: string) {
+function parseRequirements(targetImage: string, reqText: string) {
+  const whatProvidesText: string = reqText
+    .trim()
+    .split('\n')
+    .map(line => {
+      if (line.includes(' ')) {
+        line = line.split(' ')[0];
+      }
+      return '"' + line + '"';
+    })
+    .join(' ');
+
+    return new Docker(targetImage).run('rpm', [
+      '--nodigest',
+      '--nosignature',
+      '-q',
+      '--qf',
+      '"%{NAME}\n"',
+      '--whatprovides',
+      whatProvidesText,
+    ])
+      .catch(stderr => {
+        if (typeof stderr === 'string' && stderr.includes(NO_PKG)) {
+          return stderr;
+        }
+        throw new Error(stderr);
+    })
+      .then(parseProviders);
+}
+
+function parseProviders(providersText: string) {
   const pkgs: AnalyzerPkg[] = [];
-  for (const line of text.split('\n')) {
-    parseLine(line, pkgs);
+  let curPkg: any = null;
+
+  const providers: string[] = providersText.trim().split('\n');
+  // packages appear after their dependencies; iterate backwards
+  for (let i = providers.length - 1; i >= 0; i--) {
+    curPkg = parseProviderLine(providers[i], curPkg, pkgs);
   }
   return pkgs;
 }
 
-function parseLine(text: string, pkgs: AnalyzerPkg[]) {
-  const [name, version, size] = text.split('\t');
-  if (name && version && size) {
-    const pkg: AnalyzerPkg = {
-      Name: name,
+function parseProviderLine(line: string, curPkg: any, pkgs: AnalyzerPkg[]) {
+  if (line.includes(DELIM)) {
+    const [pkg, version] = line.replace(NO_PKG, '').split(DELIM);
+    curPkg = {
+      Name: pkg,
       Version: version,
       Source: undefined,
       Provides: [],
       Deps: {},
       AutoInstalled: undefined,
     };
-    pkgs.push(pkg);
+    pkgs.push(curPkg);
+    return curPkg;
   }
+  if (!line.includes(NO_PKG) && line !== curPkg.Name) {
+    curPkg.Deps[line] = true;
+  }
+  return curPkg;
 }

--- a/test/lib/analyzer/index.test.ts
+++ b/test/lib/analyzer/index.test.ts
@@ -48,9 +48,9 @@ test('analyzer', async t => {
     'rpm',
     '--nodigest',
     '--nosignature',
-    '-qa',
+    '-qaR',
     '--qf',
-    '"%{NAME}\t%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\t%{SIZE}\n"',
+    sinon.match.any
   ])
     .callsFake(async (docker, [run, rm, entry, empty, network, none, image]) => {
       try {

--- a/test/lib/analyzer/rpm-analyzer.test.ts
+++ b/test/lib/analyzer/rpm-analyzer.test.ts
@@ -6,10 +6,9 @@
 // tslint:disable:object-literal-key-quotes
 
 import { test } from 'tap';
-import * as sinon from 'sinon';
 
-import * as subProcess from '../../../lib/sub-process';
 import * as analyzer from '../../../lib/analyzer/rpm-analyzer';
+import { AnalyzerPkg } from '../../../lib/analyzer/types';
 
 test('analyze', async t => {
   const defaultPkgProps = {
@@ -21,99 +20,53 @@ test('analyze', async t => {
     AutoInstalled: null,
   };
 
-  const examples = [
+  const expectedPkgs = [
     {
-      description: 'No Rpm output',
-      rpmOutputLines: [''],
-      expectedPackages: [],
+      ...defaultPkgProps,
+      Name: 'info',
+      Version: '4.13a-8.el6',
+      Deps: {
+        'glibc': true,
+        'zlib': true,
+        'ncurses-libs': true,
+        'bash': true
+      }
     },
     {
-      description: 'Single Package',
-      rpmOutputLines: ['libcom_err\t1.41.12-23.el6\t59233'],
-      expectedPackages: [
-        { ...defaultPkgProps, Name: 'libcom_err', Version: '1.41.12-23.el6' },
-      ],
-    },
-    {
-      description: 'Multiple Packages',
-      rpmOutputLines: [
-        'basesystem\t10.0-4.el6\t0',
-        'tzdata\t2018d-1.el6\t1960357',
-        'glibc-common\t2.12-1.209.el6_9.2\t112436045',
-        'glibc\t2.12-1.209.el6_9.2\t13121423',
-      ],
-      expectedPackages: [
-        { ...defaultPkgProps, Name: 'basesystem', Version: '10.0-4.el6' },
-        { ...defaultPkgProps, Name: 'tzdata', Version: '2018d-1.el6' },
-        { ...defaultPkgProps, Name: 'glibc-common', Version: '2.12-1.209.el6_9.2' },
-        { ...defaultPkgProps, Name: 'glibc', Version: '2.12-1.209.el6_9.2' },
-      ],
+      ...defaultPkgProps,
+      Name: 'basesystem',
+      Version: '10.0-4.el6',
+      Deps: {
+        'filesystem': true,
+        'setup': true
+      },
     },
   ];
 
-  for (const example of examples) {
-    await t.test(example.description, async t => {
-      const execStub = sinon.stub(subProcess, 'execute');
+  const actual = await analyzer.analyze('centos:6');
+  const actualPkgMap = actual.Analysis.reduce(
+    (map, pkg) => {
+      map[pkg.Name] = pkg;
+      return map;
+    },
+    {}
+  );
 
-      execStub.withArgs('docker', [
-        'run', '--rm', '--entrypoint', '""', '--network', 'none',
-        sinon.match.any,
-        'rpm',
-        '--nodigest',
-        '--nosignature',
-        '-qa',
-        '--qf',
-        '"%{NAME}\t%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\t%{SIZE}\n"',
-      ]).resolves(example.rpmOutputLines.join('\n'));
-
-      t.teardown(() => execStub.restore());
-
-      const actual = await analyzer.analyze('centos:6');
-
-      t.same(actual, {
-        Image: 'centos:6',
-        AnalyzeType: 'Rpm',
-        Analysis: example.expectedPackages,
-      });
-    });
+  for (const expectedPkg of expectedPkgs) {
+    const actualPkg = actualPkgMap[expectedPkg.Name]
+    t.same(actualPkg, expectedPkg)
   }
 });
 
 test('no rpm', async t => {
-  const examples = [
-    {
-      targetImage: 'alpine:2.6',
-      rpmThrows: 'docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"rpm\": executable file not found in $PATH": unknown.',
-    },
-    {
-      targetImage: 'ubuntu:10.04',
-      rpmThrows: './docker-entrypoint.sh: line 9: exec: rpm: not found',
-    },
-  ];
+  const targetImages = ['alpine:2.6', 'ubuntu:10.04']
 
-  for (const example of examples) {
-    await t.test(example.targetImage, async t => {
-      const execStub = sinon.stub(subProcess, 'execute');
-
-      execStub.withArgs('docker', [
-        'run', '--rm', '--entrypoint', '""', '--network', 'none',
-        sinon.match.any,
-        'rpm',
-        '--nodigest',
-        '--nosignature',
-        '-qa',
-        '--qf',
-        '"%{NAME}\t%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\t%{SIZE}\n"',
-      ]).callsFake(async (docker, [run, rm, image]) => {
-        throw example.rpmThrows;
-      });
-
-      t.teardown(() => execStub.restore());
-
-      const actual = await analyzer.analyze(example.targetImage);
+  for (const targetImage of targetImages) {
+    await t.test(targetImage, async t => {
+      const actual = await analyzer.analyze(targetImage);
 
       t.same(actual, {
-        Image: example.targetImage,
+        Image: targetImage,
         AnalyzeType: 'Rpm',
         Analysis: [],
       });

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -294,29 +294,53 @@ test('inspect centos', t => {
       }, 'root pkg');
 
       const deps = pkg.dependencies;
+      const metaDeps = deps['meta-common-packages'].dependencies;
 
-      t.equal(Object.keys(deps).length, 145, 'expected number of deps');
+      const expectedDepsCount = 145;
+      t.equal(
+        Object.keys(deps).length + Object.keys(metaDeps).length,
+        expectedDepsCount + 1,
+        'expected number of deps'
+      );
       t.match(deps, {
-        'openssl-libs': {
-          name: 'openssl-libs',
-          version: '1:1.0.2k-8.el7',
-        },
         passwd: {
           name: 'passwd',
           version: '0.79-4.el7',
-        },
-        systemd: {
-          name: 'systemd',
-          version: '219-42.el7',
+          dependencies: {
+            libuser: { name: 'libuser', version: '0.60-7.el7_1' },
+            glib2: { name: 'glib2', version: '2.50.3-3.el7' }
+          }
         },
         dracut: {
           name: 'dracut',
           version: '033-502.el7', // TODO: make sure we handle this well
         },
         iputils: {
+          name: 'iputils',
           version: '20160308-10.el7',
+          dependencies: {
+            systemd: {
+              name: 'systemd',
+              version: '219-42.el7'
+            },
+            libidn: {
+              name: 'libidn',
+              version: '1.28-4.el7'
+            }
+          }
         },
+        systemd: {
+          name: 'systemd',
+          version: '219-42.el7',
+        }
       }, 'deps');
+
+      t.match(metaDeps, {
+        'openssl-libs': {
+          name: 'openssl-libs',
+          version: '1:1.0.2k-8.el7',
+        },
+      }, 'metadeps');
     });
 });
 


### PR DESCRIPTION
Currently, the RPM analyzer merely returns direct dependencies.

Compared to apt & apk, RPM package information is not conveniently
stored; deriving non-direct package dependencies is a bit difficult.

Given internet access, yum (and yum derivatives) could be used
to fetch pkg dependencies eloquently. Without internet access,
however, RPM is the only tool we can assume is present and available.

There are a couple of difficulties with getting dependencies using
RPM.

RPM has a package requirements query (-q -R) which outputs
requirements of various types (files, configurations), and another
query for packages that provide these requirements (-q --whatprovides)

There is no direct query for required packages. As such, in order
to list required packages, one most first query for requirements,
and then query for packages that satisfy these requirements.

Moreso, not all requirements are able to be satisified by packages, and,
when querying for a requirement that has no package provider,
RPM exits with a failed exit code:

[lgoldber@leongold Downloads]$ rpm -q --whatprovides "/sbin/ldconfig" "rpmlib(PayloadIsXz)"
glibc-2.26-24.fc27.x86_64 <--- provides /sbin/ldconfig
no package provides rpmlib(PayloadIsXz) <--- has no package provider
[lgoldber@leongold Downloads]$ echo $?
1

I "solved" this by simply treating stderr as valid output (checking if
the raised error was indeed due to no satisfying packages).

RPM output is not separated by packages, making it naively impossible to tell
when the requirements of some package starts and ends.

In order to solve this, it is possible to append the name of the package
to the requirements using queryformat:

[lgoldber@leongold Downloads]$ rpm -qR --queryformat "+%{NAME}+\n" libacl-2.2.52-18.fc27.x86_64
/sbin/ldconfig
/sbin/ldconfig
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
...
rpmlib(PayloadIsXz) <= 5.2-1
rtld(GNU_HASH)
+libacl+ <--- won't appear without queryformat; no separation in multi-package query

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds non-direct dependencies for RPM's analyzer.

#### Where should the reviewer start?

/lib/analyzers/rpm-analyzer.ts

#### How should this be manually tested?

scanning centos:6

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
