### PR TITLE
fix: parse pkgs with hyphen in the name

### DIFF
--- a/lib/instruction-parser.ts
+++ b/lib/instruction-parser.ts
@@ -32,9 +32,10 @@ function getPackagesFromRunInstructions(
       const packagesWithInstructions = installCommands.forEach((command) => {
         const packages = command
           .replace(installRegex, '')
-          .replace(/-\w+/g, '')
+          .replace(/(^-|\s-)\w+/g, '')
           .trim()
           .split(/\s+/);
+
         packages.forEach((pkg) => {
           dockerfilePackages[pkg] = { instruction };
         });

--- a/test/lib/instruction-parser.test.ts
+++ b/test/lib/instruction-parser.test.ts
@@ -138,5 +138,15 @@ test('instruction parsers', async (t) => {
         'wget': { instruction: instructionTwo },
       });
     });
+
+    await t.test('supports "-" in pkg name', async (t) => {
+      const instruction = 'RUN apt install 389-admin';
+      const packages = getPackagesFromRunInstructions([instruction]);
+
+      t.same(packages, {
+        '389-admin': { instruction },
+      });
+    });
+
   });
 });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Support pkgs like `389-admin`