### PR TITLE
fix: do not save distroless image in static scanning

### DIFF
--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -9,13 +9,21 @@ import { ImageType, PluginResponse } from "./types";
 
 export async function experimentalAnalysis(
   targetImage: string,
+  options: any,
 ): Promise<PluginResponse> {
   // assume Distroless scanning
-  return distroless(targetImage);
+  return distroless(targetImage, options);
 }
 
 // experimental flow expected to be merged with the static analysis when ready
-export async function distroless(targetImage: string): Promise<PluginResponse> {
+export async function distroless(
+  targetImage: string,
+  options: any,
+): Promise<PluginResponse> {
+  if (staticModule.isRequestingStaticAnalysis(options)) {
+    return staticModule.analyzeStatically(targetImage, options);
+  }
+
   await pullIfNotLocal(targetImage);
 
   const archiveDir = path.join(os.tmpdir(), "snyk-image-archives");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,7 +24,7 @@ function inspect(
   const targetImage = root;
 
   if (options && options.experimental) {
-    return experimentalAnalysis(targetImage);
+    return experimentalAnalysis(targetImage, options);
   }
 
   if (staticUtil.isRequestingStaticAnalysis(options)) {


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

In case we use the distroless flow in a static analysis contexts - don't use `docker save` to save the image and `docker pull` to pull it, just continue with the regular static analysis flow
