### PR TITLE
feat: alter analyse dockerfile by content to support SCM

### DIFF
--- a/lib/docker-file.ts
+++ b/lib/docker-file.ts
@@ -5,21 +5,26 @@ import {
   DockerFilePackages,
 } from './instruction-parser';
 
-export { analyseDockerfile };
+export { analyseDockerfile, readDockerfileAndAnalyse, DockerFileAnalysis };
 
 interface DockerFileAnalysis {
   baseImage?: string;
   dockerfilePackages: DockerFilePackages;
 }
 
-async function analyseDockerfile(targetFile?: string):
+async function readDockerfileAndAnalyse(targetFilePath?: string):
   Promise<DockerFileAnalysis|undefined> {
 
-  if (!targetFile) {
-    return undefined;
-  }
+if (!targetFilePath) {
+  return undefined;
+}
 
-  const contents = await readFile(targetFile);
+const contents = await readFile(targetFilePath);
+return analyseDockerfile(contents);
+}
+
+async function analyseDockerfile(contents: string):
+  Promise<DockerFileAnalysis|undefined> {
   const dockerfile = DockerfileParser.parse(contents);
   const from = dockerfile.getFROMs().pop();
   const runInstructions = dockerfile.getInstructions()

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,7 +24,7 @@ function inspect(root: string, targetFile?: string, options?: any) {
   return Promise.all([
     getRuntime(),
     getDependencies(targetImage, dockerOptions),
-    dockerFile.analyseDockerfile(targetFile),
+    dockerFile.readDockerfileAndAnalyse(targetFile),
   ])
     .then((result) => {
       const metadata = {

--- a/test/lib/docker-file.test.ts
+++ b/test/lib/docker-file.test.ts
@@ -14,12 +14,13 @@ const getDockerfileFixture = (folder: string) => path.join(
   'Dockerfile');
 
 test('Dockerfile not supplied', async (t) => {
-  t.equal(await dockerFile.analyseDockerfile(), undefined, 'returns undefined');
+  t.equal(await dockerFile.readDockerfileAndAnalyse(),
+   undefined, 'returns undefined');
 });
 
 test('Dockerfile not found', async (t) => {
   t.rejects(
-    () => dockerFile.analyseDockerfile('missing/Dockerfile'),
+    () => dockerFile.readDockerfileAndAnalyse('missing/Dockerfile'),
     new Error('ENOENT: no such file or directory, open \'missing/Dockerfile\''),
     'rejects with');
 });
@@ -78,7 +79,8 @@ test('Analyses dockerfiles', async (t) => {
   for (const example of examples) {
     await t.test(example.description, async (t) => {
       const pathToDockerfile = getDockerfileFixture(example.fixture);
-      const actual = await dockerFile.analyseDockerfile(pathToDockerfile);
+      const actual = await dockerFile.
+        readDockerfileAndAnalyse(pathToDockerfile);
       t.same(actual, example.expected, `returns ${example.expected}`);
     });
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
In order to support SCM Docker integration, this PR changes the way the Dockerfile is being parsed and analyzed, the `analyseDockerfile` function currently receives the path of the Dockerfile as an argument, but since in SCM integration the file system isn't available to `snyk-docker-plugin`, we must provide the actual contents of the Dockerfile instead of the path.

