### PR TITLE
feat: handle sha256 in image tag

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -210,6 +210,13 @@ function buildTree(targetImage, depType, depInfosList, targetOS) {
     imageVersion = targetImage.slice(versionSeparator + 1);
   }
 
+  const shaString = '@sha256';
+
+  if (imageName.endsWith(shaString)) {
+    imageName = imageName.slice(0, imageName.length - shaString.length);
+    imageVersion = '';
+  }
+
   const root = {
     // don't use the real image name to avoid scanning it as an issue
     name: 'docker-image|' + imageName,

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -236,6 +236,29 @@ test('inspect image with hostname ' +
   }, 'root pkg');
 });
 
+test('inspect image with sha@256 ' +
+  'ubuntu@sha256', async t => {
+  const imgName = 'ubuntu';
+  const imgTag = '';
+  const imgSha =
+    '@sha256:945039273a7b927869a07b375dc3148de16865de44dec8398672977e050a072e';
+  const img = imgName + imgSha;
+
+  await dockerPull(t, img);
+  await dockerGetImageId(t, img);
+  const res = await plugin.inspect(img);
+
+  t.match(res.package, {
+    name: 'docker-image|' + imgName,
+    version: imgTag,
+    packageFormatVersion: 'deb:0.0.1',
+    targetOS: {
+      name: 'ubuntu',
+      version: '18.04',
+    },
+  }, 'root pkg');
+});
+
 test('inspect image with hostname plus additional namespacing: ' +
   'localhost:5000/redis:3.2.11-alpine', async t => {
   const imgName = 'redis';


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
While doing `snyk monitor --docker ubuntu@sha256:945039273a7b927869a07b375dc3148de16865de44dec8398672977e050a072e`

Actual result : image name is `ubuntu@sha256` and image tag is the sha256 itself
Expected result : image name is `ubuntu` and image tag is empty