### PR TITLE
fix: export types for the plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/snyk/snyk-docker-plugin"
   },
   "main": "dist/index.js",
+  "types": "dist/index.d.js",
   "scripts": {
     "build": "tsc",
     "build-watch": "tsc -w",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     // "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

makes it easier to use the snyk-docker-plugin by exporting the types.

tested by installing this branch on the Kubernetes-Monitor and checking how it behaves in VSCode, as well as inspecting the index.d.ts file generated.

![image](https://user-images.githubusercontent.com/1255387/78510151-e2630d80-779b-11ea-9feb-6a21d72a4a11.png)