### PR TITLE
feat: support global docker options

### DIFF
--- a/lib/analyzer/apk-analyzer.ts
+++ b/lib/analyzer/apk-analyzer.ts
@@ -5,8 +5,8 @@ export {
   analyze,
 };
 
-function analyze(targetImage: string) {
-  return getPackages(targetImage)
+function analyze(targetImage: string, options?: any) {
+  return getPackages(targetImage, options)
     .then(pkgs => ({
       Image: targetImage,
       AnalyzeType: 'Apk',
@@ -14,8 +14,8 @@ function analyze(targetImage: string) {
     }));
 }
 
-function getPackages(targetImage: string) {
-  return new Docker(targetImage)
+function getPackages(targetImage: string, options?: any) {
+  return new Docker(targetImage, options)
     .catSafe('/lib/apk/db/installed')
     .then(output => parseFile(output.stdout));
 }

--- a/lib/analyzer/apk-analyzer.ts
+++ b/lib/analyzer/apk-analyzer.ts
@@ -1,11 +1,10 @@
-import { Docker } from '../docker';
+import { Docker, DockerOptions } from '../docker';
 import { AnalyzerPkg } from './types';
-
 export {
   analyze,
 };
 
-function analyze(targetImage: string, options?: any) {
+function analyze(targetImage: string, options?: DockerOptions) {
   return getPackages(targetImage, options)
     .then(pkgs => ({
       Image: targetImage,
@@ -14,7 +13,7 @@ function analyze(targetImage: string, options?: any) {
     }));
 }
 
-function getPackages(targetImage: string, options?: any) {
+function getPackages(targetImage: string, options?: DockerOptions) {
   return new Docker(targetImage, options)
     .catSafe('/lib/apk/db/installed')
     .then(output => parseFile(output.stdout));

--- a/lib/analyzer/apt-analyzer.ts
+++ b/lib/analyzer/apt-analyzer.ts
@@ -1,11 +1,11 @@
-import { Docker } from '../docker';
+import { Docker, DockerOptions } from '../docker';
 import { AnalyzerPkg } from './types';
 
 export {
   analyze,
 };
 
-async function analyze(targetImage: string, options?: any) {
+async function analyze(targetImage: string, options?: DockerOptions) {
   const docker = new Docker(targetImage, options);
   const dpkgFile = (await docker.catSafe('/var/lib/dpkg/status')).stdout;
   const pkgs = parseDpkgFile(dpkgFile);

--- a/lib/analyzer/apt-analyzer.ts
+++ b/lib/analyzer/apt-analyzer.ts
@@ -5,8 +5,8 @@ export {
   analyze,
 };
 
-async function analyze(targetImage: string) {
-  const docker = new Docker(targetImage);
+async function analyze(targetImage: string, options?: any) {
+  const docker = new Docker(targetImage, options);
   const dpkgFile = (await docker.catSafe('/var/lib/dpkg/status')).stdout;
   const pkgs = parseDpkgFile(dpkgFile);
 

--- a/lib/analyzer/binaries-analyzer.ts
+++ b/lib/analyzer/binaries-analyzer.ts
@@ -1,4 +1,5 @@
 import { Binary } from './types';
+import { DockerOptions } from '../docker';
 
 export {
   analyze,
@@ -7,10 +8,10 @@ export {
 async function analyze(
   targetImage: string,
   installedPackages: string[],
-  options?: any,
-  pkgManager?: string) {
+  pkgManager?: string,
+  options?: DockerOptions) {
   const binaries = await getBinaries(
-    targetImage, installedPackages, options, pkgManager);
+    targetImage, installedPackages, pkgManager, options);
   return {
     Image: targetImage,
     AnalyzeType: 'binaries',
@@ -26,14 +27,14 @@ const binaryVersionExtractors = {
 async function getBinaries(
   targetImage: string,
   installedPackages: string[],
-  options?: any,
   pkgManager?: string,
+  options?: DockerOptions,
   ): Promise<Binary[]> {
   const binaries: Binary[] = [];
   for (const versionExtractor of Object.keys(binaryVersionExtractors)) {
     const extractor = binaryVersionExtractors[versionExtractor];
     if (extractor.installedByPackageManager(
-      installedPackages, options, pkgManager)) {
+      installedPackages, pkgManager, options)) {
       continue;
     }
     const binary = await extractor.extract(targetImage);

--- a/lib/analyzer/binaries-analyzer.ts
+++ b/lib/analyzer/binaries-analyzer.ts
@@ -7,9 +7,10 @@ export {
 async function analyze(
   targetImage: string,
   installedPackages: string[],
+  options?: any,
   pkgManager?: string) {
   const binaries = await getBinaries(
-    targetImage, installedPackages, pkgManager);
+    targetImage, installedPackages, options, pkgManager);
   return {
     Image: targetImage,
     AnalyzeType: 'binaries',
@@ -23,12 +24,16 @@ const binaryVersionExtractors = {
 };
 
 async function getBinaries(
-  targetImage: string, installedPackages: string[], pkgManager?: string)
-  : Promise<Binary[]> {
+  targetImage: string,
+  installedPackages: string[],
+  options?: any,
+  pkgManager?: string,
+  ): Promise<Binary[]> {
   const binaries: Binary[] = [];
   for (const versionExtractor of Object.keys(binaryVersionExtractors)) {
     const extractor = binaryVersionExtractors[versionExtractor];
-    if (extractor.installedByPackageManager(installedPackages, pkgManager)) {
+    if (extractor.installedByPackageManager(
+      installedPackages, options, pkgManager)) {
       continue;
     }
     const binary = await extractor.extract(targetImage);

--- a/lib/analyzer/binary-version-extractors/node.ts
+++ b/lib/analyzer/binary-version-extractors/node.ts
@@ -8,10 +8,12 @@ export {
   installedByPackageManager,
 };
 
-async function extract(targetImage: string): Promise<Binary | null> {
+async function extract(
+  targetImage: string,
+  options?: any): Promise<Binary | null> {
   try {
-    const binaryVersion = (await new Docker(targetImage).
-      run('node', [ '--version' ])).stdout;
+    const binaryVersion = (await new Docker(targetImage, options)
+      .run('node', [ '--version' ])).stdout;
     return parseNodeBinary(binaryVersion);
   } catch (error) {
     const stderr = error.stderr;

--- a/lib/analyzer/binary-version-extractors/node.ts
+++ b/lib/analyzer/binary-version-extractors/node.ts
@@ -1,4 +1,4 @@
-import { Docker } from '../../docker';
+import { Docker, DockerOptions } from '../../docker';
 import { Binary } from '../types';
 
 const semver = require('semver');
@@ -10,7 +10,7 @@ export {
 
 async function extract(
   targetImage: string,
-  options?: any): Promise<Binary | null> {
+  options?: DockerOptions): Promise<Binary | null> {
   try {
     const binaryVersion = (await new Docker(targetImage, options)
       .run('node', [ '--version' ])).stdout;

--- a/lib/analyzer/binary-version-extractors/openjdk-jre.ts
+++ b/lib/analyzer/binary-version-extractors/openjdk-jre.ts
@@ -6,10 +6,12 @@ export {
   installedByPackageManager,
 };
 
-async function extract(targetImage: string): Promise<Binary | null> {
+async function extract(
+  targetImage: string,
+  options?: any): Promise<Binary | null> {
   try {
-    const binaryVersion = (await new Docker(targetImage).
-      run('java', [ '-version' ])).stdout;
+    const binaryVersion = (await new Docker(
+      targetImage, options).run('java', [ '-version' ])).stdout;
     return parseOpenJDKBinary(binaryVersion);
   } catch (error) {
     const stderr = error.stderr;

--- a/lib/analyzer/binary-version-extractors/openjdk-jre.ts
+++ b/lib/analyzer/binary-version-extractors/openjdk-jre.ts
@@ -1,4 +1,4 @@
-import { Docker } from '../../docker';
+import { Docker, DockerOptions } from '../../docker';
 import { Binary } from '../types';
 
 export {
@@ -8,10 +8,11 @@ export {
 
 async function extract(
   targetImage: string,
-  options?: any): Promise<Binary | null> {
+  options?: DockerOptions): Promise<Binary | null> {
   try {
-    const binaryVersion = (await new Docker(
-      targetImage, options).run('java', [ '-version' ])).stdout;
+    const binaryVersion =
+      (await new Docker(targetImage, options)
+      .run('java', [ '-version' ])).stdout;
     return parseOpenJDKBinary(binaryVersion);
   } catch (error) {
     const stderr = error.stderr;

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -1,4 +1,4 @@
-import * as subProcess from '../sub-process';
+import { Docker } from '../docker';
 
 export {
   detect,
@@ -11,11 +11,16 @@ interface Inspect {
   };
 }
 
-async function detect(targetImage: string): Promise<Inspect> {
+async function detect(targetImage: string, options?: any):
+  Promise<Inspect> {
   try {
-    const info = await subProcess.execute('docker', ['inspect', targetImage]);
+    const info = await new Docker(
+      targetImage,
+      options,
+    )
+    .inspect(targetImage);
     return JSON.parse(info.stdout)[0];
   } catch (error) {
-    throw new Error(`Docker image was not found locally: ${targetImage}`);
+    throw new Error(`Docker error: ${error.stderr}`);
   }
 }

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -1,4 +1,4 @@
-import { Docker } from '../docker';
+import { Docker, DockerOptions } from '../docker';
 
 export {
   detect,
@@ -11,7 +11,7 @@ interface Inspect {
   };
 }
 
-async function detect(targetImage: string, options?: any):
+async function detect(targetImage: string, options?: DockerOptions):
   Promise<Inspect> {
   try {
     const info = await new Docker(
@@ -21,6 +21,10 @@ async function detect(targetImage: string, options?: any):
     .inspect(targetImage);
     return JSON.parse(info.stdout)[0];
   } catch (error) {
+    if (error.stderr.includes('No such object')) {
+      throw new Error(
+        `Docker error: image was not found locally: ${targetImage}`);
+      }
     throw new Error(`Docker error: ${error.stderr}`);
+    }
   }
-}

--- a/lib/analyzer/index.ts
+++ b/lib/analyzer/index.ts
@@ -1,3 +1,4 @@
+import { DockerOptions } from '../docker';
 import * as osReleaseDetector from './os-release-detector';
 import * as imageInspector from './image-inspector';
 import * as apkAnalyzer from './apk-analyzer';
@@ -10,24 +11,22 @@ export {
   analyze,
 };
 
-async function analyze(targetImage: string, options?: any) {
+async function analyze(targetImage: string, options?: DockerOptions) {
   const [
     imageInspection,
     osRelease,
-    results,
   ] = await Promise.all([
     imageInspector.detect(targetImage, options),
-    osReleaseDetector.detect(targetImage, options),
-    Promise.all([
-      apkAnalyzer.analyze(targetImage, options),
-      aptAnalyzer.analyze(targetImage, options),
-      rpmAnalyzer.analyze(targetImage, options),
-    ]).catch((err) => {
-      debug(`Error while running analyzer: '${err}'`);
-      throw new Error(`Failed to detect installed OS packages: '${err}'`);
-    }),
+    osReleaseDetector.detect(targetImage, options)]);
 
-  ]);
+  const results = await Promise.all([
+    apkAnalyzer.analyze(targetImage, options),
+    aptAnalyzer.analyze(targetImage, options),
+    rpmAnalyzer.analyze(targetImage, options),
+    ]).catch((err) => {
+      debug(`Error while running analyzer: '${err.stderr}'`);
+      throw new Error('Failed to detect installed OS packages');
+    });
 
   const { installedPackages, pkgManager } =
     getInstalledPackages(results as any[]);

--- a/lib/analyzer/index.ts
+++ b/lib/analyzer/index.ts
@@ -10,21 +10,21 @@ export {
   analyze,
 };
 
-async function analyze(targetImage: string) {
+async function analyze(targetImage: string, options?: any) {
   const [
     imageInspection,
     osRelease,
     results,
   ] = await Promise.all([
-    imageInspector.detect(targetImage),
-    osReleaseDetector.detect(targetImage),
+    imageInspector.detect(targetImage, options),
+    osReleaseDetector.detect(targetImage, options),
     Promise.all([
-      apkAnalyzer.analyze(targetImage),
-      aptAnalyzer.analyze(targetImage),
-      rpmAnalyzer.analyze(targetImage),
+      apkAnalyzer.analyze(targetImage, options),
+      aptAnalyzer.analyze(targetImage, options),
+      rpmAnalyzer.analyze(targetImage, options),
     ]).catch((err) => {
       debug(`Error while running analyzer: '${err}'`);
-      throw new Error('Failed to detect installed OS packages');
+      throw new Error(`Failed to detect installed OS packages: '${err}'`);
     }),
 
   ]);
@@ -34,7 +34,7 @@ async function analyze(targetImage: string) {
   let binaries;
   try {
     binaries = await binariesAnalyzer.analyze(
-      targetImage, installedPackages, pkgManager);
+      targetImage, installedPackages, pkgManager, options);
   } catch (err) {
     debug(`Error while running binaries analyzer: '${err}'`);
     throw new Error('Failed to detect binaries versions');

--- a/lib/analyzer/os-release-detector.ts
+++ b/lib/analyzer/os-release-detector.ts
@@ -5,8 +5,8 @@ export {
   detect,
 };
 
-async function detect(targetImage: string): Promise<OSRelease> {
-  const docker = new Docker(targetImage);
+async function detect(targetImage: string, options?: any): Promise<OSRelease> {
+  const docker = new Docker(targetImage, options);
 
   let osRelease = await tryOSRelease(docker);
 

--- a/lib/analyzer/os-release-detector.ts
+++ b/lib/analyzer/os-release-detector.ts
@@ -1,11 +1,13 @@
-import { Docker } from '../docker';
+import { Docker, DockerOptions } from '../docker';
 import { OSRelease } from './types';
+import { TextDecoder } from 'util';
 
 export {
   detect,
 };
 
-async function detect(targetImage: string, options?: any): Promise<OSRelease> {
+async function detect(targetImage: string, options?: DockerOptions):
+  Promise<OSRelease> {
   const docker = new Docker(targetImage, options);
 
   let osRelease = await tryOSRelease(docker);
@@ -45,7 +47,7 @@ async function detect(targetImage: string, options?: any): Promise<OSRelease> {
 }
 
 async function tryOSRelease(docker: Docker): Promise<OSRelease|null> {
-  const text = (await docker.catSafe('/etc/os-release')).stdout;
+  const text = await tryRelease(docker, '/etc/os-release');
   if (!text) {
     return null;
   }
@@ -60,7 +62,7 @@ async function tryOSRelease(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryLSBRelease(docker: Docker): Promise<OSRelease|null> {
-  const text = (await docker.catSafe('/etc/lsb-release')).stdout;
+  const text = await tryRelease(docker, '/etc/lsb-release');
   if (!text) {
     return null;
   }
@@ -75,7 +77,7 @@ async function tryLSBRelease(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryDebianVersion(docker: Docker): Promise<OSRelease|null> {
-  let text = (await docker.catSafe('/etc/debian_version')).stdout;
+  let text = await tryRelease(docker, '/etc/debian_version');
   if (!text) {
     return null;
   }
@@ -87,7 +89,7 @@ async function tryDebianVersion(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryAlpineRelease(docker: Docker): Promise<OSRelease|null> {
-  let text = (await docker.catSafe('/etc/alpine-release')).stdout;
+  let text = await tryRelease(docker, '/etc/alpine-release');
   if (!text) {
     return null;
   }
@@ -99,7 +101,8 @@ async function tryAlpineRelease(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryRedHatRelease(docker: Docker): Promise<OSRelease|null> {
-  const text = (await docker.catSafe('/etc/redhat-release')).stdout;
+  const text = await tryRelease(docker, '/etc/redhat-release');
+
   if (!text) {
     return null;
   }
@@ -114,7 +117,7 @@ async function tryRedHatRelease(docker: Docker): Promise<OSRelease|null> {
 }
 
 async function tryOracleRelease(docker: Docker): Promise<OSRelease|null> {
-  const text = (await docker.catSafe('/etc/oracle-release')).stdout;
+  const text = await tryRelease(docker, '/etc/oracle-release');
   if (!text) {
     return null;
   }
@@ -127,4 +130,12 @@ async function tryOracleRelease(docker: Docker): Promise<OSRelease|null> {
   const version = versionRes[1].replace(/"/g, '');
 
   return { name, version };
+}
+
+async function tryRelease(docker: Docker, release: string): Promise<string> {
+  try {
+    return (await docker.catSafe(release)).stdout;
+  } catch (error) {
+    throw new Error(error.stderr);
+  }
 }

--- a/lib/analyzer/rpm-analyzer.ts
+++ b/lib/analyzer/rpm-analyzer.ts
@@ -1,11 +1,11 @@
-import { Docker } from '../docker';
+import { Docker, DockerOptions } from '../docker';
 import { AnalyzerPkg } from './types';
 
 export {
   analyze,
 };
 
-async function analyze(targetImage: string, options?: any) {
+async function analyze(targetImage: string, options?: DockerOptions) {
   const pkgs = await getPackages(targetImage, options);
   return {
     Image: targetImage,
@@ -14,7 +14,7 @@ async function analyze(targetImage: string, options?: any) {
   };
 }
 
-function getPackages(targetImage: string, options?: any) {
+function getPackages(targetImage: string, options?: DockerOptions) {
   return new Docker(targetImage, options).run('rpm', [
     '--nodigest',
     '--nosignature',

--- a/lib/analyzer/rpm-analyzer.ts
+++ b/lib/analyzer/rpm-analyzer.ts
@@ -5,8 +5,8 @@ export {
   analyze,
 };
 
-async function analyze(targetImage: string) {
-  const pkgs = await getPackages(targetImage);
+async function analyze(targetImage: string, options?: any) {
+  const pkgs = await getPackages(targetImage, options);
   return {
     Image: targetImage,
     AnalyzeType: 'Rpm',
@@ -14,8 +14,8 @@ async function analyze(targetImage: string) {
   };
 }
 
-function getPackages(targetImage: string) {
-  return new Docker(targetImage).run('rpm', [
+function getPackages(targetImage: string, options?: any) {
+  return new Docker(targetImage, options).run('rpm', [
     '--nodigest',
     '--nosignature',
     '-qa',

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -3,14 +3,27 @@ import * as subProcess from './sub-process';
 export { Docker };
 
 class Docker {
-  constructor(private targetImage: string) {
+
+  private optionsList: string[];
+
+  constructor(
+    private targetImage: string,
+    options?: any,
+    ) {
+      this.optionsList = this.createOptionsList(options);
   }
 
   public run(cmd: string, args: string[] = []) {
     return subProcess.execute('docker', [
+      ...this.optionsList,
       'run', '--rm', '--entrypoint', '""', '--network', 'none',
       this.targetImage, cmd, ...args,
     ]);
+  }
+
+  public async inspect(targetImage: string) {
+    return await subProcess.execute('docker',
+      [...this.optionsList, 'inspect', targetImage]);
   }
 
   public async catSafe(filename: string) {
@@ -23,5 +36,28 @@ class Docker {
       }
       throw error;
     }
+  }
+
+  private createOptionsList(options: any) {
+    const opts: string[] = [];
+    if (!options) {
+      return opts;
+    }
+    if (options.host) {
+      opts.push(`--host=${options.host}`);
+    }
+    if (options.tlsCert) {
+      opts.push(`--tlscert=${options.tlsCert}`);
+    }
+    if (options.tlsCaCert) {
+      opts.push(`--tlscacert=${options.tlsCaCert}`);
+    }
+    if (options.tlsKey) {
+      opts.push(`--tlskey=${options.tlsKey}`);
+    }
+    if (options.tlsVerify) {
+      opts.push(`--tlsverify=${options.tlsVerify}`);
+    }
+    return opts;
   }
 }

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -1,6 +1,14 @@
 import * as subProcess from './sub-process';
 
-export { Docker };
+export { Docker, DockerOptions};
+
+interface DockerOptions {
+    host?: string;
+    tlsVerify?: string;
+    tlsCert?: string;
+    tlsCaCert?: string;
+    tlsKey?: string;
+}
 
 class Docker {
 
@@ -8,7 +16,7 @@ class Docker {
 
   constructor(
     private targetImage: string,
-    options?: any,
+    options?: DockerOptions,
     ) {
       this.optionsList = this.createOptionsList(options);
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,7 +15,7 @@ function inspect(root: string, targetFile?: string, options?: any) {
   const targetImage = root;
   return Promise.all([
     getRuntime(),
-    getDependencies(targetImage),
+    getDependencies(targetImage, options),
     dockerFile.analyseDockerfile(targetFile),
   ])
     .then((result) => {
@@ -125,9 +125,9 @@ function handleCommonErrors(error, targetImage: string) {
   }
 }
 
-function getDependencies(targetImage: string) {
+function getDependencies(targetImage: string, options?: any) {
   let result;
-  return analyzer.analyze(targetImage)
+  return analyzer.analyze(targetImage, options)
     .then((output) => {
       result = parseAnalysisResults(output);
       return buildTree(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ const debug = require('debug')('snyk');
 import * as analyzer from './analyzer';
 import * as subProcess from './sub-process';
 import * as dockerFile from './docker-file';
+import { DockerOptions } from './docker';
 import {
   DockerFilePackages,
 } from './instruction-parser';
@@ -12,10 +13,17 @@ export {
 };
 
 function inspect(root: string, targetFile?: string, options?: any) {
+  const dockerOptions = options ? {
+    host: options.host,
+    tlsVerify: options.tlsVerify,
+    tlsCert: options.tlsCert,
+    tlsCaCert: options.tlsCaCert,
+    tlsKey: options.tlsKey,
+  } : {};
   const targetImage = root;
   return Promise.all([
     getRuntime(),
-    getDependencies(targetImage, options),
+    getDependencies(targetImage, dockerOptions),
     dockerFile.analyseDockerfile(targetFile),
   ])
     .then((result) => {
@@ -125,7 +133,7 @@ function handleCommonErrors(error, targetImage: string) {
   }
 }
 
-function getDependencies(targetImage: string, options?: any) {
+function getDependencies(targetImage: string, options?: DockerOptions) {
   let result;
   return analyzer.analyze(targetImage, options)
     .then((output) => {

--- a/test/lib/docker.test.ts
+++ b/test/lib/docker.test.ts
@@ -6,7 +6,7 @@ import { test } from 'tap';
 import * as sinon from 'sinon';
 import * as subProcess from '../../lib/sub-process';
 
-import { Docker } from '../../lib/docker';
+import { Docker, DockerOptions } from '../../lib/docker';
 
 test('docker run', async (t) => {
   const stub = sinon.stub(subProcess, 'execute');

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -11,9 +11,36 @@ import * as subProcess from '../../lib/sub-process';
 const getDockerfileFixturePath = (folder) => path.join(
   __dirname, '../fixtures/dockerfiles/library', folder, 'Dockerfile');
 
+test('attempt to connect to non-existent host', t => {
+  const host = 'does-not-exist:1234';
+  const options = { host };
+
+  const imgName = 'nginx';
+  const imgTag = '1.13.10';
+  const img = imgName + ':' + imgTag;
+  const dockerFileLocation = getDockerfileFixturePath('nginx');
+
+  return dockerPull(t, img)
+    .then(() => {
+      return dockerGetImageId(t, img);
+    })
+    .then((_) => {
+      return plugin.inspect(img, dockerFileLocation, options);
+    })
+    .then(() => {
+      t.fail('should have failed');
+    })
+    .catch(err => {
+      t.includes(
+        err.message,
+        'no such host');
+    });
+});
+
 test('inspect an image that does not exist', t => {
   return plugin.inspect('not-here:latest').catch((err) => {
-    t.same(err.message, 'Docker image was not found locally: not-here:latest');
+    t.includes(
+      err.message, 'No such object: not-here:latest');
     t.pass('failed as expected');
   });
 });

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -31,16 +31,14 @@ test('attempt to connect to non-existent host', t => {
       t.fail('should have failed');
     })
     .catch(err => {
-      t.includes(
-        err.message,
-        'no such host');
+      t.includes(err.message, 'no such host');
     });
 });
 
 test('inspect an image that does not exist', t => {
   return plugin.inspect('not-here:latest').catch((err) => {
-    t.includes(
-      err.message, 'No such object: not-here:latest');
+    t.same(err.message,
+      'Docker error: image was not found locally: not-here:latest');
     t.pass('failed as expected');
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

Added support for global docker options:
host (docker server: hostname:port)
tlsverify (verify tls: true/false)
tlskey (path to tls key)
tlscert (path to tls cert)
tlscacert (path to tls ca cert)

(snyk --docker --tlsverify=true --host=localhost:1234...)

entrypoint options are now being propagated all the way
through the docker module.

A couple of additional changes that had to take place:

1) We used to assume that if there's an inspection error,
it is due to missing images. This is no longer the case, and
this commit adds stderr output to the error messages.

2) the inspection module was using subprocess directly,
and it now uses the docker module wrapper in order to
also make use of the propagated options.

#### Where should the reviewer start?

docker.ts

#### How should this be manually tested?

run docker's subprocess with some options

#### What are the relevant tickets?

https://github.com/snyk/snyk/issues/299
