### PR TITLE
feat: [RUN-1197] Fail if Docker not experimental

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -68,6 +68,15 @@ async function pullWithDockerBinary(
     ) {
       throw new Error("Unknown operating system or architecture");
     }
+
+    if (
+      err.message &&
+      err.message.includes(
+        '"--platform" is only supported on a Docker daemon with experimental features enabled',
+      )
+    ) {
+      throw err;
+    }
     return pullAndSaveSuccessful;
   }
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
We support the '--platform' flag only when Docker experimental features enabled, throwing a user friendly error otherwise.


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RUN-1197
