### PR TITLE
Feat/add base image detection

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -90,6 +90,7 @@ export async function analyze(
     imageId,
     manifestLayers,
     extractedLayers,
+    rootFsLayers,
   } = await archiveExtractor.getArchiveLayersAndManifest(
     options.imageType,
     options.imagePath,
@@ -156,6 +157,7 @@ export async function analyze(
     results,
     binaries,
     imageLayers: manifestLayers,
+    rootFsLayers,
     applicationDependenciesScanResults,
     manifestFiles,
   };

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -63,6 +63,7 @@ export interface StaticAnalysis {
   results: ImageAnalysis[];
   binaries: string[];
   imageLayers: string[];
+  rootFsLayers?: string[];
   applicationDependenciesScanResults: ScannedProjectCustom[];
   manifestFiles: ManifestFile[];
 }

--- a/lib/extractor/docker-archive/index.ts
+++ b/lib/extractor/docker-archive/index.ts
@@ -1,6 +1,6 @@
 import { normalize as normalizePath } from "path";
-import { DockerArchiveManifest } from "../types";
 
+import { DockerArchiveImageConfig, DockerArchiveManifest } from "../types";
 export { extractArchive } from "./layer";
 
 export function getManifestLayers(manifest: DockerArchiveManifest) {
@@ -14,5 +14,15 @@ export function getImageIdFromManifest(
     return manifest.Config.split(".")[0];
   } catch (err) {
     throw new Error("Failed to extract image ID from archive manifest");
+  }
+}
+
+export function getRootFsLayersFromConfig(
+  imageConfig: DockerArchiveImageConfig,
+): string[] {
+  try {
+    return imageConfig.rootfs.diff_ids;
+  } catch (err) {
+    throw new Error("Failed to extract rootfs array from image config");
   }
 }

--- a/lib/extractor/docker-archive/layer.ts
+++ b/lib/extractor/docker-archive/layer.ts
@@ -44,7 +44,10 @@ export async function extractArchive(
             reject(new Error("Error reading tar archive"));
           }
         } else if (isManifestFile(normalizedName)) {
-          manifest = await getManifestFile(stream);
+          const manifestArray = await getManifestFile<DockerArchiveManifest[]>(
+            stream,
+          );
+          manifest = manifestArray[0];
         }
       }
 
