### PR TITLE
feat: pass tmpdir path for static analysis

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -56,7 +56,7 @@ export async function analyze(
   ] = await Promise.all([
     getApkDbFileContent(archiveLayers),
     getAptDbFileContent(archiveLayers),
-    getRpmDbFileContent(archiveLayers),
+    getRpmDbFileContent(archiveLayers, options.tmpDirPath),
   ]);
 
   const osRelease = await osReleaseDetector

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -126,6 +126,7 @@ function getStaticAnalysisOptions(options?: any): StaticAnalysisOptions {
     ? {
         imagePath: options.staticAnalysisOptions.imagePath,
         imageType: options.staticAnalysisOptions.imageType,
+        tmpDirPath: options.staticAnalysisOptions.tmpDirPath,
       }
     : {};
 }

--- a/lib/inputs/rpm/static.ts
+++ b/lib/inputs/rpm/static.ts
@@ -14,13 +14,14 @@ export const getRpmDbFileContentAction: ExtractAction = {
 
 export async function getRpmDbFileContent(
   extractedLayers: ExtractedLayers,
+  tmpDirPath?: string,
 ): Promise<string> {
   const apkDb = getContentAsBuffer(extractedLayers, getRpmDbFileContentAction);
   if (!apkDb) {
     return "";
   }
 
-  const filePath = generateTempFileName();
+  const filePath = generateTempFileName(tmpDirPath);
   await writeToFile(filePath, apkDb);
 
   try {
@@ -43,8 +44,11 @@ function handleError(error): CmdOutput | never {
   throw error;
 }
 
-function generateTempFileName(): string {
-  const tmpPath = tmpdir();
+/**
+ * Exported for testing
+ */
+export function generateTempFileName(tmpDirPath?: string): string {
+  const tmpPath = tmpDirPath || tmpdir();
   const randomFileName = Math.random().toString();
 
   return resolvePath(tmpPath, randomFileName);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,11 @@
 export interface StaticAnalysisOptions {
   imagePath?: string;
   imageType?: ImageType;
+  /**
+   * Provide a path to a directory where the plugin can write temporary files.
+   * If unspecified, defaults to the environment's temporary directory path.
+   */
+  tmpDirPath?: string;
 }
 
 export enum ImageType {

--- a/test/lib/analyzer/rpm-input.test.ts
+++ b/test/lib/analyzer/rpm-input.test.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+
+// tslint:disable:max-line-length
+// tslint:disable:object-literal-key-quotes
+
+import { tmpdir } from "os";
+import { test } from "tap";
+import { generateTempFileName } from "../../../lib/inputs/rpm/static";
+
+test("generateTempFileName() tests", async (t) => {
+  const firstGeneratedName = generateTempFileName();
+  const secondGeneratedName = generateTempFileName();
+  t.notEqual(
+    firstGeneratedName,
+    secondGeneratedName,
+    "subsequent runs generate different names",
+  );
+
+  const nameStartingWithTmpDir = generateTempFileName();
+  const tmpDir = tmpdir();
+  t.ok(
+    nameStartingWithTmpDir.startsWith(tmpDir),
+    "generates a file name under tmpdir() when no path is specified",
+  );
+
+  const specificPath = "/var/tmp";
+  const nameWithSpecificPath = generateTempFileName(specificPath);
+  t.ok(
+    nameWithSpecificPath.startsWith(specificPath),
+    "generates a file name under the path specified",
+  );
+});


### PR DESCRIPTION
Do not infer a path where temporary files can be stored: this is problematic for the `kubernetes-monitor` because when the Kubernetes option readOnlyRootFilesystem is set, directories like /tmp become unusable.

Instead, the plugin now receives a path to a directory where it is safe to create temporary files.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team
