### PR TITLE
Feat/rpm scanning

### DIFF
--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -38,10 +38,34 @@ async function getDockerArchiveLayersAndManifest(
   };
 }
 
-function getContent(
+function isBufferType(type: string | Buffer): type is Buffer {
+  return (type as Buffer).buffer !== undefined;
+}
+
+function isStringType(type: string | Buffer): type is string {
+  return (type as string).substring !== undefined;
+}
+
+function getContentAsBuffer(
+  extractedLayers: ExtractedLayers,
+  extractAction: ExtractAction,
+): Buffer | undefined {
+  const content = getContent(extractedLayers, extractAction);
+  return content !== undefined && isBufferType(content) ? content : undefined;
+}
+
+function getContentAsString(
   extractedLayers: ExtractedLayers,
   extractAction: ExtractAction,
 ): string | undefined {
+  const content = getContent(extractedLayers, extractAction);
+  return content !== undefined && isStringType(content) ? content : undefined;
+}
+
+function getContent(
+  extractedLayers: ExtractedLayers,
+  extractAction: ExtractAction,
+): string | Buffer | undefined {
   const fileName = extractAction.fileNamePattern;
   return fileName in extractedLayers &&
     extractAction.actionName in extractedLayers[fileName]
@@ -49,4 +73,8 @@ function getContent(
     : undefined;
 }
 
-export { getDockerArchiveLayersAndManifest, getContent };
+export {
+  getDockerArchiveLayersAndManifest,
+  getContentAsString,
+  getContentAsBuffer,
+};

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -1,8 +1,10 @@
 import { Readable } from "stream";
 
-export type ExtractCallback = (dataStream: Readable) => Promise<string>;
+export type ExtractCallback = (
+  dataStream: Readable,
+) => Promise<string | Buffer>;
 
-export type FileNameAndContent = Record<string, string>;
+export type FileNameAndContent = Record<string, string | Buffer>;
 
 export interface ExtractedLayers {
   [layerName: string]: FileNameAndContent;

--- a/lib/inputs/apk/static.ts
+++ b/lib/inputs/apk/static.ts
@@ -1,4 +1,4 @@
-import { getContent } from "../../extractor";
+import { getContentAsString } from "../../extractor";
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 
@@ -9,6 +9,6 @@ export const getApkDbFileContentAction: ExtractAction = {
 };
 
 export function getApkDbFileContent(extractedLayers: ExtractedLayers): string {
-  const apkDb = getContent(extractedLayers, getApkDbFileContentAction);
+  const apkDb = getContentAsString(extractedLayers, getApkDbFileContentAction);
   return apkDb || "";
 }

--- a/lib/inputs/apt/static.ts
+++ b/lib/inputs/apt/static.ts
@@ -1,5 +1,5 @@
 import { IAptFiles } from "../../analyzer/types";
-import { getContent } from "../../extractor";
+import { getContentAsString } from "../../extractor";
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 
@@ -18,10 +18,16 @@ export const getExtFileContentAction: ExtractAction = {
 export function getAptDbFileContent(
   extractedLayers: ExtractedLayers,
 ): IAptFiles {
-  const dpkgContent = getContent(extractedLayers, getDpkgFileContentAction);
+  const dpkgContent = getContentAsString(
+    extractedLayers,
+    getDpkgFileContentAction,
+  );
   const dpkgFile = dpkgContent || "";
 
-  const extContent = getContent(extractedLayers, getExtFileContentAction);
+  const extContent = getContentAsString(
+    extractedLayers,
+    getExtFileContentAction,
+  );
   const extFile = extContent || "";
 
   return {

--- a/lib/inputs/os-release/static.ts
+++ b/lib/inputs/os-release/static.ts
@@ -1,4 +1,4 @@
-import { getContent } from "../../extractor";
+import { getContentAsString } from "../../extractor";
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 import { OsReleaseFilePath } from "../../types";
@@ -61,7 +61,7 @@ export function getOsRelease(
   extractedLayers: ExtractedLayers,
   releasePath: OsReleaseFilePath,
 ): string {
-  const osRelease = getContent(
+  const osRelease = getContentAsString(
     extractedLayers,
     osReleaseActionMap[releasePath],
   );

--- a/lib/inputs/rpm/static.ts
+++ b/lib/inputs/rpm/static.ts
@@ -1,0 +1,71 @@
+import { unlink, writeFile } from "fs";
+import { tmpdir } from "os";
+import { resolve as resolvePath } from "path";
+import { getContentAsBuffer } from "../../extractor";
+import { ExtractAction, ExtractedLayers } from "../../extractor/types";
+import { streamToBuffer } from "../../stream-utils";
+import { CmdOutput, execute } from "../../sub-process";
+
+export const getRpmDbFileContentAction: ExtractAction = {
+  actionName: "rpm-db",
+  fileNamePattern: "/var/lib/rpm/Packages",
+  callback: streamToBuffer,
+};
+
+export async function getRpmDbFileContent(
+  extractedLayers: ExtractedLayers,
+): Promise<string> {
+  const apkDb = getContentAsBuffer(extractedLayers, getRpmDbFileContentAction);
+  if (!apkDb) {
+    return "";
+  }
+
+  const filePath = generateTempFileName();
+  await writeToFile(filePath, apkDb);
+
+  try {
+    // This is the tool that is expected to be found on the system:
+    // https://github.com/snyk/go-rpmdb
+    const cmdOutput = await execute("rpmdb", ["-f", filePath]).catch(
+      handleError,
+    );
+    return cmdOutput.stdout || "";
+  } finally {
+    await removeFile(filePath);
+  }
+}
+
+function handleError(error): CmdOutput | never {
+  const stderr = error.stderr;
+  if (typeof stderr === "string" && stderr.indexOf("not found") >= 0) {
+    return { stdout: "", stderr: "" };
+  }
+  throw error;
+}
+
+function generateTempFileName(): string {
+  const tmpPath = tmpdir();
+  const randomFileName = Math.random().toString();
+
+  return resolvePath(tmpPath, randomFileName);
+}
+
+function writeToFile(filePath: string, apkDb: Buffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    writeFile(filePath, apkDb, { encoding: "binary" }, (err) => {
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+  });
+}
+
+function removeFile(filePath: string): Promise<void> {
+  return new Promise((resolve) => {
+    unlink(filePath, () => {
+      resolve();
+    });
+  });
+}

--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -21,3 +21,21 @@ export async function streamToString(
     });
   });
 }
+
+/**
+ * Consume the data from the specified stream into a Buffer
+ * @param stream stream to cosume the data from
+ * @returns Buffer with the data consumed from the specified stream
+ */
+export async function streamToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    stream.on("end", () => {
+      resolve(Buffer.concat(chunks));
+    });
+    stream.on("error", (error) => reject(error));
+    stream.on("data", (chunk) => {
+      chunks.push(Buffer.from(chunk));
+    });
+  });
+}

--- a/test/lib/stream-utils.test.ts
+++ b/test/lib/stream-utils.test.ts
@@ -3,21 +3,21 @@
 // See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
 
 import { createReadStream } from "fs";
+import { join } from "path";
 import { test } from "tap";
 import { streamToBuffer, streamToString } from "../../lib/stream-utils";
 
+const getFixture = (fixturePath) =>
+  join(__dirname, "../fixtures/generic", fixturePath);
+
 test("stream-utils.streamToString()", async (t) => {
-  const fileStream = createReadStream(
-    "../fixtures/generic/small-sample-text.txt",
-  );
+  const fileStream = createReadStream(getFixture("small-sample-text.txt"));
   const fileContent = await streamToString(fileStream);
   t.same(fileContent, "Hello, world!");
 });
 
 test("stream-utils.streamToBuffer()", async (t) => {
-  const fileStream = createReadStream(
-    "../fixtures/generic/small-sample-text.txt",
-  );
+  const fileStream = createReadStream(getFixture("small-sample-text.txt"));
   const fileContent = await streamToBuffer(fileStream);
   t.deepEqual(
     fileContent,

--- a/test/lib/stream-utils.test.ts
+++ b/test/lib/stream-utils.test.ts
@@ -3,6 +3,7 @@
 // See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
 
 import { createReadStream } from "fs";
+import { readFileSync } from "fs";
 import { join } from "path";
 import { test } from "tap";
 import { streamToBuffer, streamToString } from "../../lib/stream-utils";
@@ -11,17 +12,25 @@ const getFixture = (fixturePath) =>
   join(__dirname, "../fixtures/generic", fixturePath);
 
 test("stream-utils.streamToString()", async (t) => {
-  const fileStream = createReadStream(getFixture("small-sample-text.txt"));
+  const fixture = getFixture("small-sample-text.txt");
+  const fileStream = createReadStream(fixture);
+
   const fileContent = await streamToString(fileStream);
-  t.same(fileContent, "Hello, world!");
+  const expectedContent = readFileSync(fixture, { encoding: "utf-8" });
+
+  t.same(fileContent, expectedContent, "Returned the expected string");
 });
 
 test("stream-utils.streamToBuffer()", async (t) => {
-  const fileStream = createReadStream(getFixture("small-sample-text.txt"));
+  const fixture = getFixture("small-sample-text.txt");
+  const fileStream = createReadStream(fixture);
+
   const fileContent = await streamToBuffer(fileStream);
+  const expectedContent = readFileSync(fixture);
+
   t.deepEqual(
     fileContent,
-    Buffer.from("Hello, world!"),
+    expectedContent,
     "streamToBuffer returns the expected content",
   );
 });

--- a/test/lib/stream-utils.test.ts
+++ b/test/lib/stream-utils.test.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from "fs";
 import { test } from "tap";
-import { streamToString } from "../../lib/stream-utils";
+import { streamToBuffer, streamToString } from "../../lib/stream-utils";
 
 test("stream-utils.streamToString()", async (t) => {
   const fileStream = createReadStream(
@@ -8,4 +8,16 @@ test("stream-utils.streamToString()", async (t) => {
   );
   const fileContent = await streamToString(fileStream);
   t.same(fileContent, "Hello, world!");
+});
+
+test("stream-utils.streamToBuffer()", async (t) => {
+  const fileStream = createReadStream(
+    "../fixtures/generic/small-sample-text.txt",
+  );
+  const fileContent = await streamToBuffer(fileStream);
+  t.deepEqual(
+    fileContent,
+    Buffer.from("Hello, world!"),
+    "streamToBuffer returns the expected content",
+  );
 });

--- a/test/lib/stream-utils.test.ts
+++ b/test/lib/stream-utils.test.ts
@@ -1,3 +1,7 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+
 import { createReadStream } from "fs";
 import { test } from "tap";
 import { streamToBuffer, streamToString } from "../../lib/stream-utils";

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -1,3 +1,7 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+
 import * as path from "path";
 import { test } from "tap";
 import * as plugin from "../../lib";


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Implement RPM package scanning in static analysis mode.

Calls into a tool named "rpmdb" which must exist on the system.
The output of the tool is then formatted into what the existing RPM analyzer expects.

This change allows @snyk/runtime to completely stop relying on Docker.

Additional small changes:
- docker-archive extractor now supports reading the file content as Buffer/byte[]: this is necessary to correctly treat and process the RPM DB data -- it is a binary DB
- fix previously added tests to actually run (and fixed a small mistake in stream-utils.test.ts)


#### What are the relevant tickets?

[Jira ticket RUN-468](https://snyksec.atlassian.net/browse/RUN-468)

