### PR TITLE
feat: return scan results array

### DIFF
--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -29,6 +29,7 @@ function buildResponse(
     plugin,
     package: pkg,
     manifestFiles,
+    scanResults: [], // TODO
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,6 +32,13 @@ export interface PluginMetadata {
   imageLayers: string[];
 }
 
+interface ScanResult {
+  type: string;
+  version: string;
+  data: any;
+}
+
+// should be renamed and organised
 export interface Package {
   dependencies: {
     [key: string]: any; // TODO
@@ -51,7 +58,8 @@ export interface Package {
 
 export interface PluginResponse {
   plugin: PluginMetadata;
-  package: Package;
+  package: Package; // under deprecation, Package is one type of scanResult
+  scanResults: ScanResult[]; // to replace package
   manifestFiles: ManifestFile[];
 }
 

--- a/test/fixtures/responses/all-deps.json
+++ b/test/fixtures/responses/all-deps.json
@@ -1115,5 +1115,6 @@
       },
       "binaries": []
     }
-  }
+  },
+  "scanResults": []
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

the ecosystem hints array contains unstructured data for different ecosystems encountered while scanning an image.
the `data` is expected to be consistent for each `type`+`version` couple.
```
Plugin Result: {
  plugin: PluginMetadata; // probably irrelevant RIGHT NOW
  package: {
    dependencies: { [key: string]: any; }; // OS dep graphs
    docker: { [key: string]: any; }; // not even god knows what’s in here
    name: string; // image name
    version: string; // image tag
    packageFormatVersion: string; // “deb:0.0.1”, used in Vuln
    targetOS: {
      name: string; // “debian”
      prettyName: string; // "Debian GNU/Linux 10 (buster)", “Distroless”
      version: string; “10”
     };
  };
   // ******** ADDING NOW ********
  scanResults: [
    {
      "type": "node",
      "version": "0.0.1",
      "data": TBD,
    {
      "type": "node",
      "version": "0.0.1",
      "data": TBD,
    },
    {
      "type": "java",
      "version": "0.0.2",
      "data": TBD,
    },
    {
      "type": "debian",
      "version": "0.0.1",
      "data": TBD,
    },
  ],
};
```