### PR TITLE
fix: resolve paths in extracted files in docker-archive

### DIFF
--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from "fs";
 import * as minimatch from "minimatch";
-import { basename } from "path";
+import { basename, resolve as resolvePath } from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
 import { streamToString } from "../stream-utils";
@@ -67,7 +67,7 @@ export async function extractImageLayer(
 
     tarExtractor.on("entry", async (headers, stream, next) => {
       if (headers.type === "file") {
-        const absoluteFileName = `/${headers.name}`;
+        const absoluteFileName = resolvePath("/", headers.name);
         const processedResult = await extractFileAndProcess(
           absoluteFileName,
           stream,


### PR DESCRIPTION
The expectation until now was that files are extracted as "some/path/to/file.xyz".
Notice it didn't start with "/" so we prepended that to the filename.

However, using a RHEL image, files are named "./some/path/to/file.xyz", and if we just prepend "/" the path becomes "/./some/..." which will never match.

This fix now properly resolves paths by using path.resolve("/", `<the path>`) so that we get consistent paths regardless of relative paths.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team
