### PR TITLE
fix: Check normalized paths if undefined

### DIFF
--- a/lib/analyzer/docker-analyzer.ts
+++ b/lib/analyzer/docker-analyzer.ts
@@ -85,8 +85,9 @@ export async function analyze(
     results: pkgManagerAnalysis,
     binaries: binariesAnalysis,
     imageLayers:
-      imageInspection.RootFS &&
-      imageInspection.RootFS.Layers.map((layer) => normalizePath(layer)),
+      imageInspection.RootFS && imageInspection.RootFS.Layers !== undefined
+        ? imageInspection.RootFS.Layers.map((layer) => normalizePath(layer))
+        : [],
   };
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixing a bug, where `map` in called on an undefined object. 
