### PR TITLE
feat: spin the event loop during legacy scanning

### DIFF
--- a/lib/ls-utils.ts
+++ b/lib/ls-utils.ts
@@ -1,3 +1,5 @@
+import { eventLoopSpinner } from "event-loop-spinner";
+
 export { DiscoveredDirectory, DiscoveredFile, parseLsOutput, iterateFiles };
 
 interface DiscoveredDirectory {
@@ -14,15 +16,20 @@ interface DiscoveredFile {
 /**
  * Iterate over all files of a given DiscoveredDirectory structure.
  */
-function iterateFiles(
+async function iterateFiles(
   root: DiscoveredDirectory,
   iterator: (f: DiscoveredFile) => void,
 ) {
   for (const f of root.files) {
     iterator(f);
   }
+
+  if (eventLoopSpinner.isStarving()) {
+    await eventLoopSpinner.spin();
+  }
+
   for (const d of root.subDirs) {
-    iterateFiles(d, iterator);
+    await iterateFiles(d, iterator);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "dockerfile-ast": "0.0.18",
+    "event-loop-spinner": "^1.1.0",
     "semver": "^6.1.0",
     "tar-stream": "^2.1.0",
     "tslib": "^1"

--- a/test/lib/ls-utils.test.ts
+++ b/test/lib/ls-utils.test.ts
@@ -209,7 +209,7 @@ test("parse ls output", async (t) => {
     t.test(data.name, async (t) => {
       const res = parseLsOutput(data.in);
       const files: string[] = [];
-      iterateFiles(res, (f) => files.push(path.join(f.path, f.name)));
+      await iterateFiles(res, (f) => files.push(path.join(f.path, f.name)));
       t.same(res, data.out);
       t.same(files, data.files);
     });


### PR DESCRIPTION
#### What does this PR do?

Explicitly spin the event loop while looping over the found files, and just before parsing. This should improve responsiveness.