### PR TITLE
fix: update nodejs-lockfile-parser to use upstream lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^6.1.0",
-    "snyk-nodejs-lockfile-parser": "1.22.0",
+    "snyk-nodejs-lockfile-parser": "1.28.1",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",
     "tslib": "^1",

--- a/test/fixtures/analysis-results/yarn.json
+++ b/test/fixtures/analysis-results/yarn.json
@@ -5308,6 +5308,6 @@
   "name": "goof",
   "size": 914,
   "version": "0.0.3",
-  "meta": { "nodeVersion": "6.14.1" },
+  "meta": { "nodeVersion": "6.14.1", "packageManagerVersion": "1" },
   "labels": {}
 }


### PR DESCRIPTION
Updating nodejs-lockfile-parser to prevent including our lodash fork.

JIRA: HAMMER-99