### PR TITLE
chore: stop lint running multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "debug": "tsc-watch --project tsconfig.json --onSuccess 'node --inspect --inspect-brk .'",
     "lint": "prettier --check \"{lib,test}/**/*.ts\" && tslint --format stylish \"{lib,test}/**/*.ts\"",
     "format": "prettier --loglevel warn --write '{lib,test}/**/*.ts' && tslint --fix --format stylish '{lib,test}/**/*.ts'",
-    "test": "npm run lint && npm run unit-test",
+    "test": "npm run unit-test",
     "test-jest": "jest --bail --logHeapUsage",
-    "test-windows": "npm run lint && tap test/windows/**/*.test.ts -R=spec --timeout=300",
+    "test-windows": "tap test/windows/**/*.test.ts -R=spec --timeout=300",
     "test-jest-windows": "jest --bail --config test/windows/jest.config.js --logHeapUsage",
     "unit-test": "tap test/**/*.test.ts -R=spec --timeout=300",
     "prepare": "npm run build"


### PR DESCRIPTION
As https://snyk.slack.com/archives/CDSMEJ29E/p1605708656050800, piping lint failures into tests outcomes can misleadingly mark test jobs in CI as failed when in fact only lint has failed, and tests are fine. This prevents that behaviour

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
