### PR TITLE
chore: extracting some commonly used types

### DIFF
--- a/lib/docker-file.ts
+++ b/lib/docker-file.ts
@@ -1,12 +1,11 @@
 import { DockerfileParser } from "dockerfile-ast";
 import * as fs from "fs";
 import {
-  DockerFileLayers,
-  DockerFilePackages,
   getDockerfileBaseImageName,
   getDockerfileLayers,
   getPackagesFromRunInstructions,
 } from "./instruction-parser";
+import { DockerFileLayers, DockerFilePackages } from "./types";
 
 export { analyseDockerfile, readDockerfileAndAnalyse, DockerFileAnalysis };
 

--- a/lib/instruction-parser.ts
+++ b/lib/instruction-parser.ts
@@ -1,25 +1,13 @@
 import { Dockerfile, Instruction } from "dockerfile-ast";
 
+import { DockerFileLayers, DockerFilePackages } from "./types";
+
 export {
   getDockerfileBaseImageName,
   getDockerfileLayers,
   getPackagesFromRunInstructions,
-  DockerFilePackages,
-  DockerFileLayers,
   instructionDigest,
 };
-
-interface DockerFilePackages {
-  [packageName: string]: {
-    instruction: string;
-  };
-}
-
-interface DockerFileLayers {
-  [id: string]: {
-    instruction: string;
-  };
-}
 
 // Naive regex; see tests for cases
 // tslint:disable-next-line:max-line-length

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -1,6 +1,3 @@
-// Module that provides functions to collect and build response after all
-// analyses' are done.
-
 import { instructionDigest } from "./instruction-parser";
 import * as types from "./types";
 

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -1,7 +1,7 @@
 // Module that provides functions to collect and build response after all
 // analyses' are done.
 
-import { DockerFilePackages, instructionDigest } from "./instruction-parser";
+import { instructionDigest } from "./instruction-parser";
 import * as types from "./types";
 
 export { buildResponse };
@@ -71,9 +71,9 @@ function collectDockerfilePkgs(dockerAnalysis, deps) {
 // packages. This gives us a reference of all transitive deps installed via
 // the dockerfile, and the instruction that installed it.
 function getDockerfileDependencies(
-  dockerfilePackages: DockerFilePackages,
+  dockerfilePackages: types.DockerFilePackages,
   dependencies,
-): DockerFilePackages {
+): types.DockerFilePackages {
   for (const dependencyName in dependencies) {
     if (dependencies.hasOwnProperty(dependencyName)) {
       const sourceOrName = dependencyName.split("/")[0];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,3 +41,15 @@ export interface PluginResponse {
   package: any;
   manifestFiles: ManifestFile[];
 }
+
+export interface DockerFilePackages {
+  [packageName: string]: {
+    instruction: string;
+  };
+}
+
+export interface DockerFileLayers {
+  [id: string]: {
+    instruction: string;
+  };
+}


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

these instruction-related types seem to be used around in a few places.
extracting them to a more common place.
it might be better to take it one step further and see what's common to everything that uses it.

I'm expecting this PR to be followed by an additional refactor decoupling the ```response-builder``` from the ```instruction-parser```, if it makes sense.
