### PR TITLE
fix: Remove flags from instruction parser

### DIFF
--- a/lib/instruction-parser.ts
+++ b/lib/instruction-parser.ts
@@ -18,8 +18,9 @@ interface DockerFileLayers {
   };
 }
 
+// Naive regex; see tests for cases
 // tslint:disable-next-line:max-line-length
-const installRegex = /\s*(rpm\s+-i|rpm\s+--install|apk\s+add|apt\s+install|apt-get\s+install|yum\s+install|aptitude\s+install)\s+/;
+const installRegex = /\s*(rpm\s+-i|rpm\s+--install|apk\s+((--update|-u)\s+)*add|apt-get\s+((--assume-yes|--yes|-y)\s+)*install|apt\s+((--assume-yes|--yes|-y)\s+)*install|yum\s+install|aptitude\s+install)\s+/;
 
 /*
  * This is fairly ugly because a single RUN could contain multiple install
@@ -44,9 +45,8 @@ function getPackagesFromRunInstructions(
       installCommands.forEach((command) => {
         const packages = command
           .replace(installRegex, "")
-          .replace(/(^-|\s-)\w+/g, "")
-          .trim()
-          .split(/\s+/);
+          .split(/\s+/)
+          .filter((arg) => arg && !arg.startsWith("-"));
 
         packages.forEach((pkg) => {
           dockerfilePackages[pkg] = { instruction };

--- a/test/lib/instruction-parser.test.ts
+++ b/test/lib/instruction-parser.test.ts
@@ -21,6 +21,13 @@ test("instruction parsers", async (t) => {
       t.same(packages, { curl: { instruction } });
     });
 
+    await t.test('supports "apt-get install" with flags', async (t) => {
+      const instruction = "RUN apt-get -y install curl";
+      const packages = getPackagesFromRunInstructions([instruction]);
+
+      t.same(packages, { curl: { instruction } });
+    });
+
     await t.test('supports "aptitude install"', async (t) => {
       const instruction = "RUN aptitude install curl";
       const packages = getPackagesFromRunInstructions([instruction]);
@@ -37,6 +44,13 @@ test("instruction parsers", async (t) => {
 
     await t.test('supports "apk add"', async (t) => {
       const instruction = "RUN apk add curl";
+      const packages = getPackagesFromRunInstructions([instruction]);
+
+      t.same(packages, { curl: { instruction } });
+    });
+
+    await t.test('supports "apk add" with flags', async (t) => {
+      const instruction = "RUN apk --update add curl";
       const packages = getPackagesFromRunInstructions([instruction]);
 
       t.same(packages, { curl: { instruction } });


### PR DESCRIPTION
The instruction parser for Dockerfiles was failing in a couple of edge cases; this patch TDDs a solution for these missing cases.