### PR TITLE
chore: Logging when the limit on app manifest files is reached.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -131,6 +131,9 @@ async function getManifestFiles(
   // to avoid overwhelming the docker daemon with cat requests
 
   if (files.length > MAX_MANIFEST_FILES) {
+    debug(
+      `Found ${files.length} manifest files in total. Only keeping the first ${MAX_MANIFEST_FILES}.`,
+    );
     files = files.slice(0, MAX_MANIFEST_FILES);
   }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [?] Reviewed by Snyk internal team

#### What does this PR do?

Adding some logging when the maximum number of manifest files was found on a given container image.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
