### PR TITLE
chore: release notes preview with checkbox requirement

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -3,6 +3,8 @@ name: Release-Notes-Preview
 on:
   pull_request:
     branches: [ master ]
+  issue_comment:
+    types: [ edited ]
 
 jobs:
   preview:
@@ -12,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow --tags
-    - uses: snyk/release-notes-preview@v1.4.0
+    - uses: snyk/release-notes-preview@v1.5.2
       with:
         releaseBranch: master
       env:


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

bump release notes preview to 1.5.2 which requires checking that the release notes have been previewed