### PR TITLE
feat: Add platform info to the CLI output

### DIFF
--- a/lib/display.ts
+++ b/lib/display.ts
@@ -156,6 +156,10 @@ function formatMetadataSection(
   if (testResult.licensesPolicy) {
     result.push(formatMetadataLine("Licenses:", chalk.green("enabled")));
   }
+  const platform = scanResult.identity.args?.platform;
+  if (platform) {
+    result.push(formatMetadataLine("Platform:", platform));
+  }
 
   return result.join(BREAK_LINE);
 }

--- a/test/fixtures/display/output/a-few-issues.txt
+++ b/test/fixtures/display/output/a-few-issues.txt
@@ -29,6 +29,7 @@
 [32mDocker image:      [39m snyk/kubernetes-monitor
 [32mBase image:        [39m ubuntu
 [32mLicenses:          [39m [32menabled[39m
+[32mPlatform:          [39m linux/amd64
 
 
 Tested 90 dependencies for known issues, [1m[31mfound 3 issues.[39m[22m

--- a/test/fixtures/display/output/no-issues-with-file-options.txt
+++ b/test/fixtures/display/output/no-issues-with-file-options.txt
@@ -5,6 +5,7 @@
 [32mPackage manager:   [39m rpm
 [32mProject name:      [39m docker-image|snyk/kubernetes-monitor
 [32mDocker image:      [39m snyk/kubernetes-monitor
+[32mPlatform:          [39m linux/amd64
 
 
 [32m✓ Tested 90 dependencies for known issues, no vulnerable paths found.[39m

--- a/test/fixtures/display/output/no-issues.txt
+++ b/test/fixtures/display/output/no-issues.txt
@@ -5,6 +5,7 @@
 [32mPackage manager:   [39m rpm
 [32mProject name:      [39m docker-image|snyk/kubernetes-monitor
 [32mDocker image:      [39m snyk/kubernetes-monitor
+[32mPlatform:          [39m linux/amd64
 
 
 [32m✓ Tested 90 dependencies for known issues, no vulnerable paths found.[39m

--- a/test/fixtures/display/output/only-base-image-remediations.txt
+++ b/test/fixtures/display/output/only-base-image-remediations.txt
@@ -6,6 +6,7 @@
 [32mProject name:      [39m docker-image|snyk/kubernetes-monitor
 [32mDocker image:      [39m snyk/kubernetes-monitor
 [32mBase image:        [39m ubuntu
+[32mPlatform:          [39m linux/amd64
 
 
 [32m✓ Tested 90 dependencies for known issues, no vulnerable paths found.[39m

--- a/test/fixtures/display/scan-results/rpm.json
+++ b/test/fixtures/display/scan-results/rpm.json
@@ -67,7 +67,8 @@
     }
   ],
   "identity": {
-    "type": "rpm"
+    "type": "rpm",
+    "args": { "platform": "linux/amd64" }
   },
   "target": {
     "image": "docker-image|snyk/kubernetes-monitor"


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When 'snyk container test', we want to see platform information in the scan output. With the new flow, CLI will call `display()` in the plugin to get the output string.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RUN-1148