### PR TITLE
Fix/static scan image

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -1,5 +1,6 @@
 import * as Debug from "debug";
 import { getDockerArchiveLayersAndManifest } from "../extractor";
+import { DockerArchiveManifest } from "../extractor/types";
 import {
   getApkDbFileContent,
   getApkDbFileContentAction,
@@ -98,7 +99,7 @@ export async function analyze(
     throw new Error("Failed to detect installed OS packages");
   }
 
-  const imageId = targetImage;
+  const imageId = imageIdFromArchiveManifest(dockerArchive.manifest);
 
   const binaries = getBinariesHashes(archiveLayers);
 
@@ -109,4 +110,14 @@ export async function analyze(
     binaries,
     imageLayers: dockerArchive.manifest.Layers,
   };
+}
+
+function imageIdFromArchiveManifest(manifest: DockerArchiveManifest): string {
+  try {
+    return manifest.Config.split(".")[0];
+  } catch (err) {
+    debug(manifest);
+    debug(err);
+    throw new Error("Failed to extract image ID from archive manifest");
+  }
 }

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -59,7 +59,7 @@ test("static analysis builds the expected response", async (t) => {
   );
   t.same(
     pluginResultWithSkopeoCopy.plugin.dockerImageId,
-    thisIsJustAnImageIdentifierInStaticAnalysis,
+    "ab56bba91343aafcdd94b7a44b42e12f32719b9a2b8579e93017c1280f48e8f3",
     "The image ID matches",
   );
   t.same(
@@ -203,7 +203,7 @@ test("static analysis works for scratch images", async (t) => {
 
   t.equals(
     pluginResultWithSkopeoCopy.plugin.dockerImageId,
-    "busybox:1.31.1",
+    "6d5fcfe5ff170471fcc3c8b47631d6d71202a1fd44cf3c147e50c8de21cf0648",
     "image ID identified correctly",
   );
   t.equals(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

fix ```image ID``` sent by the static scanning to stop showing the image name, and instead pick up the image ID (actually image digest) from the archive manifest file.

#### Where should the reviewer start?

commit by commit

#### Any background context you want to provide?

https://snyk.slack.com/archives/CVDMVLMU3/p1584953582004100