### PR TITLE
chore: typescript 3.7 breaks dockerfile-ast

### DIFF
--- a/lib/analyzer/binary-version-extractors/node.ts
+++ b/lib/analyzer/binary-version-extractors/node.ts
@@ -9,9 +9,9 @@ async function extract(
   options?: DockerOptions,
 ): Promise<Binary | null> {
   try {
-    const binaryVersion = (await new Docker(targetImage, options).run("node", [
-      "--version",
-    ])).stdout;
+    const binaryVersion = (
+      await new Docker(targetImage, options).run("node", ["--version"])
+    ).stdout;
     return parseNodeBinary(binaryVersion);
   } catch (error) {
     const stderr = error.stderr;

--- a/lib/analyzer/os-release/docker.ts
+++ b/lib/analyzer/os-release/docker.ts
@@ -19,40 +19,46 @@ export async function detect(
 ): Promise<OSRelease> {
   const docker = new Docker(targetImage, options);
 
-  let osRelease = await getOsRelease(docker, OsReleaseFilePath.Linux).then(
-    (release) => tryOSRelease(release),
-  );
+  let osRelease = await getOsRelease(
+    docker,
+    OsReleaseFilePath.Linux,
+  ).then((release) => tryOSRelease(release));
 
   // First generic fallback
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.Lsb).then(
-      (release) => tryLsbRelease(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.Lsb,
+    ).then((release) => tryLsbRelease(release));
   }
 
   // Fallbacks for specific older distributions
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.Debian).then(
-      (release) => tryDebianVersion(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.Debian,
+    ).then((release) => tryDebianVersion(release));
   }
 
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.Alpine).then(
-      (release) => tryAlpineRelease(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.Alpine,
+    ).then((release) => tryAlpineRelease(release));
   }
 
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.Oracle).then(
-      (release) => tryOracleRelease(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.Oracle,
+    ).then((release) => tryOracleRelease(release));
   }
 
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.RedHat).then(
-      (release) => tryRedHatRelease(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.RedHat,
+    ).then((release) => tryRedHatRelease(release));
   }
 
   if (!osRelease) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "ts-node": "^8.1.0",
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.4.5"
+    "typescript": "3.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^8.10.48",
     "@types/sinon": "5.0.5",
     "@types/tar-stream": "^1.6.1",
-    "prettier": "^1.17.1",
+    "prettier": "^1.19.1",
     "sinon": "^6",
     "tap": "12.3.0",
     "ts-node": "^8.1.0",


### PR DESCRIPTION
https://github.com/rcjsuen/dockerfile-ast/pull/60

For now, pin us at typescript 3.6.
