### PR TITLE
feat: allow scanning existing Docker archives on the filesystem

### DIFF
--- a/lib/image-transport.ts
+++ b/lib/image-transport.ts
@@ -1,0 +1,13 @@
+import { ImageTransport } from "./types";
+
+export function getImageTransport(targetImage: string): ImageTransport {
+  if (targetImage.startsWith("docker-archive:")) {
+    return ImageTransport.DockerArchive;
+  }
+
+  return ImageTransport.ContainerRegistry;
+}
+
+export function getDockerArchivePath(targetImage: string): string {
+  return targetImage; // TODO: strip the "docker-archive:" at the start
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,11 @@ export interface StaticAnalysisOptions {
   distroless: boolean;
 }
 
+export enum ImageTransport {
+  ContainerRegistry,
+  DockerArchive,
+}
+
 export enum ImageType {
   DockerArchive = "docker-archive",
 }


### PR DESCRIPTION
As part of the experimental option, allow the plugin to directly unpack and analyse a Docker archive that exists on the filesystem.
This uses the existing static analysis flow.

- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What are the relevant tickets?

[Jira ticket RUN-897](https://snyksec.atlassian.net/browse/RUN-897)
[Jira ticket RUN-877](https://snyksec.atlassian.net/browse/RUN-877)
