### PR TITLE
feat/allow scanning existing Docker archives on the filesystem

### DIFF
--- a/lib/dependency-tree/index.ts
+++ b/lib/dependency-tree/index.ts
@@ -25,6 +25,10 @@ export function buildTree(
     imageVersion = targetImage.slice(versionSeparator + 1);
   }
 
+  if (imageName.endsWith(".tar")) {
+    imageVersion = "";
+  }
+
   const shaString = "@sha256";
 
   if (imageName.endsWith(shaString)) {

--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 
 import { pullIfNotLocal } from "./analyzer/image-inspector";
 import { Docker } from "./docker";
+import { getImageType } from "./image-type";
 import * as staticModule from "./static";
 import { ImageType, PluginResponse } from "./types";
 
@@ -12,7 +13,14 @@ export async function experimentalAnalysis(
   options: any,
 ): Promise<PluginResponse> {
   // assume Distroless scanning
-  return distroless(targetImage, options);
+  const imageType = getImageType(targetImage);
+  switch (imageType) {
+    case ImageType.Identifier:
+      return distroless(targetImage, options);
+
+    default:
+      throw new Error("Unhandled image type for image " + targetImage);
+  }
 }
 
 // experimental flow expected to be merged with the static analysis when ready

--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -46,18 +46,25 @@ export async function distroless(
   const docker = new Docker(targetImage);
   await docker.save(targetImage, archiveFullPath);
   try {
-    const scanningOptions = {
-      staticAnalysisOptions: {
-        imagePath: archiveFullPath,
-        imageType: ImageType.DockerArchive,
-        distroless: true,
-      },
-    };
-
-    return await staticModule.analyzeStatically(targetImage, scanningOptions);
+    return await getStaticAnalysisResult(targetImage, archiveFullPath);
   } finally {
     fs.unlinkSync(archiveFullPath);
   }
+}
+
+async function getStaticAnalysisResult(
+  targetImage: string,
+  archivePath: string,
+): Promise<PluginResponse> {
+  const scanningOptions = {
+    staticAnalysisOptions: {
+      imagePath: archivePath,
+      imageType: ImageType.DockerArchive,
+      distroless: true,
+    },
+  };
+
+  return await staticModule.analyzeStatically(targetImage, scanningOptions);
 }
 
 function createTempDirIfMissing(archiveDir: string): void {

--- a/lib/image-type.ts
+++ b/lib/image-type.ts
@@ -1,5 +1,16 @@
 import { ImageType } from "./types";
 
+const dockerArchiveIdentifierLength = "docker-archive:".length;
+
 export function getImageType(targetImage: string): ImageType {
+  if (targetImage.startsWith("docker-archive:")) {
+    return ImageType.DockerArchive;
+  }
+
   return ImageType.Identifier;
+}
+
+export function getDockerArchivePath(targetImage: string): string {
+  // strip the "docker-archive:" prefix
+  return targetImage.substring(dockerArchiveIdentifierLength);
 }

--- a/lib/image-type.ts
+++ b/lib/image-type.ts
@@ -1,0 +1,5 @@
+import { ImageType } from "./types";
+
+export function getImageType(targetImage: string): ImageType {
+  return ImageType.Identifier;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,7 +5,8 @@ export interface StaticAnalysisOptions {
 }
 
 export enum ImageType {
-  DockerArchive = "docker-archive",
+  Identifier, // e.g. "nginx:latest"
+  DockerArchive = "docker-archive", // e.g. "docker-archive:/tmp/nginx.tar"
 }
 
 export enum OsReleaseFilePath {

--- a/test/lib/image-type.test.ts
+++ b/test/lib/image-type.test.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+
+import { test } from "tap";
+import { getImageType } from "../../lib/image-type";
+import { ImageType } from "../../lib/types";
+
+test("getImageType() returns the expected transports", (t) => {
+  t.plan(2);
+
+  t.same(
+    getImageType("nginx:latest"),
+    ImageType.Identifier,
+    "plain image identifier is handled",
+  );
+  t.same(
+    getImageType("docker-archive:/tmp/nginx.tar"),
+    ImageType.Identifier,
+    "docker-archive is not yet handled",
+  );
+});

--- a/test/lib/image-type.test.ts
+++ b/test/lib/image-type.test.ts
@@ -3,7 +3,7 @@
 // See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
 
 import { test } from "tap";
-import { getImageType } from "../../lib/image-type";
+import { getDockerArchivePath, getImageType } from "../../lib/image-type";
 import { ImageType } from "../../lib/types";
 
 test("getImageType() returns the expected transports", (t) => {
@@ -16,7 +16,22 @@ test("getImageType() returns the expected transports", (t) => {
   );
   t.same(
     getImageType("docker-archive:/tmp/nginx.tar"),
-    ImageType.Identifier,
-    "docker-archive is not yet handled",
+    ImageType.DockerArchive,
+    "docker-archive is handled",
+  );
+});
+
+test("getDockerArchivePath() returns the expected results", (t) => {
+  t.plan(2);
+
+  t.same(
+    getDockerArchivePath("docker-archive:/tmp/nginx.tar"),
+    "/tmp/nginx.tar",
+    "returns extracted path",
+  );
+  t.same(
+    getDockerArchivePath("bad-path"),
+    "",
+    "does not handle errors and returns empty path",
   );
 });

--- a/test/system/experimental.test.ts
+++ b/test/system/experimental.test.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+
+import * as path from "path";
+import { test } from "tap";
+
+import * as plugin from "../../lib";
+
+function getFixture(fixturePath): string {
+  return path.join(__dirname, "../fixtures/docker-archives", fixturePath);
+}
+
+test("docker-archive image type can be scanned", async (t) => {
+  const fixturePath = getFixture("docker-save/nginx.tar");
+  const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+  const dockerfile = undefined;
+  const pluginOptions = {
+    experimental: true,
+  };
+
+  const pluginResult = await plugin.inspect(
+    imageNameAndTag,
+    dockerfile,
+    pluginOptions,
+  );
+
+  t.ok(
+    "manifestFiles" in pluginResult &&
+      "package" in pluginResult &&
+      "plugin" in pluginResult,
+    "Has the expected result properties",
+  );
+  t.same(
+    pluginResult.package.name,
+    "docker-image|nginx.tar",
+    "Image name matches",
+  );
+  t.same(pluginResult.package.version, "", "Version must be empty");
+  t.deepEqual(pluginResult.manifestFiles, [], "Empty manifest files");
+  t.same(
+    pluginResult.plugin.dockerImageId,
+    "5a3221f0137beb960c34b9cf4455424b6210160fd618c5e79401a07d6e5a2ced",
+    "The image ID matches",
+  );
+  t.same(
+    pluginResult.plugin.packageManager,
+    "deb",
+    "Correct package manager detected",
+  );
+  t.ok(
+    pluginResult.package.dependencies &&
+      "adduser" in pluginResult.package.dependencies,
+    "Contains some expected dependency",
+  );
+  t.deepEqual(
+    pluginResult.plugin.imageLayers,
+    [
+      "ac415f8e415b242117277e7ee5224b30389698b46101e0f28224490af3b90a9d/layer.tar",
+    ],
+    "Layers are read correctly",
+  );
+});
+
+test("docker-archive image type throws on bad files", async (t) => {
+  t.plan(2);
+
+  const dockerfile = undefined;
+  const pluginOptions = {
+    experimental: true,
+  };
+
+  await t.rejects(
+    async () =>
+      await plugin.inspect(
+        "docker-archive:missing-path",
+        dockerfile,
+        pluginOptions,
+      ),
+    Error("The provided docker archive path does not exist on the filesystem"),
+    "throws when a file does not exists",
+  );
+
+  await t.rejects(
+    async () =>
+      await plugin.inspect("docker-archive:/tmp", dockerfile, pluginOptions),
+    Error("The provided docker archive path is not a file"),
+    "throws when the provided path is a directory",
+  );
+});

--- a/test/system/rpm.test.ts
+++ b/test/system/rpm.test.ts
@@ -1,3 +1,7 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+
 import * as path from "path";
 import { test } from "tap";
 
@@ -35,7 +39,7 @@ test("scanning an rpm-based image produces the expected response", async (t) => 
   t.deepEqual(pluginResult.manifestFiles, [], "Empty manifest files");
   t.same(
     pluginResult.plugin.dockerImageId,
-    "cd2d92bc1c0c25b0e15c00cfaa44320d84af71ab3fe97280d53a7b769cd96c19",
+    "7f335821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538",
     "The image ID matches",
   );
   t.same(
@@ -45,7 +49,7 @@ test("scanning an rpm-based image produces the expected response", async (t) => 
   );
   t.deepEqual(
     pluginResult.plugin.imageLayers,
-    ["8a14b09953616e7e30d647996c12da4228e63fc93c59d04a060db6f5eb0074f4.tar"],
+    ["2943de48ac85f6eaeecbf35ed894375b5001e9001fd908e40d8e577b77e6bfeb.tar"],
     "Layers are read correctly",
   );
 

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -52,6 +52,11 @@ test("static analysis builds the expected response", async (t) => {
     "Has the expected result properties",
   );
 
+  t.same(
+    pluginResultWithSkopeoCopy.package.version,
+    "doesnotexist",
+    "Version matches",
+  );
   t.deepEqual(
     pluginResultWithSkopeoCopy.manifestFiles,
     [],
@@ -253,6 +258,11 @@ test("static analysis works for scratch images", async (t) => {
     { name: "unknown", version: "0.0", prettyName: "" },
     "operating system for scratch image is unknown",
   );
+  t.same(
+    pluginResultWithSkopeoCopy.package.version,
+    "1.31.1",
+    "Version matches",
+  );
 });
 
 test("static analysis for distroless base-debian9", async (t) => {
@@ -310,6 +320,11 @@ test("static analysis for distroless base-debian9", async (t) => {
     pluginResult.package.targetOS,
     { name: "debian", version: "9", prettyName: "Distroless" },
     "recognised it's debian 9",
+  );
+  t.same(
+    pluginResult.package.version,
+    "70b8c7f2d41a844d310c23e0695388c916a364ed",
+    "Version matches",
   );
 });
 
@@ -369,6 +384,11 @@ test("static analysis for distroless base-debian10", async (t) => {
     { name: "debian", version: "10", prettyName: "Distroless" },
     "recognised it's debian 10",
   );
+  t.same(
+    pluginResult.package.version,
+    "70b8c7f2d41a844d310c23e0695388c916a364ed",
+    "Version matches",
+  );
 });
 
 test("experimental static analysis for debian images", async (t) => {
@@ -427,6 +447,7 @@ test("experimental static analysis for debian images", async (t) => {
     1,
     "static experimental flag does not save the image",
   );
+  t.same(pluginResultStatic.package.version, "10", "Version matches");
 });
 
 test("static and dynamic scanning results are aligned", async (t) => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Allows to scan Docker archives as long as:
- the `experimental` flag is used
- the image is present on the filesystem

The image should be provided as `docker-archive:/path/to/archive.tar`.

#### What are the relevant tickets?

[Jira ticket RUN-897](https://snyksec.atlassian.net/browse/RUN-897)
[Jira ticket RUN-877](https://snyksec.atlassian.net/browse/RUN-877)
