### PR TITLE
fix: race condition in the experimental scans for deleting the image

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow --tags
-    - uses: snyk/release-notes-preview@v1.4.0
+    - uses: snyk/release-notes-preview@v1.5.2
       with:
         releaseBranch: master
       env:

--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -46,7 +46,7 @@ export async function distroless(
       },
     };
 
-    return staticModule.analyzeStatically(targetImage, scanningOptions);
+    return await staticModule.analyzeStatically(targetImage, scanningOptions);
   } finally {
     fs.unlinkSync(archiveFullPath);
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

there's a race condition between deleting the image archive we save and scanning it because we do not ```await``` on the analysis before the ```finally``` clause is invoked.

adding an ```await``` in the proper place to fix it.

#### How should this be manually tested?

logging in the proper places

#### Any background context you want to provide?

https://snyk.slack.com/archives/CDSMEJ29E/p1586348999177100?thread_ts=1586348254.175800&cid=CDSMEJ29E

#### What are the relevant tickets?

🎫 🎟️ 