### PR TITLE
fix: Exlcude system directories when calling findGlobs on the root path

### DIFF
--- a/test/lib/ls-utils.test.ts
+++ b/test/lib/ls-utils.test.ts
@@ -6,9 +6,6 @@ import * as path from "path";
 import { test } from "tap";
 import { iterateFiles, parseLsOutput } from "../../lib/ls-utils";
 
-import { writeFileSync } from "fs";
-import { Docker } from "../../lib/docker";
-
 const PARSER_TESTS = [
   {
     name: "Empty string",
@@ -45,7 +42,23 @@ const PARSER_TESTS = [
     in: "./\n../\ndir1/\ndir2/\ndir3/\nfile1.txt\nfile2.txt\n",
     out: {
       name: "/",
-      subDirs: [],
+      subDirs: [
+        {
+          files: [],
+          name: "dir1",
+          subDirs: [],
+        },
+        {
+          files: [],
+          name: "dir2",
+          subDirs: [],
+        },
+        {
+          files: [],
+          name: "dir3",
+          subDirs: [],
+        },
+      ],
       files: [
         {
           name: "file1.txt",
@@ -214,15 +227,4 @@ test("parse ls output", async (t) => {
       t.same(files, data.files);
     });
   }
-});
-
-const getLSOutputFixture = (file: string) =>
-  path.join(__dirname, "../fixtures/ls-output", file);
-
-test("output ls", async (t) => {
-  const d = new Docker("mladkau/ghost:latest");
-
-  const out = await d.lsSafe("/", true);
-
-  writeFileSync(getLSOutputFixture("xxx.txt"), out.stdout);
 });


### PR DESCRIPTION
- [x ] Ready for review
- [ x] Follows CONTRIBUTING rules
- [x ] Reviewed by Snyk internal team

#### What does this PR do?

This PR adds a special case to findGlobs to make it more efficient. The function now excludes system directories when it is called on the root directory.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/DC-382

#### Screenshots


#### Additional questions
