### PR TITLE
feat: event-loop-spinner for fewer blocky blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 package-lock.json
 yarn.lock
 .DS_Store
+test/fixtures/ls-output/xxx.txt

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "build": "tsc",
     "build-watch": "tsc -w",
     "debug": "tsc-watch --project tsconfig.json --onSuccess 'node --inspect --inspect-brk .'",
-    "lint": "prettier --check '**/*.ts' && tslint --format stylish '**/*.ts' --exclude 'node_modules/**'",
-    "format": "prettier --loglevel warn --write '**/*.ts' && tslint --fix --format stylish '**/*.ts' --exclude 'node_modules/**'",
+    "lint": "prettier --check '{lib,test}/**/*.ts' && tslint --format stylish '{lib,test}/**/*.ts'",
+    "format": "prettier --loglevel warn --write '{lib,test}/**/*.ts' && tslint --fix --format stylish '{lib,test}/**/*.ts'",
     "test": "npm run lint && npm run unit-test",
     "unit-test": "tap test/system test/lib -R=spec --timeout=300",
     "prepare": "npm run build"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",
     "dockerfile-ast": "0.0.19",
-    "event-loop-spinner": "^1.1.0",
+    "event-loop-spinner": "^2.0.0",
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^6.1.0",


### PR DESCRIPTION
#### What does this PR do?

`event-loop-spinner@2` brings better sharing, which should reduce overall blocking for everyone, especially across library. It requires node 8, and so should we.