### PR TITLE
support retrieving arbitrary files for static scans

### DIFF
--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -1,4 +1,4 @@
-import { ScannedProjectCustom } from "../types";
+import { ManifestFile, ScannedProjectCustom } from "../types";
 
 export interface AnalyzedPackage {
   Name: string;
@@ -64,4 +64,5 @@ export interface StaticAnalysis {
   binaries: string[];
   imageLayers: string[];
   applicationDependenciesScanResults: ScannedProjectCustom[];
+  manifestFiles: ManifestFile[];
 }

--- a/lib/inputs/file-pattern/static.ts
+++ b/lib/inputs/file-pattern/static.ts
@@ -1,0 +1,64 @@
+import * as minimatch from "minimatch";
+import * as path from "path";
+
+import { ExtractAction, ExtractedLayers } from "../../extractor/types";
+import { streamToString } from "../../stream-utils";
+import { ManifestFile } from "../../types";
+
+function generatePathMatcher(
+  globsInclude: string[],
+  globsExclude: string[],
+): (filePath: string) => boolean {
+  return (filePath: string): boolean => {
+    let exclude = false;
+    for (const g of globsExclude) {
+      if (!exclude && minimatch(filePath, g)) {
+        exclude = true;
+      }
+    }
+    if (!exclude) {
+      for (const g of globsInclude) {
+        if (minimatch(filePath, g)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+}
+
+export function generateExtractAction(
+  globsInclude: string[],
+  globsExclude: string[],
+): ExtractAction {
+  return {
+    actionName: "find-files-by-pattern",
+    filePathMatches: generatePathMatcher(globsInclude, globsExclude),
+    callback: streamToString,
+  };
+}
+
+export function getMatchingFiles(
+  extractedLayers: ExtractedLayers,
+): ManifestFile[] {
+  const manifestFiles: ManifestFile[] = [];
+
+  for (const filePath of Object.keys(extractedLayers)) {
+    for (const actionName of Object.keys(extractedLayers[filePath])) {
+      if (actionName !== "find-files-by-pattern") {
+        continue;
+      }
+      if (!(typeof extractedLayers[filePath][actionName] === "string")) {
+        throw new Error("expected string");
+      }
+
+      manifestFiles.push({
+        name: path.basename(filePath),
+        path: path.dirname(filePath),
+        contents: extractedLayers[filePath][actionName] as string,
+      });
+    }
+  }
+
+  return manifestFiles;
+}

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -20,9 +20,6 @@ export async function analyzeStatically(
   // Relevant only if using a Docker runtime. Optional, but we may consider what to put here
   // to present to the user in Snyk UI.
   const runtime = undefined;
-  // Both the analysis and the manifest files are relevant if inspecting a Dockerfile.
-  // This is not the case for static scanning.
-  const manifestFiles = [];
 
   try {
     const staticAnalysis = await analyzer.analyzeStatically(
@@ -59,7 +56,7 @@ export async function analyzeStatically(
         runtime,
         analysis,
         dockerfileAnalysis,
-        manifestFiles,
+        staticAnalysis.manifestFiles,
         staticAnalysisOptions,
       ),
       hashes: [],
@@ -76,6 +73,7 @@ export function isRequestingStaticAnalysis(options?: any): boolean {
   return options && options.staticAnalysisOptions;
 }
 
+// TODO: this function needs to go as soon as the dynamic scanning goes
 function getStaticAnalysisOptions(options: any): StaticAnalysisOptions {
   if (
     !options ||
@@ -90,5 +88,9 @@ function getStaticAnalysisOptions(options: any): StaticAnalysisOptions {
     imagePath: options.staticAnalysisOptions.imagePath,
     imageType: options.staticAnalysisOptions.imageType,
     distroless: options.staticAnalysisOptions.distroless,
+    globsToFind: {
+      include: options.manifestGlobs,
+      exclude: options.manifestExcludeGlobs,
+    },
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,10 @@ export interface StaticAnalysisOptions {
   imagePath: string;
   imageType: ImageType;
   distroless: boolean;
+  globsToFind: {
+    include: string[];
+    exclude: string[];
+  };
 }
 
 export enum ImageType {

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -503,9 +503,9 @@ test("static and dynamic scanning results are aligned", async (t) => {
   );
   t.ok(osDepsStatic !== undefined);
 
-  t.equals(
-    JSON.stringify(osDepsDynamic!.depTree.dependencies),
-    JSON.stringify(osDepsStatic!.depTree.dependencies),
+  t.same(
+    osDepsDynamic!.depTree.dependencies,
+    osDepsStatic!.depTree.dependencies,
     "identical dependencies for regular Debian images between dynamic and static scans",
   );
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

first proposal for collecting arbitrary files (right now called manifestGlobs/manifestGlobsExclude) for the static scan.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-933