### PR TITLE
feat: allow to choose the image save path for downloaded image

### DIFF
--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -77,3 +77,8 @@ export interface ImageDetails {
   imageName: string;
   tag: string;
 }
+
+export interface DestinationDir {
+  name: string;
+  removeCallback: () => void;
+}

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -119,6 +119,7 @@ class Docker {
     registry: string,
     repo: string,
     tag: string,
+    imageSavePath: string,
     username?: string,
     password?: string,
   ): Promise<DockerPullResult> {
@@ -127,6 +128,7 @@ class Docker {
       username,
       password,
       loadImage: false,
+      imageSavePath,
     };
     return await dockerPull.pull(registry, repo, tag, opt);
   }

--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -1,5 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as tmp from "tmp";
+import { v4 as uuidv4 } from "uuid";
 
 import { getImageArchive } from "./analyzer/image-inspector";
 import { DockerFileAnalysis } from "./docker-file";
@@ -67,8 +69,10 @@ export async function distroless(
     );
   }
 
+  const imageSavePath = fullImageSavePath(options?.imageSavePath);
   const archiveResult = await getImageArchive(
     targetImage,
+    imageSavePath,
     options?.username,
     options?.password,
   );
@@ -106,4 +110,13 @@ async function getStaticAnalysisResult(
     dockerfileAnalysis,
     scanningOptions,
   );
+}
+
+export function fullImageSavePath(imageSavePath: string | undefined): string {
+  let imagePath = tmp.dirSync().name;
+  if (imageSavePath) {
+    imagePath = imageSavePath;
+  }
+
+  return path.join(imagePath, uuidv4());
 }

--- a/package.json
+++ b/package.json
@@ -25,17 +25,19 @@
   },
   "dependencies": {
     "@snyk/rpm-parser": "^2.0.0",
-    "@snyk/snyk-docker-pull": "^3.1.3",
+    "@snyk/snyk-docker-pull": "^3.2.0",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",
     "dockerfile-ast": "0.0.19",
     "event-loop-spinner": "^1.1.0",
     "gunzip-maybe": "^1.4.2",
+    "mkdirp": "^1.0.4",
     "semver": "^6.1.0",
     "snyk-nodejs-lockfile-parser": "1.22.0",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",
-    "tslib": "^1"
+    "tslib": "^1",
+    "uuid": "^8.2.0"
   },
   "devDependencies": {
     "@types/node": "^8.10.48",

--- a/test/lib/experimental.test.ts
+++ b/test/lib/experimental.test.ts
@@ -1,0 +1,34 @@
+import { test } from "tap";
+
+import { fullImageSavePath } from "../../lib/experimental";
+
+test("generate image save path", (c) => {
+  c.test("when there is no custom image save path", (t) => {
+    const imageSavePath = undefined;
+
+    const generatedImagePath = fullImageSavePath(imageSavePath);
+
+    t.ok(
+      generatedImagePath.match(
+        /.*[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/g,
+      ),
+      "path created using system tmp folder",
+    );
+    t.done();
+  });
+
+  c.test("when there is custom image save path", (t) => {
+    const imageSavePath = "./custom/image/path";
+
+    const generatedImagePath = fullImageSavePath(imageSavePath);
+
+    t.ok(
+      generatedImagePath.match(
+        /custom\/image\/path\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/g,
+      ),
+      "path created using custom folder",
+    );
+    t.done();
+  });
+  c.done();
+});

--- a/test/system/experimental.test.ts
+++ b/test/system/experimental.test.ts
@@ -82,3 +82,54 @@ test("docker-archive image type throws on bad files", async (t) => {
     "throws when the provided path is a directory",
   );
 });
+
+test("static scan for Identifier type image (nginx:1.19.0)", async (t) => {
+  const imageNameAndTag = `nginx:1.19.0`;
+  const dockerfile = undefined;
+  const pluginOptions = {
+    experimental: true,
+  };
+
+  const pluginResult = await plugin.inspect(
+    imageNameAndTag,
+    dockerfile,
+    pluginOptions,
+  );
+
+  t.same(
+    pluginResult.scannedProjects[0].depTree.name,
+    "docker-image|nginx",
+    "Image name matches",
+  );
+  t.same(
+    pluginResult.scannedProjects[0].depTree.version,
+    "1.19.0",
+    "Version must not be empty",
+  );
+  t.same(
+    pluginResult.plugin.dockerImageId,
+    "2622e6cca7ebbb6e310743abce3fc47335393e79171b9d76ba9d4f446ce7b163",
+    "The image ID matches",
+  );
+  t.same(
+    pluginResult.plugin.packageManager,
+    "deb",
+    "Correct package manager detected",
+  );
+  t.ok(
+    pluginResult.scannedProjects[0].depTree.dependencies &&
+      "nginx" in pluginResult.scannedProjects[0].depTree.dependencies,
+    "Contains some expected dependency",
+  );
+  t.deepEqual(
+    pluginResult.plugin.imageLayers,
+    [
+      "29a4ff5c2250ab72c60545ba67bd67d87daa05e4abd186e7d488d921287c893b/layer.tar",
+      "bd0f0d2dba229cb9005123b54a646fe612882343c06b68c4722f221fdc597d82/layer.tar",
+      "5a88377adcb6f00f0388d45a929fe1159916d7c9e733db78d6defb3fcd325a68/layer.tar",
+      "94f68a38cdeff495ef63de6533b7d7486312ff7bc184120a620ad738536f548d/layer.tar",
+      "44fc3f4af0d0f3587192b742d77b7c1c85cfd230bfb5474f6e1619da7962e3e3/layer.tar",
+    ],
+    "Layers are read correctly",
+  );
+});


### PR DESCRIPTION
 Currently the plugin saves the downloaded image in a tmp folder. Now we allow the user to a custom location on disk with the best storage characteristics to download an image from a registry.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
 Includes the option `imageSavePath` that if is set indicate the path where the downloaded image should be save.

#### Where should the reviewer start?
You should follow the flow when the flag `--experimental` is set.

#### How should this be manually tested?
You can create a manual test and pass in the options `imageSavePath` with where you'd like to save the image. Be aware that it's a temporary file and the image will be removed once it finishes.

#### Any background context you want to provide?
 It's good to notice when the image doesn't exist in local and there is no docker binary, it will pull the via `snyk-docker-pull`. It was changed to do the same.

#### What are the relevant tickets?
- [RUN-582](https://snyksec.atlassian.net/browse/RUN-582)
- [RUN-654](https://snyksec.atlassian.net/browse/RUN-654)
