### PR TITLE
feat: upgrade node-lockfile-parser (uuid upgrade)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^6.1.0",
-    "snyk-nodejs-lockfile-parser": "1.28.1",
+    "snyk-nodejs-lockfile-parser": "1.29.0",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",
     "tslib": "^1",


### PR DESCRIPTION
This snyk-nodejs-lockfile-parser upgrade uses the newer uuid library,
which we're already using. (uuid 8)
