### PR TITLE
fix: allow one more type of rpm failures in dynamic scanning

### DIFF
--- a/lib/inputs/rpm/docker.ts
+++ b/lib/inputs/rpm/docker.ts
@@ -18,6 +18,13 @@ export function getRpmDbFileContent(
       if (typeof stderr === "string" && stderr.indexOf("not found") >= 0) {
         return { stdout: "", stderr: "" };
       }
+
+      if (
+        typeof stderr === "string" &&
+        stderr.toLowerCase().indexOf("no such") >= 0
+      ) {
+        return { stdout: "", stderr: "" };
+      }
       // allowing failure if analysing BusyBox
       if (
         typeof stderr === "string" &&

--- a/test/lib/analyzer/rpm-analyzer.test.ts
+++ b/test/lib/analyzer/rpm-analyzer.test.ts
@@ -164,6 +164,10 @@ test("BusyBox's multi-call binary for rpm", async (t) => {
           -qpc	List config files
         `,
     },
+    {
+      targetImage: "notsure:latest",
+      rpmThrows: "FATAL tini (6)] exec rpm failed: No such file or directory\n",
+    },
   ];
 
   for (const example of examples) {


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
allow one more type of rpm failures in dynamic scanning
