### PR TITLE
fix: the plugin was missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@snyk/dep-graph": "^1.19.4",
     "@snyk/rpm-parser": "^2.0.0",
     "@snyk/snyk-docker-pull": "^3.2.0",
+    "chalk": "^2.4.2",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",
     "dockerfile-ast": "0.0.30",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Include `chalk` dependency.

#### Where should the reviewer start?
It was missing as a prod dependency and `tap` was brought it during the local and CI test. However it won't work when some application, like the CLI, tries to run it.

#### How should this be manually tested?
`rm -rf dist && rm -rf node_modules && npm install`
