### PR TITLE
fix: subprocess: include both stdout and stderr

### DIFF
--- a/lib/analyzer/apk-analyzer.ts
+++ b/lib/analyzer/apk-analyzer.ts
@@ -1,6 +1,6 @@
 import { Docker } from '../docker';
 import { AnalyzerPkg } from './types';
-
+import { Output } from '../sub-process';
 export {
   analyze,
 };
@@ -20,10 +20,10 @@ function getPackages(targetImage: string) {
     .then(parseFile);
 }
 
-function parseFile(text: string) {
+function parseFile(output: Output) {
   const pkgs: AnalyzerPkg[] = [];
   let curPkg: any = null;
-  for (const line of text.split('\n')) {
+  for (const line of output.stdout.split('\n')) {
     curPkg = parseLine(line, curPkg, pkgs);
   }
   return pkgs;

--- a/lib/analyzer/apk-analyzer.ts
+++ b/lib/analyzer/apk-analyzer.ts
@@ -1,6 +1,6 @@
 import { Docker } from '../docker';
 import { AnalyzerPkg } from './types';
-import { Output } from '../sub-process';
+
 export {
   analyze,
 };
@@ -17,13 +17,13 @@ function analyze(targetImage: string) {
 function getPackages(targetImage: string) {
   return new Docker(targetImage)
     .catSafe('/lib/apk/db/installed')
-    .then(parseFile);
+    .then(output => parseFile(output.stdout));
 }
 
-function parseFile(output: Output) {
+function parseFile(text: string) {
   const pkgs: AnalyzerPkg[] = [];
   let curPkg: any = null;
-  for (const line of output.stdout.split('\n')) {
+  for (const line of text.split('\n')) {
     curPkg = parseLine(line, curPkg, pkgs);
   }
   return pkgs;

--- a/lib/analyzer/apt-analyzer.ts
+++ b/lib/analyzer/apt-analyzer.ts
@@ -7,10 +7,10 @@ export {
 
 async function analyze(targetImage: string) {
   const docker = new Docker(targetImage);
-  const dpkgFile = await docker.catSafe('/var/lib/dpkg/status');
+  const dpkgFile = (await docker.catSafe('/var/lib/dpkg/status')).stdout;
   const pkgs = parseDpkgFile(dpkgFile);
 
-  const extFile = await docker.catSafe('/var/lib/apt/extended_states');
+  const extFile = (await docker.catSafe('/var/lib/apt/extended_states')).stdout;
   if (extFile) {
     setAutoInstalledPackages(extFile, pkgs);
   }

--- a/lib/analyzer/binary-version-extractors/node.ts
+++ b/lib/analyzer/binary-version-extractors/node.ts
@@ -9,16 +9,18 @@ export {
 };
 
 async function extract(targetImage: string): Promise<Binary | null> {
+  let binaryVersion: string;
   try {
-    const binaryVersion = await new Docker(targetImage).
-      run('node', [ '--version' ]);
-    return parseNodeBinary(binaryVersion);
-  } catch (stderr) {
+    binaryVersion = (await new Docker(targetImage).
+      run('node', [ '--version' ])).stdout;
+  } catch (error) {
+    const stderr = error.stderr;
     if (typeof stderr === 'string' && stderr.indexOf('not found') >= 0) {
       return null;
     }
     throw new Error(stderr);
   }
+  return parseNodeBinary(binaryVersion);
 }
 
 function parseNodeBinary(version: string) {

--- a/lib/analyzer/binary-version-extractors/node.ts
+++ b/lib/analyzer/binary-version-extractors/node.ts
@@ -9,10 +9,10 @@ export {
 };
 
 async function extract(targetImage: string): Promise<Binary | null> {
-  let binaryVersion: string;
   try {
-    binaryVersion = (await new Docker(targetImage).
+    const binaryVersion = (await new Docker(targetImage).
       run('node', [ '--version' ])).stdout;
+    return parseNodeBinary(binaryVersion);
   } catch (error) {
     const stderr = error.stderr;
     if (typeof stderr === 'string' && stderr.indexOf('not found') >= 0) {
@@ -20,7 +20,6 @@ async function extract(targetImage: string): Promise<Binary | null> {
     }
     throw new Error(stderr);
   }
-  return parseNodeBinary(binaryVersion);
 }
 
 function parseNodeBinary(version: string) {

--- a/lib/analyzer/binary-version-extractors/openjdk-jre.ts
+++ b/lib/analyzer/binary-version-extractors/openjdk-jre.ts
@@ -7,18 +7,17 @@ export {
 };
 
 async function extract(targetImage: string): Promise<Binary | null> {
-  let binaryVersion: string;
   try {
-    binaryVersion = (await new Docker(targetImage).
+    const binaryVersion = (await new Docker(targetImage).
       run('java', [ '-version' ])).stdout;
+    return parseOpenJDKBinary(binaryVersion);
   } catch (error) {
-    const stderr: string = error.stderr;
+    const stderr = error.stderr;
     if (typeof stderr === 'string' && stderr.indexOf('not found') >= 0) {
       return null;
     }
     throw new Error(stderr);
   }
-  return parseOpenJDKBinary(binaryVersion);
 }
 
 function parseOpenJDKBinary(fullVersionOutput: string) {

--- a/lib/analyzer/binary-version-extractors/openjdk-jre.ts
+++ b/lib/analyzer/binary-version-extractors/openjdk-jre.ts
@@ -7,16 +7,18 @@ export {
 };
 
 async function extract(targetImage: string): Promise<Binary | null> {
+  let binaryVersion: string;
   try {
-    const binaryVersion = await new Docker(targetImage).
-      run('java', [ '-version' ]);
-    return parseOpenJDKBinary(binaryVersion);
-  } catch (stderr) {
+    binaryVersion = (await new Docker(targetImage).
+      run('java', [ '-version' ])).stdout;
+  } catch (error) {
+    const stderr: string = error.stderr;
     if (typeof stderr === 'string' && stderr.indexOf('not found') >= 0) {
       return null;
     }
     throw new Error(stderr);
   }
+  return parseOpenJDKBinary(binaryVersion);
 }
 
 function parseOpenJDKBinary(fullVersionOutput: string) {

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -14,7 +14,7 @@ interface Inspect {
 async function detect(targetImage: string): Promise<Inspect> {
   try {
     const info = await subProcess.execute('docker', ['inspect', targetImage]);
-    return JSON.parse(info)[0];
+    return JSON.parse(info.stdout)[0];
   } catch (error) {
     throw new Error(`Docker image was not found locally: ${targetImage}`);
   }

--- a/lib/analyzer/os-release-detector.ts
+++ b/lib/analyzer/os-release-detector.ts
@@ -45,7 +45,7 @@ async function detect(targetImage: string): Promise<OSRelease> {
 }
 
 async function tryOSRelease(docker: Docker): Promise<OSRelease|null> {
-  const text = await docker.catSafe('/etc/os-release');
+  const text = (await docker.catSafe('/etc/os-release')).stdout;
   if (!text) {
     return null;
   }
@@ -60,7 +60,7 @@ async function tryOSRelease(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryLSBRelease(docker: Docker): Promise<OSRelease|null> {
-  const text = await docker.catSafe('/etc/lsb-release');
+  const text = (await docker.catSafe('/etc/lsb-release')).stdout;
   if (!text) {
     return null;
   }
@@ -75,7 +75,7 @@ async function tryLSBRelease(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryDebianVersion(docker: Docker): Promise<OSRelease|null> {
-  let text = await docker.catSafe('/etc/debian_version');
+  let text = (await docker.catSafe('/etc/debian_version')).stdout;
   if (!text) {
     return null;
   }
@@ -87,7 +87,7 @@ async function tryDebianVersion(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryAlpineRelease(docker: Docker): Promise<OSRelease|null> {
-  let text = await docker.catSafe('/etc/alpine-release');
+  let text = (await docker.catSafe('/etc/alpine-release')).stdout;
   if (!text) {
     return null;
   }
@@ -99,7 +99,7 @@ async function tryAlpineRelease(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryRedHatRelease(docker: Docker): Promise<OSRelease|null> {
-  const text = await docker.catSafe('/etc/redhat-release');
+  const text = (await docker.catSafe('/etc/redhat-release')).stdout;
   if (!text) {
     return null;
   }
@@ -114,7 +114,7 @@ async function tryRedHatRelease(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryOracleRelease(docker: Docker): Promise<OSRelease|null> {
-  const text = await docker.catSafe('/etc/oracle-release');
+  const text = (await docker.catSafe('/etc/oracle-release')).stdout;
   if (!text) {
     return null;
   }

--- a/lib/analyzer/rpm-analyzer.ts
+++ b/lib/analyzer/rpm-analyzer.ts
@@ -1,5 +1,6 @@
 import { Docker } from '../docker';
 import { AnalyzerPkg } from './types';
+import { Output } from '../sub-process';
 
 export {
   analyze,
@@ -22,18 +23,19 @@ function getPackages(targetImage: string) {
     '--qf',
     '"%{NAME}\t%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\t%{SIZE}\n"',
   ])
-    .catch(stderr => {
+    .catch(error => {
+      const stderr = error.stderr;
       if (typeof stderr === 'string' && stderr.indexOf('not found') >= 0) {
-        return '';
+        return { stdout: '', stderr: ''};
       }
-      throw new Error(stderr);
+      throw error;
     })
     .then(parseOutput);
 }
 
-function parseOutput(text: string) {
+function parseOutput(output: Output) {
   const pkgs: AnalyzerPkg[] = [];
-  for (const line of text.split('\n')) {
+  for (const line of output.stdout.split('\n')) {
     parseLine(line, pkgs);
   }
   return pkgs;

--- a/lib/analyzer/rpm-analyzer.ts
+++ b/lib/analyzer/rpm-analyzer.ts
@@ -1,6 +1,5 @@
 import { Docker } from '../docker';
 import { AnalyzerPkg } from './types';
-import { Output } from '../sub-process';
 
 export {
   analyze,
@@ -30,12 +29,12 @@ function getPackages(targetImage: string) {
       }
       throw error;
     })
-    .then(parseOutput);
+    .then(output => parseOutput(output.stdout));
 }
 
-function parseOutput(output: Output) {
+function parseOutput(output: string) {
   const pkgs: AnalyzerPkg[] = [];
-  for (const line of output.stdout.split('\n')) {
+  for (const line of output.split('\n')) {
     parseLine(line, pkgs);
   }
   return pkgs;

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -16,11 +16,12 @@ class Docker {
   public async catSafe(filename: string) {
     try {
       return await this.run('cat', [filename]);
-    } catch (stderr) {
+    } catch (error) {
+      const stderr: string = error.stderr;
       if (typeof stderr === 'string' && stderr.indexOf('No such file') >= 0) {
-        return '';
+        return { stdout: '', stderr: '' };
       }
-      throw new Error(stderr);
+      throw error;
     }
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -86,7 +86,7 @@ function collectDeps(pkg) {
 function getRuntime() {
   return subProcess.execute('docker', ['version'])
     .then((output) => {
-      const versionMatch = /Version:\s+(.*)\n/.exec(output);
+      const versionMatch = /Version:\s+(.*)\n/.exec(output.stdout);
       if (versionMatch) {
         return 'docker ' + versionMatch[1];
       }

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,10 +1,16 @@
 import * as childProcess from 'child_process';
 
-export function execute(
+export { execute, Output };
+interface Output {
+  stdout: string;
+  stderr: string;
+}
+
+function execute(
   command: string,
   args?: string[],
   options?,
-): Promise<string> {
+): Promise<Output> {
 
   const spawnOptions: any = { shell: true };
   if (options && options.cwd) {
@@ -24,10 +30,11 @@ export function execute(
     });
 
     proc.on('close', (code) => {
+      const output = {stdout, stderr};
       if (code !== 0) {
-        return reject(stdout || stderr);
+        return reject(output);
       }
-      resolve(stdout || stderr);
+      resolve(output);
     });
-  }) as Promise<string>;
+  }) as Promise<Output>;
 }

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,7 +1,7 @@
 import * as childProcess from 'child_process';
 
-export { execute, Output };
-interface Output {
+export { execute, CmdOutput };
+interface CmdOutput {
   stdout: string;
   stderr: string;
 }
@@ -10,7 +10,7 @@ function execute(
   command: string,
   args?: string[],
   options?,
-): Promise<Output> {
+): Promise<CmdOutput> {
 
   const spawnOptions: any = { shell: true };
   if (options && options.cwd) {
@@ -36,5 +36,5 @@ function execute(
       }
       resolve(output);
     });
-  }) as Promise<Output>;
+  }) as Promise<CmdOutput>;
 }

--- a/test/lib/analyzer/apk-analyzer.test.ts
+++ b/test/lib/analyzer/apk-analyzer.test.ts
@@ -149,7 +149,7 @@ test('analyze', async t => {
       execStub.withArgs('docker', [
         'run', '--rm', '--entrypoint', '""', '--network', 'none',
         sinon.match.any, 'cat', '/lib/apk/db/installed',
-      ]).resolves(example.manifestLines.join('\n'));
+      ]).resolves({ stdout: example.manifestLines.join('\n'), stderr: ''});
 
       t.teardown(() => execStub.restore());
 

--- a/test/lib/analyzer/apt-analyzer.test.ts
+++ b/test/lib/analyzer/apt-analyzer.test.ts
@@ -351,12 +351,12 @@ test('analyze', async t => {
       execStub.withArgs('docker', [
         'run', '--rm', '--entrypoint', '""', '--network', 'none',
         sinon.match.any, 'cat', '/var/lib/dpkg/status',
-      ]).resolves(example.dpkgManifestLines.join('\n'));
+      ]).resolves({stdout: example.dpkgManifestLines.join('\n'), stderr: ''});
 
       execStub.withArgs('docker', [
         'run', '--rm', '--entrypoint', '""', '--network', 'none',
         sinon.match.any, 'cat', '/var/lib/apt/extended_states',
-      ]).resolves(example.extManifestLines.join('\n'));
+      ]).resolves({stdout: example.extManifestLines.join('\n'), stderr: ''});
 
       t.teardown(() => execStub.restore());
 

--- a/test/lib/analyzer/binaries-analyzer.test.ts
+++ b/test/lib/analyzer/binaries-analyzer.test.ts
@@ -119,14 +119,14 @@ test('analyze', async t => {
         sinon.match.any,
         'node',
         '--version',
-      ]).resolves(example.binariesOutputLines.node);
+      ]).resolves({stdout: example.binariesOutputLines.node, stderr: ''});
 
       execStub.withArgs('docker', [
         'run', '--rm', '--entrypoint', '""', '--network', 'none',
         sinon.match.any,
         'java',
         '-version',
-      ]).resolves(example.binariesOutputLines.openjdk);
+      ]).resolves({stdout: example.binariesOutputLines.openjdk, stderr: ''});
 
       t.teardown(() => execStub.restore());
 

--- a/test/lib/analyzer/image-inspector.test.ts
+++ b/test/lib/analyzer/image-inspector.test.ts
@@ -28,7 +28,7 @@ test('image id', async t => {
 
   const execStub = sinon.stub(subProcess, 'execute');
   execStub.withArgs('docker', ['inspect', 'alpine:2.6'])
-    .resolves(JSON.stringify(stubbedData));
+    .resolves({stdout: JSON.stringify(stubbedData), stderr: ''});
   t.teardown(() => execStub.restore());
 
   const imageData = await imageInspector.detect('alpine:2.6');

--- a/test/lib/analyzer/index.test.ts
+++ b/test/lib/analyzer/index.test.ts
@@ -33,10 +33,10 @@ test('analyzer', async t => {
       [run, rm, entry, empty, network, none, image, cat, file]) => {
       try {
         const example = examples[image];
-        return readOsFixtureFile(example.dir, 'fs', file);
+        return {stdout: readOsFixtureFile(example.dir, 'fs', file), stderr: ''};
       } catch {
         // tslint:disable-next-line:no-string-throw
-        throw `cat: ${file}: No such file or directory`;
+        throw {stderr: `cat: ${file}: No such file or directory`, stdout: ''};
       }
     });
 
@@ -55,12 +55,15 @@ test('analyzer', async t => {
       [run, rm, entry, empty, network, none, image]) => {
       try {
         const example = examples[image];
-        return readOsFixtureFile(example.dir, 'rpm-output.txt');
+        return {
+          stdout: readOsFixtureFile(example.dir, 'rpm-output.txt'),
+          stderr: ''};
       } catch {
         // tslint:disable-next-line:no-string-throw
-        throw `docker: Error response from daemon: OCI runtime \
+        throw {stderr: `docker: Error response from daemon: OCI runtime \
         create failed: container_linux.go:348: starting container process\
-        caused "exec: \"rpm\": executable file not found in $PATH": unknown.`;
+        caused "exec: \"rpm\": executable file not found in $PATH": unknown.`,
+        stdout: ''};
       }
     });
 
@@ -75,10 +78,14 @@ test('analyzer', async t => {
         [run, rm, entry, empty, network, none, image]) => {
         try {
           const example = examples[image];
-          return readOsFixtureFile(example.dir, 'node-version.txt');
+          return {
+            stdout: readOsFixtureFile(example.dir, 'node-version.txt'),
+            stderr: ''};
         } catch {
           // tslint:disable-next-line:no-string-throw
-          throw 'docker: Error running `docker node --version`';
+          throw {
+            stderr: 'docker: Error running `docker node --version`',
+            stdout: ''};
         }
       });
 
@@ -96,7 +103,9 @@ test('analyzer', async t => {
           return readOsFixtureFile(example.dir, 'openjdk-jre-version.txt');
         } catch {
           // tslint:disable-next-line:no-string-throw
-          throw 'docker: Error running `docker java -version`';
+          throw {
+            stderr: 'docker: Error running `docker java -version`',
+            stdout: ''};
         }
       });
 

--- a/test/lib/analyzer/os-release-detector.test.ts
+++ b/test/lib/analyzer/os-release-detector.test.ts
@@ -119,9 +119,9 @@ test('os release detection', async t => {
     .callsFake(async (docker, [run, rm, entry, empty, network, none, image, cat, file]) => {
       try {
         const example = examples[image];
-        return readOsFixtureFile(example.dir, 'fs', file);
+        return {stdout: readOsFixtureFile(example.dir, 'fs', file), stderr: ''};
       } catch {
-        throw `cat: ${file}: No such file or directory`;
+        throw {stderr: `cat: ${file}: No such file or directory`, stdout: ''};
       }
     });
   t.teardown(() => execStub.restore());
@@ -166,9 +166,9 @@ test('failed detection', async t => {
     .callsFake(async (docker, [run, rm, entry, empty, network, none, image, cat, file]) => {
       try {
         const example = examples[image];
-        return readOsFixtureFile(example.dir, 'fs', file);
+        return {stdout: readOsFixtureFile(example.dir, 'fs', file), stderr: ''};
       } catch {
-        throw `cat: ${file}: No such file or directory`;
+        throw {stderr: `cat: ${file}: No such file or directory`, stdout: ''};
       }
     });
   t.teardown(() => execStub.restore());

--- a/test/lib/analyzer/rpm-analyzer.test.ts
+++ b/test/lib/analyzer/rpm-analyzer.test.ts
@@ -64,7 +64,7 @@ test('analyze', async t => {
         '-qa',
         '--qf',
         '"%{NAME}\t%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\t%{SIZE}\n"',
-      ]).resolves(example.rpmOutputLines.join('\n'));
+      ]).resolves({stdout: example.rpmOutputLines.join('\n'), stderr: ''});
 
       t.teardown(() => execStub.restore());
 
@@ -105,7 +105,7 @@ test('no rpm', async t => {
         '--qf',
         '"%{NAME}\t%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\t%{SIZE}\n"',
       ]).callsFake(async (docker, [run, rm, image]) => {
-        throw example.rpmThrows;
+        throw {stderr: example.rpmThrows, stdout: ''};
       });
 
       t.teardown(() => execStub.restore());

--- a/test/lib/docker.test.ts
+++ b/test/lib/docker.test.ts
@@ -59,28 +59,28 @@ test('safeCat', async (t) => {
   const docker = new Docker(targetImage);
 
   t.test('file found', async (t) => {
-    stub.resolves('file contents');
-    const content = await docker.catSafe('present.txt');
+    stub.resolves({stdout: 'file contents'});
+    const content = (await docker.catSafe('present.txt')).stdout;
     t.equal(content, 'file contents', 'file contents returned');
   });
 
   t.test('file not found', async (t) => {
     stub.callsFake(() => {
       // tslint:disable-next-line:no-string-throw
-      throw 'cat: absent.txt: No such file or directory';
+      throw {stderr: 'cat: absent.txt: No such file or directory'};
     });
-    const content = await docker.catSafe('absent.txt');
+    const content = (await docker.catSafe('absent.txt')).stderr;
     t.equal(content, '', 'empty string returned');
   });
 
   t.test('unexpected error', async (t) => {
     stub.callsFake(() => {
       // tslint:disable-next-line:no-string-throw
-      throw 'something went horribly wrong';
+      throw { stderr: 'something went horribly wrong', stdout: '' };
     });
     await t.rejects(
       docker.catSafe('absent.txt'),
-      new Error('something went horribly wrong'),
+      { stderr: 'something went horribly wrong', stdout: '' },
       'rejects with expected error',
     );
   });

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -421,7 +421,7 @@ function dockerTag(t, fromName, toName) {
 function dockerGetImageId(t, name) {
   return subProcess.execute('docker', ['inspect', name])
     .then((output) => {
-      const inspection = JSON.parse(output);
+      const inspection = JSON.parse(output.stdout);
 
       const id = inspection[0].Id;
 


### PR DESCRIPTION
Process may emit both stdout and stderr.

We currently only propagate one (giving precedence to stdout), potentially causing loss of data, e.g.:

```
Leons-MBP:snyk-docker-plugin leongold$ docker inspect foo:123
[] <--- stdout
Error: No such object: foo:123 <--- stderr
```

Refactor the project to return both in a single object, i.e {stdout, stderr}

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team
