### PR TITLE
feat: upgrade node lockfile parser (dropping weird transitive)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^6.1.0",
-    "snyk-nodejs-lockfile-parser": "1.29.0",
+    "snyk-nodejs-lockfile-parser": "1.30.0",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",
     "tslib": "^1",


### PR DESCRIPTION
Pick up a minor release of `snyk-nodejs-lockfile-parser`, which we have pinned.
This version bump brings the removal of source-map-support, which is inappropriate behaviour for a library.