### PR TITLE
feat: accept static analysis flags

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ import * as analyzer from "./analyzer";
 import { Docker, DockerOptions } from "./docker";
 import * as dockerFile from "./docker-file";
 import { buildResponse } from "./response-builder";
+import { StaticScanningOptions } from "./types";
 
 export { inspect, dockerFile };
 
@@ -23,6 +24,16 @@ function inspect(root: string, targetFile?: string, options?: any) {
         manifestExcludeGlobs: options.manifestExcludeGlobs,
       }
     : {};
+
+  const staticScanningOptions: StaticScanningOptions =
+    options && options.staticScanningOptions
+      ? {
+          imagePath: options.staticScanningOptions.imagePath,
+          imageType: options.staticScanningOptions.imageType,
+        }
+      : {};
+  debug(staticScanningOptions);
+
   const targetImage = root;
 
   return dockerFile

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,8 @@
+export interface StaticScanningOptions {
+  imagePath?: string;
+  imageType?: ImageType;
+}
+
+export enum ImageType {
+  DockerArchive,
+}


### PR DESCRIPTION
Add a mechanism to pass flags for static analysis.
These will be later used both as hints to use static analysis and also as configuration, for example locating the image to statically scan, whether to process key binaries, etc.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### Where should the reviewer start?

https://github.com/snyk/snyk-docker-plugin/compare/feat/static-scanning-flags?expand=1#diff-13b5b151431c7e7a17f273559ed212d5R28

#### How should this be manually tested?

Try to pass the expected flag, observe it in the debug logs!

#### Any background context you want to provide?

To be used by @snyk/runtime when hinting to the plugin to use static analysis for images.

#### What are the relevant tickets?

[Jira ticket RUN-442](https://snyksec.atlassian.net/browse/RUN-442)

