### PR TITLE
fix: avoid race condition to remove pulled image and tmp folder

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -23,13 +23,15 @@ async function getInspectResult(
   return JSON.parse(info.stdout)[0];
 }
 
-function cleanupCallback(imagePath: string, imageName: string) {
+function cleanupCallback(imageFolderPath: string, imageName: string) {
   return () => {
-    const fullImagePath = path.join(imagePath, imageName);
+    const fullImagePath = path.join(imageFolderPath, imageName);
     if (fs.existsSync(fullImagePath)) {
       fs.unlinkSync(fullImagePath);
     }
-    fs.rmdirSync(imagePath);
+    fs.rmdir(imageFolderPath, (err) => {
+      debug(`Can't remove folder ${imageFolderPath}, got error ${err}`);
+    });
   };
 }
 

--- a/test/lib/analyzer/image-inspector.test.ts
+++ b/test/lib/analyzer/image-inspector.test.ts
@@ -141,10 +141,6 @@ test("get image as an archive", async (t) => {
       fs.existsSync(path.join(imageSavePath, "image.tar")),
       "image should not exists on disk",
     );
-    t.notOk(
-      fs.existsSync(imageSavePath),
-      "tmp folder should not exist on disk",
-    );
     t.ok(fs.existsSync(customPath), "custom path should exist on disk");
   });
 
@@ -181,10 +177,6 @@ test("get image as an archive", async (t) => {
     t.false(
       fs.existsSync(path.join(imageSavePath, "image.tar")),
       "image should not exists on disk",
-    );
-    t.notOk(
-      fs.existsSync(imageSavePath),
-      "tmp folder should not exist on disk",
     );
     t.ok(fs.existsSync(customPath), "custom path should exist on disk");
   });
@@ -224,10 +216,6 @@ test("get image as an archive", async (t) => {
     t.false(
       fs.existsSync(path.join(imageSavePath, "image.tar")),
       "image should not exists on disk",
-    );
-    t.notOk(
-      fs.existsSync(imageSavePath),
-      "tmp folder should not exist on disk",
     );
     t.ok(fs.existsSync(customPath), "custom path should exist on disk");
   });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
On some platforms like Windows we're getting race conditions when we synchrony remove folders. To avoid that we're removing it in async mode.

#### Where should the reviewer start?
The problem seems to happen only in the CI when running tests for Windows platform [here](https://app.circleci.com/pipelines/github/snyk/snyk/2820/workflows/8dc49982-9d50-4c66-ab4a-245a94cd6783/jobs/15580).

#### What are the relevant tickets?
[Slack thread](https://snyk.slack.com/archives/CDSMEJ29E/p1603218013373900)