### PR TITLE
Revert "fix: Correctly detect oracle linux version"

### DIFF
--- a/lib/analyzer/os-release-detector.ts
+++ b/lib/analyzer/os-release-detector.ts
@@ -65,12 +65,7 @@ async function tryOSRelease(docker: Docker): Promise<OSRelease | null> {
   }
   const name = idRes[1].replace(/"/g, "");
   const versionRes = text.match(/^VERSION_ID=(.+)$/m);
-  let version = versionRes ? versionRes[1].replace(/"/g, "") : "unstable";
-
-  if (name === "ol") {
-    version = version.split(".")[0];
-  }
-
+  const version = versionRes ? versionRes[1].replace(/"/g, "") : "unstable";
   return { name, version };
 }
 
@@ -140,7 +135,7 @@ async function tryOracleRelease(docker: Docker): Promise<OSRelease | null> {
     throw new Error("Failed to parse /etc/oracle-release");
   }
   const name = idRes[1].replace(/"/g, "").toLowerCase();
-  const version = versionRes[1].replace(/"/g, "").split(".")[0];
+  const version = versionRes[1].replace(/"/g, "");
 
   return { name, version };
 }

--- a/test/lib/analyzer/os-release-detector.test.ts
+++ b/test/lib/analyzer/os-release-detector.test.ts
@@ -70,17 +70,17 @@ test("os release detection", async (t) => {
     },
     "oracle:5.11": {
       dir: "oraclelinux_5_11",
-      expected: { name: "oracle", version: "5" },
+      expected: { name: "oracle", version: "5.11" },
       notes: "uses /etc/oracle-release",
     },
     "oracle:6.9": {
       dir: "oraclelinux_6_9",
-      expected: { name: "oracle", version: "6" },
+      expected: { name: "oracle", version: "6.9" },
       notes: "uses /etc/os-release",
     },
     "oracle:7.5": {
       dir: "oraclelinux_7_5",
-      expected: { name: "oracle", version: "7" },
+      expected: { name: "oracle", version: "7.5" },
       notes: "uses /etc/os-release",
     },
     "ubuntu:10.04": {


### PR DESCRIPTION
Reverts snyk/snyk-docker-plugin#84

The correct fix is https://github.com/snyk/vuln/pull/477 i.e. fixing this internally, not at the edges of the system.