### PR TITLE
fix: match file paths using string comparison instead of using minimatch

### DIFF
--- a/lib/inputs/binaries/static/index.ts
+++ b/lib/inputs/binaries/static/index.ts
@@ -1,17 +1,15 @@
-import * as minimatch from "minimatch";
-
 import { ExtractAction, ExtractedLayers } from "../../../extractor/types";
 import { streamToHash } from "../../../stream-utils";
 
 export const getOpenJDKBinariesFileContentAction: ExtractAction = {
   actionName: "java",
-  filePathMatches: (filePath) => minimatch(filePath, "**/java", { dot: true }),
+  filePathMatches: (filePath) => filePath.endsWith("java"),
   callback: streamToHash,
 };
 
 export const getNodeBinariesFileContentAction: ExtractAction = {
   actionName: "node",
-  filePathMatches: (filePath) => minimatch(filePath, "**/node", { dot: true }),
+  filePathMatches: (filePath) => filePath.endsWith("node"),
   callback: streamToHash,
 };
 

--- a/lib/inputs/distroless/static.ts
+++ b/lib/inputs/distroless/static.ts
@@ -1,12 +1,9 @@
-import * as minimatch from "minimatch";
-
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 
 export const getDpkgPackageFileContentAction: ExtractAction = {
   actionName: "dpkg",
-  filePathMatches: (filePath) =>
-    minimatch(filePath, "/var/lib/dpkg/status.d/*", { dot: true }),
+  filePathMatches: (filePath) => filePath.startsWith("/var/lib/dpkg/status.d/"),
   callback: streamToString, // TODO replace with a parser for apt data extractor
 };
 

--- a/test/lib/extractor/index.test.ts
+++ b/test/lib/extractor/index.test.ts
@@ -2,7 +2,6 @@
 // Shebang is required, and file *has* to be executable: chmod +x file.test.js
 // See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
 
-import * as minimatch from "minimatch";
 import { test } from "tap";
 import { getContentAsString } from "../../../lib/extractor";
 import { ExtractAction, ExtractedLayers } from "../../../lib/extractor/types";
@@ -10,8 +9,7 @@ import { ExtractAction, ExtractedLayers } from "../../../lib/extractor/types";
 test("getContentAsString() does matches when a pattern is used in the extract action", async (t) => {
   const extractAction: ExtractAction = {
     actionName: "match-any-node",
-    filePathMatches: (filePath) =>
-      minimatch(filePath, "**/node", { dot: true }),
+    filePathMatches: (filePath) => filePath.endsWith("node"),
   };
   const extractedLayers: ExtractedLayers = {
     "/var/lib/node": {


### PR DESCRIPTION
minimatch is a heavy library that we don't need to call often. Instead we could use a simple string comparison to achieve the same thing in static scanning.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What are the relevant tickets?

[Jira ticket RUN-861](https://snyksec.atlassian.net/browse/RUN-861)