### PR TITLE
feat: add flag imageNameAndTag to preserve this data in archive scans

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -69,8 +69,11 @@ async function localArchiveAnalysis(
     throw new Error("The provided archive path is not a file");
   }
 
-  // The target image becomes the base of the path, e.g. "archive.tar" for "/var/tmp/archive.tar"
-  const imageIdentifier = path.basename(archivePath);
+  const imageIdentifier =
+    options.imageNameAndTag ||
+    // The target image becomes the base of the path, e.g. "archive.tar" for "/var/tmp/archive.tar"
+    path.basename(archivePath);
+
   return await staticModule.analyzeStatically(
     imageIdentifier,
     dockerfileAnalysis,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -102,6 +102,18 @@ export interface PluginOptions {
   file: string;
 
   /**
+   * Override the "name" and "version" fields of the OS dependencies result.
+   * WARNING! This is NOT used by the Snyk CLI!
+   *
+   * It is used by K8s-Monitor and DRA to preserve the image identifier when scanning archives.
+   * The archives do not contain any data about the image's name and tag (since they are only
+   * known by the container registry) and in some contexts we know this data and want to keep it.
+   *
+   * This flag will be processed only when scanning image archives. In other cases "path" is used.
+   */
+  imageNameAndTag: string;
+
+  /**
    * Provide patterns on which to match for detecting applications.
    * Used for the APP+OS deps feature, not by the CLI.
    */

--- a/test/system/flags/image-name-and-tag.spec.ts
+++ b/test/system/flags/image-name-and-tag.spec.ts
@@ -1,0 +1,60 @@
+import { DepGraph } from "@snyk/dep-graph";
+import { join as pathJoin } from "path";
+import { scan } from "../../../lib/index";
+
+function getFixture(fixturePath: string): string {
+  return pathJoin(__dirname, "../../fixtures", fixturePath);
+}
+
+describe("imageNameAndTag tests", () => {
+  it("it overrides name and version when reading a docker archive", async () => {
+    const fixturePath = getFixture("docker-archives/docker-save/nginx.tar");
+    const path = `docker-archive:${fixturePath}`;
+    const imageNameAndTag = "nginx:1.23.4";
+
+    const pluginResult = await scan({
+      path,
+      imageNameAndTag,
+    });
+
+    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "depGraph",
+    )!.data;
+    expect(depGraph.rootPkg.name).toEqual("docker-image|nginx");
+    expect(depGraph.rootPkg.version).toEqual("1.23.4");
+  });
+
+  it("it overrides name and version when reading an oci archive", async () => {
+    const fixturePath = getFixture("oci-archives/alpine-3.12.0.tar");
+    const path = `oci-archive:${fixturePath}`;
+    const imageNameAndTag = "nginx:1.23.4";
+
+    const pluginResult = await scan({
+      path,
+      imageNameAndTag,
+    });
+
+    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "depGraph",
+    )!.data;
+    expect(depGraph.rootPkg.name).toEqual("docker-image|nginx");
+    expect(depGraph.rootPkg.version).toEqual("1.23.4");
+  });
+
+  it("it ignores imageNameAndTag when passed an image identifier", async () => {
+    const path =
+      "hello-world@sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042";
+    // Attempting to override the "path" above
+    const imageNameAndTag = "nginx:1.23.4";
+    const pluginResult = await scan({
+      path,
+      imageNameAndTag,
+    });
+
+    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "depGraph",
+    )!.data;
+    expect(depGraph.rootPkg.name).toEqual("docker-image|hello-world");
+    expect(depGraph.rootPkg.version).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Override the "name" and "version" fields of the OS dependencies result when scanning image archives.

This is NOT used by the Snyk CLI!
It is used by K8s-Monitor and DRA to preserve the image identifier when scanning archives.
The archives do not contain any data about the image's name and tag (since they are only known by the container registry) and in some contexts we know this data and want to keep it.

#### What are the relevant tickets?

[Jira ticket RUN-1220](https://snyksec.atlassian.net/browse/RUN-1220)
