### PR TITLE
test: add tests to assert transitive deps are not found with RPM

### DIFF
--- a/test/fixtures/dockerfiles/bug/Dockerfile
+++ b/test/fixtures/dockerfiles/bug/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:centos7
+
+RUN \
+  curl -fsSL https://rpm.nodesource.com/setup_10.x | bash - \
+  && curl -fsSLo /etc/yum.repos.d/yarn.repo https://dl.yarnpkg.com/rpm/yarn.repo \
+  && yum clean all
+
+ENV \
+  NODE_VER=10.15.3-1nodesource \
+  npm_config_unsafe_perm=true
+
+RUN \
+  yum install -y "nodejs-${NODE_VER}" yarn make gcc-c++ \
+  && yum clean all
+
+CMD [ "node" ]


### PR DESCRIPTION
Shows that there is a bug/limitation in the way we produce the dependencies for RPM projects.
Currently the dependencies are a flat list rather than a dependency tree or graph.

This means that transitive dependencies introduced by installing a package are not linked back to the Dockerfile instruction that introduced them.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What are the relevant tickets?

[Jira ticket RUN-1009](https://snyksec.atlassian.net/browse/RUN-1009)
