### PR TITLE
fix: more precise typing for analyseDockerfile()

### DIFF
--- a/lib/docker-file.ts
+++ b/lib/docker-file.ts
@@ -29,7 +29,7 @@ async function readDockerfileAndAnalyse(
 
 async function analyseDockerfile(
   contents: string,
-): Promise<DockerFileAnalysis | undefined> {
+): Promise<DockerFileAnalysis> {
   const dockerfile = DockerfileParser.parse(contents);
   const baseImage = getDockerfileBaseImageName(dockerfile);
   const dockerfilePackages = getPackagesFromRunInstructions(dockerfile);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

more precise typing for analyseDockerfile()
this function may only return a DockerFileAnalysis type, so there's no need for declaring it to be DockerFileAnalysis | undefined.

#### Any background context you want to provide?

https://snyk.slack.com/archives/CGSNWAE76/p1588257666067100