### PR TITLE
fix: fix several docker option bugs

### DIFF
--- a/lib/analyzer/binaries-analyzer.ts
+++ b/lib/analyzer/binaries-analyzer.ts
@@ -37,7 +37,7 @@ async function getBinaries(
       installedPackages, pkgManager, options)) {
       continue;
     }
-    const binary = await extractor.extract(targetImage);
+    const binary = await extractor.extract(targetImage, options);
     if (binary) {
       binaries.push(binary);
     }

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -12,13 +12,42 @@ interface DockerOptions {
 
 class Docker {
 
+  public static run(args: string[], options?: DockerOptions) {
+    return subProcess.execute('docker', [
+      ...Docker.createOptionsList(options), ...args,
+    ]);
+  }
+
+  private static createOptionsList(options: any) {
+    const opts: string[] = [];
+    if (!options) {
+      return opts;
+    }
+    if (options.host) {
+      opts.push(`--host=${options.host}`);
+    }
+    if (options.tlscert) {
+      opts.push(`--tlscert=${options.tlscert}`);
+    }
+    if (options.tlscacert) {
+      opts.push(`--tlscacert=${options.tlscacert}`);
+    }
+    if (options.tlskey) {
+      opts.push(`--tlskey=${options.tlskey}`);
+    }
+    if (options.tlsverify) {
+      opts.push(`--tlsverify=${options.tlsverify}`);
+    }
+    return opts;
+  }
+
   private optionsList: string[];
 
   constructor(
     private targetImage: string,
     options?: DockerOptions,
     ) {
-      this.optionsList = this.createOptionsList(options);
+      this.optionsList = Docker.createOptionsList(options);
   }
 
   public run(cmd: string, args: string[] = []) {
@@ -44,28 +73,5 @@ class Docker {
       }
       throw error;
     }
-  }
-
-  private createOptionsList(options: any) {
-    const opts: string[] = [];
-    if (!options) {
-      return opts;
-    }
-    if (options.host) {
-      opts.push(`--host=${options.host}`);
-    }
-    if (options.tlsCert) {
-      opts.push(`--tlscert=${options.tlsCert}`);
-    }
-    if (options.tlsCaCert) {
-      opts.push(`--tlscacert=${options.tlsCaCert}`);
-    }
-    if (options.tlsKey) {
-      opts.push(`--tlskey=${options.tlsKey}`);
-    }
-    if (options.tlsVerify) {
-      opts.push(`--tlsverify=${options.tlsVerify}`);
-    }
-    return opts;
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ const debug = require('debug')('snyk');
 import * as analyzer from './analyzer';
 import * as subProcess from './sub-process';
 import * as dockerFile from './docker-file';
-import { DockerOptions } from './docker';
+import { Docker, DockerOptions } from './docker';
 import {
   DockerFilePackages,
 } from './instruction-parser';
@@ -15,14 +15,14 @@ export {
 function inspect(root: string, targetFile?: string, options?: any) {
   const dockerOptions = options ? {
     host: options.host,
-    tlsVerify: options.tlsVerify,
-    tlsCert: options.tlsCert,
-    tlsCaCert: options.tlsCaCert,
-    tlsKey: options.tlsKey,
+    tlsverify: options.tlsverify,
+    tlscert: options.tlscert,
+    tlscacert: options.tlscacert,
+    tlskey: options.tlskey,
   } : {};
   const targetImage = root;
   return Promise.all([
-    getRuntime(),
+    getRuntime(dockerOptions),
     getDependencies(targetImage, dockerOptions),
     dockerFile.analyseDockerfile(targetFile),
   ])
@@ -91,14 +91,17 @@ function collectDeps(pkg) {
     : [];
 }
 
-function getRuntime() {
-  return subProcess.execute('docker', ['version'])
+function getRuntime(options: DockerOptions) {
+  return Docker.run(['version'], options)
     .then((output) => {
       const versionMatch = /Version:\s+(.*)\n/.exec(output.stdout);
       if (versionMatch) {
         return 'docker ' + versionMatch[1];
       }
       return undefined;
+    })
+    .catch(error => {
+      throw new Error(`Docker error: ${error.stderr}`);
     });
 }
 


### PR DESCRIPTION
I've noticed (unfortunately post merge) that some of my changes
weren't included in the original PR (#61). I've included them now (and added
some stylistic changes)

Primarily what was missing in the original PR was options propagation to getRuntime
and to binaries extractor's extract method.

PR is verified via:

Leons-MBP:snyk leongold$ node dist/cli test --tlscacert=/Users/leongold/ca.pem --docker alpine

Testing alpine...

Docker error: could not read CA certificate "/Users/leongold/ca.pem": open /Users/leongold/ca.pem: no such file or directory

Leons-MBP:snyk leongold$
Leons-MBP:snyk leongold$ mv /Users/leongold/.docker/machine/machines/default/ca.pem ~/ca.pem
Leons-MBP:snyk leongold$ node dist/cli test --tlscacert=/Users/leongold/ca.pem --docker alpine

Testing alpine...

Organisation:      leon-irn
Package manager:   apk
Docker image:      alpine

✓ Tested 14 dependencies for known vulnerabilities , no vulnerable paths found.


- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team