### PR TITLE
fix: make semantic-release work with node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
           command: npm run build
       - run:
           name: Release on GitHub
-          command: npx semantic-release
+          command: npx -p node@8 -c "npx semantic-release"
 
 workflows:
   version: 2


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

make semantic-release work with node 8
https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md#alternative-solutions