### PR TITLE
Feat/distroless os info

### DIFF
--- a/lib/analyzer/os-release/docker.ts
+++ b/lib/analyzer/os-release/docker.ts
@@ -65,9 +65,9 @@ export async function detect(
     if (dockerfileAnalysis && dockerfileAnalysis.baseImage === "scratch") {
       // If the docker file was build from a scratch image
       // then we don't have a known OS
-      osRelease = { name: "scratch", version: "0.0" };
+      osRelease = { name: "scratch", version: "0.0", prettyName: "" };
     } else {
-      osRelease = { name: "unknown", version: "0.0" };
+      osRelease = { name: "unknown", version: "0.0", prettyName: "" };
     }
   }
 

--- a/lib/analyzer/os-release/docker.ts
+++ b/lib/analyzer/os-release/docker.ts
@@ -65,7 +65,6 @@ export async function detect(
     if (dockerfileAnalysis && dockerfileAnalysis.baseImage === "scratch") {
       // If the docker file was build from a scratch image
       // then we don't have a known OS
-
       osRelease = { name: "scratch", version: "0.0" };
     } else {
       osRelease = { name: "unknown", version: "0.0" };

--- a/lib/analyzer/os-release/release-analyzer.ts
+++ b/lib/analyzer/os-release/release-analyzer.ts
@@ -16,7 +16,13 @@ export async function tryOSRelease(text: string): Promise<OSRelease | null> {
     version = version.split(".")[0];
   }
 
-  return { name, version };
+  let prettyName: string = "";
+  const prettyNameRes = text.match(/^PRETTY_NAME=(.+)$/m);
+  if (prettyNameRes) {
+    prettyName = prettyNameRes[1].replace(/"/g, "");
+  }
+
+  return { name, version, prettyName };
 }
 
 export async function tryLsbRelease(text: string): Promise<OSRelease | null> {
@@ -30,7 +36,7 @@ export async function tryLsbRelease(text: string): Promise<OSRelease | null> {
   }
   const name = idRes[1].replace(/"/g, "").toLowerCase();
   const version = versionRes[1].replace(/"/g, "");
-  return { name, version };
+  return { name, version, prettyName: "" };
 }
 
 export async function tryDebianVersion(
@@ -43,7 +49,7 @@ export async function tryDebianVersion(
   if (text.length < 2) {
     throw new Error("Failed to parse /etc/debian_version");
   }
-  return { name: "debian", version: text.split(".")[0] };
+  return { name: "debian", version: text.split(".")[0], prettyName: "" };
 }
 
 export async function tryAlpineRelease(
@@ -56,7 +62,7 @@ export async function tryAlpineRelease(
   if (text.length < 2) {
     throw new Error("Failed to parse /etc/alpine-release");
   }
-  return { name: "alpine", version: text };
+  return { name: "alpine", version: text, prettyName: "" };
 }
 
 export async function tryRedHatRelease(
@@ -72,7 +78,7 @@ export async function tryRedHatRelease(
   }
   const name = idRes[1].replace(/"/g, "").toLowerCase();
   const version = versionRes[1].replace(/"/g, "");
-  return { name, version };
+  return { name, version, prettyName: "" };
 }
 
 export async function tryOracleRelease(
@@ -89,5 +95,5 @@ export async function tryOracleRelease(
   const name = idRes[1].replace(/"/g, "").toLowerCase();
   const version = versionRes[1].replace(/"/g, "").split(".")[0];
 
-  return { name, version };
+  return { name, version, prettyName: "" };
 }

--- a/lib/analyzer/os-release/static.ts
+++ b/lib/analyzer/os-release/static.ts
@@ -59,7 +59,7 @@ export async function detect(
   }
 
   if (!osRelease) {
-    osRelease = { name: "unknown", version: "0.0" };
+    osRelease = { name: "unknown", version: "0.0", prettyName: "" };
   }
 
   // Oracle Linux identifies itself as "ol"

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -34,6 +34,7 @@ export enum AnalysisType {
 export interface OSRelease {
   name: string;
   version: string;
+  prettyName: string;
 }
 
 export interface Binary {

--- a/test/fixtures/os/alpine_2_6_6/analyzer-expect.json
+++ b/test/fixtures/os/alpine_2_6_6/analyzer-expect.json
@@ -7,7 +7,8 @@
   ],
   "osRelease": {
     "name": "alpine",
-    "version": "2.6.6"
+    "version": "2.6.6",
+    "prettyName": ""
   },
   "results": [
     {

--- a/test/lib/analyzer/os-release-detector.test.ts
+++ b/test/lib/analyzer/os-release-detector.test.ts
@@ -20,97 +20,145 @@ test("os release detection", async (t) => {
   const examples = {
     "alpine:2.6": {
       dir: "alpine_2_6_6",
-      expected: { name: "alpine", version: "2.6.6" },
+      expected: { name: "alpine", version: "2.6.6", prettyName: "" },
       notes: "uses /etc/alpine-release",
     },
     "alpine:3.7": {
       dir: "alpine_3_7_0",
-      expected: { name: "alpine", version: "3.7.0" },
+      expected: {
+        name: "alpine",
+        version: "3.7.0",
+        prettyName: "Alpine Linux v3.7",
+      },
       notes: "uses /etc/os-release",
     },
     "centos:5": {
       dir: "centos_5",
-      expected: { name: "centos", version: "5" },
+      expected: { name: "centos", version: "5", prettyName: "" },
       notes: "uses /etc/redhat-release",
     },
     "centos:6": {
       dir: "centos_6",
-      expected: { name: "centos", version: "6" },
+      expected: { name: "centos", version: "6", prettyName: "" },
       notes: "uses /etc/redhat-release",
     },
     "centos:7": {
       dir: "centos_7",
-      expected: { name: "centos", version: "7" },
+      expected: {
+        name: "centos",
+        version: "7",
+        prettyName: "CentOS Linux 7 (Core)",
+      },
       notes: "uses /etc/os-release",
     },
     "debian:6": {
       dir: "debian_6",
-      expected: { name: "debian", version: "6" },
+      expected: { name: "debian", version: "6", prettyName: "" },
       notes: "uses /etc/debian_version",
     },
     "debian:7": {
       dir: "debian_7",
-      expected: { name: "debian", version: "7" },
+      expected: {
+        name: "debian",
+        version: "7",
+        prettyName: "Debian GNU/Linux 7 (wheezy)",
+      },
       notes: "uses /etc/os-release",
     },
     "debian:8": {
       dir: "debian_8",
-      expected: { name: "debian", version: "8" },
+      expected: {
+        name: "debian",
+        version: "8",
+        prettyName: "Debian GNU/Linux 8 (jessie)",
+      },
       notes: "uses /etc/os-release",
     },
     "debian:9": {
       dir: "debian_9",
-      expected: { name: "debian", version: "9" },
+      expected: {
+        name: "debian",
+        version: "9",
+        prettyName: "Debian GNU/Linux 9 (stretch)",
+      },
       notes: "uses /etc/os-release",
     },
     "debian:unstable": {
       dir: "debian_unstable",
-      expected: { name: "debian", version: "unstable" },
+      expected: {
+        name: "debian",
+        version: "unstable",
+        prettyName: "Debian GNU/Linux buster/sid",
+      },
       notes: "uses /etc/os-release",
     },
     "oracle:5.11": {
       dir: "oraclelinux_5_11",
-      expected: { name: "oracle", version: "5" },
+      expected: { name: "oracle", version: "5", prettyName: "" },
       notes: "uses /etc/oracle-release",
     },
     "oracle:6.9": {
       dir: "oraclelinux_6_9",
-      expected: { name: "oracle", version: "6" },
+      expected: {
+        name: "oracle",
+        version: "6",
+        prettyName: "Oracle Linux Server 6.9",
+      },
       notes: "uses /etc/os-release",
     },
     "oracle:7.5": {
       dir: "oraclelinux_7_5",
-      expected: { name: "oracle", version: "7" },
+      expected: {
+        name: "oracle",
+        version: "7",
+        prettyName: "Oracle Linux Server 7.5",
+      },
       notes: "uses /etc/os-release",
     },
     "ubuntu:10.04": {
       dir: "ubuntu_10_04",
-      expected: { name: "ubuntu", version: "10.04" },
+      expected: { name: "ubuntu", version: "10.04", prettyName: "" },
       notes: "uses /etc/lsb-release",
     },
     "ubuntu:12.04": {
       dir: "ubuntu_12_04",
-      expected: { name: "ubuntu", version: "12.04" },
+      expected: {
+        name: "ubuntu",
+        version: "12.04",
+        prettyName: "Ubuntu precise (12.04.5 LTS)",
+      },
       notes: "uses /etc/os-release",
     },
     "ubuntu:14.04": {
       dir: "ubuntu_14_04",
-      expected: { name: "ubuntu", version: "14.04" },
+      expected: {
+        name: "ubuntu",
+        version: "14.04",
+        prettyName: "Ubuntu 14.04.5 LTS",
+      },
       notes: "uses /etc/os-release",
     },
     "ubuntu:16.04": {
       dir: "ubuntu_16_04",
-      expected: { name: "ubuntu", version: "16.04" },
+      expected: {
+        name: "ubuntu",
+        version: "16.04",
+        prettyName: "Ubuntu 16.04.4 LTS",
+      },
       notes: "uses /etc/os-release",
     },
     "ubuntu:18.04": {
       dir: "ubuntu_18_04",
-      expected: { name: "ubuntu", version: "18.04" },
+      expected: {
+        name: "ubuntu",
+        version: "18.04",
+        prettyName: "Ubuntu 18.04 LTS",
+      },
       notes: "uses /etc/os-release",
     },
     scratch: {
       dir: "",
-      expected: { name: "scratch", version: "0.0" },
+      expected: { name: "scratch", version: "0.0", prettyName: "" },
       notes: "uses dockerfile",
       dockerfileAnalysis: {
         baseImage: "scratch",
@@ -119,7 +167,7 @@ test("os release detection", async (t) => {
     },
     "unexpected:unexpected": {
       dir: "missing",
-      expected: { name: "unknown", version: "0.0" },
+      expected: { name: "unknown", version: "0.0", prettyName: "" },
       notes: "when nothing is found",
     },
   };

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -147,6 +147,7 @@ test("/etc/os-release links to /usr/lib/os-release", async (t) => {
   t.deepEqual(pluginResultWithDockerSave.package.targetOS, {
     name: "debian",
     version: "10",
+    prettyName: "Debian GNU/Linux 10 (buster)",
   });
 });
 
@@ -222,7 +223,7 @@ test("static analysis works for scratch images", async (t) => {
   );
   t.deepEquals(
     pluginResultWithSkopeoCopy.package.targetOS,
-    { name: "unknown", version: "0.0" },
+    { name: "unknown", version: "0.0", prettyName: "" },
     "operating system for scratch image is unknown",
   );
 });
@@ -280,7 +281,7 @@ test("static analysis for distroless base-debian9", async (t) => {
   t.ok("targetOS" in pluginResult.package, "OS discovered");
   t.deepEquals(
     pluginResult.package.targetOS,
-    { name: "debian", version: "9" },
+    { name: "debian", version: "9", prettyName: "Distroless" },
     "recognised it's debian 9",
   );
 });
@@ -338,7 +339,7 @@ test("static analysis for distroless base-debian10", async (t) => {
   t.ok("targetOS" in pluginResult.package, "OS discovered");
   t.deepEquals(
     pluginResult.package.targetOS,
-    { name: "debian", version: "10" },
+    { name: "debian", version: "10", prettyName: "Distroless" },
     "recognised it's debian 10",
   );
 });

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -61,7 +61,7 @@ test("inspect an image with an unsupported pkg manager", async (t) => {
   );
   t.same(
     pluginResult.package.targetOS,
-    { name: "arch", version: "unstable" },
+    { name: "arch", version: "unstable", prettyName: "Arch Linux" },
     "target operating system found",
   );
   t.same(
@@ -87,7 +87,7 @@ test("inspect a scratch image", async (t) => {
   );
   t.same(
     pluginResult.package.targetOS,
-    { name: "unknown", version: "0.0" },
+    { name: "unknown", version: "0.0", prettyName: "" },
     "target operating system found",
   );
   t.same(
@@ -135,6 +135,7 @@ test("inspect node:6.14.2 - provider and regular pkg as same dependency", (t) =>
           targetOS: {
             name: "debian",
             version: "8",
+            prettyName: "Debian GNU/Linux 8 (jessie)",
           },
           docker: {
             baseImage: "buildpack-deps:stretch",
@@ -238,6 +239,7 @@ test("inspect nginx:1.13.10", (t) => {
           targetOS: {
             name: "debian",
             version: "9",
+            prettyName: "Debian GNU/Linux 9 (stretch)",
           },
           docker: {
             baseImage: "debian:stretch-slim",
@@ -394,6 +396,7 @@ test("inspect redis:3.2.11-alpine", (t) => {
           targetOS: {
             name: "alpine",
             version: "3.7.0",
+            prettyName: "Alpine Linux v3.7",
           },
           docker: {
             baseImage: "alpine:3.7",
@@ -451,6 +454,7 @@ test(
         targetOS: {
           name: "alpine",
           version: "3.7.0",
+          prettyName: "Alpine Linux v3.7",
         },
         docker: {
           baseImage: "alpine:3.7",
@@ -481,6 +485,7 @@ test("inspect image with sha@256 " + "ubuntu@sha256", async (t) => {
       targetOS: {
         name: "ubuntu",
         version: "18.04",
+        prettyName: "Ubuntu 18.04.1 LTS",
       },
     },
     "root pkg",
@@ -553,6 +558,7 @@ test("inspect centos", (t) => {
           targetOS: {
             name: "centos",
             version: "7",
+            prettyName: "CentOS Linux 7 (Core)",
           },
           docker: {
             baseImage: "scratch",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

when analysing ```/etc/os-release``` for OS information, look for the ```PRETTY_NAME```.
if it's there, return it.
otherwise, return an empty string.

regardless, the OS Release data structure will now start containing a ```prettyName``` value.

#### Any background context you want to provide?

https://github.com/GoogleContainerTools/distroless/issues/487

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-805