### PR TITLE
[RUN-660] feat: support dockerfile analysis during static scan

### DIFF
--- a/lib/analyzer/os-release/static.ts
+++ b/lib/analyzer/os-release/static.ts
@@ -1,3 +1,4 @@
+import { DockerFileAnalysis } from "../../docker-file";
 import { ExtractedLayers } from "../../extractor/types";
 import { getOsReleaseStatic as getOsRelease } from "../../inputs/os-release";
 import { OsReleaseFilePath } from "../../types";
@@ -13,6 +14,7 @@ import {
 
 export async function detect(
   extractedLayers: ExtractedLayers,
+  dockerfileAnalysis: DockerFileAnalysis | undefined,
 ): Promise<OSRelease> {
   let osRelease = await tryOSRelease(
     getOsRelease(extractedLayers, OsReleaseFilePath.Linux),
@@ -59,7 +61,13 @@ export async function detect(
   }
 
   if (!osRelease) {
-    osRelease = { name: "unknown", version: "0.0", prettyName: "" };
+    if (dockerfileAnalysis && dockerfileAnalysis.baseImage === "scratch") {
+      // If the docker file was build from a scratch image
+      // then we don't have a known OS
+      osRelease = { name: "scratch", version: "0.0", prettyName: "" };
+    } else {
+      osRelease = { name: "unknown", version: "0.0", prettyName: "" };
+    }
   }
 
   // Oracle Linux identifies itself as "ol"

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -1,4 +1,5 @@
 import * as Debug from "debug";
+import { DockerFileAnalysis } from "../docker-file";
 import { getDockerArchiveLayersAndManifest } from "../extractor";
 import { DockerArchiveManifest } from "../extractor/types";
 import {
@@ -38,6 +39,7 @@ const debug = Debug("snyk");
 
 export async function analyze(
   targetImage: string,
+  dockerfileAnalysis: DockerFileAnalysis | undefined,
   options: StaticAnalysisOptions,
 ): Promise<StaticAnalysis> {
   if (options.imageType !== ImageType.DockerArchive) {
@@ -82,7 +84,10 @@ export async function analyze(
 
   let osRelease: OSRelease;
   try {
-    osRelease = await osReleaseDetector.detectStatically(archiveLayers);
+    osRelease = await osReleaseDetector.detectStatically(
+      archiveLayers,
+      dockerfileAnalysis,
+    );
   } catch (err) {
     debug(err);
     throw new Error("Failed to detect OS release");

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -1,6 +1,7 @@
 // Module that provides functions to collect and build response after all
 // analyses' are done.
 
+import { DockerFileAnalysis } from "./docker-file";
 import { DockerFilePackages, instructionDigest } from "./instruction-parser";
 import * as types from "./types";
 
@@ -9,7 +10,7 @@ export { buildResponse };
 function buildResponse(
   runtime: string | undefined,
   depsAnalysis,
-  dockerfileAnalysis,
+  dockerfileAnalysis: DockerFileAnalysis | undefined,
   manifestFiles: types.ManifestFile[],
   options,
 ): types.PluginResponse {

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -1,5 +1,6 @@
 import * as analyzer from "./analyzer";
 import { buildTree } from "./dependency-tree";
+import { DockerFileAnalysis } from "./docker-file";
 import { tryGetAnalysisError } from "./errors";
 import { parseAnalysisResults } from "./parser";
 import { buildResponse } from "./response-builder";
@@ -11,6 +12,7 @@ import {
 
 export async function analyzeStatically(
   targetImage: string,
+  dockerfileAnalysis: DockerFileAnalysis | undefined,
   options: any,
 ): Promise<PluginResponse> {
   const staticAnalysisOptions = getStaticAnalysisOptions(options);
@@ -20,12 +22,12 @@ export async function analyzeStatically(
   const runtime = undefined;
   // Both the analysis and the manifest files are relevant if inspecting a Dockerfile.
   // This is not the case for static scanning.
-  const dockerfileAnalysis = undefined;
   const manifestFiles = [];
 
   try {
     const staticAnalysis = await analyzer.analyzeStatically(
       targetImage,
+      dockerfileAnalysis,
       staticAnalysisOptions,
     );
 

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -495,3 +495,48 @@ test("static and dynamic scanning results are aligned", async (t) => {
   );
   // TODO: imageLayers is completely different
 });
+
+test("static scanning NGINX with dockerfile analysis matches expected values", async (t) => {
+  const thisIsJustAnImageIdentifierInStaticAnalysis = "nginx:latest";
+  const dockerfilePath = path.join(
+    __dirname,
+    "../fixtures/dockerfiles/library/nginx/Dockerfile",
+  );
+  const pluginOptionsWithDockerSave = {
+    staticAnalysisOptions: {
+      imagePath: getFixture("docker-save/nginx.tar"),
+      imageType: ImageType.DockerArchive,
+    },
+  };
+
+  const pluginResultStatic = await plugin.inspect(
+    thisIsJustAnImageIdentifierInStaticAnalysis,
+    dockerfilePath,
+    pluginOptionsWithDockerSave,
+  );
+
+  const results = pluginResultStatic.scannedProjects[0].depTree.docker;
+
+  t.equals(
+    results.baseImage,
+    "debian:stretch-slim",
+    "base image matches expected",
+  );
+
+  t.ok(
+    "apt-transport-https" in results.dockerfilePackages,
+    "found apt-transport-https in dockerfile packages",
+  );
+  t.ok(
+    "ca-certificates" in results.dockerfilePackages,
+    "found ca-certificates in dockerfile packages",
+  );
+  t.ok(
+    "gettext-base" in results.dockerfilePackages,
+    "found gettext-base in dockerfile packages",
+  );
+  t.ok(
+    "gnupg1" in results.dockerfilePackages,
+    "found gnupg1 in dockerfile packages",
+  );
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds support for Dockerfile analysis when completing a static docker archive scan. This was a feature that was available previously when dynamically scanning the docker image.

The main advantage of this is that we can now retreive the base image used to build the container as long as the user provides us with the Dockerfile that was used to build it.
