### PR TITLE
fix: ensure some static analysis options are required

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -26,10 +26,6 @@ export async function analyze(
   targetImage: string,
   options: StaticAnalysisOptions,
 ) {
-  if (!options.imagePath || options.imageType === undefined) {
-    throw new Error("Missing required parameters for static analysis");
-  }
-
   if (options.imageType !== ImageType.DockerArchive) {
     throw new Error("Unhandled image type");
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -51,7 +51,7 @@ function analyzeDynamically(
   });
 }
 
-async function analyzeStatically(targetImage: string, options?: any) {
+async function analyzeStatically(targetImage: string, options: any) {
   const staticAnalysisOptions = getStaticAnalysisOptions(options);
 
   // Relevant only if using a Docker runtime. Optional, but we may consider what to put here
@@ -121,14 +121,21 @@ function isRequestingStaticAnalysis(options?: any): boolean {
   return options && options.staticAnalysisOptions;
 }
 
-function getStaticAnalysisOptions(options?: any): StaticAnalysisOptions {
-  return options && options.staticAnalysisOptions
-    ? {
-        imagePath: options.staticAnalysisOptions.imagePath,
-        imageType: options.staticAnalysisOptions.imageType,
-        tmpDirPath: options.staticAnalysisOptions.tmpDirPath,
-      }
-    : {};
+function getStaticAnalysisOptions(options: any): StaticAnalysisOptions {
+  if (
+    !options ||
+    !options.staticAnalysisOptions ||
+    !options.staticAnalysisOptions.imagePath ||
+    options.staticAnalysisOptions.imageType === undefined
+  ) {
+    throw new Error("Missing required parameters for static analysis");
+  }
+
+  return {
+    imagePath: options.staticAnalysisOptions.imagePath,
+    imageType: options.staticAnalysisOptions.imageType,
+    tmpDirPath: options.staticAnalysisOptions.tmpDirPath,
+  };
 }
 
 // TODO: return type should be "DynamicAnalysisOptions" or something that extends DockerOptions

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
 export interface StaticAnalysisOptions {
-  imagePath?: string;
-  imageType?: ImageType;
+  imagePath: string;
+  imageType: ImageType;
   /**
    * Provide a path to a directory where the plugin can write temporary files.
    * If unspecified, defaults to the environment's temporary directory path.

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -88,3 +88,37 @@ test("static analysis builds the expected response", async (t) => {
     "The plugin scans both skopeo-copy and docker-save archives the same way",
   );
 });
+
+test("omitting required options for static analysis", async (t) => {
+  const emptyOptions = {
+    staticAnalysisOptions: {},
+  };
+  const targetFile = undefined;
+  await t.rejects(
+    plugin.inspect("nginx:latest", targetFile, emptyOptions),
+    Error("Missing required parameters for static analysis"),
+    "static analysis requires parameters",
+  );
+
+  const onlyPathOptions = {
+    staticAnalysisOptions: {
+      imagePath: "/var/tmp/image.nonexistent",
+    },
+  };
+  await t.rejects(
+    plugin.inspect("nginx:latest", targetFile, onlyPathOptions),
+    Error("Missing required parameters for static analysis"),
+    "static analysis rejects on having imagePath but missing imageType",
+  );
+
+  const onlyTypeOptions = {
+    staticAnalysisOptions: {
+      imageType: ImageType.DockerArchive,
+    },
+  };
+  await t.rejects(
+    plugin.inspect("nginx:latest", targetFile, onlyTypeOptions),
+    Error("Missing required parameters for static analysis"),
+    "static analysis rejects on having imageTypee but missing imagePath",
+  );
+});


### PR DESCRIPTION
To better capture the intention that some options in static analysis are required, change the types of the relevant fields.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team
