### PR TITLE
test: change test node version to 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   resource_class: small
   docker:
-    - image: node:12
+    - image: node:8
   working_directory: ~/snyk-docker-plugin
 
 commands:
@@ -61,7 +61,7 @@ jobs:
   test:
     <<: *defaults
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:8
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
to match the minimal supported node version in Snyk cli

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

change test node version to 8, to match the minimal supported node version in Snyk cli

