### PR TITLE
Fix/unknown images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-* @snyk/magma
+* @snyk/runtime
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -284,22 +284,13 @@ function parseAnalysisResults(
   })[0];
 
   if (!analysisResult) {
-    if (dockerfileAnalysis && dockerfileAnalysis.baseImage === "scratch") {
-      // Special case when we have no package management
-      // on scratch images
-
-      analysisResult = {
-        Image: targetImage,
-        AnalyzeType: "linux",
-        Analysis: [],
-      };
-    } else {
-      analysisResult = {
-        Image: targetImage,
-        AnalyzeType: "unknown",
-        Analysis: [],
-      };
-    }
+    // Special case when we have no package management
+    // on scratch images or images with unknown package manager
+    analysisResult = {
+      Image: targetImage,
+      AnalyzeType: "linux",
+      Analysis: [],
+    };
   }
 
   let depType;

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -66,14 +66,10 @@ test("inspect an image with an unsupported pkg manager", async (t) => {
   );
   t.same(
     pluginResult.package.packageFormatVersion,
-    "unknown:0.0.1",
-    "package manager unknown",
+    "linux:0.0.1",
+    "package manager linux",
   );
-  t.same(
-    pluginResult.plugin.packageManager,
-    "unknown",
-    "package manager unknown",
-  );
+  t.same(pluginResult.plugin.packageManager, "linux", "package manager linux");
 });
 
 test("inspect a scratch image", async (t) => {
@@ -96,14 +92,10 @@ test("inspect a scratch image", async (t) => {
   );
   t.same(
     pluginResult.package.packageFormatVersion,
-    "unknown:0.0.1",
-    "package manager unknown",
+    "linux:0.0.1",
+    "package manager linux",
   );
-  t.same(
-    pluginResult.plugin.packageManager,
-    "unknown",
-    "package manager unknown",
-  );
+  t.same(pluginResult.plugin.packageManager, "linux", "package manager linux");
 });
 
 test("inspect node:6.14.2 - provider and regular pkg as same dependency", (t) => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

1. changing the code owners to team Runtime.

2. merging "unknown" and "linux" package manager paths

"linux" is being used when we positively identify a scratch image.
"unknown" was used tentatively when we couldn't identify a package manager at all.
merging the two flows as they should have the same behaviour.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-734