### PR TITLE
test: show a bug exists with injected base image in Dockerfiles

### DIFF
--- a/test/system/bugs/Dockerfile.injected
+++ b/test/system/bugs/Dockerfile.injected
@@ -1,0 +1,6 @@
+ARG FROM
+ARG TAG
+
+FROM ${FROM}:${TAG}
+
+RUN apk add openssl

--- a/test/system/bugs/injected-dockerfile-base-image.spec.ts
+++ b/test/system/bugs/injected-dockerfile-base-image.spec.ts
@@ -1,0 +1,29 @@
+import { join as pathJoin } from "path";
+
+import { scan } from "../../../lib/index";
+
+describe("demonstrates a bug with detecting injected Dockerfile base image name and tag", () => {
+  it("returns null:null for base image analysis if the parameters are injected in the Dockerfile", async () => {
+    const imagePath = pathJoin(
+      __dirname,
+      "../../fixtures/docker-archives/docker-save/hello-world.tar",
+    );
+    const dockerfilePath = pathJoin(__dirname, "Dockerfile.injected");
+
+    const pluginResult = await scan({
+      path: `docker-archive:${imagePath}`,
+      file: dockerfilePath,
+    });
+
+    const dockerfileAnalysis = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "dockerfileAnalysis",
+    )?.data;
+
+    expect(dockerfileAnalysis).toMatchObject(
+      expect.objectContaining({
+        // This is the bug!
+        baseImage: "null:null",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

If the base image name and tag are injected using ARG in the Dockerfile, the analysis will incorrectly mark the baseImage as null:null.

#### What are the relevant tickets?

[ZenDesk ticket 7256](https://snyk.zendesk.com/agent/tickets/7256)

