### PR TITLE
fix: debug print when the limit on "app" manifest files is reached.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+import * as Debug from "debug";
 import * as path from "path";
 
 import * as analyzer from "./analyzer";
@@ -15,6 +16,7 @@ import { ManifestFile, PluginResponse } from "./types";
 export { inspect, dockerFile };
 
 const MAX_MANIFEST_FILES = 5;
+const debug = Debug("snyk");
 
 function inspect(
   root: string,
@@ -131,6 +133,9 @@ async function getManifestFiles(
   // to avoid overwhelming the docker daemon with cat requests
 
   if (files.length > MAX_MANIFEST_FILES) {
+    debug(
+      `Found ${files.length} manifest files in total. Only keeping the first ${MAX_MANIFEST_FILES}.`,
+    );
     files = files.slice(0, MAX_MANIFEST_FILES);
   }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

add debug traces when dynamically scanning too many "app"-manifest files

#### Any background context you want to provide?

https://github.com/snyk/snyk-docker-plugin/pull/181
https://snyk.slack.com/archives/CLB5WDQRF/p1586446845149000