### PR TITLE
fix: rename .inspect() in Docker class due to deprecation

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -8,7 +8,9 @@ async function detect(
   options?: DockerOptions,
 ): Promise<DockerInspectOutput> {
   try {
-    const info = await new Docker(targetImage, options).inspect(targetImage);
+    const info = await new Docker(targetImage, options).inspectImage(
+      targetImage,
+    );
     return JSON.parse(info.stdout)[0];
   } catch (error) {
     if (error.stderr.includes("No such object")) {

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -89,7 +89,7 @@ class Docker {
     ]);
   }
 
-  public async inspect(targetImage: string) {
+  public async inspectImage(targetImage: string) {
     return subProcess.execute("docker", [
       ...this.optionsList,
       "inspect",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
BREAKING CHANGE:
Renamed .inspect() to inspectImage() in Docker class due to -
[DEP0079] DeprecationWarning: Custom inspection function on
Objects via .inspect() is deprecated
.inspect() is currently EOL
