### PR TITLE
feat: Introducing docker layers

### DIFF
--- a/lib/instruction-parser.ts
+++ b/lib/instruction-parser.ts
@@ -1,9 +1,19 @@
-export { getPackagesFromRunInstructions, DockerFilePackages };
+export {
+  getPackagesFromRunInstructions,
+  DockerLayer,
+  DockerFilePackages,
+};
 
 interface DockerFilePackages {
   [packageName: string]: {
     instruction: string;
   };
+}
+
+interface DockerLayer {
+  cmd?: string;
+  id: string;
+  packages: any;
 }
 
 // tslint:disable-next-line:max-line-length


### PR DESCRIPTION
This work introduces the concept of layers in the plugin. Its immediate
use will be to propagate layer ID (eventually to consist of a layer's SHA,
currently merely an index representation) to registry in order to help
displaying layers in vuln snapshots.

- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team