### PR TITLE
test: proof that we do not support scratch image without docker file

### DIFF
--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -67,6 +67,20 @@ test("inspect an image with an unsupported pkg manager", (t) => {
     });
 });
 
+test("inspect a scratch image", async (t) => {
+  const imgName = "busybox";
+  const imgTag = "1.31.1";
+  const img = imgName + ":" + imgTag;
+
+  await dockerPull(t, img);
+  try {
+    await plugin.inspect(img);
+    t.fail("should have failed");
+  } catch (err) {
+    t.match(err.message, "Failed to detect OS release", "error msg is correct");
+  }
+});
+
 test("inspect node:6.14.2 - provider and regular pkg as same dependency", (t) => {
   const imgName = "node";
   const imgTag = "6.14.2";


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

currently the docker-plugin throws errors when scanning scratch images without Dockerfiles provided.
this test asserts the existing behaviour.

#### How should this be manually tested?

`snyk test --docker busybox`

#### Any background context you want to provide?

https://www.notion.so/snyk/Improve-how-we-handle-scratch-images-6fe2d0dbb1584c69b2d185a0cee9e976

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-709

#### Screenshots

![image](https://user-images.githubusercontent.com/1255387/75368858-098c0c80-58cb-11ea-8ac5-bf7f81faa210.png)