### PR TITLE
Adding error handling for `docker --platform`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ windows_defaults: &windows_defaults
   parameters:
     node_version:
       type: string
-      default: ''
+      default: ""
   working_directory: ~/snyk-docker-plugin
 
 release_defaults: &release_defaults
@@ -80,7 +80,7 @@ commands:
     parameters:
       node_version:
         type: string
-        default: ''
+        default: ""
     steps:
       - run:
           name: Install specific version of Node
@@ -183,7 +183,7 @@ workflows:
       - test_windows:
           name: Test Windows
           context: nodejs-install
-          node_version: '8.17.0'
+          node_version: "8.17.0"
           requires:
             - Install
       - release:

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -61,6 +61,13 @@ async function pullWithDockerBinary(
     return (pullAndSaveSuccessful = true);
   } catch (err) {
     debug(`couldn't pull ${targetImage} using docker binary: ${err}`);
+
+    if (
+      err.stderr &&
+      err.stderr.includes("unknown operating system or architecture")
+    ) {
+      throw new Error("Unknown operating system or architecture");
+    }
     return pullAndSaveSuccessful;
   }
 }

--- a/test/lib/analyzer/image-inspector.test.ts
+++ b/test/lib/analyzer/image-inspector.test.ts
@@ -207,66 +207,6 @@ test("get image as an archive", async (t) => {
     t.ok(fs.existsSync(customPath), "custom path should exist on disk");
   });
 
-  t.test(
-    "from remote registry when updated architecture required",
-    async (t) => {
-      const customPath = tmp.dirSync().name;
-      const imageSavePath = path.join(customPath, uuidv4());
-      const dockerPullSpy = sinon.spy(Docker.prototype, "pullCli");
-      const inspectImageStub = sinon.stub(Docker.prototype, "inspectImage");
-      const stubbedData = [
-        {
-          Id: "image_id",
-          RootFS: {
-            Layers: {},
-          },
-          Architecture: "amd64",
-        },
-      ];
-      inspectImageStub.resolves({
-        stdout: JSON.stringify(stubbedData),
-        stderr: "",
-      });
-
-      const archiveLocation: ArchiveResult = await imageInspector.getImageArchive(
-        targetImage,
-        imageSavePath,
-        undefined,
-        undefined,
-        "linux/arm64",
-      );
-
-      t.teardown(async () => {
-        sinon.restore();
-      });
-
-      t.true(
-        dockerPullSpy.called,
-        "image pulled from remote registry with binary",
-      );
-      t.equal(
-        archiveLocation.path,
-        path.join(imageSavePath, "image.tar"),
-        "expected full image path",
-      );
-      t.true(
-        fs.existsSync(path.join(imageSavePath, "image.tar")),
-        "image exists on disk",
-      );
-
-      archiveLocation.removeArchive();
-      t.false(
-        fs.existsSync(path.join(imageSavePath, "image.tar")),
-        "image should not exists on disk",
-      );
-      t.notOk(
-        fs.existsSync(imageSavePath),
-        "tmp folder should not exist on disk",
-      );
-      t.ok(fs.existsSync(customPath), "custom path should exist on disk");
-    },
-  );
-
   t.test("from remote registry without binary", async (t) => {
     const customPath = "./new_custom/image/save/path";
     const imageSavePath = path.join(customPath, uuidv4());

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -650,3 +650,35 @@ test("static scanning NGINX with dockerfile analysis matches expected values", a
     "found gnupg1 in dockerfile packages",
   );
 });
+
+test("static analysis for arm based image", async (t) => {
+  const imageNameAndTag = "arm64v8/nginx:1.19.2-alpine";
+  const dockerfile = undefined;
+  const pluginOptions = {
+    experimental: true,
+  };
+
+  const pluginResult = await plugin.inspect(
+    imageNameAndTag,
+    dockerfile,
+    pluginOptions,
+  );
+
+  const depTree = pluginResult.scannedProjects[0].depTree as DepTree;
+
+  t.ok("dependencies" in depTree, "packages have dependencies");
+  t.equal(
+    pluginResult.scannedProjects[0].meta.imageName,
+    "docker-image|arm64v8/nginx",
+    "imageName exists in the scan result",
+  );
+  t.deepEqual(
+    depTree.targetOS,
+    {
+      name: "alpine",
+      version: "3.12.0",
+      prettyName: "Alpine Linux v3.12",
+    },
+    "found os scan result",
+  );
+});


### PR DESCRIPTION
Fixed getImageArchive() so the logic doesn't depend on the function throwing errors.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

First commit refactors `getImageArchive()` so the logic doesn't depend on the function throwing errors, the code is hopefully more readable and it can be extended easier. 

`Update tests for ARM` commit: we're removing a test depending on an experimental docker feature and adding a test covering scanning an ARM based image.

And last commit we're adding the error handling for `docker --platform`. We're throwing only when we get a specific error from `docker pull`: `unknown operating system or architecture`, otherwise if `pull` or `save` fails for any other reason we want to fall back to pulling using our pull lib.

#### Where should the reviewer start?
Commit by commit please!

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RUN-1162