### PR TITLE
feat: check openjdk installed by pkg manager

### DIFF
--- a/lib/analyzer/binaries-analyzer.ts
+++ b/lib/analyzer/binaries-analyzer.ts
@@ -4,8 +4,12 @@ export {
   analyze,
 };
 
-async function analyze(targetImage: string, installedPackages: string[]) {
-  const binaries = await getBinaries(targetImage, installedPackages);
+async function analyze(
+  targetImage: string,
+  installedPackages: string[],
+  pkgManager?: string) {
+  const binaries = await getBinaries(
+    targetImage, installedPackages, pkgManager);
   return {
     Image: targetImage,
     AnalyzeType: 'binaries',
@@ -18,12 +22,13 @@ const binaryVersionExtractors = {
   openjdk: require('./binary-version-extractors/openjdk-jre'),
 };
 
-async function getBinaries(targetImage: string, installedPackages: string[])
+async function getBinaries(
+  targetImage: string, installedPackages: string[], pkgManager?: string)
   : Promise<Binary[]> {
   const binaries: Binary[] = [];
   for (const versionExtractor of Object.keys(binaryVersionExtractors)) {
     const extractor = binaryVersionExtractors[versionExtractor];
-    if (installedByPackageManager(extractor.packageNames, installedPackages)) {
+    if (extractor.installedByPackageManager(installedPackages, pkgManager)) {
       continue;
     }
     const binary = await extractor.extract(targetImage);
@@ -32,11 +37,4 @@ async function getBinaries(targetImage: string, installedPackages: string[])
     }
   }
   return binaries;
-}
-
-function installedByPackageManager(
-  binaryPkgNames: string[],
-  installedPackages: string[]): boolean {
-  return installedPackages
-    .filter(pkg => binaryPkgNames.indexOf(pkg) > -1).length > 0;
 }

--- a/lib/analyzer/binary-version-extractors/node.ts
+++ b/lib/analyzer/binary-version-extractors/node.ts
@@ -5,10 +5,8 @@ const semver = require('semver');
 
 export {
   extract,
-  packageNames,
+  installedByPackageManager,
 };
-
-const packageNames = ['node', 'nodejs'];
 
 async function extract(targetImage: string): Promise<Binary | null> {
   try {
@@ -32,4 +30,12 @@ function parseNodeBinary(version: string) {
     name: 'node',
     version: nodeVersion,
   };
+}
+
+const packageNames = ['node', 'nodejs'];
+
+function installedByPackageManager(
+  installedPackages: string[], pkgManager?: string): boolean {
+  return installedPackages
+    .filter(pkg => packageNames.indexOf(pkg) > -1).length > 0;
 }

--- a/test/lib/analyzer/binaries-analyzer.test.ts
+++ b/test/lib/analyzer/binaries-analyzer.test.ts
@@ -93,7 +93,7 @@ test('analyze', async t => {
                              openjdk: `java version "1.8.0_191"
                                        Java(TM) SE Runtime Environment (build 1.8.0_191-b12)
                                        Java HotSpot(TM) 64-Bit Server VM (build 25.191-b12, mixed mode)` },
-      installedPackages: ['java'],
+      installedPackages: ['openjdk-8-jre-headless'],
       expectedBinaries: [ ],
     },
     {
@@ -131,7 +131,7 @@ test('analyze', async t => {
       t.teardown(() => execStub.restore());
 
       const {targetImage, installedPackages, expectedBinaries} = example;
-      const actual = await analyzer.analyze(targetImage, installedPackages);
+      const actual = await analyzer.analyze(targetImage, installedPackages, 'apt');
 
       t.same(actual, {
         Image: targetImage,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds package names for `openjdk-jre` according to package manager `APK`, `APT`, `RPM`.
Refactors logic by insertion of `installedByPackageManager` function into each binary `extractor` as it needs to be unique per binary.

#### How should this be manually tested?
snyk docker test any node image.
