### PR TITLE
[RUN-987] fix: add origin to apk packages

### DIFF
--- a/lib/analyzer/package-managers/apk.ts
+++ b/lib/analyzer/package-managers/apk.ts
@@ -58,6 +58,9 @@ function parseLine(
         }
       }
       break;
+    case "o": // Origin
+      curPkg.Source = value;
+      break;
   }
   return curPkg;
 }

--- a/test/fixtures/os/alpine_2_6_6/analyzer-expect.json
+++ b/test/fixtures/os/alpine_2_6_6/analyzer-expect.json
@@ -18,7 +18,7 @@
         {
           "Name": "libc",
           "Version": "0.9.33.2-r22",
-          "Source": null,
+          "Source": "libc0.9.32",
           "Provides": [
             "so:ld64-uClibc.so.0.9.32",
             "so:libc.so.0.9.32",
@@ -37,7 +37,7 @@
         {
           "Name": "busybox",
           "Version": "1.21.1-r2",
-          "Source": null,
+          "Source": "busybox",
           "Provides": [],
           "Deps": {
             "so:libc.so.0.9.32": true,
@@ -49,7 +49,7 @@
         {
           "Name": "alpine-baselayout",
           "Version": "2.2.0-r6",
-          "Source": null,
+          "Source": "alpine-baselayout",
           "Provides": [],
           "Deps": {
             "busybox": true,
@@ -60,7 +60,7 @@
         {
           "Name": "openrc",
           "Version": "0.11.8-r0",
-          "Source": null,
+          "Source": "openrc",
           "Provides": [
             "so:libeinfo.so.1",
             "so:librc.so.1"
@@ -76,7 +76,7 @@
         {
           "Name": "alpine-conf",
           "Version": "2.12.0-r6",
-          "Source": null,
+          "Source": "alpine-conf",
           "Provides": [],
           "Deps": {
             "openrc": true,
@@ -87,7 +87,7 @@
         {
           "Name": "zlib",
           "Version": "1.2.8-r0",
-          "Source": null,
+          "Source": "zlib",
           "Provides": [
             "so:libz.so.1"
           ],
@@ -99,7 +99,7 @@
         {
           "Name": "libcrypto1.0",
           "Version": "1.0.1m-r0",
-          "Source": null,
+          "Source": "openssl",
           "Provides": [
             "so:libcrypto.so.1.0.0"
           ],
@@ -115,7 +115,7 @@
         {
           "Name": "apk-tools",
           "Version": "2.4.0-r1",
-          "Source": null,
+          "Source": "apk-tools",
           "Provides": [],
           "Deps": {
             "so:libc.so.0.9.32": true,
@@ -127,7 +127,7 @@
         {
           "Name": "busybox-initscripts",
           "Version": "2.2-r15",
-          "Source": null,
+          "Source": "busybox-initscripts",
           "Provides": [],
           "Deps": {
             "busybox": true,
@@ -138,7 +138,7 @@
         {
           "Name": "uclibc-utils",
           "Version": "0.9.33.2-r22",
-          "Source": null,
+          "Source": "libc0.9.32",
           "Provides": [],
           "Deps": {
             "busybox": true,
@@ -151,7 +151,7 @@
         {
           "Name": "libc-utils",
           "Version": "0.1-r0",
-          "Source": null,
+          "Source": "libc",
           "Provides": [],
           "Deps": {
             "uclibc-utils": true
@@ -161,7 +161,7 @@
         {
           "Name": "alpine-keys",
           "Version": "1.0-r0",
-          "Source": null,
+          "Source": "alpine-keys",
           "Provides": [],
           "Deps": {
             "alpine-base": true
@@ -171,7 +171,7 @@
         {
           "Name": "alpine-base",
           "Version": "2.6.6-r0",
-          "Source": null,
+          "Source": "alpine-base",
           "Provides": [],
           "Deps": {
             "alpine-baselayout": true,

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -403,17 +403,147 @@ test("inspect redis:3.2.11-alpine", (t) => {
       t.match(
         deps,
         {
-          busybox: {
-            name: "busybox",
+          "busybox/busybox": {
+            name: "busybox/busybox",
             version: "1.27.2-r7",
+            dependencies: {
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+            },
           },
-          "libressl2.6-libcrypto": {
-            name: "libressl2.6-libcrypto",
+          "alpine-baselayout/alpine-baselayout": {
+            name: "alpine-baselayout/alpine-baselayout",
+            version: "3.0.5-r2",
+            dependencies: {
+              "busybox/busybox": {
+                name: "busybox/busybox",
+                version: "1.27.2-r7",
+              },
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+            },
+          },
+          "alpine-keys/alpine-keys": {
+            name: "alpine-keys/alpine-keys",
+            version: "2.1-r1",
+          },
+          "libressl/libressl2.6-libcrypto": {
+            name: "libressl/libressl2.6-libcrypto",
             version: "2.6.3-r0",
+            dependencies: {
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+            },
           },
-          zlib: {
-            name: "zlib",
+          "libressl/libressl2.6-libssl": {
+            name: "libressl/libressl2.6-libssl",
+            version: "2.6.3-r0",
+            dependencies: {
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+              "libressl/libressl2.6-libcrypto": {
+                name: "libressl/libressl2.6-libcrypto",
+                version: "2.6.3-r0",
+              },
+            },
+          },
+          "zlib/zlib": {
+            name: "zlib/zlib",
             version: "1.2.11-r1",
+            dependencies: {
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+            },
+          },
+          "apk-tools/apk-tools": {
+            name: "apk-tools/apk-tools",
+            version: "2.8.2-r0",
+            dependencies: {
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+              "libressl/libressl2.6-libcrypto": {
+                name: "libressl/libressl2.6-libcrypto",
+                version: "2.6.3-r0",
+              },
+              "libressl/libressl2.6-libssl": {
+                name: "libressl/libressl2.6-libssl",
+                version: "2.6.3-r0",
+              },
+              "zlib/zlib": {
+                name: "zlib/zlib",
+                version: "1.2.11-r1",
+              },
+            },
+          },
+          "pax-utils/scanelf": {
+            name: "pax-utils/scanelf",
+            version: "1.2.2-r1",
+            dependencies: {
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+            },
+          },
+          "libc-dev/libc-utils": {
+            name: "libc-dev/libc-utils",
+            version: "0.7.1-r0",
+            dependencies: {
+              "musl/musl-utils": {
+                name: "musl/musl-utils",
+                version: "1.1.18-r3",
+                dependencies: {
+                  "pax-utils/scanelf": {
+                    name: "pax-utils/scanelf",
+                    version: "1.2.2-r1",
+                  },
+                  "musl/musl": {
+                    name: "musl/musl",
+                    version: "1.1.18-r3",
+                  },
+                },
+              },
+            },
+          },
+          "su-exec/su-exec": {
+            name: "su-exec/su-exec",
+            version: "0.2-r0",
+            dependencies: {
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+            },
+          },
+          "musl/musl": {
+            name: "musl/musl",
+            version: "1.1.18-r3",
+          },
+          "musl/musl-utils": {
+            name: "musl/musl-utils",
+            version: "1.1.18-r3",
+          },
+          ".redis-rundeps": {
+            name: ".redis-rundeps",
+            version: "0",
+            dependencies: {
+              "musl/musl": {
+                name: "musl/musl",
+                version: "1.1.18-r3",
+              },
+            },
           },
         },
         "deps",


### PR DESCRIPTION
we do it in order to better query vulns for alpine packages

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
we used to ignore package origins in apk, this fixes this


https://snyksec.atlassian.net/browse/RUN-987
