### PR TITLE
fix: layers annotation when a package version is specified in instruction

### DIFF
--- a/lib/instruction-parser.ts
+++ b/lib/instruction-parser.ts
@@ -23,7 +23,7 @@ interface DockerFileLayers {
 
 // Naive regex; see tests for cases
 // tslint:disable-next-line:max-line-length
-const installRegex = /\s*(rpm\s+-i|rpm\s+--install|apk\s+((--update|-u)\s+)*add|apt-get\s+((--assume-yes|--yes|-y)\s+)*install|apt\s+((--assume-yes|--yes|-y)\s+)*install|yum\s+install|aptitude\s+install)\s+/;
+const installRegex = /\s*(rpm\s+-i|rpm\s+--install|apk\s+((--update|-u|--no-cache)\s+)*add(\s+(--update|-u|--no-cache))*|apt-get\s+((--assume-yes|--yes|-y)\s+)*install(\s+(--assume-yes|--yes|-y))*|apt\s+((--assume-yes|--yes|-y)\s+)*install|yum\s+install|aptitude\s+install)\s+/;
 
 /*
  * This is fairly ugly because a single RUN could contain multiple install
@@ -59,7 +59,9 @@ function getPackagesFromRunInstructions(
           .filter((arg) => arg && !arg.startsWith("-"));
 
         packages.forEach((pkg) => {
-          dockerfilePackages[pkg] = { instruction };
+          // Use package name without version as the key
+          const name = pkg.split("=")[0];
+          dockerfilePackages[name] = { instruction };
         });
       });
     }
@@ -69,7 +71,7 @@ function getPackagesFromRunInstructions(
 }
 
 /**
- * Return the specified test with variables expanded
+ * Return the specified text with variables expanded
  * @param instruction the instruction associated with this string
  * @param dockerfile Dockerfile to use for expanding the variables
  * @param text a string with variables to expand, if not specified

--- a/test/lib/docker-file.test.ts
+++ b/test/lib/docker-file.test.ts
@@ -42,8 +42,16 @@ test("Analyses dockerfiles", async (t) => {
       fixture: "multi-stage",
       expected: {
         baseImage: "alpine:latest",
-        dockerfilePackages: {},
-        dockerfileLayers: {},
+        dockerfilePackages: {
+          "ca-certificates": {
+            instruction: "RUN apk --no-cache add ca-certificates",
+          },
+        },
+        dockerfileLayers: {
+          "UlVOIGFwayAtLW5vLWNhY2hlIGFkZCBjYS1jZXJ0aWZpY2F0ZXM=": {
+            instruction: "RUN apk --no-cache add ca-certificates",
+          },
+        },
       },
     },
     {
@@ -51,8 +59,16 @@ test("Analyses dockerfiles", async (t) => {
       fixture: "multi-stage-as",
       expected: {
         baseImage: "alpine:latest",
-        dockerfilePackages: {},
-        dockerfileLayers: {},
+        dockerfilePackages: {
+          "ca-certificates": {
+            instruction: "RUN apk --no-cache add ca-certificates",
+          },
+        },
+        dockerfileLayers: {
+          "UlVOIGFwayAtLW5vLWNhY2hlIGFkZCBjYS1jZXJ0aWZpY2F0ZXM=": {
+            instruction: "RUN apk --no-cache add ca-certificates",
+          },
+        },
       },
     },
     {
@@ -165,7 +181,7 @@ test("Analyses dockerfiles", async (t) => {
       const actual = await dockerFile.readDockerfileAndAnalyse(
         pathToDockerfile,
       );
-      t.same(actual, example.expected, `returns ${example.expected}`);
+      t.same(actual, example.expected, "returns unexpected result");
     });
   }
 });

--- a/test/lib/response-builder.test.ts
+++ b/test/lib/response-builder.test.ts
@@ -22,6 +22,8 @@ test("buildResponse", async (t) => {
       const deps = response.package.dependencies;
 
       t.ok(deps.wget, "include wget from dockerfile");
+      t.ok(deps.wget.labels, "include extra information on label");
+      t.ok(deps.wget.labels.dockerLayerId, "include docker layer ID");
       t.ok(deps.openssl, "include openssl via wget from dockerfile");
       t.ok(deps.bash, "include bash from base image");
       t.ok(deps.grep, "include grep from base image");


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- use the package name w/o version as the dockerfile instruction key
- support apt-get -y options after the command position
- update tests to verify the label hook content

#### Where should the reviewer start?
Dockerfile instruction parser

#### How should this be manually tested?
test and monitor an image with a dockerfile that includes a `RUN` line similar to:
`RUN apk add --no-cache --update git=2.18.1-r0`
