### PR TITLE
Feat/add platform to docker pull

### DIFF
--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -13,6 +13,7 @@ export interface AnalyzedPackage {
 
 export interface DockerInspectOutput {
   Id: string;
+  Architecture: string;
   RootFS: {
     Type: string;
     Layers: string[];

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -23,6 +23,7 @@ interface DockerOptions {
   tlsCaCert?: string;
   tlsKey?: string;
   socketPath?: string;
+  platform?: string;
 }
 
 const SystemDirectories = ["dev", "proc", "sys"];
@@ -136,8 +137,12 @@ class Docker {
     return await dockerPull.pull(registry, repo, tag, opt);
   }
 
-  public async pullCli(targetImage: string) {
-    return subProcess.execute("docker", ["pull", targetImage]);
+  public async pullCli(targetImage: string, options?: DockerOptions) {
+    return subProcess.execute("docker", [
+      "pull",
+      options?.platform ? `--platform=${options.platform}` : "",
+      targetImage,
+    ]);
   }
 
   public async save(targetImage: string, destination: string) {

--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -75,6 +75,7 @@ export async function distroless(
     imageSavePath,
     options?.username,
     options?.password,
+    options?.platform,
   );
   try {
     return await getStaticAnalysisResult(

--- a/test/lib/docker.test.ts
+++ b/test/lib/docker.test.ts
@@ -503,3 +503,37 @@ test("findGlobs", async (t) => {
     },
   );
 });
+
+test("pullCli", async (t) => {
+  const stub = sinon.stub(subProcess, "execute");
+  stub.resolves("text");
+  t.beforeEach(async () => {
+    stub.resetHistory();
+  });
+  t.tearDown(() => {
+    stub.restore();
+  });
+
+  const targetImage = "some:image";
+  const docker = new Docker(targetImage);
+
+  t.test("no args", async (t) => {
+    await docker.pullCli(targetImage);
+    const subProcessArgs = stub.getCall(0).args;
+    t.same(
+      subProcessArgs,
+      ["docker", ["pull", "", targetImage]],
+      "args passed to subProcess.execute as expected",
+    );
+  });
+
+  t.test("with args", async (t) => {
+    await docker.pullCli(targetImage, { platform: "linux/arm64/v8" });
+    const subProcessArgs = stub.getCall(0).args;
+    t.same(
+      subProcessArgs,
+      ["docker", ["pull", "--platform=linux/arm64/v8", targetImage]],
+      "args passed to subProcess.execute as expected",
+    );
+  });
+});

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -443,9 +443,8 @@ test("experimental static analysis for debian images", async (t) => {
     pluginOptionsExperimental,
   );
 
-  t.equal(
-    dockerSaveStub.callCount,
-    2, // once before the pull and once after
+  t.true(
+    dockerSaveStub.calledOnce,
     "non-static experimental flag saves the image",
   );
 
@@ -477,9 +476,8 @@ test("experimental static analysis for debian images", async (t) => {
     "identical dependencies for regular Debian images between experimental and static scans",
   );
 
-  t.equal(
-    dockerSaveStub.callCount,
-    2,
+  t.true(
+    dockerSaveStub.calledOnce,
     "static experimental flag does not save the image",
   );
   t.same(


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
We're adding ability to pull architecture specific docker image like: 'docker pull --platform=linux/arm64' and scan it.
As a first step the user will be able to scan an `arm` image if `docker` available on the host machine.

The `platform` format is the same as `docker pull` or `docker buildx` so it's familiar to the user.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RUN-1158

