### PR TITLE
Fix/scratch images

### DIFF
--- a/lib/analyzer/os-release/docker.ts
+++ b/lib/analyzer/os-release/docker.ts
@@ -68,7 +68,7 @@ export async function detect(
 
       osRelease = { name: "scratch", version: "0.0" };
     } else {
-      throw new Error("Failed to detect OS release");
+      osRelease = { name: "unknown", version: "0.0" };
     }
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -294,9 +294,11 @@ function parseAnalysisResults(
         Analysis: [],
       };
     } else {
-      throw new Error(
-        "Failed to detect a supported Linux package manager (deb/rpm/apk)",
-      );
+      analysisResult = {
+        Image: targetImage,
+        AnalyzeType: "unknown",
+        Analysis: [],
+      };
     }
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -200,36 +200,40 @@ function handleCommonErrors(error, targetImage: string) {
   }
 }
 
-function getDependencies(
+async function getDependencies(
   targetImage: string,
   dockerfileAnalysis?: dockerFile.DockerFileAnalysis,
   options?: DockerOptions,
 ) {
-  let result;
-  return analyzer
-    .analyzeDynamically(targetImage, dockerfileAnalysis, options)
-    .then((output) => {
-      result = parseAnalysisResults(targetImage, output, dockerfileAnalysis);
-      return buildTree(
-        targetImage,
-        result.type,
-        result.depInfosList,
-        result.targetOS,
-      );
-    })
-    .then((pkg) => {
-      return {
-        package: pkg,
-        packageManager: result.type,
-        imageId: result.imageId,
-        binaries: result.binaries,
-        imageLayers: result.imageLayers,
-      };
-    })
-    .catch((error) => {
-      const analysisError = tryGetAnalysisError(error, targetImage);
-      throw analysisError;
-    });
+  try {
+    const output = await analyzer.analyzeDynamically(
+      targetImage,
+      dockerfileAnalysis,
+      options,
+    );
+    const result = parseAnalysisResults(
+      targetImage,
+      output,
+      dockerfileAnalysis,
+    );
+    const pkg = buildTree(
+      targetImage,
+      result.type,
+      result.depInfosList,
+      result.targetOS,
+    );
+
+    return {
+      package: pkg,
+      packageManager: result.type,
+      imageId: result.imageId,
+      binaries: result.binaries,
+      imageLayers: result.imageLayers,
+    };
+  } catch (error) {
+    const analysisError = tryGetAnalysisError(error, targetImage);
+    throw analysisError;
+  }
 }
 
 async function getManifestFiles(

--- a/lib/inputs/rpm/docker.ts
+++ b/lib/inputs/rpm/docker.ts
@@ -14,7 +14,17 @@ export function getRpmDbFileContent(
     ])
     .catch((error) => {
       const stderr = error.stderr;
+      // allowing failure if rpm is not installed
       if (typeof stderr === "string" && stderr.indexOf("not found") >= 0) {
+        return { stdout: "", stderr: "" };
+      }
+      // allowing failure if analysing BusyBox
+      if (
+        typeof stderr === "string" &&
+        stderr.indexOf("invalid option -- -") >= 0 &&
+        stderr.indexOf("multi-call binary") >= 0 &&
+        stderr.indexOf("BusyBox") >= 0
+      ) {
         return { stdout: "", stderr: "" };
       }
       throw error;

--- a/test/lib/analyzer/os-release-detector.test.ts
+++ b/test/lib/analyzer/os-release-detector.test.ts
@@ -117,6 +117,11 @@ test("os release detection", async (t) => {
         dockerfilePackages: [],
       },
     },
+    "unexpected:unexpected": {
+      dir: "missing",
+      expected: { name: "unknown", version: "0.0" },
+      notes: "when nothing is found",
+    },
   };
 
   const execStub = sinon.stub(subProcess, "execute");
@@ -171,10 +176,6 @@ test("os release detection", async (t) => {
 
 test("failed detection", async (t) => {
   const examples = {
-    "unexpected:unexpected": {
-      dir: "missing",
-      expectedError: "Failed to detect OS release",
-    },
     "os-release:corrupt": {
       dir: "os_release_corrupt",
       expectedError: "Failed to parse /etc/os-release",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

support scratch images by:
1. stop throwing on unidentified operating systems
2. allow rpm data extraction to fail on BusyBox
3. stop throwing on unidentified package managers

#### Where should the reviewer start?

each commit separately

#### How should this be manually tested?

link the CLI to this version of the docker-plugin and test a scratch image such as BusyBox 1.31.1

#### Any background context you want to provide?

https://www.notion.so/snyk/Improve-how-we-handle-scratch-images-6fe2d0dbb1584c69b2d185a0cee9e976

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-727
https://snyksec.atlassian.net/browse/RUN-734