### PR TITLE
feat: manifest files contents are now returned as a ScanResult Fact

### DIFF
--- a/lib/inputs/file-pattern/static.ts
+++ b/lib/inputs/file-pattern/static.ts
@@ -2,7 +2,7 @@ import * as minimatch from "minimatch";
 import * as path from "path";
 
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
-import { streamToBuffer } from "../../stream-utils";
+import { streamToString } from "../../stream-utils";
 import { ManifestFile } from "../../types";
 
 function generatePathMatcher(
@@ -34,7 +34,7 @@ export function generateExtractAction(
   return {
     actionName: "find-files-by-pattern",
     filePathMatches: generatePathMatcher(globsInclude, globsExclude),
-    callback: streamToBuffer,
+    callback: (dataStream) => streamToString(dataStream, "base64"),
   };
 }
 
@@ -48,14 +48,15 @@ export function getMatchingFiles(
       if (actionName !== "find-files-by-pattern") {
         continue;
       }
-      if (!Buffer.isBuffer(extractedLayers[filePath][actionName])) {
-        throw new Error("expected a buffer");
+
+      if (typeof extractedLayers[filePath][actionName] !== "string") {
+        throw new Error("expected a string");
       }
 
       manifestFiles.push({
         name: path.basename(filePath),
         path: path.dirname(filePath),
-        contents: extractedLayers[filePath][actionName] as Buffer,
+        contents: extractedLayers[filePath][actionName] as string,
       });
     }
   }

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -73,6 +73,17 @@ function buildResponse(
     });
   }
 
