### PR TITLE
fix: correctly parse dockerfile written in lowercase

### DIFF
--- a/lib/instruction-parser.ts
+++ b/lib/instruction-parser.ts
@@ -38,7 +38,9 @@ function getPackagesFromRunInstructions(
 ): DockerFilePackages {
   const runInstructions = dockerfile
     .getInstructions()
-    .filter((instruction) => instruction.getInstruction() === "RUN")
+    .filter(
+      (instruction) => instruction.getInstruction().toUpperCase() === "RUN",
+    )
     .map((instruction) =>
       getInstructionExpandVariables(instruction, dockerfile),
     );
@@ -123,7 +125,7 @@ function getDockerfileBaseImageName(
       );
       // store the resolved stage name
       stagesNames.last = stagesNames.aliases[expandedName] || expandedName;
-      if (args.length > 2 && args[1].getValue() === "AS") {
+      if (args.length > 2 && args[1].getValue().toUpperCase() === "AS") {
         // the AS alias name
         const aliasName = args[2].getValue();
         // support nested referral

--- a/test/fixtures/dockerfiles/multi-stage-lowercase/Dockerfile
+++ b/test/fixtures/dockerfiles/multi-stage-lowercase/Dockerfile
@@ -1,0 +1,15 @@
+from golang:1.7.3 as builder
+workdir /go/src/github.com/alexellis/href-counter/
+run go get -d -v golang.org/x/net/html
+copy app.go .
+run cgo_enabled=0 goos=linux go build -a -installsuffix cgo -o app .
+
+from alpine:latest as base
+run apk --no-cache add ca-certificates
+workdir /root/
+copy --from=builder /go/src/github.com/alexellis/href-counter/app .
+cmd ["./app"]
+
+from base as extended
+
+from extended

--- a/test/lib/docker-file.test.ts
+++ b/test/lib/docker-file.test.ts
@@ -174,6 +174,23 @@ test("Analyses dockerfiles", async (t) => {
         },
       },
     },
+    {
+      description: "multi stage Dockerfile with lowercase instructions",
+      fixture: "multi-stage-lowercase",
+      expected: {
+        baseImage: "alpine:latest",
+        dockerfilePackages: {
+          "ca-certificates": {
+            instruction: "RUN apk --no-cache add ca-certificates",
+          },
+        },
+        dockerfileLayers: {
+          "UlVOIGFwayAtLW5vLWNhY2hlIGFkZCBjYS1jZXJ0aWZpY2F0ZXM=": {
+            instruction: "RUN apk --no-cache add ca-certificates",
+          },
+        },
+      },
+    },
   ];
   for (const example of examples) {
     await t.test(example.description, async (t) => {


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fixing an edge case where some/all instructions in the dockerfile are written in lowercase. 