### PR TITLE
chore: release-notes-preview should run on issue_comment edit

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -3,6 +3,8 @@ name: Release-Notes-Preview
 on:
   pull_request:
     branches: [ master ]
+  issue_comment:
+    types: [ edited ]
 
 jobs:
   preview:


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

release-notes-preview should run on issue_comment edit, that's how it knows release notes were acknowledged