### PR TITLE
fix: update docker-pull so that errors are properly serialized

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@snyk/dep-graph": "^1.19.4",
     "@snyk/rpm-parser": "^2.0.0",
-    "@snyk/snyk-docker-pull": "^3.2.0",
+    "@snyk/snyk-docker-pull": "3.2.1",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Correctly serializes errors returned on failures to contact the container registries, see https://github.com/snyk/docker-registry-v2-client/pull/55.

#### What are the relevant tickets?

[ZenDesk #7485](https://snyk.zendesk.com/agent/tickets/7485)

