### PR TITLE
fix: return "java -version"'s both stdout and stderr

### DIFF
--- a/lib/analyzer/binary-version-extractors/openjdk-jre.ts
+++ b/lib/analyzer/binary-version-extractors/openjdk-jre.ts
@@ -10,10 +10,12 @@ async function extract(
   targetImage: string,
   options?: DockerOptions): Promise<Binary | null> {
   try {
-    const binaryVersion =
+    // https://stackoverflow.com/questions/
+    // 13483443/why-does-java-version-go-to-stderr
+    const output =
       (await new Docker(targetImage, options)
-      .run('java', [ '-version' ])).stdout;
-    return parseOpenJDKBinary(binaryVersion);
+      .run('java', [ '-version' ]));
+    return parseOpenJDKBinary(output.stdout + output.stderr);
   } catch (error) {
     const stderr = error.stderr;
     if (typeof stderr === 'string' && stderr.indexOf('not found') >= 0) {


### PR DESCRIPTION
For backward compatibility java -version outputs to stderr, causing
open to return empty strings as we expected output in stdout.

Include both stdout and stderr when parsing java -version.

Reference:
https://stackoverflow.com/questions/17968856/redirect-to-stdout-in-bash