### PR TITLE
fix: pass 'distroless' flag to static scanning

### DIFF
--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -21,6 +21,7 @@ export async function distroless(
   options: any,
 ): Promise<PluginResponse> {
   if (staticModule.isRequestingStaticAnalysis(options)) {
+    options.staticAnalysisOptions.distroless = true;
     return staticModule.analyzeStatically(targetImage, options);
   }
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes the way we handle distroless scanning in static scanning flow

This was tested manually with a running kubernetes-monitor
