### PR TITLE
fix: update nodejs-lockfile parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^6.1.0",
-    "snyk-nodejs-lockfile-parser": "1.30.0",
+    "snyk-nodejs-lockfile-parser": "1.30.1",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",
     "tslib": "^1",


### PR DESCRIPTION
Updates to the new snyk-config version that should get shipped with the CLI first.

Requirement for snyk/snyk#1524
Follow up to the snyk/config#43 and https://github.com/snyk/nodejs-lockfile-parser/pull/89