### PR TITLE
fix: Correctly detect oracle linux version

### DIFF
--- a/lib/analyzer/os-release-detector.ts
+++ b/lib/analyzer/os-release-detector.ts
@@ -65,7 +65,12 @@ async function tryOSRelease(docker: Docker): Promise<OSRelease | null> {
   }
   const name = idRes[1].replace(/"/g, "");
   const versionRes = text.match(/^VERSION_ID=(.+)$/m);
-  const version = versionRes ? versionRes[1].replace(/"/g, "") : "unstable";
+  let version = versionRes ? versionRes[1].replace(/"/g, "") : "unstable";
+
+  if (name === "ol") {
+    version = version.split(".")[0];
+  }
+
   return { name, version };
 }
 
@@ -135,7 +140,7 @@ async function tryOracleRelease(docker: Docker): Promise<OSRelease | null> {
     throw new Error("Failed to parse /etc/oracle-release");
   }
   const name = idRes[1].replace(/"/g, "").toLowerCase();
-  const version = versionRes[1].replace(/"/g, "");
+  const version = versionRes[1].replace(/"/g, "").split(".")[0];
 
   return { name, version };
 }

--- a/test/lib/analyzer/os-release-detector.test.ts
+++ b/test/lib/analyzer/os-release-detector.test.ts
@@ -70,17 +70,17 @@ test("os release detection", async (t) => {
     },
     "oracle:5.11": {
       dir: "oraclelinux_5_11",
-      expected: { name: "oracle", version: "5.11" },
+      expected: { name: "oracle", version: "5" },
       notes: "uses /etc/oracle-release",
     },
     "oracle:6.9": {
       dir: "oraclelinux_6_9",
-      expected: { name: "oracle", version: "6.9" },
+      expected: { name: "oracle", version: "6" },
       notes: "uses /etc/os-release",
     },
     "oracle:7.5": {
       dir: "oraclelinux_7_5",
-      expected: { name: "oracle", version: "7.5" },
+      expected: { name: "oracle", version: "7" },
       notes: "uses /etc/os-release",
     },
     "ubuntu:10.04": {


### PR DESCRIPTION
The Snyk DB stores Oracle vulns with single digit versions, but detection by the plugin was picking up a 2 digit version i.e. "7" instead of "7.6".

This patch adds some simple handle to ensure the oracle version is always single-digit