### PR TITLE
Fix app scan bug with undeterministical manifest files results

### DIFF
--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -50,6 +50,10 @@ class Docker {
     this.optionsList = Docker.createOptionsList(options);
   }
 
+  /**
+   * Runs the command, catching any expected errors and returning them as normal
+   * stderr/stdout result.
+   */
   public async runSafe(cmd: string, args: string[] = []) {
     try {
       return await this.run(cmd, args);
@@ -60,7 +64,7 @@ class Docker {
           stderr.indexOf("No such file") >= 0 ||
           stderr.indexOf("file not found") >= 0
         ) {
-          return { stdout: "", stderr: "" };
+          return { stdout: error.stdout, stderr };
         }
       }
       throw error;

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -87,7 +87,7 @@ class Docker {
   }
 
   public async inspect(targetImage: string) {
-    return await subProcess.execute("docker", [
+    return subProcess.execute("docker", [
       ...this.optionsList,
       "inspect",
       targetImage,
@@ -95,7 +95,7 @@ class Docker {
   }
 
   public async catSafe(filename: string) {
-    return await this.runSafe("cat", [filename]);
+    return this.runSafe("cat", [filename]);
   }
 
   public async lsSafe(path: string, recursive?: boolean) {
@@ -103,7 +103,7 @@ class Docker {
     if (recursive) {
       params += "R";
     }
-    return await this.runSafe("ls", [params, path]);
+    return this.runSafe("ls", [params, path]);
   }
 
   /**

--- a/test/lib/docker.test.ts
+++ b/test/lib/docker.test.ts
@@ -89,17 +89,16 @@ test("safeCat", async (t) => {
   });
 
   t.test("file not found", async (t) => {
+    const error = "cat: absent.txt: No such file or directory";
     stub.callsFake(() => {
-      // tslint:disable-next-line:no-string-throw
-      throw { stderr: "cat: absent.txt: No such file or directory" };
+      throw { stderr: error };
     });
     const content = (await docker.catSafe("absent.txt")).stderr;
-    t.equal(content, "", "empty string returned");
+    t.equal(content, error, "error string returned");
   });
 
   t.test("unexpected error", async (t) => {
     stub.callsFake(() => {
-      // tslint:disable-next-line:no-string-throw
       throw { stderr: "something went horribly wrong", stdout: "" };
     });
     await t.rejects(
@@ -135,31 +134,28 @@ test("safeLs", async (t) => {
   });
 
   t.test("directory not found", async (t) => {
+    const error = "ls: /abc: No such file or directory";
     stub.callsFake(() => {
-      // tslint:disable-next-line:no-string-throw
-      throw { stderr: "ls: /abc: No such file or directory" };
+      throw { stderr: error };
     });
     const content = (await docker.lsSafe("/abc")).stderr;
-    t.equal(content, "", "empty string returned");
+    t.equal(content, error, "error string returned");
   });
 
   t.test("command not found", async (t) => {
-    stub.callsFake(() => {
-      // tslint:disable-next-line:no-string-throw
-      throw {
-        stderr: `>
+    const error = `>
       docker: Error response from daemon: OCI runtime create failed:
       container_linux.go:345: starting container process caused "exec: \"ls\":
-      executable file not found in $PATH": unknown.`,
-      };
+      executable file not found in $PATH": unknown.`;
+    stub.callsFake(() => {
+      throw { stderr: error };
     });
     const content = (await docker.lsSafe("/")).stderr;
-    t.equal(content, "", "empty string returned");
+    t.equal(content, error, "error string returned");
   });
 
   t.test("unexpected error", async (t) => {
     stub.callsFake(() => {
-      // tslint:disable-next-line:no-string-throw
       throw { stderr: "something went horribly wrong", stdout: "" };
     });
     await t.rejects(


### PR DESCRIPTION
In app scanning we had an onerous issue where we would sometimes return empty results for manifest files, even though files were present on image. This was tracked down to be an issue of error handling inside `runSafe()`.
    
Therefore, update `runSafe()` not to nullify stdout/stderr result, even if some command resulted in error code. This shouldn't change existing clients' behaviour, except for the case of listing multiple files (`ls -R /`). In that case some files might become inaccessible during long operation and make the command return error code (alongside valid stdout results). In this we return stdout/stderr to the caller, so the result can be used.