### PR TITLE
Feat/pull image if not local

### DIFF
--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -89,6 +89,10 @@ class Docker {
     ]);
   }
 
+  public async pull(targetImage: string) {
+    return subProcess.execute("docker", ["pull", targetImage]);
+  }
+
   public async inspectImage(targetImage: string) {
     return subProcess.execute("docker", [
       ...this.optionsList,

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -35,11 +35,11 @@ test("attempt to connect to non-existent host", (t) => {
     });
 });
 
-test("inspect an image that does not exist", (t) => {
+test("inspect an image that does not exist and is not pullable", (t) => {
   return plugin.inspect("not-here:latest").catch((err) => {
     t.same(
       err.message,
-      "Docker error: image was not found locally: not-here:latest",
+      "Docker error: image was not found locally and pulling failed: not-here:latest",
     );
     t.pass("failed as expected");
   });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Modified to try pulling before inspecting an image when using inspect(). Changed some of the errors to better reflect the new flow. 

#### How should this be manually tested?
Try to inspect an image that doesn't exist locally. If it's possible to pull the image from docker hub, inspect should succeed. 

#### Any background context you want to provide?
https://github.com/snyk/snyk/issues/595

