### PR TITLE
fix: Manifest files are kept in a Buffer to avoid encoding issues

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -165,8 +165,8 @@ async function getManifestFiles(
       return {
         name: path.basename(g),
         path: path.dirname(g),
-        contents: Buffer.from(contents[i].stdout).toString("base64"),
+        contents: Buffer.from(contents[i].stdout),
       };
     })
-    .filter((i) => i.contents !== "");
+    .filter((i) => i.contents.length > 0);
 }

--- a/lib/inputs/file-pattern/static.ts
+++ b/lib/inputs/file-pattern/static.ts
@@ -2,7 +2,7 @@ import * as minimatch from "minimatch";
 import * as path from "path";
 
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
-import { streamToString } from "../../stream-utils";
+import { streamToBuffer } from "../../stream-utils";
 import { ManifestFile } from "../../types";
 
 function generatePathMatcher(
@@ -34,7 +34,7 @@ export function generateExtractAction(
   return {
     actionName: "find-files-by-pattern",
     filePathMatches: generatePathMatcher(globsInclude, globsExclude),
-    callback: streamToString,
+    callback: streamToBuffer,
   };
 }
 
@@ -48,14 +48,14 @@ export function getMatchingFiles(
       if (actionName !== "find-files-by-pattern") {
         continue;
       }
-      if (!(typeof extractedLayers[filePath][actionName] === "string")) {
-        throw new Error("expected string");
+      if (!Buffer.isBuffer(extractedLayers[filePath][actionName])) {
+        throw new Error("expected a buffer");
       }
 
       manifestFiles.push({
         name: path.basename(filePath),
         path: path.dirname(filePath),
-        contents: extractedLayers[filePath][actionName] as string,
+        contents: extractedLayers[filePath][actionName] as Buffer,
       });
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,7 +28,7 @@ export enum OsReleaseFilePath {
 export interface ManifestFile {
   name: string;
   path: string;
-  contents: string;
+  contents: Buffer;
 }
 
 export interface PluginMetadata {

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -573,10 +573,9 @@ test("static and dynamic scanning results are aligned", async (t) => {
     manifestFilesDynamic.data[1].contents,
     "symbolic links generate the same content",
   );
-  t.same(
-    Buffer.from(manifestFilesStatic.data[0].contents).toString("base64"),
-    manifestFilesDynamic.data[0].contents,
-    "dynamic scanned manifest files are base64 encoded",
+  t.true(
+    Buffer.isBuffer(manifestFilesStatic.data[0].contents),
+    "static scanned manifest files are held in buffer",
   );
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Manifest files read from disk are kept in a Buffer instead of decoding them to a string.

This is to avoid encoding issues. See also: https://snyk.slack.com/archives/CBXS33GJY/p1589820258095800?thread_ts=1589385083.016900&cid=CBXS33GJY

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
