### PR TITLE
fix: Build process to include compiled js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,18 @@ jobs:
           name: Install dependencies
           command: npm install
       - run:
-          name: Run tests
+          name: Build
           command: npm run build
   release:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: Install dependencies
+          command: npm install
+      - run:
+          name: Build
+          command: npm run build
       - run:
           name: Release on GitHub
           command: npx semantic-release


### PR DESCRIPTION
We have noticed that since `1.37.0` (when migrating to CircleCI) our published versions no longer include compiled js, but only typescript sources and these versions cannot be used in other projects.

This should fix it.