### PR TITLE
Revert "fix: scan symbolic and hard links in static image scans"

### DIFF
--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -12,8 +12,6 @@ import {
   FileNameAndContent,
 } from "./types";
 
-const FILE_TYPES_TO_EXTRACT = ["file", "link", "symlink"];
-
 /**
  * Retrieve the products of files content from the specified docker-archive.
  * @param dockerArchiveFilesystemPath Path to image file saved in docker-archive format.
@@ -67,7 +65,7 @@ export async function extractImageLayer(
     const tarExtractor: Extract = extract();
 
     tarExtractor.on("entry", async (headers, stream, next) => {
-      if (headers.type && FILE_TYPES_TO_EXTRACT.includes(headers.type)) {
+      if (headers.type === "file") {
         const absoluteFileName = resolvePath("/", headers.name);
         // TODO wouldn't it be simpler to first check
         // if the filename matches any patterns?


### PR DESCRIPTION
Reverts snyk/snyk-docker-plugin#202

the links found (at least the symbolic links) have no content generated from their stream, making this change useless/misleading.