### PR TITLE
chore: refactor the apk analyzer to decouple docker from the logic

### DIFF
--- a/lib/analyzer/inputs/apk/docker.ts
+++ b/lib/analyzer/inputs/apk/docker.ts
@@ -1,0 +1,13 @@
+import { Docker, DockerOptions } from "../../../docker";
+
+export { getApkDbFileContent };
+
+function getApkDbFileContent(targetImage: string, options?: DockerOptions) {
+  return getPackages(targetImage, options);
+}
+
+function getPackages(targetImage: string, options?: DockerOptions) {
+  return new Docker(targetImage, options)
+    .catSafe("/lib/apk/db/installed")
+    .then((output) => output.stdout);
+}

--- a/lib/analyzer/inputs/apk/static.ts
+++ b/lib/analyzer/inputs/apk/static.ts
@@ -1,0 +1,7 @@
+export { getApkDbFileContent };
+
+function getApkDbFileContent(
+  thingsRequiredForRetrievingApkFileFromImageStatically: any,
+) {
+  throw new Error("Not implemented");
+}

--- a/lib/analyzer/inputs/apk/static.ts
+++ b/lib/analyzer/inputs/apk/static.ts
@@ -1,7 +1,7 @@
 export { getApkDbFileContent };
 
-function getApkDbFileContent(
+async function getApkDbFileContent(
   thingsRequiredForRetrievingApkFileFromImageStatically: any,
-) {
+): Promise<string> {
   throw new Error("Not implemented");
 }

--- a/lib/analyzer/package-managers/apk.ts
+++ b/lib/analyzer/package-managers/apk.ts
@@ -1,19 +1,16 @@
-import { Docker, DockerOptions } from "../docker";
-import { AnalyzerPkg } from "./types";
+import { AnalyzerPkg, AnalyzerResult } from "../types";
+
 export { analyze };
 
-function analyze(targetImage: string, options?: DockerOptions) {
-  return getPackages(targetImage, options).then((pkgs) => ({
+function analyze(
+  targetImage: string,
+  apkDbFileContent: string,
+): AnalyzerResult {
+  return {
     Image: targetImage,
     AnalyzeType: "Apk",
-    Analysis: pkgs,
-  }));
-}
-
-function getPackages(targetImage: string, options?: DockerOptions) {
-  return new Docker(targetImage, options)
-    .catSafe("/lib/apk/db/installed")
-    .then((output) => parseFile(output.stdout));
+    Analysis: parseFile(apkDbFileContent),
+  };
 }
 
 function parseFile(text: string) {

--- a/lib/analyzer/types.d.ts
+++ b/lib/analyzer/types.d.ts
@@ -9,6 +9,12 @@ export interface AnalyzerPkg {
   AutoInstalled?: boolean;
 }
 
+export interface AnalyzerResult {
+  Image: string;
+  AnalyzeType: string;
+  Analysis: AnalyzerPkg[];
+}
+
 export interface OSRelease {
   name: string;
   version: string;

--- a/test/lib/analyzer/apk-analyzer.test.ts
+++ b/test/lib/analyzer/apk-analyzer.test.ts
@@ -8,7 +8,8 @@
 import * as sinon from "sinon";
 import { test } from "tap";
 
-import * as analyzer from "../../../lib/analyzer/apk-analyzer";
+import * as apkInput from "../../../lib/analyzer/inputs/apk/docker";
+import * as analyzer from "../../../lib/analyzer/package-managers/apk";
 import * as subProcess from "../../../lib/sub-process";
 
 test("analyze", async (t) => {
@@ -140,7 +141,8 @@ test("analyze", async (t) => {
 
       t.teardown(() => execStub.restore());
 
-      const actual = await analyzer.analyze("alpine:2.6");
+      const apkDbFileContent = await apkInput.getApkDbFileContent("alpine:2.6");
+      const actual = await analyzer.analyze("alpine:2.6", apkDbFileContent);
 
       t.same(actual, {
         Image: "alpine:2.6",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

decouple the way the retrieve the apk data (apk DB file) which is done by running "docker run ..." from the logic that acts on the file's content.
this will allow reusing the logic to analyse a file acquired in a different way (static scanning) while still supporting the existing way.

right now this does absolutely nothing except for showing an initial proposal of how the rest of the analysers might look like.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-461
