### PR TITLE
fix: improve java binary analysis

### DIFF
--- a/lib/analyzer/binary-version-extractors/openjdk-jre.ts
+++ b/lib/analyzer/binary-version-extractors/openjdk-jre.ts
@@ -30,15 +30,19 @@ function parseOpenJDKBinary(fullVersionOutput: string) {
   */
   const jdkVersionLines = fullVersionOutput &&
                           fullVersionOutput.trim().split('\n');
-  if (!jdkVersionLines || jdkVersionLines.length !== 3) {
+  if (!jdkVersionLines) {
     return null;
   }
   const bracketsRE = /\(build (.*)\)$/;
-  const buildVersion = jdkVersionLines[1].match(bracketsRE);
-  const version = buildVersion && buildVersion[1];
+  const runtimeEnv = 'Runtime Environment';
+  const buildVersion =
+    (jdkVersionLines.filter(line => line.includes(runtimeEnv)).pop() || '')
+    .match(bracketsRE);
+  let version = buildVersion && buildVersion[1];
   if (!version) {
     return null;
   }
+  version = version.replace('-adoptopenjdk', '');
   return {
     name: 'openjdk-jre',
     version,

--- a/lib/analyzer/binary-version-extractors/openjdk-jre.ts
+++ b/lib/analyzer/binary-version-extractors/openjdk-jre.ts
@@ -39,11 +39,10 @@ function parseOpenJDKBinary(fullVersionOutput: string) {
 
   const bracketsRE = /\(build (.*)\)$/;
   const buildVersion = runtimeLine.match(bracketsRE);
-  let version = buildVersion && buildVersion[1];
+  const version = buildVersion && buildVersion[1];
   if (!version) {
     return null;
   }
-  version = version.replace('-adoptopenjdk', '');
   return {
     name: 'openjdk-jre',
     version,

--- a/lib/analyzer/binary-version-extractors/openjdk-jre.ts
+++ b/lib/analyzer/binary-version-extractors/openjdk-jre.ts
@@ -28,16 +28,17 @@ function parseOpenJDKBinary(fullVersionOutput: string) {
    Java HotSpot(TM) 64-Bit Server VM (build 25.191-b12, mixed mode)`
   => extracting `1.8.0_191-b12`
   */
-  const jdkVersionLines = fullVersionOutput &&
-                          fullVersionOutput.trim().split('\n');
-  if (!jdkVersionLines) {
+  const runtimeEnv = 'Runtime Environment';
+  const runtimeLine = fullVersionOutput &&
+                      fullVersionOutput.trim()
+                      .split('\n')
+                      .find(line => line.includes(runtimeEnv));
+  if (!runtimeLine) {
     return null;
   }
+
   const bracketsRE = /\(build (.*)\)$/;
-  const runtimeEnv = 'Runtime Environment';
-  const buildVersion =
-    (jdkVersionLines.filter(line => line.includes(runtimeEnv)).pop() || '')
-    .match(bracketsRE);
+  const buildVersion = runtimeLine.match(bracketsRE);
   let version = buildVersion && buildVersion[1];
   if (!version) {
     return null;

--- a/test/lib/analyzer/binaries-analyzer.test.ts
+++ b/test/lib/analyzer/binaries-analyzer.test.ts
@@ -109,6 +109,32 @@ test('analyze', async t => {
         { name: 'openjdk-jre', version: '1.8.0_191-b12' },
       ],
     },
+    {
+      description: 'adoptopenjdk version with hyphen in image',
+      targetImage: 'adoptopenjdk/openjdk10',
+      binariesOutputLines: { node: '',
+                             openjdk: `Picked up JAVA_TOOL_OPTIONS: -XX:+UseContainerSupport
+                                       openjdk 10.0.2-adoptopenjdk 2018-07-17
+                                       OpenJDK Runtime Environment (build 10.0.2-adoptopenjdk+13)
+                                       OpenJDK 64-Bit Server VM (build 10.0.2-adoptopenjdk+13, mixed mode)` },
+      installedPackages: [],
+      expectedBinaries: [
+        { name: 'openjdk-jre', version: '10.0.2+13' },
+      ],
+    },
+    {
+      description: 'adoptopenjdk version without hyphen in image',
+      targetImage: 'adoptopenjdk/openjdk11',
+      binariesOutputLines: { node: '',
+                             openjdk: `Picked up JAVA_TOOL_OPTIONS: -XX:+UseContainerSupport
+                                       openjdk 11.0.2 2019-01-15
+                                       OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.2+9)
+                                       OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.2+9, mixed mode)` },
+      installedPackages: [],
+      expectedBinaries: [
+        { name: 'openjdk-jre', version: '11.0.2+9' },
+      ],
+    },
   ];
 
   for (const example of examples) {

--- a/test/lib/analyzer/binaries-analyzer.test.ts
+++ b/test/lib/analyzer/binaries-analyzer.test.ts
@@ -119,7 +119,7 @@ test('analyze', async t => {
                                        OpenJDK 64-Bit Server VM (build 10.0.2-adoptopenjdk+13, mixed mode)` },
       installedPackages: [],
       expectedBinaries: [
-        { name: 'openjdk-jre', version: '10.0.2+13' },
+        { name: 'openjdk-jre', version: '10.0.2-adoptopenjdk+13' },
       ],
     },
     {


### PR DESCRIPTION
Current JRE parsing logic is too restrictive:

1) Expects RE version to appear strictly in the 2nd line --
I'm now looking for "Runtime Environment" to determine the line.
This is merely a better heuristic, but it does fix adoptOpenJDK
detection.

2) Expects the output to be exactly 3 lines long.
I don't see the necessity.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team