### PR TITLE
fix: Make safeLs more tolerant for expected errors

### DIFF
--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -54,16 +54,18 @@ class Docker {
    * Runs the command, catching any expected errors and returning them as normal
    * stderr/stdout result.
    */
-  public async runSafe(cmd: string, args: string[] = []) {
+  public async runSafe(
+    cmd: string,
+    args: string[] = [],
+    // no error is thrown if any of listed errors is found in stderr
+    ignoreErrors: string[] = ["No such file", "file not found"],
+  ) {
     try {
       return await this.run(cmd, args);
     } catch (error) {
       const stderr: string = error.stderr;
       if (typeof stderr === "string") {
-        if (
-          stderr.indexOf("No such file") >= 0 ||
-          stderr.indexOf("file not found") >= 0
-        ) {
+        if (ignoreErrors.some((errMsg) => stderr.indexOf(errMsg) >= 0)) {
           return { stdout: error.stdout, stderr };
         }
       }
@@ -103,7 +105,14 @@ class Docker {
     if (recursive) {
       params += "R";
     }
-    return this.runSafe("ls", [params, path]);
+
+    const ignoreErrors = [
+      "No such file",
+      "file not found",
+      "Permission denied",
+    ];
+
+    return this.runSafe("ls", [params, path], ignoreErrors);
   }
 
   /**

--- a/test/lib/docker.test.ts
+++ b/test/lib/docker.test.ts
@@ -133,6 +133,18 @@ test("safeLs", async (t) => {
     );
   });
 
+  t.test("directory found, some files inaccessable", async (t) => {
+    const lsResult = ".\n..\n.dockerenv\nbin/\ndev/\netc/\nusr/\nvar/\n";
+    const lsErrors = "ls: can't open '/root': Permission denied";
+    stub.callsFake(() => {
+      throw { stdout: lsResult, stderr: lsErrors };
+    });
+
+    const result = await docker.lsSafe("/abc");
+    t.equal(result.stdout, lsResult, "results returned");
+    t.equal(result.stderr, lsErrors, "errors also returned");
+  });
+
   t.test("directory not found", async (t) => {
     const error = "ls: /abc: No such file or directory";
     stub.callsFake(() => {


### PR DESCRIPTION
Recursive listing of files (safeLs) is used for finding manifest files. Make this process more robust by handling expected errors/warning, such as permission denied. This allows for scanning to continue even if some (system) folders are inaccessible.

There's more we could do here for better error handling, but stopping sooner because upcoming switch to static scanning.