### PR TITLE
fix: export display() to be used by the Snyk CLI for issues output

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+import { display } from "./display";
 import * as dockerFile from "./docker-file";
 import { experimentalAnalysis } from "./experimental";
 import {
@@ -11,6 +12,7 @@ import {
 
 export {
   scan,
+  display,
   dockerFile,
   ScanResult,
   PluginResponse,

--- a/test/lib/display.test.ts
+++ b/test/lib/display.test.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { test } from "tap";
 
 import { DepGraphData } from "@snyk/dep-graph";
-import { display } from "../../lib/display";
+import { display } from "../../lib";
 import { Options, ScanResult, TestResult } from "../../lib/types";
 
 function readFixture(fixture: string, filename: string): Promise<string> {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Export `display()` to be used by the Snyk CLI for issues output.
This function up until now was only used internally but needs to be accessible by the CLI.
