### PR TITLE
chore: fix the node image version for semantic release works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
           name: Build
           command: npm run build
   release:
-    <<: *defaults
+    <<: *release_defaults
     steps:
       - checkout
       - run:


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
 Change the node image for release step to 10. It will allow the semantic release works.
