### PR TITLE
feat: introducing dockerfileLayers & annotating dep trees with layer ids

### DIFF
--- a/lib/docker-file.ts
+++ b/lib/docker-file.ts
@@ -1,7 +1,9 @@
 import { DockerfileParser } from "dockerfile-ast";
 import * as fs from "fs";
 import {
+  DockerFileLayers,
   DockerFilePackages,
+  getDockerfileLayers,
   getPackagesFromRunInstructions,
 } from "./instruction-parser";
 
@@ -10,6 +12,7 @@ export { analyseDockerfile, readDockerfileAndAnalyse, DockerFileAnalysis };
 interface DockerFileAnalysis {
   baseImage?: string;
   dockerfilePackages: DockerFilePackages;
+  dockerfileLayers: DockerFileLayers;
 }
 
 async function readDockerfileAndAnalyse(
@@ -35,6 +38,7 @@ async function analyseDockerfile(
     })
     .map((instruction) => instruction.toString());
   const dockerfilePackages = getPackagesFromRunInstructions(runInstructions);
+  const dockerfileLayers = getDockerfileLayers(dockerfilePackages);
 
   let baseImage;
 
@@ -65,6 +69,7 @@ async function analyseDockerfile(
   return {
     baseImage,
     dockerfilePackages,
+    dockerfileLayers,
   };
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -317,7 +317,6 @@ function buildTreeRecurisve(
     name: fullName,
     version: depInfo.Version,
   };
-
   if (depInfo._visited) {
     return tree;
   }

--- a/lib/instruction-parser.ts
+++ b/lib/instruction-parser.ts
@@ -1,7 +1,19 @@
-export { getPackagesFromRunInstructions, DockerFilePackages };
+export {
+  getDockerfileLayers,
+  getPackagesFromRunInstructions,
+  DockerFilePackages,
+  DockerFileLayers,
+  instructionDigest,
+};
 
 interface DockerFilePackages {
   [packageName: string]: {
+    instruction: string;
+  };
+}
+
+interface DockerFileLayers {
+  [id: string]: {
     instruction: string;
   };
 }
@@ -43,5 +55,19 @@ function getPackagesFromRunInstructions(
     }
 
     return dockerfilePackages;
+  }, {});
+}
+
+function instructionDigest(instruction): string {
+  return Buffer.from(instruction).toString("base64");
+}
+
+function getDockerfileLayers(
+  dockerfilePkgs: DockerFilePackages,
+): DockerFileLayers {
+  return Object.keys(dockerfilePkgs).reduce((res, pkg) => {
+    const { instruction } = dockerfilePkgs[pkg];
+    res[instructionDigest(instruction)] = { instruction };
+    return res;
   }, {});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -419,7 +419,7 @@
     },
     "foreground-child": {
       "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "resolved": "http://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
@@ -706,7 +706,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -730,7 +730,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -739,7 +739,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -802,7 +802,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1985,8 +1984,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -3418,7 +3416,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -3439,7 +3437,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3503,7 +3501,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "optional": true,
@@ -3669,7 +3667,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {

--- a/test/fixtures/dockerfiles/with-installation-instruction/Dockerfile
+++ b/test/fixtures/dockerfiles/with-installation-instruction/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:bionic
+
+RUN apt-get install curl
+
+CMD ["bash"]

--- a/test/fixtures/responses/all-deps.json
+++ b/test/fixtures/responses/all-deps.json
@@ -127,6 +127,9 @@
                   }
                 }
               }
+            },
+            "labels": {
+              "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
             }
           },
           "pam/libpam-modules": {
@@ -161,13 +164,19 @@
                   },
                   "debconf": {
                     "name": "debconf",
-                    "version": "1.5.66"
+                    "version": "1.5.66",
+                    "labels": {
+                      "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+                    }
                   }
                 }
               },
               "debconf": {
                 "name": "debconf",
-                "version": "1.5.66"
+                "version": "1.5.66",
+                "labels": {
+                  "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+                }
               },
               "pam/libpam-modules-bin": {
                 "name": "pam/libpam-modules-bin",
@@ -367,7 +376,10 @@
       },
       "debconf": {
         "name": "debconf",
-        "version": "1.5.66"
+        "version": "1.5.66",
+        "labels": {
+          "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+        }
       },
       "zlib/zlib1g": {
         "name": "zlib/zlib1g",
@@ -503,6 +515,9 @@
                 "name": "zlib/zlib1g",
                 "version": "1:1.2.11.dfsg-0ubuntu2"
               }
+            },
+            "labels": {
+              "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
             }
           },
           "util-linux/libblkid1": {
@@ -791,7 +806,10 @@
           },
           "util-linux": {
             "name": "util-linux",
-            "version": "2.31.1-0.4ubuntu3.3"
+            "version": "2.31.1-0.4ubuntu3.3",
+            "labels": {
+              "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+            }
           }
         }
       },
@@ -839,7 +857,10 @@
             "dependencies": {
               "debconf": {
                 "name": "debconf",
-                "version": "1.5.66"
+                "version": "1.5.66",
+                "labels": {
+                  "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+                }
               }
             }
           },
