### PR TITLE
fix: Support for scratch images

### DIFF
--- a/lib/analyzer/index.ts
+++ b/lib/analyzer/index.ts
@@ -1,4 +1,5 @@
 import { DockerOptions } from '../docker';
+import * as dockerFile from '../docker-file';
 import * as osReleaseDetector from './os-release-detector';
 import * as imageInspector from './image-inspector';
 import * as apkAnalyzer from './apk-analyzer';
@@ -11,13 +12,15 @@ export {
   analyze,
 };
 
-async function analyze(targetImage: string, options?: DockerOptions) {
+async function analyze(targetImage: string,
+  dockerfileAnalysis?: dockerFile.DockerFileAnalysis, options?: DockerOptions) {
+
   const [
     imageInspection,
     osRelease,
   ] = await Promise.all([
     imageInspector.detect(targetImage, options),
-    osReleaseDetector.detect(targetImage, options)]);
+    osReleaseDetector.detect(targetImage, dockerfileAnalysis, options)]);
 
   const results = await Promise.all([
     apkAnalyzer.analyze(targetImage, options),

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -68,8 +68,11 @@ class Docker {
       return await this.run('cat', [filename]);
     } catch (error) {
       const stderr: string = error.stderr;
-      if (typeof stderr === 'string' && stderr.indexOf('No such file') >= 0) {
-        return { stdout: '', stderr: '' };
+      if (typeof stderr === 'string') {
+        if (stderr.indexOf('No such file') >= 0 ||
+            stderr.indexOf('file not found') >= 0) {
+          return { stdout: '', stderr: '' };
+        }
       }
       throw error;
     }


### PR DESCRIPTION
I did not find a way to detect scratch images without the help of Dockerfiles. Here are my proposed changes to support scratch images with the help of a Dcokerfile. Once we see "FROM scratch" in the dockerfile we basically skip past some tests and only perform the key-binary tests if we don't find a package manager.