### PR TITLE
[RUN-994] feat: pull images directly from docker registry API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Snyk helps you find, fix and monitor for known vulnerabilities in your dependenc
 ## Snyk Docker CLI Plugin
 
 This plugin provides dependency metadata for Docker images. 
+
+## Running Tests
+
+To run tests the following environment variables need to be set:
+
+`DOCKER_HUB_PRIVATE_IMAGE`
+`DOCKER_HUB_USERNAME`
+`DOCKER_HUB_PASSWORD`
+
+`DOCKER_HUB_PRIVATE_IMAGE` should refer to an image that is hosted on Docker Hub but not available publicly. During CI test this is set to `snykgoof/dockergoof:alpine`.

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -1,7 +1,12 @@
+import * as Debug from "debug";
+import * as path from "path";
+import * as tmp from "tmp";
 import { Docker, DockerOptions } from "../docker";
-import { DockerInspectOutput } from "./types";
+import { ArchiveResult, DockerInspectOutput, ImageDetails } from "./types";
 
-export { detect, pullIfNotLocal };
+export { detect, getImageArchive, extractImageDetails, pullIfNotLocal };
+
+const debug = Debug("snyk");
 
 async function detect(
   targetImage: string,
@@ -12,6 +17,124 @@ async function detect(
   return JSON.parse(info.stdout)[0];
 }
 
+/**
+ * In the case that an `ImageType.Identifier` is detected we need to produce
+ * an image archive, either by saving the image if it's already loaded into
+ * the local docker daemon, or by pulling the image from a remote registry and
+ * saving it to the filesystem directly.
+ *
+ * Users may also provide us with a URL to an image in a Docker compatible
+ * remote registry.
+ *
+ * @param {string} targetImage - The image to test, this could be in one of
+ *    the following forms:
+ *      * [registry/]<repo>/<image>[:tag]
+ *      * <repo>/<image>[:tag]
+ *      * <image>[:tag]
+ *    In the case that a registry is not provided, the plugin will default
+ *    this to Docker Hub. If a tag is not provided this will default to
+ *    `latest`.
+ * @param {string} [username] - Optional username for private repo auth.
+ * @param {string} [password] - Optional password for private repo auth.
+ */
+async function getImageArchive(
+  targetImage: string,
+  username?: string,
+  password?: string,
+): Promise<ArchiveResult> {
+  const docker = new Docker(targetImage);
+  const destination = tmp.dirSync({ unsafeCleanup: true });
+  const saveLocation: string = path.join(destination.name, "image.tar");
+
+  try {
+    // TODO: Eventually need to provide support for specifying a user-defined
+    // temporary directory.
+    await docker.save(targetImage, saveLocation);
+    return {
+      path: saveLocation,
+      removeArchive: destination.removeCallback,
+    };
+  } catch {
+    debug(
+      `${targetImage} does not exist locally, proceeding to pull image from remote registry.`,
+    );
+  }
+
+  if (await Docker.binaryExists()) {
+    try {
+      if (username || password) {
+        debug(
+          "using local docker binary credentials. the credentials you provided will be ignored",
+        );
+      }
+
+      await docker.pullCli(targetImage);
+      await docker.save(targetImage, saveLocation);
+      return {
+        path: saveLocation,
+        removeArchive: destination.removeCallback,
+      };
+    } catch (err) {
+      debug(`couldn't pull ${targetImage} using docker binary: ${err}`);
+    }
+  }
+
+  destination.removeCallback();
+  const { hostname, imageName, tag } = await extractImageDetails(targetImage);
+
+  debug(
+    `Attempting to pull: registry: ${hostname}, image: ${imageName}, tag: ${tag}`,
+  );
+  const pullResult = await docker.pull(
+    hostname,
+    imageName,
+    tag,
+    username,
+    password,
+  );
+  return {
+    path: path.join(pullResult.stagingDir!.name, "image.tar"),
+    removeArchive: pullResult.stagingDir!.removeCallback,
+  };
+}
+
+async function extractImageDetails(targetImage: string): Promise<ImageDetails> {
+  let remainder: string;
+  let hostname: string;
+  let imageName: string;
+  let tag: string;
+
+  // We need to detect if the `targetImage` is part of a URL. Based on the Docker specification,
+  // the hostname should contain a `.` or `:` before the first instance of a `/` otherwise the
+  // default hostname will be used (registry-1.docker.io). ref: https://stackoverflow.com/a/37867949
+  const i = targetImage.indexOf("/");
+  if (
+    i === -1 ||
+    (!targetImage.substring(0, i).includes(".") &&
+      !targetImage.substring(0, i).includes(":") &&
+      targetImage.substring(0, i) !== "localhost")
+  ) {
+    hostname = "registry-1.docker.io";
+    remainder = targetImage;
+    [imageName, tag] = remainder.split(":");
+    imageName =
+      imageName.indexOf("/") === -1 ? "library/" + imageName : imageName;
+  } else {
+    hostname = targetImage.substring(0, i);
+    remainder = targetImage.substring(i + 1);
+    [imageName, tag] = remainder.split(":");
+  }
+
+  // Assume the latest tag if no tag was found.
+  tag = tag || "latest";
+
+  return {
+    hostname,
+    imageName,
+    tag,
+  };
+}
+
 async function pullIfNotLocal(targetImage: string, options?: DockerOptions) {
   const docker = new Docker(targetImage);
   try {
@@ -20,5 +143,5 @@ async function pullIfNotLocal(targetImage: string, options?: DockerOptions) {
   } catch (err) {
     // image doesn't exist locally
   }
-  await docker.pull(targetImage);
+  await docker.pullCli(targetImage);
 }

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -66,3 +66,14 @@ export interface StaticAnalysis {
   applicationDependenciesScanResults: ScannedProjectCustom[];
   manifestFiles: ManifestFile[];
 }
+
+export interface ArchiveResult {
+  path: string;
+  removeArchive(): void;
+}
+
+export interface ImageDetails {
+  hostname: string;
+  imageName: string;
+  tag: string;
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@snyk/rpm-parser": "^2.0.0",
-    "@snyk/snyk-docker-pull": "^3.1.0",
+    "@snyk/snyk-docker-pull": "^3.1.3",
     "@types/tmp": "^0.2.0",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,17 @@
   },
   "dependencies": {
     "@snyk/rpm-parser": "^2.0.0",
+    "@snyk/snyk-docker-pull": "^3.1.0",
+    "@types/tmp": "^0.2.0",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",
     "dockerfile-ast": "0.0.19",
     "event-loop-spinner": "^1.1.0",
+    "gunzip-maybe": "^1.4.2",
     "semver": "^6.1.0",
     "snyk-nodejs-lockfile-parser": "1.22.0",
     "tar-stream": "^2.1.0",
-    "gunzip-maybe": "^1.4.2",
+    "tmp": "^0.2.1",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@snyk/rpm-parser": "^2.0.0",
     "@snyk/snyk-docker-pull": "^3.1.3",
-    "@types/tmp": "^0.2.0",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",
     "dockerfile-ast": "0.0.19",
@@ -39,6 +38,7 @@
     "@types/node": "^8.10.48",
     "@types/sinon": "5.0.5",
     "@types/tar-stream": "^1.6.1",
+    "@types/tmp": "^0.2.0",
     "prettier": "^1.19.1",
     "sinon": "^6",
     "tap": "^14.10.6",

--- a/test/lib/analyzer/image-inspector.test.ts
+++ b/test/lib/analyzer/image-inspector.test.ts
@@ -1,10 +1,14 @@
 // tslint:disable:max-line-length
 // tslint:disable:object-literal-key-quotes
 
+import * as fs from "fs";
+import * as path from "path";
 import * as sinon from "sinon";
 import { test } from "tap";
 
 import * as imageInspector from "../../../lib/analyzer/image-inspector";
+import { ArchiveResult } from "../../../lib/analyzer/types";
+import { Docker } from "../../../lib/docker";
 import * as subProcess from "../../../lib/sub-process";
 
 test("image id", async (t) => {
@@ -35,4 +39,163 @@ test("image id", async (t) => {
   const imageData = await imageInspector.detect("alpine:2.6");
   t.same(imageData.Id, expectedId, "id as expected");
   t.same(imageData.RootFS.Layers, expectedLayers, "layers as expected");
+});
+
+test("extract image details", async (t) => {
+  const tests = {
+    "hello-world": {
+      expected: {
+        hostname: "registry-1.docker.io",
+        imageName: "library/hello-world",
+        tag: "latest",
+      },
+    },
+    "gcr.io/kubernetes/someImage:alpine": {
+      expected: {
+        hostname: "gcr.io",
+        imageName: "kubernetes/someImage",
+        tag: "alpine",
+      },
+    },
+    "nginx:1.18": {
+      expected: {
+        hostname: "registry-1.docker.io",
+        imageName: "library/nginx",
+        tag: "1.18",
+      },
+    },
+    "calico/cni:release-v3.14": {
+      expected: {
+        hostname: "registry-1.docker.io",
+        imageName: "calico/cni",
+        tag: "release-v3.14",
+      },
+    },
+    "gcr.io:3000/kubernetes/someImage:alpine": {
+      expected: {
+        hostname: "gcr.io:3000",
+        imageName: "kubernetes/someImage",
+        tag: "alpine",
+      },
+      "localhost/alpine": {
+        expected: {
+          hostname: "localhost",
+          imageName: "alpine",
+          tag: "latest",
+        },
+      },
+      "localhost:1337/kubernetes/someImage:alpine": {
+        expected: {
+          hostname: "localhost:1337",
+          imageName: "kubernetes/someImage",
+          tag: "alpine",
+        },
+      },
+    },
+  };
+
+  for (const image of Object.keys(tests)) {
+    const testCase = tests[image];
+    const {
+      hostname,
+      imageName,
+      tag,
+    } = await imageInspector.extractImageDetails(image);
+    t.equal(hostname, testCase.expected.hostname);
+    t.equal(imageName, testCase.expected.imageName);
+    t.equal(tag, testCase.expected.tag);
+  }
+});
+
+test("get image as an archive", async (t) => {
+  const targetImage = "library/hello-world:latest";
+
+  t.test("from the local daemon if it exists", async (t) => {
+    const dockerPullSpy = sinon.spy(Docker.prototype, "pull");
+
+    const loadImage = path.join(
+      __dirname,
+      "../../fixtures/docker-archives",
+      "docker-save/hello-world.tar",
+    );
+    await subProcess.execute("docker", ["load", "--input", loadImage]);
+    const archiveLocation = await imageInspector.getImageArchive(targetImage);
+
+    t.teardown(async () => {
+      dockerPullSpy.restore();
+      archiveLocation.removeArchive();
+      await subProcess.execute("docker", ["image", "rm", targetImage]);
+    });
+
+    t.true(fs.existsSync(archiveLocation.path), "file exists on disk");
+    t.false(dockerPullSpy.called, "image was not pulled from remote registry");
+  });
+
+  t.test("from remote registry with binary", async (t) => {
+    const dockerPullSpy = sinon.spy(Docker.prototype, "pull");
+
+    const archiveLocation: ArchiveResult = await imageInspector.getImageArchive(
+      targetImage,
+    );
+    t.teardown(async () => {
+      dockerPullSpy.restore();
+      archiveLocation.removeArchive();
+      await subProcess.execute("docker", ["image", "rm", targetImage]);
+    });
+
+    t.true(
+      dockerPullSpy.notCalled,
+      "image pulled from remote registry with binary",
+    );
+    t.true(fs.existsSync(archiveLocation.path), "image exists on disks");
+  });
+
+  t.test("from remote registry without binary", async (t) => {
+    const dockerPullSpy = sinon.spy(Docker.prototype, "pull");
+    const subprocessStub = sinon.stub(subProcess, "execute");
+    subprocessStub.throws();
+
+    const archiveLocation = await imageInspector.getImageArchive(targetImage);
+    t.teardown(() => {
+      dockerPullSpy.restore();
+      subprocessStub.restore();
+      archiveLocation.removeArchive();
+    });
+
+    t.true(
+      dockerPullSpy.called,
+      "image pulled from remote registry without binary",
+    );
+    t.true(fs.existsSync(archiveLocation.path), "image exists on disks");
+  });
+
+  t.test("from remote registry with authentication", async (t) => {
+    const dockerPullSpy: sinon.SinonSpy = sinon.spy(Docker.prototype, "pull");
+    const subprocessStub = sinon.stub(subProcess, "execute");
+    subprocessStub.throws();
+    const targetImage = process.env.DOCKER_HUB_PRIVATE_IMAGE;
+    if (targetImage === undefined) {
+      throw new Error(
+        "DOCKER_HUB_PRIVATE_IMAGE environment variable is not defined",
+      );
+    }
+
+    const username = process.env.DOCKER_HUB_USERNAME;
+    const password = process.env.DOCKER_HUB_PASSWORD;
+
+    const archiveLocation = await imageInspector.getImageArchive(
+      targetImage!,
+      username,
+      password,
+    );
+
+    t.teardown(() => {
+      dockerPullSpy.restore();
+      subprocessStub.restore();
+      archiveLocation.removeArchive();
+    });
+
+    t.true(dockerPullSpy.calledOnce, "image pulled from remote registry");
+    t.true(fs.existsSync(archiveLocation.path), "image exists on disks");
+  });
 });

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -426,7 +426,7 @@ test("experimental static analysis for debian images", async (t) => {
 
   t.equal(
     dockerSaveStub.callCount,
-    1,
+    2, // once before the pull and once after
     "non-static experimental flag saves the image",
   );
 
@@ -460,7 +460,7 @@ test("experimental static analysis for debian images", async (t) => {
 
   t.equal(
     dockerSaveStub.callCount,
-    1,
+    2,
     "static experimental flag does not save the image",
   );
   t.same(


### PR DESCRIPTION
## Do not merge - need to make some dependencies public before

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

We want to remove the inherent reliance on the docker daemon when pulling container images from remote Docker v2 compliant repositories. This PR utilises the `snyk-docker-pull` lib to pull and save images to the local file system for scanning via the static scanning flow.

#### What are the relevant tickets?

[RUN-994](https://snyksec.atlassian.net/browse/RUN-994)
