### PR TITLE
fix: refactor code to add sha1 future support

### DIFF
--- a/lib/inputs/binaries/static/index.ts
+++ b/lib/inputs/binaries/static/index.ts
@@ -1,16 +1,16 @@
 import { ExtractAction, ExtractedLayers } from "../../../extractor/types";
-import { streamToHash } from "../../../stream-utils";
+import { streamToHashSHA256 } from "../../../stream-utils";
 
 export const getOpenJDKBinariesFileContentAction: ExtractAction = {
   actionName: "java",
   filePathMatches: (filePath) => filePath.endsWith("java"),
-  callback: streamToHash,
+  callback: streamToHashSHA256,
 };
 
 export const getNodeBinariesFileContentAction: ExtractAction = {
   actionName: "node",
   filePathMatches: (filePath) => filePath.endsWith("node"),
-  callback: streamToHash,
+  callback: streamToHashSHA256,
 };
 
 const binariesExtractActions = [

--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -1,8 +1,9 @@
 import * as crypto from "crypto";
 import { Readable } from "stream";
 
-const HASH_ALGORITHM = "sha256"; // TODO algorithm?
-const HASH_ENCODING = "hex";
+export const HASH_ALGORITHM_SHA256 = "sha256"; // TODO algorithm?
+export const HASH_ALGORITHM_SHA1 = "sha1";
+export const HASH_ENCODING = "hex";
 
 export async function streamToString(
   stream: Readable,
@@ -33,10 +34,22 @@ export async function streamToBuffer(stream: Readable): Promise<Buffer> {
   });
 }
 
-export async function streamToHash(stream: Readable): Promise<string> {
+export async function streamToHashSHA1(stream: Readable): Promise<string> {
+  return doStreamToHash(stream, HASH_ALGORITHM_SHA1, HASH_ENCODING);
+}
+
+export async function streamToHashSHA256(stream: Readable): Promise<string> {
+  return doStreamToHash(stream, HASH_ALGORITHM_SHA256, HASH_ENCODING);
+}
+
+async function doStreamToHash(
+  stream: Readable,
+  hashAlgorithm: string,
+  hashEncoding: string,
+): Promise<string> {
   return new Promise((resolve, reject) => {
-    const hash = crypto.createHash(HASH_ALGORITHM);
-    hash.setEncoding(HASH_ENCODING);
+    const hash = crypto.createHash(hashAlgorithm);
+    hash.setEncoding(hashEncoding);
 
     stream.on("end", () => {
       hash.end();

--- a/test/lib/stream-utils.test.ts
+++ b/test/lib/stream-utils.test.ts
@@ -6,7 +6,12 @@ import { createReadStream } from "fs";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { test } from "tap";
-import { streamToBuffer, streamToString } from "../../lib/stream-utils";
+import {
+  streamToBuffer,
+  streamToHashSHA1,
+  streamToHashSHA256,
+  streamToString,
+} from "../../lib/stream-utils";
 
 const getFixture = (fixturePath) =>
   join(__dirname, "../fixtures/generic", fixturePath);
@@ -32,5 +37,31 @@ test("stream-utils.streamToBuffer()", async (t) => {
     fileContent,
     expectedContent,
     "streamToBuffer returns the expected content",
+  );
+});
+
+test("stream-utils.streamToHashSHA1()", async (t) => {
+  const fixture = getFixture("small-sample-text.txt");
+  const fileStream = createReadStream(fixture);
+
+  const hashOfFile = await streamToHashSHA1(fileStream);
+
+  t.deepEqual(
+    hashOfFile,
+    "943a702d06f34599aee1f8da8ef9f7296031d699",
+    "streamToHashSHA1 returns the expected hash",
+  );
+});
+
+test("stream-utils.streamToHashSHA256()", async (t) => {
+  const fixture = getFixture("small-sample-text.txt");
+  const fileStream = createReadStream(fixture);
+
+  const hashOfFile = await streamToHashSHA256(fileStream);
+
+  t.deepEqual(
+    hashOfFile,
+    "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+    "streamToHashSHA256 returns the expected hash",
   );
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
In order to support sha1 hashing as well in the future, I've refactored the code a bit to be able to select the type of hash we are going to do.

sha1 will be used going forward for jar scanning, as maven central stores only sha1 in the query api
