### PR TITLE
feat: use for..of

### DIFF
--- a/lib/analyzer/binary-version-extractors/node.ts
+++ b/lib/analyzer/binary-version-extractors/node.ts
@@ -9,9 +9,9 @@ async function extract(
   options?: DockerOptions,
 ): Promise<Binary | null> {
   try {
-    const binaryVersion = (await new Docker(targetImage, options).run("node", [
-      "--version",
-    ])).stdout;
+    const binaryVersion = (
+      await new Docker(targetImage, options).run("node", ["--version"])
+    ).stdout;
     return parseNodeBinary(binaryVersion);
   } catch (error) {
     const stderr = error.stderr;

--- a/lib/analyzer/os-release/docker.ts
+++ b/lib/analyzer/os-release/docker.ts
@@ -19,40 +19,46 @@ export async function detect(
 ): Promise<OSRelease> {
   const docker = new Docker(targetImage, options);
 
-  let osRelease = await getOsRelease(docker, OsReleaseFilePath.Linux).then(
-    (release) => tryOSRelease(release),
-  );
+  let osRelease = await getOsRelease(
+    docker,
+    OsReleaseFilePath.Linux,
+  ).then((release) => tryOSRelease(release));
 
   // First generic fallback
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.Lsb).then(
-      (release) => tryLsbRelease(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.Lsb,
+    ).then((release) => tryLsbRelease(release));
   }
 
   // Fallbacks for specific older distributions
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.Debian).then(
-      (release) => tryDebianVersion(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.Debian,
+    ).then((release) => tryDebianVersion(release));
   }
 
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.Alpine).then(
-      (release) => tryAlpineRelease(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.Alpine,
+    ).then((release) => tryAlpineRelease(release));
   }
 
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.Oracle).then(
-      (release) => tryOracleRelease(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.Oracle,
+    ).then((release) => tryOracleRelease(release));
   }
 
   if (!osRelease) {
-    osRelease = await getOsRelease(docker, OsReleaseFilePath.RedHat).then(
-      (release) => tryRedHatRelease(release),
-    );
+    osRelease = await getOsRelease(
+      docker,
+      OsReleaseFilePath.RedHat,
+    ).then((release) => tryRedHatRelease(release));
   }
 
   if (!osRelease) {

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -123,17 +123,17 @@ class Docker {
     lsu.iterateFiles(root, (f) => {
       const filepath = fspath.join(f.path, f.name);
       let exclude = false;
-      exclusionGlobs.forEach((g) => {
+      for (const g of exclusionGlobs) {
         if (!exclude && minimatch(filepath, g)) {
           exclude = true;
         }
-      });
+      }
       if (!exclude) {
-        globs.forEach((g) => {
+        for (const g of globs) {
           if (minimatch(filepath, g)) {
             res.push(filepath);
           }
-        });
+        }
       }
     });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -346,14 +346,14 @@ function buildTree(targetImage, depType, depInfosList, targetOS) {
 
   const virtualDepsMap = depInfosList.reduce((acc, depInfo) => {
     const providesNames = depInfo.Provides || [];
-    providesNames.forEach((name) => {
+    for (const name of providesNames) {
       acc[name] = depInfo;
-    });
+    }
     return acc;
   }, {});
 
   const depsCounts = {};
-  depInfosList.forEach((depInfo) => {
+  for (const depInfo of depInfosList) {
     countDepsRecursive(
       depInfo.Name,
       new Set(),
@@ -361,7 +361,7 @@ function buildTree(targetImage, depType, depInfosList, targetOS) {
       virtualDepsMap,
       depsCounts,
     );
-  });
+  }
   const DEP_FREQ_THRESHOLD = 100;
   const tooFrequentDepNames = Object.keys(depsCounts).filter((depName) => {
     return depsCounts[depName] > DEP_FREQ_THRESHOLD;
@@ -369,7 +369,7 @@ function buildTree(targetImage, depType, depInfosList, targetOS) {
 
   const attachDeps = (depInfos) => {
     const depNamesToSkip = new Set(tooFrequentDepNames);
-    depInfos.forEach((depInfo) => {
+    for (const depInfo of depInfos) {
       const subtree = buildTreeRecurisve(
         depInfo.Name,
         new Set(),
@@ -380,7 +380,7 @@ function buildTree(targetImage, depType, depInfosList, targetOS) {
       if (subtree) {
         root.dependencies[subtree.name] = subtree;
       }
-    });
+    }
   };
 
   // attach (as direct deps) pkgs not marked auto-installed:
@@ -409,13 +409,13 @@ function buildTree(targetImage, depType, depInfosList, targetOS) {
       dependencies: {},
     };
 
-    tooFrequentDeps.forEach((depInfo) => {
+    for (const depInfo of tooFrequentDeps) {
       const pkg = {
         name: depFullName(depInfo),
         version: depInfo.Version,
       };
       metaSubtree.dependencies[pkg.name] = pkg;
-    });
+    }
 
     root.dependencies[metaSubtree.name] = metaSubtree;
   }
@@ -458,7 +458,7 @@ function buildTreeRecurisve(
   const newAncestors = new Set(ancestors).add(fullName);
 
   const deps = depInfo.Deps || {};
-  Object.keys(deps).forEach((name) => {
+  for (const name of Object.keys(deps)) {
     const subTree = buildTreeRecurisve(
       name,
       newAncestors,
@@ -474,7 +474,7 @@ function buildTreeRecurisve(
         tree.dependencies[subTree.name] = subTree;
       }
     }
-  });
+  }
 
   return tree;
 }
@@ -501,9 +501,9 @@ function countDepsRecursive(
 
   const newAncestors = new Set(ancestors).add(realName);
   const deps = depInfo.Deps || {};
-  Object.keys(deps).forEach((name) => {
+  for (const name of Object.keys(deps)) {
     countDepsRecursive(name, newAncestors, depsMap, virtualDepsMap, depCounts);
-  });
+  }
 }
 
 function depFullName(depInfo) {

--- a/lib/instruction-parser.ts
+++ b/lib/instruction-parser.ts
@@ -52,7 +52,7 @@ function getPackagesFromRunInstructions(
 
     if (installCommands.length) {
       // Get the packages per install command and flatten them
-      installCommands.forEach((command) => {
+      for (const command of installCommands) {
         const packages = command
           .replace(installRegex, "")
           .split(/\s+/)
@@ -63,7 +63,7 @@ function getPackagesFromRunInstructions(
           const name = pkg.split("=")[0];
           dockerfilePackages[name] = { instruction };
         });
-      });
+      }
     }
 
     return dockerfilePackages;
@@ -90,7 +90,7 @@ function getInstructionExpandVariables(
     resolvedVars[name] = dockerfile.resolveVariable(name, line);
     return resolvedVars;
   }, {});
-  Object.keys(resolvedVariables).forEach((variable) => {
+  for (const variable of Object.keys(resolvedVariables)) {
     // The $ is a special regexp character that should be escaped with a backslash
     // Support both notations either with $variable_name or ${variable_name}
     // The global search "g" flag is used to match and replace all occurrences
@@ -98,7 +98,7 @@ function getInstructionExpandVariables(
       RegExp(`\\$\{${variable}\}|\\$${variable}`, "g"),
       resolvedVariables[variable],
     );
-  });
+  }
   return str;
 }
 

--- a/lib/ls-utils.ts
+++ b/lib/ls-utils.ts
@@ -18,8 +18,12 @@ function iterateFiles(
   root: DiscoveredDirectory,
   iterator: (f: DiscoveredFile) => void,
 ) {
-  root.files.forEach((f) => iterator(f));
-  root.subDirs.forEach((d) => iterateFiles(d, iterator));
+  for (const f of root.files) {
+    iterator(f);
+  }
+  for (const d of root.subDirs) {
+    iterateFiles(d, iterator);
+  }
 }
 
 /**

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -76,9 +76,9 @@ function getDockerfileDependencies(
       const dockerfilePackage = dockerfilePackages[sourceOrName];
 
       if (dockerfilePackage) {
-        collectDeps(dependencies[dependencyName]).forEach((dep) => {
+        for (const dep of collectDeps(dependencies[dependencyName])) {
           dockerfilePackages[dep.split("/")[0]] = { ...dockerfilePackage };
-        });
+        }
       }
     }
   }
@@ -122,7 +122,7 @@ function annotateLayerIds(deps, dockerfilePkgs) {
     return;
   }
 
-  Object.keys(deps).forEach((dep) => {
+  for (const dep of Object.keys(deps)) {
     const pkg = deps[dep];
     const dockerfilePkg = dockerfilePkgs[dep];
     if (dockerfilePkg) {
@@ -134,5 +134,5 @@ function annotateLayerIds(deps, dockerfilePkgs) {
     if (pkg.dependencies) {
       annotateLayerIds(pkg.dependencies, dockerfilePkgs);
     }
-  });
+  }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "ts-node": "^8.1.0",
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.4.5"
+    "typescript": "3.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^8.10.48",
     "@types/sinon": "5.0.5",
     "@types/tar-stream": "^1.6.1",
-    "prettier": "^1.17.1",
+    "prettier": "^1.19.1",
     "sinon": "^6",
     "tap": "12.3.0",
     "ts-node": "^8.1.0",

--- a/test/lib/ls-utils.test.ts
+++ b/test/lib/ls-utils.test.ts
@@ -205,7 +205,7 @@ const PARSER_TESTS = [
 ];
 
 test("parse ls output", async (t) => {
-  PARSER_TESTS.forEach((data) => {
+  for (const data of PARSER_TESTS) {
     t.test(data.name, async (t) => {
       const res = parseLsOutput(data.in);
       const files: string[] = [];
@@ -213,7 +213,7 @@ test("parse ls output", async (t) => {
       t.same(res, data.out);
       t.same(files, data.files);
     });
-  });
+  }
 });
 
 const getLSOutputFixture = (file: string) =>

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -609,9 +609,9 @@ function uniquePkgSpecs(tree) {
     }
 
     const deps = pkg.dependencies || {};
-    Object.keys(deps).forEach((name) => {
+    for (const name of Object.keys(deps)) {
       scan(deps[name]);
-    });
+    }
   }
 
   scan(tree);


### PR DESCRIPTION
Follows: #123.

Change out `.forEach` for `for..of` where possible.

> `.forEach()` makes the stack-traces ugly, and messes with the ability to use `async`/`await`, which we're going to need in here soon.

    at Object.keys.forEach (/srv/app/node_modules/snyk-docker-plugin/dist/index.js:359:9)
    at countDepsRecursive (/srv/app/node_modules/snyk-docker-plugin/dist/index.js:358:23)
    at Object.keys.forEach (/srv/app/node_modules/snyk-docker-plugin/dist/index.js:359:9)
    at countDepsRecursive (/srv/app/node_modules/snyk-docker-plugin/dist/index.js:358:23)