### PR TITLE
Feat/allow complex file matching

### DIFF
--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -66,12 +66,17 @@ function getContent(
   extractedLayers: ExtractedLayers,
   extractAction: ExtractAction,
 ): string | Buffer | undefined {
-  // TODO the following is a bug
-  // that treats a file pattern as a file name
-  const fileName = extractAction.fileNamePattern;
-  return fileName in extractedLayers &&
-    extractAction.actionName in extractedLayers[fileName]
-    ? extractedLayers[fileName][extractAction.actionName]
+  const fileNames = Object.keys(extractedLayers);
+  const fileNamesProducedByTheExtractAction = fileNames.filter(
+    (name) => extractAction.actionName in extractedLayers[name],
+  );
+
+  const firstFileNameMatch = fileNamesProducedByTheExtractAction.find((match) =>
+    extractAction.filePathMatches(match),
+  );
+
+  return firstFileNameMatch !== undefined
+    ? extractedLayers[firstFileNameMatch][extractAction.actionName]
     : undefined;
 }
 

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -1,5 +1,4 @@
 import { createReadStream } from "fs";
-import * as minimatch from "minimatch";
 import { basename, resolve as resolvePath } from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
@@ -104,7 +103,7 @@ async function extractFileAndProcess(
   extractActions: ExtractAction[],
 ): Promise<FileNameAndContent | undefined> {
   const matchedActions = extractActions.filter((action) =>
-    minimatch(fileName, action.fileNamePattern, { dot: true }),
+    action.filePathMatches(fileName),
   );
 
   if (matchedActions.length > 0) {

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -28,6 +28,7 @@ export interface ExtractAction {
   actionName: string;
   // The path patter to look for.
   fileNamePattern: string;
+  filePathMatches: (filePath: string) => boolean;
   // Applies the given callback once a file match is found given the pattern above.
   // The idea is that the file content can be transformed in any way.
   callback?: ExtractCallback;

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -26,8 +26,6 @@ export interface DockerArchiveManifest {
 export interface ExtractAction {
   // This name should be unique across all actions used.
   actionName: string;
-  // The path patter to look for.
-  fileNamePattern: string;
   filePathMatches: (filePath: string) => boolean;
   // Applies the given callback once a file match is found given the pattern above.
   // The idea is that the file content can be transformed in any way.

--- a/lib/inputs/apk/static.ts
+++ b/lib/inputs/apk/static.ts
@@ -4,7 +4,6 @@ import { streamToString } from "../../stream-utils";
 
 export const getApkDbFileContentAction: ExtractAction = {
   actionName: "apk-db",
-  fileNamePattern: "/lib/apk/db/installed",
   filePathMatches: (filePath) => filePath === "/lib/apk/db/installed",
   callback: streamToString,
 };

--- a/lib/inputs/apk/static.ts
+++ b/lib/inputs/apk/static.ts
@@ -5,6 +5,7 @@ import { streamToString } from "../../stream-utils";
 export const getApkDbFileContentAction: ExtractAction = {
   actionName: "apk-db",
   fileNamePattern: "/lib/apk/db/installed",
+  filePathMatches: (filePath) => filePath === "/lib/apk/db/installed",
   callback: streamToString,
 };
 

--- a/lib/inputs/apt/static.ts
+++ b/lib/inputs/apt/static.ts
@@ -6,12 +6,14 @@ import { streamToString } from "../../stream-utils";
 export const getDpkgFileContentAction: ExtractAction = {
   actionName: "dpkg",
   fileNamePattern: "/var/lib/dpkg/status",
+  filePathMatches: (filePath) => filePath === "/var/lib/dpkg/status",
   callback: streamToString,
 };
 
 export const getExtFileContentAction: ExtractAction = {
   actionName: "ext",
   fileNamePattern: "/var/lib/apt/extended_states",
+  filePathMatches: (filePath) => filePath === "/var/lib/apt/extended_states",
   callback: streamToString,
 };
 

--- a/lib/inputs/apt/static.ts
+++ b/lib/inputs/apt/static.ts
@@ -5,14 +5,12 @@ import { streamToString } from "../../stream-utils";
 
 export const getDpkgFileContentAction: ExtractAction = {
   actionName: "dpkg",
-  fileNamePattern: "/var/lib/dpkg/status",
   filePathMatches: (filePath) => filePath === "/var/lib/dpkg/status",
   callback: streamToString,
 };
 
 export const getExtFileContentAction: ExtractAction = {
   actionName: "ext",
-  fileNamePattern: "/var/lib/apt/extended_states",
   filePathMatches: (filePath) => filePath === "/var/lib/apt/extended_states",
   callback: streamToString,
 };

--- a/lib/inputs/binaries/static/index.ts
+++ b/lib/inputs/binaries/static/index.ts
@@ -5,14 +5,12 @@ import { streamToHash } from "../../../stream-utils";
 
 export const getOpenJDKBinariesFileContentAction: ExtractAction = {
   actionName: "java",
-  fileNamePattern: "**/java",
   filePathMatches: (filePath) => minimatch(filePath, "**/java", { dot: true }),
   callback: streamToHash,
 };
 
 export const getNodeBinariesFileContentAction: ExtractAction = {
   actionName: "node",
-  fileNamePattern: "**/node",
   filePathMatches: (filePath) => minimatch(filePath, "**/node", { dot: true }),
   callback: streamToHash,
 };

--- a/lib/inputs/binaries/static/index.ts
+++ b/lib/inputs/binaries/static/index.ts
@@ -1,15 +1,19 @@
+import * as minimatch from "minimatch";
+
 import { ExtractAction, ExtractedLayers } from "../../../extractor/types";
 import { streamToHash } from "../../../stream-utils";
 
 export const getOpenJDKBinariesFileContentAction: ExtractAction = {
   actionName: "java",
   fileNamePattern: "**/java",
+  filePathMatches: (filePath) => minimatch(filePath, "**/java", { dot: true }),
   callback: streamToHash,
 };
 
 export const getNodeBinariesFileContentAction: ExtractAction = {
   actionName: "node",
   fileNamePattern: "**/node",
+  filePathMatches: (filePath) => minimatch(filePath, "**/node", { dot: true }),
   callback: streamToHash,
 };
 

--- a/lib/inputs/distroless/static.ts
+++ b/lib/inputs/distroless/static.ts
@@ -5,7 +5,6 @@ import { streamToString } from "../../stream-utils";
 
 export const getDpkgPackageFileContentAction: ExtractAction = {
   actionName: "dpkg",
-  fileNamePattern: "/var/lib/dpkg/status.d/*",
   filePathMatches: (filePath) =>
     minimatch(filePath, "/var/lib/dpkg/status.d/*", { dot: true }),
   callback: streamToString, // TODO replace with a parser for apt data extractor

--- a/lib/inputs/distroless/static.ts
+++ b/lib/inputs/distroless/static.ts
@@ -1,9 +1,13 @@
+import * as minimatch from "minimatch";
+
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 
 export const getDpkgPackageFileContentAction: ExtractAction = {
   actionName: "dpkg",
   fileNamePattern: "/var/lib/dpkg/status.d/*",
+  filePathMatches: (filePath) =>
+    minimatch(filePath, "/var/lib/dpkg/status.d/*", { dot: true }),
   callback: streamToString, // TODO replace with a parser for apt data extractor
 };
 

--- a/lib/inputs/os-release/static.ts
+++ b/lib/inputs/os-release/static.ts
@@ -5,49 +5,42 @@ import { OsReleaseFilePath } from "../../types";
 
 const getOsReleaseAction: ExtractAction = {
   actionName: "os-release",
-  fileNamePattern: OsReleaseFilePath.Linux,
   filePathMatches: (filePath) => filePath === OsReleaseFilePath.Linux,
   callback: streamToString,
 };
 
 const getFallbackOsReleaseAction: ExtractAction = {
   actionName: "os-release-fallback",
-  fileNamePattern: OsReleaseFilePath.LinuxFallback,
   filePathMatches: (filePath) => filePath === OsReleaseFilePath.LinuxFallback,
   callback: streamToString,
 };
 
 const getLsbReleaseAction: ExtractAction = {
   actionName: "lsb-release",
-  fileNamePattern: OsReleaseFilePath.Lsb,
   filePathMatches: (filePath) => filePath === OsReleaseFilePath.Lsb,
   callback: streamToString,
 };
 
 const getDebianVersionAction: ExtractAction = {
   actionName: "debian-version",
-  fileNamePattern: OsReleaseFilePath.Debian,
   filePathMatches: (filePath) => filePath === OsReleaseFilePath.Debian,
   callback: streamToString,
 };
 
 const getAlpineReleaseAction: ExtractAction = {
   actionName: "alpine-release",
-  fileNamePattern: OsReleaseFilePath.Alpine,
   filePathMatches: (filePath) => filePath === OsReleaseFilePath.Alpine,
   callback: streamToString,
 };
 
 const getRedHatReleaseAction: ExtractAction = {
   actionName: "redhat-release",
-  fileNamePattern: OsReleaseFilePath.RedHat,
   filePathMatches: (filePath) => filePath === OsReleaseFilePath.RedHat,
   callback: streamToString,
 };
 
 const getOracleReleaseAction: ExtractAction = {
   actionName: "oracle-release",
-  fileNamePattern: OsReleaseFilePath.Oracle,
   filePathMatches: (filePath) => filePath === OsReleaseFilePath.Oracle,
   callback: streamToString,
 };

--- a/lib/inputs/os-release/static.ts
+++ b/lib/inputs/os-release/static.ts
@@ -6,42 +6,49 @@ import { OsReleaseFilePath } from "../../types";
 const getOsReleaseAction: ExtractAction = {
   actionName: "os-release",
   fileNamePattern: OsReleaseFilePath.Linux,
+  filePathMatches: (filePath) => filePath === OsReleaseFilePath.Linux,
   callback: streamToString,
 };
 
 const getFallbackOsReleaseAction: ExtractAction = {
   actionName: "os-release-fallback",
   fileNamePattern: OsReleaseFilePath.LinuxFallback,
+  filePathMatches: (filePath) => filePath === OsReleaseFilePath.LinuxFallback,
   callback: streamToString,
 };
 
 const getLsbReleaseAction: ExtractAction = {
   actionName: "lsb-release",
   fileNamePattern: OsReleaseFilePath.Lsb,
+  filePathMatches: (filePath) => filePath === OsReleaseFilePath.Lsb,
   callback: streamToString,
 };
 
 const getDebianVersionAction: ExtractAction = {
   actionName: "debian-version",
   fileNamePattern: OsReleaseFilePath.Debian,
+  filePathMatches: (filePath) => filePath === OsReleaseFilePath.Debian,
   callback: streamToString,
 };
 
 const getAlpineReleaseAction: ExtractAction = {
   actionName: "alpine-release",
   fileNamePattern: OsReleaseFilePath.Alpine,
+  filePathMatches: (filePath) => filePath === OsReleaseFilePath.Alpine,
   callback: streamToString,
 };
 
 const getRedHatReleaseAction: ExtractAction = {
   actionName: "redhat-release",
   fileNamePattern: OsReleaseFilePath.RedHat,
+  filePathMatches: (filePath) => filePath === OsReleaseFilePath.RedHat,
   callback: streamToString,
 };
 
 const getOracleReleaseAction: ExtractAction = {
   actionName: "oracle-release",
   fileNamePattern: OsReleaseFilePath.Oracle,
+  filePathMatches: (filePath) => filePath === OsReleaseFilePath.Oracle,
   callback: streamToString,
 };
 

--- a/lib/inputs/rpm/static.ts
+++ b/lib/inputs/rpm/static.ts
@@ -8,7 +8,6 @@ const debug = Debug("snyk");
 
 export const getRpmDbFileContentAction: ExtractAction = {
   actionName: "rpm-db",
-  fileNamePattern: "/var/lib/rpm/Packages",
   filePathMatches: (filePath) => filePath === "/var/lib/rpm/Packages",
   callback: streamToBuffer,
 };

--- a/lib/inputs/rpm/static.ts
+++ b/lib/inputs/rpm/static.ts
@@ -9,6 +9,7 @@ const debug = Debug("snyk");
 export const getRpmDbFileContentAction: ExtractAction = {
   actionName: "rpm-db",
   fileNamePattern: "/var/lib/rpm/Packages",
+  filePathMatches: (filePath) => filePath === "/var/lib/rpm/Packages",
   callback: streamToBuffer,
 };
 

--- a/test/lib/extractor/image.test.ts
+++ b/test/lib/extractor/image.test.ts
@@ -1,3 +1,7 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+
 import * as path from "path";
 import { test } from "tap";
 import { getDockerArchiveLayersAndManifest } from "../../../lib/extractor";

--- a/test/lib/extractor/image.test.ts
+++ b/test/lib/extractor/image.test.ts
@@ -14,6 +14,7 @@ test("image extractor: callbacks are issued when files are found", async (t) => 
     {
       actionName: "read_as_string",
       fileNamePattern: "/snyk/mock.txt",
+      filePathMatches: (filePath) => filePath === "/snyk/mock.txt",
       callback: async (stream) => {
         const content = await streamToString(stream);
         t.same(content, "Hello, world!", "content read is as expected");
@@ -42,6 +43,7 @@ test("image extractor: can read content with multiple callbacks", async (t) => {
     {
       actionName: "read_as_string",
       fileNamePattern: "/snyk/mock.txt",
+      filePathMatches: (filePath) => filePath === "/snyk/mock.txt",
       callback: async (stream) => {
         const content = await streamToString(stream);
         t.same(content, "Hello, world!", "content read is as expected");
@@ -51,6 +53,7 @@ test("image extractor: can read content with multiple callbacks", async (t) => {
     {
       actionName: "read_as_buffer",
       fileNamePattern: "/snyk/mock.txt",
+      filePathMatches: (filePath) => filePath === "/snyk/mock.txt",
       callback: async (stream) => {
         const content = await streamToString(stream);
         t.same(content, "Hello, world!", "content read is as expected");
@@ -81,6 +84,7 @@ test("image extractor: ensure the layer results are the same for docker and for 
     {
       actionName,
       fileNamePattern,
+      filePathMatches: (filePath) => filePath === "/snyk/mock.txt",
       callback: async () => returnedContent,
     },
   ];

--- a/test/lib/extractor/image.test.ts
+++ b/test/lib/extractor/image.test.ts
@@ -17,7 +17,6 @@ test("image extractor: callbacks are issued when files are found", async (t) => 
   const extractActions: ExtractAction[] = [
     {
       actionName: "read_as_string",
-      fileNamePattern: "/snyk/mock.txt",
       filePathMatches: (filePath) => filePath === "/snyk/mock.txt",
       callback: async (stream) => {
         const content = await streamToString(stream);
@@ -46,7 +45,6 @@ test("image extractor: can read content with multiple callbacks", async (t) => {
   const extractActions: ExtractAction[] = [
     {
       actionName: "read_as_string",
-      fileNamePattern: "/snyk/mock.txt",
       filePathMatches: (filePath) => filePath === "/snyk/mock.txt",
       callback: async (stream) => {
         const content = await streamToString(stream);
@@ -56,7 +54,6 @@ test("image extractor: can read content with multiple callbacks", async (t) => {
     },
     {
       actionName: "read_as_buffer",
-      fileNamePattern: "/snyk/mock.txt",
       filePathMatches: (filePath) => filePath === "/snyk/mock.txt",
       callback: async (stream) => {
         const content = await streamToString(stream);
@@ -87,7 +84,6 @@ test("image extractor: ensure the layer results are the same for docker and for 
   const extractActions: ExtractAction[] = [
     {
       actionName,
-      fileNamePattern,
       filePathMatches: (filePath) => filePath === "/snyk/mock.txt",
       callback: async () => returnedContent,
     },

--- a/test/lib/extractor/index.test.ts
+++ b/test/lib/extractor/index.test.ts
@@ -7,10 +7,9 @@ import { test } from "tap";
 import { getContentAsString } from "../../../lib/extractor";
 import { ExtractAction, ExtractedLayers } from "../../../lib/extractor/types";
 
-test("BUG: getContentAsString() does not match when a pattern is used in the extract action", async (t) => {
+test("getContentAsString() does matches when a pattern is used in the extract action", async (t) => {
   const extractAction: ExtractAction = {
     actionName: "match-any-node",
-    fileNamePattern: "**/node",
     filePathMatches: (filePath) =>
       minimatch(filePath, "**/node", { dot: true }),
   };
@@ -20,5 +19,5 @@ test("BUG: getContentAsString() does not match when a pattern is used in the ext
     },
   };
   const result = getContentAsString(extractedLayers, extractAction);
-  t.same(result, undefined, "BUG: extracted string should be Hello, world!");
+  t.same(result, "Hello, world!", "extracted string matches");
 });

--- a/test/lib/extractor/index.test.ts
+++ b/test/lib/extractor/index.test.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+
+import * as minimatch from "minimatch";
+import { test } from "tap";
+import { getContentAsString } from "../../../lib/extractor";
+import { ExtractAction, ExtractedLayers } from "../../../lib/extractor/types";
+
+test("BUG: getContentAsString() does not match when a pattern is used in the extract action", async (t) => {
+  const extractAction: ExtractAction = {
+    actionName: "match-any-node",
+    fileNamePattern: "**/node",
+    filePathMatches: (filePath) =>
+      minimatch(filePath, "**/node", { dot: true }),
+  };
+  const extractedLayers: ExtractedLayers = {
+    "/var/lib/node": {
+      "match-any-node": "Hello, world!",
+    },
+  };
+  const result = getContentAsString(extractedLayers, extractAction);
+  t.same(result, undefined, "BUG: extracted string should be Hello, world!");
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes two issues with the current extraction logic, namely:
- Complex file pattern matching was not possible (e.g. if we want to exclude certain paths), so now this logic is handled by a function in every ExtractAction
- A bug in `getContent()` that treats match patterns as the file names, so files extracted by an ExtractAction that used patterns could never be read (we didn't use those, but would be a bug if we did).

#### Where should the reviewer start?

Commit by commit as usual 🙏 

#### What are the relevant tickets?

[Jira ticket RUN-859](https://snyksec.atlassian.net/browse/RUN-859)
[Jira ticket RUN-860](https://snyksec.atlassian.net/browse/RUN-860)
