### PR TITLE
chore: newer release-notes-preview that discovers userID alone

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -12,10 +12,9 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow --tags
-    - uses: snyk/release-notes-preview@v1.3.4
+    - uses: snyk/release-notes-preview@v1.4.0
       with:
         releaseBranch: master
-        githubPosterId: 18642669
       env:
         GITHUB_PR_USERNAME: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_NOTES_GITHUB_TOKEN }}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

bump release-notes-preview to 1.4.0 that is capable of discovering the ID of the tokened user instead of having to provide it.