@@ -847,6 +868,9 @@
             "name": "util-linux/libuuid1",
             "version": "2.31.1-0.4ubuntu3.3"
           }
+        },
+        "labels": {
+          "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
         }
       },
       "apt": {
@@ -863,7 +887,10 @@
               },
               "debconf": {
                 "name": "debconf",
-                "version": "1.5.66"
+                "version": "1.5.66",
+                "labels": {
+                  "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+                }
               }
             }
           },
@@ -983,7 +1010,10 @@
       },
       "util-linux": {
         "name": "util-linux",
-        "version": "2.31.1-0.4ubuntu3.3"
+        "version": "2.31.1-0.4ubuntu3.3",
+        "labels": {
+          "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+        }
       },
       "sed": {
         "name": "sed",
@@ -1005,6 +1035,9 @@
             "name": "openssl/libssl1.1",
             "version": "1.1.0g-2ubuntu4.3"
           }
+        },
+        "labels": {
+          "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
         }
       },
       "ca-certificates": {
@@ -1013,11 +1046,17 @@
         "dependencies": {
           "openssl": {
             "name": "openssl",
-            "version": "1.1.0g-2ubuntu4.3"
+            "version": "1.1.0g-2ubuntu4.3",
+            "labels": {
+              "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+            }
           },
           "debconf": {
             "name": "debconf",
-            "version": "1.5.66"
+            "version": "1.5.66",
+            "labels": {
+              "dockerLayerId": "UlVOIGFwdC1nZXQgdXBkYXRlICYmIGFwdC1nZXQgaW5zdGFsbCAteSB3Z2V0"
+            }
           }
         }
       },

--- a/test/lib/docker-file.test.ts
+++ b/test/lib/docker-file.test.ts
@@ -34,6 +34,7 @@ test("Analyses dockerfiles", async (t) => {
       expected: {
         baseImage: "ubuntu:bionic",
         dockerfilePackages: {},
+        dockerfileLayers: {},
       },
     },
     {
@@ -42,6 +43,7 @@ test("Analyses dockerfiles", async (t) => {
       expected: {
         baseImage: "alpine:latest",
         dockerfilePackages: {},
+        dockerfileLayers: {},
       },
     },
     {
@@ -50,6 +52,7 @@ test("Analyses dockerfiles", async (t) => {
       expected: {
         baseImage: "scratch",
         dockerfilePackages: {},
+        dockerfileLayers: {},
       },
     },
     {
@@ -58,6 +61,7 @@ test("Analyses dockerfiles", async (t) => {
       expected: {
         baseImage: null,
         dockerfilePackages: {},
+        dockerfileLayers: {},
       },
     },
     {
@@ -66,6 +70,7 @@ test("Analyses dockerfiles", async (t) => {
       expected: {
         baseImage: null,
         dockerfilePackages: {},
+        dockerfileLayers: {},
       },
     },
     {
@@ -74,6 +79,24 @@ test("Analyses dockerfiles", async (t) => {
       expected: {
         baseImage: "node:dubnium",
         dockerfilePackages: {},
+        dockerfileLayers: {},
+      },
+    },
+    {
+      description: "a Dockerfile with an installation instruction",
+      fixture: "with-installation-instruction",
+      expected: {
+        baseImage: "ubuntu:bionic",
+        dockerfileLayers: {
+          UlVOIGFwdC1nZXQgaW5zdGFsbCBjdXJs: {
+            instruction: "RUN apt-get install curl",
+          },
+        },
+        dockerfilePackages: {
+          curl: {
+            instruction: "RUN apt-get install curl",
+          },
+        },
       },
     },
   ];

--- a/test/lib/response-builder.test.ts
+++ b/test/lib/response-builder.test.ts
@@ -14,7 +14,6 @@ test("buildResponse", async (t) => {
 
     await t.test("returns a complete response", async (t) => {
       const response = buildResponse(runtime, depsAna, dockerfileAna, {});
-
       t.same(response, expected, "response matches fixture");
     });
 

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -282,6 +282,22 @@ test("inspect nginx:1.13.10", (t) => {
         "nginx-module-xslt -> ngxinx has do deps",
       );
 
+      t.equal(
+        Object.keys(pkg.docker.dockerfileLayers).length,
+        1,
+        "expected number of dockerfile layers",
+      );
+
+      const digest = Object.keys(pkg.docker.dockerfileLayers)[0];
+      const instruction = Buffer.from(digest, "base64").toString();
+      t.match(
+        pkg.docker.dockerfileLayers,
+        {
+          [digest]: { instruction },
+        },
+        "dockerfile instruction digest points to the correct instruction",
+      );
+
       const commonDeps = deps["meta-common-packages"].dependencies;
       t.equal(
         Object.keys(commonDeps).length,


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

Introducing a structure (`dockerfileLayers`) that maps dockerfile layer digests to dockerfile install instructions. Additionally, the dependency tree is now annotated with dockerfile layer digests (using the new "labels" container (https://github.com/snyk/dep-graph/pull/19)

These two changes/additions will be directly used in displaying layer information for vulnerabilities in snapshots, as well as allowing us to filter base image vulnerabilities in the UI.