+  const manifestFiles =
+    depsAnalysis.manifestFiles.length > 0
+      ? depsAnalysis.manifestFiles
+      : undefined;
+  if (manifestFiles) {
+    additionalOsDepsFacts.push({
+      type: "imageManifestFiles",
+      data: manifestFiles,
+    });
+  }
+
   const applicationDependenciesScanResults: types.ScanResult[] = (
     depsAnalysis.applicationDependenciesScanResults || []
   ).map((appDepsScanResult) => ({
@@ -107,14 +118,8 @@ function buildResponse(
     ...applicationDependenciesScanResults,
   ];
 
-  const manifestFiles =
-    depsAnalysis.manifestFiles.length > 0
-      ? depsAnalysis.manifestFiles
-      : undefined;
-
   return {
     scanResults,
-    manifestFiles,
   };
 }
 

--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -4,9 +4,14 @@ import { Readable } from "stream";
 const HASH_ALGORITHM = "sha256"; // TODO algorithm?
 const HASH_ENCODING = "hex";
 
+/**
+ * https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
+ */
+type SupportedEncodings = "utf8" | "base64";
+
 export async function streamToString(
   stream: Readable,
-  encoding: string = "utf8",
+  encoding: SupportedEncodings = "utf8",
 ): Promise<string> {
   const chunks: string[] = [];
   return new Promise((resolve, reject) => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,7 +23,12 @@ export enum OsReleaseFilePath {
 export interface ManifestFile {
   name: string;
   path: string;
-  contents: Buffer;
+  /**
+   * Base64-encoded file contents.
+   * We use Base64 to avoid any assumptions about the original file encoding,
+   * which is difficult to infer and may be corrupted when the data is transferred over the network.
+   */
+  contents: string;
 }
 
 export type FactType =
@@ -33,20 +38,12 @@ export type FactType =
   | "dockerfileAnalysis"
   | "rootFs"
   | "imageId"
-  | "imageOsReleasePrettyName";
+  | "imageOsReleasePrettyName"
+  | "imageManifestFiles";
 
 export interface PluginResponse {
   /** The first result is guaranteed to be the OS dependencies scan result. */
   scanResults: ScanResult[];
-
-  /**
-   * WARNING: This field does not appear in other CLI plugins! NOT to be used by the CLI.
-   *
-   * Manifests file are a special case, used only for the APP+OS deps feature.
-   * They are collected if "globsToFind" are included in the options passed to the plugin.
-   * They are NOT be processed like a normal ScanResult+Fact and they flow through a separate code path.
-   */
-  manifestFiles?: ManifestFile[];
 }
 
 export interface ScanResult {

--- a/test/lib/stream-utils.test.ts
+++ b/test/lib/stream-utils.test.ts
@@ -17,6 +17,16 @@ test("stream-utils.streamToString()", async (t) => {
   t.same(fileContent, expectedContent, "Returned the expected string");
 });
 
+test("stream-utils.streamToString(base64)", async (t) => {
+  const fixture = getFixture("small-sample-text.txt");
+  const fileStream = createReadStream(fixture);
+
+  const fileContent = await streamToString(fileStream, "base64");
+  const expectedContent = readFileSync(fixture, { encoding: "base64" });
+
+  t.same(fileContent, expectedContent, "Returned the expected string");
+});
+
 test("stream-utils.streamToBuffer()", async (t) => {
   const fixture = getFixture("small-sample-text.txt");
   const fileStream = createReadStream(fixture);

--- a/test/system/app-os/__snapshots__/globs.spec.ts.snap
+++ b/test/system/app-os/__snapshots__/globs.spec.ts.snap
@@ -1,276 +1,1907 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`find globs tests should correctly return manifest files when detected by globs 1`] = `
-Array [
-  Object {
-    "contents": Object {
-      "data": Array [
-        80,
-        82,
-        69,
-        84,
-        84,
-        89,
-        95,
-        78,
-        65,
-        77,
-        69,
-        61,
-        34,
-        68,
-        101,
-        98,
-        105,
-        97,
-        110,
-        32,
-        71,
-        78,
-        85,
-        47,
-        76,
-        105,
-        110,
-        117,
-        120,
-        32,
-        49,
-        48,
-        32,
-        40,
-        98,
-        117,
-        115,
-        116,
-        101,
-        114,
-        41,
-        34,
-        10,
-        78,
-        65,
-        77,
-        69,
-        61,
-        34,
-        68,
-        101,
-        98,
-        105,
-        97,
-        110,
-        32,
-        71,
-        78,
-        85,
-        47,
-        76,
-        105,
-        110,
-        117,
-        120,
-        34,
-        10,
-        86,
-        69,
-        82,
-        83,
-        73,
-        79,
-        78,
-        95,
-        73,
-        68,
-        61,
-        34,
-        49,
-        48,
-        34,
-        10,
-        86,
-        69,
-        82,
-        83,
-        73,
-        79,
-        78,
-        61,
-        34,
-        49,
-        48,
-        32,
-        40,
-        98,
-        117,
-        115,
-        116,
-        101,
-        114,
-        41,
-        34,
-        10,
-        86,
-        69,
-        82,
-        83,
-        73,
-        79,
-        78,
-        95,
-        67,
-        79,
-        68,
-        69,
-        78,
-        65,
-        77,
-        69,
-        61,
-        98,
-        117,
-        115,
-        116,
-        101,
-        114,
-        10,
-        73,
-        68,
-        61,
-        100,
-        101,
-        98,
-        105,
-        97,
-        110,
-        10,
-        72,
-        79,
-        77,
-        69,
-        95,
-        85,
-        82,
-        76,
-        61,
-        34,
-        104,
-        116,
-        116,
-        112,
-        115,
-        58,
-        47,
-        47,
-        119,
-        119,
-        119,
-        46,
-        100,
-        101,
-        98,
-        105,
-        97,
-        110,
-        46,
-        111,
-        114,
-        103,
-        47,
-        34,
-        10,
-        83,
-        85,
-        80,
-        80,
-        79,
-        82,
-        84,
-        95,
-        85,
-        82,
-        76,
-        61,
-        34,
-        104,
-        116,
-        116,
-        112,
-        115,
-        58,
-        47,
-        47,
-        119,
-        119,
-        119,
-        46,
-        100,
-        101,
-        98,
-        105,
-        97,
-        110,
-        46,
-        111,
-        114,
-        103,
-        47,
-        115,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-        34,
-        10,
-        66,
-        85,
-        71,
-        95,
-        82,
-        69,
-        80,
-        79,
-        82,
-        84,
-        95,
-        85,
-        82,
-        76,
-        61,
-        34,
-        104,
-        116,
-        116,
-        112,
-        115,
-        58,
-        47,
-        47,
-        98,
-        117,
-        103,
-        115,
-        46,
-        100,
-        101,
-        98,
-        105,
-        97,
-        110,
-        46,
-        111,
-        114,
-        103,
-        47,
-        34,
-        10,
+Object {
+  "scanResults": Array [
+    Object {
+      "facts": Array [
+        Object {
+          "data": Object {
+            "graph": Object {
+              "nodes": Array [
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "adduser@3.118|1",
+                    },
+                    Object {
+                      "nodeId": "apt@1.8.2.1",
+                    },
+                    Object {
+                      "nodeId": "apt/libapt-pkg5.0@1.8.2.1|2",
+                    },
+                    Object {
+                      "nodeId": "audit/libaudit-common@1:2.8.4-3",
+                    },
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.8.4-3|2",
+                    },
+                    Object {
+                      "nodeId": "base-files@10.3+deb10u6|1",
+                    },
+                    Object {
+                      "nodeId": "base-passwd@3.5.46",
+                    },
+                    Object {
+                      "nodeId": "bash@5.0-4",
+                    },
+                    Object {
+                      "nodeId": "cdebconf/libdebconfclient0@0.249",
+                    },
+                    Object {
+                      "nodeId": "coreutils@8.30-3",
+                    },
+                    Object {
+                      "nodeId": "dash@0.5.10.2-5",
+                    },
+                    Object {
+                      "nodeId": "debian-archive-keyring@2019.1",
+                    },
+                    Object {
+                      "nodeId": "debianutils@4.8.6.1",
+                    },
+                    Object {
+                      "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "e2fsprogs@1.44.5-1+deb10u3",
+                    },
+                    Object {
+                      "nodeId": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
+                    },
+                    Object {
+                      "nodeId": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
+                    },
+                    Object {
+                      "nodeId": "e2fsprogs/libss2@1.44.5-1+deb10u3|2",
+                    },
+                    Object {
+                      "nodeId": "findutils@4.6.0+git+20190209-2",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libstdc++6@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
+                    },
+                    Object {
+                      "nodeId": "gnupg2/gpgv@2.2.12-1+deb10u1|2",
+                    },
+                    Object {
+                      "nodeId": "gnutls28/libgnutls30@3.6.7-4+deb10u5|2",
+                    },
+                    Object {
+                      "nodeId": "grep@3.3-1",
+                    },
+                    Object {
+                      "nodeId": "gzip@1.9-3",
+                    },
+                    Object {
+                      "nodeId": "hostname@3.21",
+                    },
+                    Object {
+                      "nodeId": "init-system-helpers@1.56+nmu1",
+                    },
+                    Object {
+                      "nodeId": "iproute2@4.20.0-2",
+                    },
+                    Object {
+                      "nodeId": "iputils/iputils-ping@3:20180629-2+deb10u1",
+                    },
+                    Object {
+                      "nodeId": "libcap-ng/libcap-ng0@0.7.9-2",
+                    },
+                    Object {
+                      "nodeId": "libffi/libffi6@3.2.1-9",
+                    },
+                    Object {
+                      "nodeId": "libgcrypt20@1.8.4-5|1",
+                    },
+                    Object {
+                      "nodeId": "libgpg-error/libgpg-error0@1.35-1",
+                    },
+                    Object {
+                      "nodeId": "libseccomp/libseccomp2@2.3.3-4",
+                    },
+                    Object {
+                      "nodeId": "libsemanage/libsemanage-common@2.8-2",
+                    },
+                    Object {
+                      "nodeId": "libsemanage/libsemanage1@2.8-2|2",
+                    },
+                    Object {
+                      "nodeId": "libsepol/libsepol1@2.8-1",
+                    },
+                    Object {
+                      "nodeId": "libtasn1-6@4.13-3",
+                    },
+                    Object {
+                      "nodeId": "libzstd/libzstd1@1.3.8+dfsg-3",
+                    },
+                    Object {
+                      "nodeId": "lz4/liblz4-1@1.8.3-1",
+                    },
+                    Object {
+                      "nodeId": "mawk/mawk@1.3.3-17+b3",
+                    },
+                    Object {
+                      "nodeId": "meta-common-packages@meta",
+                    },
+                    Object {
+                      "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2|1",
+                    },
+                    Object {
+                      "nodeId": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                    },
+                    Object {
+                      "nodeId": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
+                    },
+                    Object {
+                      "nodeId": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
+                    },
+                    Object {
+                      "nodeId": "nettle/libhogweed4@3.4.1-1|2",
+                    },
+                    Object {
+                      "nodeId": "p11-kit/libp11-kit0@0.23.15-2|2",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam-modules@1.3.1-5|2",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam-modules-bin@1.3.1-5|2",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam-runtime@1.3.1-5|1",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam0g@1.3.1-5|1",
+                    },
+                    Object {
+                      "nodeId": "sed@4.7-1",
+                    },
+                    Object {
+                      "nodeId": "shadow/login@1:4.5-1.1|1",
+                    },
+                    Object {
+                      "nodeId": "shadow/passwd@1:4.5-1.1|2",
+                    },
+                    Object {
+                      "nodeId": "systemd/libsystemd0@241-7~deb10u4|2",
+                    },
+                    Object {
+                      "nodeId": "systemd/libudev1@241-7~deb10u4",
+                    },
+                    Object {
+                      "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tzdata@2020a-0+deb10u1",
+                    },
+                    Object {
+                      "nodeId": "util-linux@2.33.1-0.1|1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/bsdutils@1:2.33.1-0.1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/fdisk@2.33.1-0.1|1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libblkid1@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libfdisk1@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libmount1@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libsmartcols1@2.33.1-0.1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libuuid1@2.33.1-0.1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/mount@2.33.1-0.1",
+                    },
+                  ],
+                  "nodeId": "root-node",
+                  "pkgId": "docker-image|debian@10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "audit/libaudit-common@1:2.8.4-3",
+                  "pkgId": "audit/libaudit-common@1:2.8.4-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libcap-ng/libcap-ng0@0.7.9-2",
+                  "pkgId": "libcap-ng/libcap-ng0@0.7.9-2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "audit/libaudit-common@1:2.8.4-3",
+                    },
+                    Object {
+                      "nodeId": "libcap-ng/libcap-ng0@0.7.9-2",
+                    },
+                  ],
+                  "nodeId": "audit/libaudit1@1:2.8.4-3|1",
+                  "pkgId": "audit/libaudit1@1:2.8.4-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "audit/libaudit1@1:2.8.4-3|2",
+                  "pkgId": "audit/libaudit1@1:2.8.4-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libsemanage/libsemanage-common@2.8-2",
+                  "pkgId": "libsemanage/libsemanage-common@2.8-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libsepol/libsepol1@2.8-1",
+                  "pkgId": "libsepol/libsepol1@2.8-1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.8.4-3|2",
+                    },
+                    Object {
+                      "nodeId": "libsemanage/libsemanage-common@2.8-2",
+                    },
+                    Object {
+                      "nodeId": "libsepol/libsepol1@2.8-1",
+                    },
+                  ],
+                  "nodeId": "libsemanage/libsemanage1@2.8-2|1",
+                  "pkgId": "libsemanage/libsemanage1@2.8-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libsemanage/libsemanage1@2.8-2|2",
+                  "pkgId": "libsemanage/libsemanage1@2.8-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
+                  "pkgId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pam/libpam0g@1.3.1-5|1",
+                  "pkgId": "pam/libpam0g@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.8.4-3|2",
+                    },
+                  ],
+                  "nodeId": "pam/libpam0g@1.3.1-5|2",
+                  "pkgId": "pam/libpam0g@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.8.4-3|2",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam0g@1.3.1-5|1",
+                    },
+                  ],
+                  "nodeId": "pam/libpam-modules-bin@1.3.1-5|1",
+                  "pkgId": "pam/libpam-modules-bin@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pam/libpam-modules-bin@1.3.1-5|2",
+                  "pkgId": "pam/libpam-modules-bin@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.8.4-3|2",
+                    },
+                    Object {
+                      "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam-modules-bin@1.3.1-5|1",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam0g@1.3.1-5|1",
+                    },
+                  ],
+                  "nodeId": "pam/libpam-modules@1.3.1-5|1",
+                  "pkgId": "pam/libpam-modules@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pam/libpam-modules@1.3.1-5|2",
+                  "pkgId": "pam/libpam-modules@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.8.4-3|1",
+                    },
+                    Object {
+                      "nodeId": "libsemanage/libsemanage1@2.8-2|1",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam-modules@1.3.1-5|1",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam0g@1.3.1-5|2",
+                    },
+                  ],
+                  "nodeId": "shadow/passwd@1:4.5-1.1|1",
+                  "pkgId": "shadow/passwd@1:4.5-1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "shadow/passwd@1:4.5-1.1|2",
+                  "pkgId": "shadow/passwd@1:4.5-1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "shadow/passwd@1:4.5-1.1|1",
+                    },
+                  ],
+                  "nodeId": "adduser@3.118|1",
+                  "pkgId": "adduser@3.118",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "adduser@3.118|2",
+                  "pkgId": "adduser@3.118",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libstdc++6@8.3.0-6",
+                  "pkgId": "gcc-8/libstdc++6@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libzstd/libzstd1@1.3.8+dfsg-3",
+                  "pkgId": "libzstd/libzstd1@1.3.8+dfsg-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lz4/liblz4-1@1.8.3-1",
+                  "pkgId": "lz4/liblz4-1@1.8.3-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libgcrypt20@1.8.4-5|1",
+                  "pkgId": "libgcrypt20@1.8.4-5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libgpg-error/libgpg-error0@1.35-1",
+                    },
+                  ],
+                  "nodeId": "libgcrypt20@1.8.4-5|2",
+                  "pkgId": "libgcrypt20@1.8.4-5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libgcrypt20@1.8.4-5|1",
+                    },
+                    Object {
+                      "nodeId": "lz4/liblz4-1@1.8.3-1",
+                    },
+                  ],
+                  "nodeId": "systemd/libsystemd0@241-7~deb10u4|1",
+                  "pkgId": "systemd/libsystemd0@241-7~deb10u4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "systemd/libsystemd0@241-7~deb10u4|2",
+                  "pkgId": "systemd/libsystemd0@241-7~deb10u4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "systemd/libudev1@241-7~deb10u4",
+                  "pkgId": "systemd/libudev1@241-7~deb10u4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "gcc-8/libstdc++6@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "libzstd/libzstd1@1.3.8+dfsg-3",
+                    },
+                    Object {
+                      "nodeId": "lz4/liblz4-1@1.8.3-1",
+                    },
+                    Object {
+                      "nodeId": "systemd/libsystemd0@241-7~deb10u4|1",
+                    },
+                    Object {
+                      "nodeId": "systemd/libudev1@241-7~deb10u4",
+                    },
+                  ],
+                  "nodeId": "apt/libapt-pkg5.0@1.8.2.1|1",
+                  "pkgId": "apt/libapt-pkg5.0@1.8.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "apt/libapt-pkg5.0@1.8.2.1|2",
+                  "pkgId": "apt/libapt-pkg5.0@1.8.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "debian-archive-keyring@2019.1",
+                  "pkgId": "debian-archive-keyring@2019.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libgpg-error/libgpg-error0@1.35-1",
+                  "pkgId": "libgpg-error/libgpg-error0@1.35-1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libgcrypt20@1.8.4-5|2",
+                    },
+                    Object {
+                      "nodeId": "libgpg-error/libgpg-error0@1.35-1",
+                    },
+                  ],
+                  "nodeId": "gnupg2/gpgv@2.2.12-1+deb10u1|1",
+                  "pkgId": "gnupg2/gpgv@2.2.12-1+deb10u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gnupg2/gpgv@2.2.12-1+deb10u1|2",
+                  "pkgId": "gnupg2/gpgv@2.2.12-1+deb10u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
+                  "pkgId": "gmp/libgmp10@2:6.1.2+dfsg-4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libidn2/libidn2-0@2.0.5-1+deb10u1|1",
+                  "pkgId": "libidn2/libidn2-0@2.0.5-1+deb10u1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libunistring/libunistring2@0.9.10-1",
+                    },
+                  ],
+                  "nodeId": "libidn2/libidn2-0@2.0.5-1+deb10u1|2",
+                  "pkgId": "libidn2/libidn2-0@2.0.5-1+deb10u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libtasn1-6@4.13-3",
+                  "pkgId": "libtasn1-6@4.13-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libunistring/libunistring2@0.9.10-1",
+                  "pkgId": "libunistring/libunistring2@0.9.10-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "nettle/libnettle6@3.4.1-1",
+                  "pkgId": "nettle/libnettle6@3.4.1-1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
+                    },
+                    Object {
+                      "nodeId": "nettle/libnettle6@3.4.1-1",
+                    },
+                  ],
+                  "nodeId": "nettle/libhogweed4@3.4.1-1|1",
+                  "pkgId": "nettle/libhogweed4@3.4.1-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "nettle/libhogweed4@3.4.1-1|2",
+                  "pkgId": "nettle/libhogweed4@3.4.1-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libffi/libffi6@3.2.1-9",
+                  "pkgId": "libffi/libffi6@3.2.1-9",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libffi/libffi6@3.2.1-9",
+                    },
+                  ],
+                  "nodeId": "p11-kit/libp11-kit0@0.23.15-2|1",
+                  "pkgId": "p11-kit/libp11-kit0@0.23.15-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p11-kit/libp11-kit0@0.23.15-2|2",
+                  "pkgId": "p11-kit/libp11-kit0@0.23.15-2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
+                    },
+                    Object {
+                      "nodeId": "libidn2/libidn2-0@2.0.5-1+deb10u1|1",
+                    },
+                    Object {
+                      "nodeId": "libtasn1-6@4.13-3",
+                    },
+                    Object {
+                      "nodeId": "libunistring/libunistring2@0.9.10-1",
+                    },
+                    Object {
+                      "nodeId": "nettle/libhogweed4@3.4.1-1|1",
+                    },
+                    Object {
+                      "nodeId": "nettle/libnettle6@3.4.1-1",
+                    },
+                    Object {
+                      "nodeId": "p11-kit/libp11-kit0@0.23.15-2|1",
+                    },
+                  ],
+                  "nodeId": "gnutls28/libgnutls30@3.6.7-4+deb10u5|1",
+                  "pkgId": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gnutls28/libgnutls30@3.6.7-4+deb10u5|2",
+                  "pkgId": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libseccomp/libseccomp2@2.3.3-4",
+                  "pkgId": "libseccomp/libseccomp2@2.3.3-4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "adduser@3.118|2",
+                    },
+                    Object {
+                      "nodeId": "apt/libapt-pkg5.0@1.8.2.1|1",
+                    },
+                    Object {
+                      "nodeId": "debian-archive-keyring@2019.1",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libstdc++6@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gnupg2/gpgv@2.2.12-1+deb10u1|1",
+                    },
+                    Object {
+                      "nodeId": "gnutls28/libgnutls30@3.6.7-4+deb10u5|1",
+                    },
+                    Object {
+                      "nodeId": "libseccomp/libseccomp2@2.3.3-4",
+                    },
+                  ],
+                  "nodeId": "apt@1.8.2.1",
+                  "pkgId": "apt@1.8.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mawk/mawk@1.3.3-17+b3",
+                  "pkgId": "mawk/mawk@1.3.3-17+b3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mawk/mawk@1.3.3-17+b3",
+                    },
+                  ],
+                  "nodeId": "base-files@10.3+deb10u6|1",
+                  "pkgId": "base-files@10.3+deb10u6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "base-files@10.3+deb10u6|2",
+                  "pkgId": "base-files@10.3+deb10u6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "cdebconf/libdebconfclient0@0.249",
+                  "pkgId": "cdebconf/libdebconfclient0@0.249",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cdebconf/libdebconfclient0@0.249",
+                    },
+                  ],
+                  "nodeId": "base-passwd@3.5.46",
+                  "pkgId": "base-passwd@3.5.46",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "debianutils@4.8.6.1",
+                  "pkgId": "debianutils@4.8.6.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                  "pkgId": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "base-files@10.3+deb10u6|2",
+                    },
+                    Object {
+                      "nodeId": "debianutils@4.8.6.1",
+                    },
+                    Object {
+                      "nodeId": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                    },
+                  ],
+                  "nodeId": "bash@5.0-4",
+                  "pkgId": "bash@5.0-4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "coreutils@8.30-3",
+                  "pkgId": "coreutils@8.30-3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debianutils@4.8.6.1",
+                    },
+                  ],
+                  "nodeId": "dash@0.5.10.2-5",
+                  "pkgId": "dash@0.5.10.2-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "diffutils@1:3.7-3",
+                  "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
+                  "pkgId": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
+                  "pkgId": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
+                    },
+                  ],
+                  "nodeId": "e2fsprogs/libss2@1.44.5-1+deb10u3|1",
+                  "pkgId": "e2fsprogs/libss2@1.44.5-1+deb10u3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "e2fsprogs/libss2@1.44.5-1+deb10u3|2",
+                  "pkgId": "e2fsprogs/libss2@1.44.5-1+deb10u3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-linux/libuuid1@2.33.1-0.1",
+                  "pkgId": "util-linux/libuuid1@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "util-linux/libuuid1@2.33.1-0.1",
+                    },
+                  ],
+                  "nodeId": "util-linux/libblkid1@2.33.1-0.1|1",
+                  "pkgId": "util-linux/libblkid1@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-linux/libblkid1@2.33.1-0.1|2",
+                  "pkgId": "util-linux/libblkid1@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
+                    },
+                    Object {
+                      "nodeId": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
+                    },
+                    Object {
+                      "nodeId": "e2fsprogs/libss2@1.44.5-1+deb10u3|1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libblkid1@2.33.1-0.1|1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libuuid1@2.33.1-0.1",
+                    },
+                  ],
+                  "nodeId": "e2fsprogs@1.44.5-1+deb10u3",
+                  "pkgId": "e2fsprogs@1.44.5-1+deb10u3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "findutils@4.6.0+git+20190209-2",
+                  "pkgId": "findutils@4.6.0+git+20190209-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc-bin@2.28-10",
+                  "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "grep@3.3-1",
+                  "pkgId": "grep@3.3-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gzip@1.9-3",
+                  "pkgId": "gzip@1.9-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "hostname@3.21",
+                  "pkgId": "hostname@3.21",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "init-system-helpers@1.56+nmu1",
+                  "pkgId": "init-system-helpers@1.56+nmu1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "elfutils/libelf1@0.176-1.1",
+                  "pkgId": "elfutils/libelf1@0.176-1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "iptables/libxtables12@1.8.2-4",
+                  "pkgId": "iptables/libxtables12@1.8.2-4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libcap2@1:2.25-2",
+                  "pkgId": "libcap2@1:2.25-2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libcap2@1:2.25-2",
+                    },
+                  ],
+                  "nodeId": "libcap2/libcap2-bin@1:2.25-2",
+                  "pkgId": "libcap2/libcap2-bin@1:2.25-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libmnl/libmnl0@1.0.4-2",
+                  "pkgId": "libmnl/libmnl0@1.0.4-2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
+                    },
+                    Object {
+                      "nodeId": "elfutils/libelf1@0.176-1.1",
+                    },
+                    Object {
+                      "nodeId": "iptables/libxtables12@1.8.2-4",
+                    },
+                    Object {
+                      "nodeId": "libcap2@1:2.25-2",
+                    },
+                    Object {
+                      "nodeId": "libcap2/libcap2-bin@1:2.25-2",
+                    },
+                    Object {
+                      "nodeId": "libmnl/libmnl0@1.0.4-2",
+                    },
+                  ],
+                  "nodeId": "iproute2@4.20.0-2",
+                  "pkgId": "iproute2@4.20.0-2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libcap2@1:2.25-2",
+                    },
+                    Object {
+                      "nodeId": "libidn2/libidn2-0@2.0.5-1+deb10u1|2",
+                    },
+                    Object {
+                      "nodeId": "nettle/libnettle6@3.4.1-1",
+                    },
+                  ],
+                  "nodeId": "iputils/iputils-ping@3:20180629-2+deb10u1",
+                  "pkgId": "iputils/iputils-ping@3:20180629-2+deb10u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                  "pkgId": "libselinux/libselinux1@2.8-1+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
+                    },
+                    Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
+                    },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
+                  ],
+                  "nodeId": "meta-common-packages@meta",
+                  "pkgId": "meta-common-packages@meta",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2|1",
+                  "pkgId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                    },
+                  ],
+                  "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2|2",
+                  "pkgId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
+                  "pkgId": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                    },
+                  ],
+                  "nodeId": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
+                  "pkgId": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pam/libpam-modules@1.3.1-5|2",
+                    },
+                  ],
+                  "nodeId": "pam/libpam-runtime@1.3.1-5|1",
+                  "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pam/libpam-runtime@1.3.1-5|2",
+                  "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "sed@4.7-1",
+                  "pkgId": "sed@4.7-1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.8.4-3|2",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam-modules@1.3.1-5|2",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam-runtime@1.3.1-5|2",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam0g@1.3.1-5|1",
+                    },
+                  ],
+                  "nodeId": "shadow/login@1:4.5-1.1|1",
+                  "pkgId": "shadow/login@1:4.5-1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "shadow/login@1:4.5-1.1|2",
+                  "pkgId": "shadow/login@1:4.5-1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-linux@2.33.1-0.1|1",
+                  "pkgId": "util-linux@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.8.4-3|2",
+                    },
+                    Object {
+                      "nodeId": "libcap-ng/libcap-ng0@0.7.9-2",
+                    },
+                    Object {
+                      "nodeId": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam0g@1.3.1-5|1",
+                    },
+                    Object {
+                      "nodeId": "shadow/login@1:4.5-1.1|2",
+                    },
+                    Object {
+                      "nodeId": "systemd/libsystemd0@241-7~deb10u4|2",
+                    },
+                    Object {
+                      "nodeId": "systemd/libudev1@241-7~deb10u4",
+                    },
+                    Object {
+                      "nodeId": "util-linux/fdisk@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libblkid1@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libmount1@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libsmartcols1@2.33.1-0.1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libuuid1@2.33.1-0.1",
+                    },
+                  ],
+                  "nodeId": "util-linux@2.33.1-0.1|2",
+                  "pkgId": "util-linux@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "init-system-helpers@1.56+nmu1",
+                    },
+                    Object {
+                      "nodeId": "util-linux@2.33.1-0.1|1",
+                    },
+                  ],
+                  "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                  "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tzdata@2020a-0+deb10u1",
+                  "pkgId": "tzdata@2020a-0+deb10u1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "systemd/libsystemd0@241-7~deb10u4|2",
+                    },
+                  ],
+                  "nodeId": "util-linux/bsdutils@1:2.33.1-0.1",
+                  "pkgId": "util-linux/bsdutils@1:2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "util-linux/libblkid1@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libuuid1@2.33.1-0.1",
+                    },
+                  ],
+                  "nodeId": "util-linux/libfdisk1@2.33.1-0.1|1",
+                  "pkgId": "util-linux/libfdisk1@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-linux/libfdisk1@2.33.1-0.1|2",
+                  "pkgId": "util-linux/libfdisk1@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "util-linux/libblkid1@2.33.1-0.1|2",
+                    },
+                  ],
+                  "nodeId": "util-linux/libmount1@2.33.1-0.1|1",
+                  "pkgId": "util-linux/libmount1@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-linux/libmount1@2.33.1-0.1|2",
+                  "pkgId": "util-linux/libmount1@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-linux/libsmartcols1@2.33.1-0.1",
+                  "pkgId": "util-linux/libsmartcols1@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2|2",
+                    },
+                    Object {
+                      "nodeId": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libfdisk1@2.33.1-0.1|1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libmount1@2.33.1-0.1|1",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libsmartcols1@2.33.1-0.1",
+                    },
+                  ],
+                  "nodeId": "util-linux/fdisk@2.33.1-0.1|1",
+                  "pkgId": "util-linux/fdisk@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-linux/fdisk@2.33.1-0.1|2",
+                  "pkgId": "util-linux/fdisk@2.33.1-0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "util-linux@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libblkid1@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libmount1@2.33.1-0.1|2",
+                    },
+                    Object {
+                      "nodeId": "util-linux/libsmartcols1@2.33.1-0.1",
+                    },
+                  ],
+                  "nodeId": "util-linux/mount@2.33.1-0.1",
+                  "pkgId": "util-linux/mount@2.33.1-0.1",
+                },
+              ],
+              "rootNodeId": "root-node",
+            },
+            "pkgManager": Object {
+              "name": "deb",
+              "repositories": Array [
+                Object {
+                  "alias": "debian:10",
+                },
+              ],
+            },
+            "pkgs": Array [
+              Object {
+                "id": "docker-image|debian@10",
+                "info": Object {
+                  "name": "docker-image|debian",
+                  "version": "10",
+                },
+              },
+              Object {
+                "id": "audit/libaudit-common@1:2.8.4-3",
+                "info": Object {
+                  "name": "audit/libaudit-common",
+                  "version": "1:2.8.4-3",
+                },
+              },
+              Object {
+                "id": "libcap-ng/libcap-ng0@0.7.9-2",
+                "info": Object {
+                  "name": "libcap-ng/libcap-ng0",
+                  "version": "0.7.9-2",
+                },
+              },
+              Object {
+                "id": "audit/libaudit1@1:2.8.4-3",
+                "info": Object {
+                  "name": "audit/libaudit1",
+                  "version": "1:2.8.4-3",
+                },
+              },
+              Object {
+                "id": "libsemanage/libsemanage-common@2.8-2",
+                "info": Object {
+                  "name": "libsemanage/libsemanage-common",
+                  "version": "2.8-2",
+                },
+              },
+              Object {
+                "id": "libsepol/libsepol1@2.8-1",
+                "info": Object {
+                  "name": "libsepol/libsepol1",
+                  "version": "2.8-1",
+                },
+              },
+              Object {
+                "id": "libsemanage/libsemanage1@2.8-2",
+                "info": Object {
+                  "name": "libsemanage/libsemanage1",
+                  "version": "2.8-2",
+                },
+              },
+              Object {
+                "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
+                "info": Object {
+                  "name": "db5.3/libdb5.3",
+                  "version": "5.3.28+dfsg1-0.5",
+                },
+              },
+              Object {
+                "id": "pam/libpam0g@1.3.1-5",
+                "info": Object {
+                  "name": "pam/libpam0g",
+                  "version": "1.3.1-5",
+                },
+              },
+              Object {
+                "id": "pam/libpam-modules-bin@1.3.1-5",
+                "info": Object {
+                  "name": "pam/libpam-modules-bin",
+                  "version": "1.3.1-5",
+                },
+              },
+              Object {
+                "id": "pam/libpam-modules@1.3.1-5",
+                "info": Object {
+                  "name": "pam/libpam-modules",
+                  "version": "1.3.1-5",
+                },
+              },
+              Object {
+                "id": "shadow/passwd@1:4.5-1.1",
+                "info": Object {
+                  "name": "shadow/passwd",
+                  "version": "1:4.5-1.1",
+                },
+              },
+              Object {
+                "id": "adduser@3.118",
+                "info": Object {
+                  "name": "adduser",
+                  "version": "3.118",
+                },
+              },
+              Object {
+                "id": "gcc-8/libstdc++6@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libstdc++6",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "libzstd/libzstd1@1.3.8+dfsg-3",
+                "info": Object {
+                  "name": "libzstd/libzstd1",
+                  "version": "1.3.8+dfsg-3",
+                },
+              },
+              Object {
+                "id": "lz4/liblz4-1@1.8.3-1",
+                "info": Object {
+                  "name": "lz4/liblz4-1",
+                  "version": "1.8.3-1",
+                },
+              },
+              Object {
+                "id": "libgcrypt20@1.8.4-5",
+                "info": Object {
+                  "name": "libgcrypt20",
+                  "version": "1.8.4-5",
+                },
+              },
+              Object {
+                "id": "systemd/libsystemd0@241-7~deb10u4",
+                "info": Object {
+                  "name": "systemd/libsystemd0",
+                  "version": "241-7~deb10u4",
+                },
+              },
+              Object {
+                "id": "systemd/libudev1@241-7~deb10u4",
+                "info": Object {
+                  "name": "systemd/libudev1",
+                  "version": "241-7~deb10u4",
+                },
+              },
+              Object {
+                "id": "apt/libapt-pkg5.0@1.8.2.1",
+                "info": Object {
+                  "name": "apt/libapt-pkg5.0",
+                  "version": "1.8.2.1",
+                },
+              },
+              Object {
+                "id": "debian-archive-keyring@2019.1",
+                "info": Object {
+                  "name": "debian-archive-keyring",
+                  "version": "2019.1",
+                },
+              },
+              Object {
+                "id": "libgpg-error/libgpg-error0@1.35-1",
+                "info": Object {
+                  "name": "libgpg-error/libgpg-error0",
+                  "version": "1.35-1",
+                },
+              },
+              Object {
+                "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
+                "info": Object {
+                  "name": "gnupg2/gpgv",
+                  "version": "2.2.12-1+deb10u1",
+                },
+              },
+              Object {
+                "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
+                "info": Object {
+                  "name": "gmp/libgmp10",
+                  "version": "2:6.1.2+dfsg-4",
+                },
+              },
+              Object {
+                "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
+                "info": Object {
+                  "name": "libidn2/libidn2-0",
+                  "version": "2.0.5-1+deb10u1",
+                },
+              },
+              Object {
+                "id": "libtasn1-6@4.13-3",
+                "info": Object {
+                  "name": "libtasn1-6",
+                  "version": "4.13-3",
+                },
+              },
+              Object {
+                "id": "libunistring/libunistring2@0.9.10-1",
+                "info": Object {
+                  "name": "libunistring/libunistring2",
+                  "version": "0.9.10-1",
+                },
+              },
+              Object {
+                "id": "nettle/libnettle6@3.4.1-1",
+                "info": Object {
+                  "name": "nettle/libnettle6",
+                  "version": "3.4.1-1",
+                },
+              },
+              Object {
+                "id": "nettle/libhogweed4@3.4.1-1",
+                "info": Object {
+                  "name": "nettle/libhogweed4",
+                  "version": "3.4.1-1",
+                },
+              },
+              Object {
+                "id": "libffi/libffi6@3.2.1-9",
+                "info": Object {
+                  "name": "libffi/libffi6",
+                  "version": "3.2.1-9",
+                },
+              },
+              Object {
+                "id": "p11-kit/libp11-kit0@0.23.15-2",
+                "info": Object {
+                  "name": "p11-kit/libp11-kit0",
+                  "version": "0.23.15-2",
+                },
+              },
+              Object {
+                "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
+                "info": Object {
+                  "name": "gnutls28/libgnutls30",
+                  "version": "3.6.7-4+deb10u5",
+                },
+              },
+              Object {
+                "id": "libseccomp/libseccomp2@2.3.3-4",
+                "info": Object {
+                  "name": "libseccomp/libseccomp2",
+                  "version": "2.3.3-4",
+                },
+              },
+              Object {
+                "id": "apt@1.8.2.1",
+                "info": Object {
+                  "name": "apt",
+                  "version": "1.8.2.1",
+                },
+              },
+              Object {
+                "id": "mawk/mawk@1.3.3-17+b3",
+                "info": Object {
+                  "name": "mawk/mawk",
+                  "version": "1.3.3-17+b3",
+                },
+              },
+              Object {
+                "id": "base-files@10.3+deb10u6",
+                "info": Object {
+                  "name": "base-files",
+                  "version": "10.3+deb10u6",
+                },
+              },
+              Object {
+                "id": "cdebconf/libdebconfclient0@0.249",
+                "info": Object {
+                  "name": "cdebconf/libdebconfclient0",
+                  "version": "0.249",
+                },
+              },
+              Object {
+                "id": "base-passwd@3.5.46",
+                "info": Object {
+                  "name": "base-passwd",
+                  "version": "3.5.46",
+                },
+              },
+              Object {
+                "id": "debianutils@4.8.6.1",
+                "info": Object {
+                  "name": "debianutils",
+                  "version": "4.8.6.1",
+                },
+              },
+              Object {
+                "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
+                "info": Object {
+                  "name": "ncurses/libtinfo6",
+                  "version": "6.1+20181013-2+deb10u2",
+                },
+              },
+              Object {
+                "id": "bash@5.0-4",
+                "info": Object {
+                  "name": "bash",
+                  "version": "5.0-4",
+                },
+              },
+              Object {
+                "id": "coreutils@8.30-3",
+                "info": Object {
+                  "name": "coreutils",
+                  "version": "8.30-3",
+                },
+              },
+              Object {
+                "id": "dash@0.5.10.2-5",
+                "info": Object {
+                  "name": "dash",
+                  "version": "0.5.10.2-5",
+                },
+              },
+              Object {
+                "id": "diffutils@1:3.7-3",
+                "info": Object {
+                  "name": "diffutils",
+                  "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
+                "info": Object {
+                  "name": "e2fsprogs/libcom-err2",
+                  "version": "1.44.5-1+deb10u3",
+                },
+              },
+              Object {
+                "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
+                "info": Object {
+                  "name": "e2fsprogs/libext2fs2",
+                  "version": "1.44.5-1+deb10u3",
+                },
+              },
+              Object {
+                "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
+                "info": Object {
+                  "name": "e2fsprogs/libss2",
+                  "version": "1.44.5-1+deb10u3",
+                },
+              },
+              Object {
+                "id": "util-linux/libuuid1@2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux/libuuid1",
+                  "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "util-linux/libblkid1@2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux/libblkid1",
+                  "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "e2fsprogs@1.44.5-1+deb10u3",
+                "info": Object {
+                  "name": "e2fsprogs",
+                  "version": "1.44.5-1+deb10u3",
+                },
+              },
+              Object {
+                "id": "findutils@4.6.0+git+20190209-2",
+                "info": Object {
+                  "name": "findutils",
+                  "version": "4.6.0+git+20190209-2",
+                },
+              },
+              Object {
+                "id": "glibc/libc-bin@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc-bin",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "grep@3.3-1",
+                "info": Object {
+                  "name": "grep",
+                  "version": "3.3-1",
+                },
+              },
+              Object {
+                "id": "gzip@1.9-3",
+                "info": Object {
+                  "name": "gzip",
+                  "version": "1.9-3",
+                },
+              },
+              Object {
+                "id": "hostname@3.21",
+                "info": Object {
+                  "name": "hostname",
+                  "version": "3.21",
+                },
+              },
+              Object {
+                "id": "init-system-helpers@1.56+nmu1",
+                "info": Object {
+                  "name": "init-system-helpers",
+                  "version": "1.56+nmu1",
+                },
+              },
+              Object {
+                "id": "elfutils/libelf1@0.176-1.1",
+                "info": Object {
+                  "name": "elfutils/libelf1",
+                  "version": "0.176-1.1",
+                },
+              },
+              Object {
+                "id": "iptables/libxtables12@1.8.2-4",
+                "info": Object {
+                  "name": "iptables/libxtables12",
+                  "version": "1.8.2-4",
+                },
+              },
+              Object {
+                "id": "libcap2@1:2.25-2",
+                "info": Object {
+                  "name": "libcap2",
+                  "version": "1:2.25-2",
+                },
+              },
+              Object {
+                "id": "libcap2/libcap2-bin@1:2.25-2",
+                "info": Object {
+                  "name": "libcap2/libcap2-bin",
+                  "version": "1:2.25-2",
+                },
+              },
+              Object {
+                "id": "libmnl/libmnl0@1.0.4-2",
+                "info": Object {
+                  "name": "libmnl/libmnl0",
+                  "version": "1.0.4-2",
+                },
+              },
+              Object {
+                "id": "iproute2@4.20.0-2",
+                "info": Object {
+                  "name": "iproute2",
+                  "version": "4.20.0-2",
+                },
+              },
+              Object {
+                "id": "iputils/iputils-ping@3:20180629-2+deb10u1",
+                "info": Object {
+                  "name": "iputils/iputils-ping",
+                  "version": "3:20180629-2+deb10u1",
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
+                },
+              },
+              Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
+                },
+              },
+              Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "libselinux/libselinux1@2.8-1+b1",
+                "info": Object {
+                  "name": "libselinux/libselinux1",
+                  "version": "2.8-1+b1",
+                },
+              },
+              Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6+deb10u1",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6+deb10u1",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
+                },
+              },
+              Object {
+                "id": "meta-common-packages@meta",
+                "info": Object {
+                  "name": "meta-common-packages",
+                  "version": "meta",
+                },
+              },
+              Object {
+                "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
+                "info": Object {
+                  "name": "ncurses/libncursesw6",
+                  "version": "6.1+20181013-2+deb10u2",
+                },
+              },
+              Object {
+                "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
+                "info": Object {
+                  "name": "ncurses/ncurses-base",
+                  "version": "6.1+20181013-2+deb10u2",
+                },
+              },
+              Object {
+                "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
+                "info": Object {
+                  "name": "ncurses/ncurses-bin",
+                  "version": "6.1+20181013-2+deb10u2",
+                },
+              },
+              Object {
+                "id": "pam/libpam-runtime@1.3.1-5",
+                "info": Object {
+                  "name": "pam/libpam-runtime",
+                  "version": "1.3.1-5",
+                },
+              },
+              Object {
+                "id": "sed@4.7-1",
+                "info": Object {
+                  "name": "sed",
+                  "version": "4.7-1",
+                },
+              },
+              Object {
+                "id": "shadow/login@1:4.5-1.1",
+                "info": Object {
+                  "name": "shadow/login",
+                  "version": "1:4.5-1.1",
+                },
+              },
+              Object {
+                "id": "util-linux@2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux",
+                  "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "sysvinit/sysvinit-utils@2.93-8",
+                "info": Object {
+                  "name": "sysvinit/sysvinit-utils",
+                  "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tzdata@2020a-0+deb10u1",
+                "info": Object {
+                  "name": "tzdata",
+                  "version": "2020a-0+deb10u1",
+                },
+              },
+              Object {
+                "id": "util-linux/bsdutils@1:2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux/bsdutils",
+                  "version": "1:2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "util-linux/libfdisk1@2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux/libfdisk1",
+                  "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "util-linux/libmount1@2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux/libmount1",
+                  "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "util-linux/libsmartcols1@2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux/libsmartcols1",
+                  "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "util-linux/fdisk@2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux/fdisk",
+                  "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "util-linux/mount@2.33.1-0.1",
+                "info": Object {
+                  "name": "util-linux/mount",
+                  "version": "2.33.1-0.1",
+                },
+              },
+            ],
+            "schemaVersion": "1.2.0",
+          },
+          "type": "depGraph",
+        },
+        Object {
+          "data": "1510e850178318cd2b654439b56266e7b6cbff36f95f343f662c708cd51d0610",
+          "type": "imageId",
+        },
+        Object {
+          "data": Array [
+            "c54cdd496b5433ab119608a8cf58fa602d3e43616edcc54a86d1808170b1b5cb/layer.tar",
+          ],
+          "type": "imageLayers",
+        },
+        Object {
+          "data": Array [
+            "sha256:9780f6d83e45878749497a6297ed9906c19ee0cc48cc88dc63827564bb8768fd",
+          ],
+          "type": "rootFs",
+        },
+        Object {
+          "data": "Debian GNU/Linux 10 (buster)",
+          "type": "imageOsReleasePrettyName",
+        },
+        Object {
+          "data": Array [
+            Object {
+              "contents": "UFJFVFRZX05BTUU9IkRlYmlhbiBHTlUvTGludXggMTAgKGJ1c3RlcikiCk5BTUU9IkRlYmlhbiBHTlUvTGludXgiClZFUlNJT05fSUQ9IjEwIgpWRVJTSU9OPSIxMCAoYnVzdGVyKSIKVkVSU0lPTl9DT0RFTkFNRT1idXN0ZXIKSUQ9ZGViaWFuCkhPTUVfVVJMPSJodHRwczovL3d3dy5kZWJpYW4ub3JnLyIKU1VQUE9SVF9VUkw9Imh0dHBzOi8vd3d3LmRlYmlhbi5vcmcvc3VwcG9ydCIKQlVHX1JFUE9SVF9VUkw9Imh0dHBzOi8vYnVncy5kZWJpYW4ub3JnLyIK",
+              "name": "os-release",
+              "path": "/usr/lib",
+            },
+          ],
+          "type": "imageManifestFiles",
+        },
       ],
-      "type": "Buffer",
+      "identity": Object {
+        "args": Object {
+          "platform": "linux/amd64",
+        },
+        "type": "deb",
+      },
+      "target": Object {
+        "image": "docker-image|debian",
+      },
     },
-    "name": "os-release",
-    "path": "/usr/lib",
-  },
-]
+  ],
+}
 `;

--- a/test/system/app-os/globs.spec.ts
+++ b/test/system/app-os/globs.spec.ts
@@ -16,6 +16,6 @@ describe("find globs tests", () => {
       },
     });
 
-    expect(pluginResult.manifestFiles).toMatchSnapshot();
+    expect(pluginResult).toMatchSnapshot();
   });
 });

--- a/test/system/application-scans/__snapshots__/node.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/node.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`node application scans should correctly return applications as multiple scan results 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/bugs/__snapshots__/rpm-transitive-dependencies.spec.ts.snap
+++ b/test/system/bugs/__snapshots__/rpm-transitive-dependencies.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`BUG: Dockerfile analysis does not produce transitive dependencies for RPM projects should not produce transitive dependencies 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/dockerfile-analysis/__snapshots__/docker-file.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/docker-file.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`dockerfile analysis should correctly return a dockerfile analysis as part of image scanning 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`compressed archive scanning should correctly scan a compressed archive 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`docker archive scanning should correctly scan a docker archive 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/image-type/__snapshots__/oci-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/oci-archive.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`oci archive scanning should correctly scan an oci archive 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
+++ b/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`key binaries hashes scanning should correctly scan java key binaries hashes 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [
@@ -78,7 +77,6 @@ Object {
 
 exports[`key binaries hashes scanning should correctly scan node key binaries hashes 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/alpine3.7.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/alpine3.7.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`alpine tests should correctly analyze an alpine image by sha256 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [
@@ -378,7 +377,6 @@ Object {
 
 exports[`alpine tests should correctly analyze an alpine image by tag 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/busybox1.32.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/busybox1.32.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`busybox tests should correctly analyze a busybox image by sha256 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/centos7.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/centos7.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`centos tests should correctly analyze a centos image by sha256 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [
@@ -2282,7 +2281,6 @@ Object {
 
 exports[`centos tests should correctly analyze a centos image by tag 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`debian tests should correctly analyze a debian image by sha256 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`distroless tests should correctly analyze a distroless image by sha256 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/oraclelinux8.2.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/oraclelinux8.2.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`oracle linux tests should correctly analyze an oracle linux image by sha256 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [
@@ -2807,7 +2806,6 @@ Object {
 
 exports[`oracle linux tests should correctly analyze an oracle linux image by tag 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/scratch.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/scratch.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`scratch tests should correctly analyze an scratch image by sha256 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`suse linux enterprise server tests should correctly analyze an sles image by tag 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`redhat ubi8 tests should correctly analyze an ubi8 image by tag 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/package-managers/__snapshots__/apk.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/apk.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`apk package manager tests should correctly analyze an apk image 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/package-managers/__snapshots__/deb.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/deb.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`deb package manager tests should correctly analyze a deb image 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`rpm package manager tests should correctly analyze an rpm image 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/platforms/__snapshots__/amd.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/amd.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`AMD platform tests should correctly scan an AMD image and return platform: amd64 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [
@@ -1828,7 +1827,6 @@ Object {
 
 exports[`AMD platform tests should correctly scan an AMD image when the user provides --platform=amd64 and return platform: amd64 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/platforms/__snapshots__/arm.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/arm.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`ARM platform tests should correctly scan an ARM image 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/platforms/__snapshots__/ppc64le.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/ppc64le.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`PPC64 platform tests should correctly scan a PPC image and return platform: ppc64le 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [
@@ -825,7 +824,6 @@ Object {
 
 exports[`PPC64 platform tests should correctly scan a PPC image when the user provides --platform=ppc64le and return platform: ppc64le 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
+++ b/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`username and password authentication should correctly authenticate to the container registry when username and password are provided 1`] = `
 Object {
-  "manifestFiles": undefined,
   "scanResults": Array [
     Object {
       "facts": Array [

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -4,6 +4,7 @@ import { test } from "tap";
 
 import * as plugin from "../../lib";
 import { DockerFileAnalysis } from "../../lib/docker-file";
+import { ManifestFile } from "../../lib/types";
 
 const getFixture = (fixturePath) =>
   path.join(__dirname, "../fixtures/docker-archives", fixturePath);
@@ -377,16 +378,20 @@ test("manifest files are detected", async (t) => {
   const osDepsStatic = pluginResultStatic.scanResults[0];
   t.ok(osDepsStatic !== undefined);
 
-  const manifestFiles = pluginResultStatic.manifestFiles;
+  const manifestFiles: ManifestFile[] = osDepsStatic.facts.find(
+    (fact) => fact.type === "imageManifestFiles",
+  )!.data;
   t.ok(manifestFiles !== undefined, "found manifest files in static scan");
   t.equals(
-    manifestFiles?.length,
+    manifestFiles.length,
     1,
     "static scan finds one manifest file because it doesn't follow on symlinks",
   );
-  t.true(
-    Buffer.isBuffer(manifestFiles?.[0].contents),
-    "static scanned manifest files are held in buffer",
+  t.match(
+    manifestFiles[0].contents,
+    // match on some of the contents (the end of the file)
+    "kZWJpYW4ub3JnLyIK",
+    "static scanned manifest files are held in a base64-encoded string",
   );
 });
 

--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -259,7 +259,9 @@ test("inspect redis:3.2.11-alpine", async (t) => {
 
   t.equal(depGraph.getDepPkgs().length, 13, "expected number of deps");
 
-  const manifestFiles: ManifestFile[] = pluginResponse.manifestFiles!;
+  const manifestFiles: ManifestFile[] = pluginResponse.scanResults[0].facts.find(
+    (fact) => fact.type === "imageManifestFiles",
+  )!.data;
   t.ok(Array.isArray(manifestFiles), "manifest files data is an array");
   t.equals(manifestFiles.length, 1, "two manifest files found");
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Having the manifest files returned at the top-level plugin response does not conform with other Snyk CLI plugins.
The manifest files have only two use-cases: kubernetes-monitor and DRA.

We prefer to "hide" the manifest files as a Fact in the OS dependencies ScanResult (the 1st ScanResult).
These manifest files need further processing so we can extract actual package manager information and to create projects in Snyk.

Additionally, as part of this change, change the interface of the manifest files to return their contents as a Base64 string.
This is needed for two reasons:
- the existing Buffer interface cannot cleanly be transferred over the network (considering we use JSON in our APIs)
- we cannot make assumptions about the file encoding otherwise we can accidentally corrupt the data we receive

#### Any background context you want to provide?

[Discussion on Slack](https://snyk.slack.com/archives/CBXS33GJY/p1589787181070700?thread_ts=1589385083.016900&cid=CBXS33GJY)

#### What are the relevant tickets?

[Jira ticket RUN-1219](https://snyksec.atlassian.net/browse/RUN-1219)