@@ -99,10 +102,8 @@ function getLayersContentAndArchiveManifest(
 /**
  * Note: consumes the stream.
  */
-function getManifestFile(stream: Readable): Promise<DockerArchiveManifest> {
-  return streamToJson<DockerArchiveManifest>(stream).then((manifest) => {
-    return manifest[0];
-  });
+async function getManifestFile<T>(stream: Readable): Promise<T> {
+  return streamToJson<T>(stream);
 }
 
 function isManifestFile(name: string): boolean {

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -41,6 +41,9 @@ export async function getArchiveLayersAndManifest(
         extractedLayers: layersWithLatestFileModifications(
           dockerArchive.layers,
         ),
+        rootFsLayers: dockerExtractor.getRootFsLayersFromConfig(
+          dockerArchive.imageConfig,
+        ),
       };
   }
 }

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -10,6 +10,7 @@ export interface ExtractionResult {
   imageId: string;
   manifestLayers: string[];
   extractedLayers: ExtractedLayers;
+  rootFsLayers?: string[];
 }
 
 export interface ExtractedLayers {
@@ -19,6 +20,7 @@ export interface ExtractedLayers {
 export interface ExtractedLayersAndManifest {
   layers: ExtractedLayers[];
   manifest: DockerArchiveManifest;
+  imageConfig: DockerArchiveImageConfig;
 }
 
 export interface DockerArchiveManifest {
@@ -27,6 +29,10 @@ export interface DockerArchiveManifest {
   RepoTags: string[];
   // The names of the layers in this archive, usually in the format "<sha256>.tar" or "<sha256>/layer.tar".
   Layers: string[];
+}
+
+export interface DockerArchiveImageConfig {
+  rootfs: { diff_ids: string[] };
 }
 
 export interface OciArchiveLayer {

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -83,6 +83,7 @@ function pluginMetadataRes(
     packageManager: depsAnalysis.packageManager,
     dockerImageId: depsAnalysis.imageId,
     imageLayers: depsAnalysis.imageLayers,
+    rootFs: depsAnalysis.rootFsLayers,
   };
 }
 

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -46,6 +46,7 @@ export async function analyzeStatically(
       imageId: parsedAnalysisResult.imageId,
       binaries: parsedAnalysisResult.binaries,
       imageLayers: parsedAnalysisResult.imageLayers,
+      rootFsLayers: staticAnalysis.rootFsLayers,
       applicationDependenciesScanResults:
         staticAnalysis.applicationDependenciesScanResults,
     };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -40,6 +40,7 @@ export interface PluginMetadata {
   packageManager: any;
   dockerImageId: string;
   imageLayers: string[];
+  rootFs?: string[];
 }
 
 export interface PluginResponseStatic extends PluginResponse {

--- a/test/lib/extractor/image.test.ts
+++ b/test/lib/extractor/image.test.ts
@@ -128,6 +128,16 @@ test("image extractor: ensure the layer results are the same for docker and for 
     ["ce3539cc184915f96add8551b0e7a37d80c560fe3ffe40cfe4585ea3a8dc14e9.tar"],
     "Layers match",
   );
+
+  t.deepEqual(
+    dockerResult.rootFsLayers,
+    [
+      "sha256:2db44bce66cde56fca25aeeb7d09dc924b748e3adfe58c9cc3eb2bd2f68a1b68",
+      "sha256:16d1b1dd2a23a7a79426299fde8be361194007dfebb3438f96735755283becf8",
+      "sha256:ce3539cc184915f96add8551b0e7a37d80c560fe3ffe40cfe4585ea3a8dc14e9",
+    ],
+    "Base image layers match",
+  );
 });
 
 test("oci image extractor: extracted image content returned as expected", async (t) => {
@@ -187,6 +197,8 @@ test("oci image extractor: extracted image content returned as expected", async 
     ],
     "Manifest returns expected layers content",
   );
+
+  t.notOk(result.rootFsLayers, "Base image layers is null");
 });
 
 test("image extractor: user friendly error thrown when invalid archive provided", async (t) => {

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -89,6 +89,15 @@ test("static analysis builds the expected response", async (t) => {
     ["ce3539cc184915f96add8551b0e7a37d80c560fe3ffe40cfe4585ea3a8dc14e9.tar"],
     "Layers are read correctly",
   );
+  t.deepEqual(
+    pluginResultWithSkopeoCopy.plugin.rootFs,
+    [
+      "sha256:2db44bce66cde56fca25aeeb7d09dc924b748e3adfe58c9cc3eb2bd2f68a1b68",
+      "sha256:16d1b1dd2a23a7a79426299fde8be361194007dfebb3438f96735755283becf8",
+      "sha256:ce3539cc184915f96add8551b0e7a37d80c560fe3ffe40cfe4585ea3a8dc14e9",
+    ],
+    "Base image layers are read correctly",
+  );
   t.ok(
     pluginResultWithSkopeoCopy.scannedProjects[0].depTree.dependencies &&
       "adduser" in
@@ -103,6 +112,16 @@ test("static analysis builds the expected response", async (t) => {
       "ac415f8e415b242117277e7ee5224b30389698b46101e0f28224490af3b90a9d/layer.tar",
     ],
     "Layers are read correctly",
+  );
+
+  t.deepEqual(
+    pluginResultWithSkopeoCopy.plugin.rootFs,
+    [
+      "sha256:2db44bce66cde56fca25aeeb7d09dc924b748e3adfe58c9cc3eb2bd2f68a1b68",
+      "sha256:16d1b1dd2a23a7a79426299fde8be361194007dfebb3438f96735755283becf8",
+      "sha256:ce3539cc184915f96add8551b0e7a37d80c560fe3ffe40cfe4585ea3a8dc14e9",
+    ],
+    "Base image layers are read correctly",
   );
 
   t.deepEqual(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adding base image detection support.

First commit is a small refactor to accommodate extracting another type of manifest.
 
Second commit we're adding rootfs array extraction from image config in docker archive. Extracted array is added to the plugin response as one of the PluginMetadata.

#### Where should the reviewer start?

commit by commit :-) 

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-1096
