### PR TITLE
fix: Adding a flag to activate application scans

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -144,10 +144,12 @@ export async function analyze(
   const binaries = getBinariesHashes(extractedLayers);
 
   const applicationDependenciesScanResults: ScannedProjectCustom[] = [];
-  const nodeDependenciesScanResults = await nodeFilesToScannedProjects(
-    getNodeAppFileContent(extractedLayers),
-  );
-  applicationDependenciesScanResults.push(...nodeDependenciesScanResults);
+  if (options.appScan) {
+    const nodeDependenciesScanResults = await nodeFilesToScannedProjects(
+      getNodeAppFileContent(extractedLayers),
+    );
+    applicationDependenciesScanResults.push(...nodeDependenciesScanResults);
+  }
   return {
     imageId,
     osRelease,

--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -19,7 +19,7 @@ export async function experimentalAnalysis(
   switch (imageType) {
     case ImageType.DockerArchive:
     case ImageType.OciArchive:
-      return localArchive(targetImage, imageType, dockerfileAnalysis);
+      return localArchive(targetImage, imageType, dockerfileAnalysis, options);
     case ImageType.Identifier:
       return distroless(targetImage, dockerfileAnalysis, options);
 
@@ -32,6 +32,7 @@ async function localArchive(
   targetImage: string,
   imageType: ImageType,
   dockerfileAnalysis: DockerFileAnalysis | undefined,
+  options: any,
 ): Promise<PluginResponse> {
   const archivePath = getArchivePath(targetImage);
   if (!fs.existsSync(archivePath)) {
@@ -49,6 +50,7 @@ async function localArchive(
     archivePath,
     dockerfileAnalysis,
     imageType,
+    options["app-vulns"],
   );
 }
 
@@ -85,6 +87,7 @@ export async function distroless(
       archiveFullPath,
       dockerfileAnalysis,
       ImageType.DockerArchive,
+      options["app-vulns"],
     );
   } finally {
     fs.unlinkSync(archiveFullPath);
@@ -96,12 +99,14 @@ async function getStaticAnalysisResult(
   archivePath: string,
   dockerfileAnalysis: DockerFileAnalysis | undefined,
   imageType: ImageType,
+  appScan: boolean,
 ): Promise<PluginResponse> {
   const scanningOptions = {
     staticAnalysisOptions: {
       imagePath: archivePath,
       imageType,
       distroless: true,
+      appScan,
     },
   };
 

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -88,6 +88,7 @@ function getStaticAnalysisOptions(options: any): StaticAnalysisOptions {
     imagePath: options.staticAnalysisOptions.imagePath,
     imageType: options.staticAnalysisOptions.imageType,
     distroless: options.staticAnalysisOptions.distroless,
+    appScan: options.staticAnalysisOptions.appScan,
     globsToFind: {
       include: options.manifestGlobs,
       exclude: options.manifestExcludeGlobs,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export interface StaticAnalysisOptions {
   imagePath: string;
   imageType: ImageType;
   distroless: boolean;
+  appScan: boolean;
   globsToFind: {
     include: string[];
     exclude: string[];

--- a/test/system/application-scans.test.ts
+++ b/test/system/application-scans.test.ts
@@ -15,6 +15,7 @@ test("scanning a container image with 2 applications", async (t) => {
   const staticAnalysisOptions = {
     imagePath: getFixture("docker-archives/skopeo-copy/rpm-npm-yarn.tar"),
     imageType: ImageType.DockerArchive,
+    appScan: true,
   };
 
   const pluginResult = await plugin.inspect(imageNameAndTag, dockerfile, {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adding a flag to the docker plugin to activate parser based application scanning.

#### How should this be manually tested?
Add a flag next to the experimental flag to the CLI

#### Any background context you want to provide?
See also this slack update: https://snyk.slack.com/archives/CLB5WDQRF/p1592497289002300
I open this at first as a draft PR since product needs to still decide about the actual name for the flag.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/DC-820
