### PR TITLE
feat: Reading of manifest files

### DIFF
--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -5,7 +5,13 @@ import { DockerFilePackages, instructionDigest } from "./instruction-parser";
 
 export { buildResponse };
 
-function buildResponse(runtime, depsAnalysis, dockerfileAnalysis, options) {
+function buildResponse(
+  runtime,
+  depsAnalysis,
+  dockerfileAnalysis,
+  manifestFiles,
+  options,
+) {
   const deps = depsAnalysis.package.dependencies;
   const dockerfilePkgs = collectDockerfilePkgs(dockerfileAnalysis, deps);
   const finalDeps = excludeBaseImageDeps(deps, dockerfilePkgs, options);
@@ -21,6 +27,7 @@ function buildResponse(runtime, depsAnalysis, dockerfileAnalysis, options) {
   return {
     plugin,
     package: pkg,
+    manifestFiles,
   };
 }
 

--- a/test/fixtures/responses/all-deps.json
+++ b/test/fixtures/responses/all-deps.json
@@ -12,6 +12,7 @@
       "sha256:09dd19285fc51a1978d9b4607eca5fe84e085cf166765f7b7a1b8adafb00827e"
     ]
   },
+  "manifestFiles": [],
   "package": {
     "name": "docker-image|my-ubuntu2",
     "version": "latest",

--- a/test/lib/response-builder.test.ts
+++ b/test/lib/response-builder.test.ts
@@ -13,12 +13,12 @@ test("buildResponse", async (t) => {
     const expected = require("../fixtures/responses/all-deps");
 
     await t.test("returns a complete response", async (t) => {
-      const response = buildResponse(runtime, depsAna, dockerfileAna, {});
+      const response = buildResponse(runtime, depsAna, dockerfileAna, [], {});
       t.same(response, expected, "response matches fixture");
     });
 
     await t.test("returns package dependencies", async (t) => {
-      const response = buildResponse(runtime, depsAna, dockerfileAna, {});
+      const response = buildResponse(runtime, depsAna, dockerfileAna, [], {});
       const deps = response.package.dependencies;
 
       t.ok(deps.wget, "include wget from dockerfile");
@@ -35,6 +35,7 @@ test("buildResponse", async (t) => {
           runtime,
           depsAna,
           dockerfileAna,
+          [],
           options,
         );
         const deps = response.package.dependencies;

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -337,11 +337,14 @@ test("inspect redis:3.2.11-alpine", (t) => {
     })
     .then((imageId) => {
       expectedImageId = imageId;
-      return plugin.inspect(img, dockerFileLocation);
+      return plugin.inspect(img, dockerFileLocation, {
+        manifestGlobs: ["/etc/redhat-release*", "/etc/foo", "/nonexist/bar"],
+      });
     })
     .then((res) => {
       const plugin = res.plugin;
       const pkg = res.package;
+      const manifest = res.manifestFiles;
 
       t.equal(plugin.name, "snyk-docker-plugin", "name");
       t.equal(
@@ -389,6 +392,7 @@ test("inspect redis:3.2.11-alpine", (t) => {
         },
         "deps",
       );
+      t.match(manifest, [], "manifest files");
     });
 });
 
@@ -492,11 +496,14 @@ test("inspect centos", (t) => {
     })
     .then((imageId) => {
       expectedImageId = imageId;
-      return plugin.inspect(img, dockerFileLocation);
+      return plugin.inspect(img, dockerFileLocation, {
+        manifestGlobs: ["/etc/redhat-release", "/etc/foo"],
+      });
     })
     .then((res) => {
       const plugin = res.plugin;
       const pkg = res.package;
+      const manifest = res.manifestFiles;
 
       t.equal(plugin.name, "snyk-docker-plugin", "name");
       t.equal(
@@ -550,6 +557,18 @@ test("inspect centos", (t) => {
           },
         },
         "deps",
+      );
+
+      t.match(
+        manifest,
+        [
+          {
+            name: "redhat-release",
+            path: "/etc",
+            contents: "Q2VudE9TIExpbnV4IHJlbGVhc2UgNy40LjE3MDggKENvcmUpIAo=",
+          },
+        ],
+        "manifest files",
       );
     });
 });


### PR DESCRIPTION
This plugin is now able to read multiple manifest files. Only the manifest files which could be found are included in the response.