### PR TITLE
fix: corrected app-vulns flag parsing

### DIFF
--- a/lib/experimental.ts
+++ b/lib/experimental.ts
@@ -50,7 +50,7 @@ async function localArchive(
     archivePath,
     dockerfileAnalysis,
     imageType,
-    options["app-vulns"],
+    isTrue(options["app-vulns"]),
   );
 }
 
@@ -83,7 +83,7 @@ export async function distroless(
       archiveResult.path,
       dockerfileAnalysis,
       ImageType.DockerArchive,
-      options["app-vulns"],
+      isTrue(options["app-vulns"]),
     );
   } finally {
     archiveResult.removeArchive();
@@ -120,4 +120,8 @@ export function fullImageSavePath(imageSavePath: string | undefined): string {
   }
 
   return path.join(imagePath, uuidv4());
+}
+
+function isTrue(value: boolean | string): boolean {
+  return String(value).toLowerCase() === "true";
 }

--- a/test/system/experimental.test.ts
+++ b/test/system/experimental.test.ts
@@ -195,3 +195,155 @@ test("static scan for Identifier type image (nginx:1.19.0)", async (t) => {
     "Correct platform detected",
   );
 });
+
+test("scanning a container with 2 applications (--app-vulns)", async (t) => {
+  const imageNameAndTag = "snykgoof/os-app:node-snykin";
+  const dockerfile = undefined;
+
+  const pluginOptions = {
+    experimental: true,
+    docker: true,
+    "app-vulns": true,
+  };
+
+  const pluginResult = await plugin.inspect(
+    imageNameAndTag,
+    dockerfile,
+    pluginOptions,
+  );
+
+  t.ok(
+    "scannedProjects" in pluginResult &&
+      Array.isArray(pluginResult.scannedProjects),
+    "scannedProjects is in plugin response and has the correct type",
+  );
+  t.same(pluginResult.scannedProjects.length, 3, "contains 3 scan results");
+
+  const osScan = pluginResult.scannedProjects[0];
+  t.ok(osScan.meta, "os scan meta is not falsy");
+  t.same(
+    osScan.meta.platform,
+    "linux/amd64",
+    "os scan meta includes platform information",
+  );
+
+  const yarnScan = pluginResult.scannedProjects[1];
+  await t.test("first scanned project is scanned correctly", async (subt) => {
+    subt.same(
+      yarnScan.packageManager,
+      "yarn",
+      "yarn as package manager is scanned correctly",
+    );
+    subt.same(
+      yarnScan.targetFile,
+      "/app2/package.json",
+      "path to targetFile is correct",
+    );
+  });
+
+  const npmScan = pluginResult.scannedProjects[2];
+  await t.test("second scanned project is scanned correctly", async (subt) => {
+    subt.same(
+      npmScan.packageManager,
+      "npm",
+      "yarn as package manager is scanned correctly",
+    );
+    subt.same(
+      npmScan.targetFile,
+      "/app1/package.json",
+      "path to targetFile is correct",
+    );
+  });
+});
+
+test("scanning a container with 0 applications (--app-vulns=false)", async (t) => {
+  const imageNameAndTag = "snykgoof/os-app:node-snykin";
+  const dockerfile = undefined;
+
+  const pluginOptions = {
+    experimental: true,
+    docker: true,
+    "app-vulns": "false",
+  };
+
+  const pluginResult = await plugin.inspect(
+    imageNameAndTag,
+    dockerfile,
+    pluginOptions,
+  );
+
+  t.ok(
+    "scannedProjects" in pluginResult &&
+      Array.isArray(pluginResult.scannedProjects),
+    "scannedProjects is in plugin response and has the correct type",
+  );
+  t.same(pluginResult.scannedProjects.length, 1, "contains 1 scan results");
+
+  const osScan = pluginResult.scannedProjects[0];
+  t.ok(osScan.meta, "os scan meta is not falsy");
+  t.same(
+    osScan.meta.platform,
+    "linux/amd64",
+    "os scan meta includes platform information",
+  );
+});
+
+test("scanning a container with 2 applications (--app-vulns=true)", async (t) => {
+  const imageNameAndTag = "snykgoof/os-app:node-snykin";
+  const dockerfile = undefined;
+
+  const pluginOptions = {
+    experimental: true,
+    docker: true,
+    "app-vulns": "true",
+  };
+
+  const pluginResult = await plugin.inspect(
+    imageNameAndTag,
+    dockerfile,
+    pluginOptions,
+  );
+
+  t.ok(
+    "scannedProjects" in pluginResult &&
+      Array.isArray(pluginResult.scannedProjects),
+    "scannedProjects is in plugin response and has the correct type",
+  );
+  t.same(pluginResult.scannedProjects.length, 3, "contains 3 scan results");
+
+  const osScan = pluginResult.scannedProjects[0];
+  t.ok(osScan.meta, "os scan meta is not falsy");
+  t.same(
+    osScan.meta.platform,
+    "linux/amd64",
+    "os scan meta includes platform information",
+  );
+
+  const yarnScan = pluginResult.scannedProjects[1];
+  await t.test("first scanned project is scanned correctly", async (subt) => {
+    subt.same(
+      yarnScan.packageManager,
+      "yarn",
+      "yarn as package manager is scanned correctly",
+    );
+    subt.same(
+      yarnScan.targetFile,
+      "/app2/package.json",
+      "path to targetFile is correct",
+    );
+  });
+
+  const npmScan = pluginResult.scannedProjects[2];
+  await t.test("second scanned project is scanned correctly", async (subt) => {
+    subt.same(
+      npmScan.packageManager,
+      "npm",
+      "yarn as package manager is scanned correctly",
+    );
+    subt.same(
+      npmScan.targetFile,
+      "/app1/package.json",
+      "path to targetFile is correct",
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Converts `boolean|string` parameter received from cli input to `boolean` at point where interface requires `boolean`

Examples:
```
snyk test --docker --experimental --app-vulns=false mladkau/snykin
```

#### How should this be manually tested?

1) from snyk/snyk-docker-plugin run `npm run build`
2) from snyk/snyk project run `npm link /path/to/snyk-docker-plugin`
3) from snyk/snyk project run `npm run build`
4) from snyk/snyk for os vuln test:
    * `node dist/cli test --docker --experimental mladkau/snykin`
    * `node dist/cli test --docker --experimental --app-vulns=false mladkau/snykin`
5) from snyk/snyk for app+os test:
    * `node dist/cli test --docker --experimental --app-vulns mladkau/snykin`
    * `node dist/cli test --docker --experimental --app-vulns=true mladkau/snykin`

#### What are the relevant tickets?

* [DC-852](https://snyksec.atlassian.net/browse/DC-852)

#### Screenshots

`node dist/cli test --docker --experimental mladkau/snykin`
![Screenshot 2020-09-29 at 17 26 16](https://user-images.githubusercontent.com/70949530/94586497-35b0a700-0279-11eb-8704-04a6d9526707.png)

`node dist/cli test --docker --experimental --app-vulns=false mladkau/snykin`
![Screenshot 2020-09-29 at 17 27 02](https://user-images.githubusercontent.com/70949530/94586499-36e1d400-0279-11eb-8aa4-fc0b6ae120f5.png)

`node dist/cli test --docker --experimental --app-vulns mladkau/snykin`
![Screenshot 2020-09-29 at 17 27 32](https://user-images.githubusercontent.com/70949530/94586504-377a6a80-0279-11eb-82d0-eb89339070bc.png)

`node dist/cli test --docker --experimental --app-vulns=true mladkau/snykin`
![Screenshot 2020-09-29 at 17 27 59](https://user-images.githubusercontent.com/70949530/94586506-38130100-0279-11eb-819d-311d8f8961da.png)
