### PR TITLE
fix: Scratch images have now a "linux" package manager

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -126,7 +126,7 @@ function parseAnalysisResults(targetImage, analysisJson,
 
       analysisResult = {
         Image: targetImage,
-        AnalyzeType: 'none',
+        AnalyzeType: 'linux',
         Analysis: [],
       };
     } else {


### PR DESCRIPTION
Scratch images will now have a "linux" package manager. This should just work with the current registry code.