### PR TITLE
fix: scan symbolic and hard links in static image scans

### DIFF
--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -12,6 +12,8 @@ import {
   FileNameAndContent,
 } from "./types";
 
+const FILE_TYPES_TO_EXTRACT = ["file", "link", "symlink"];
+
 /**
  * Retrieve the products of files content from the specified docker-archive.
  * @param dockerArchiveFilesystemPath Path to image file saved in docker-archive format.
@@ -65,7 +67,7 @@ export async function extractImageLayer(
     const tarExtractor: Extract = extract();
 
     tarExtractor.on("entry", async (headers, stream, next) => {
-      if (headers.type === "file") {
+      if (headers.type && FILE_TYPES_TO_EXTRACT.includes(headers.type)) {
         const absoluteFileName = resolvePath("/", headers.name);
         // TODO wouldn't it be simpler to first check
         // if the filename matches any patterns?


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

today the static scan only scans files in the layers that are defined as "file", meaning we skip symbolic and hard links.
it's different from the dynamic scan that doesn't check for a file type.
moreover, it means we could miss some files in some circumstances.
this PR changes the static scan behaviour to also include links and symbolic links.

#### Any background context you want to provide?

couldn't figure out why ```/etc/os-release``` isn't processed.
thanks to @shaimendel, discovered it's a symlink.
https://snyk.slack.com/archives/CDSMEJ29E/p1589115058473500