### PR TITLE
chore: Dont run tests in CI if lint fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,25 +184,29 @@ workflows:
       - build:
           name: Build
           requires:
-            - Install
+            - Lint
       - test:
           name: Test
           context: nodejs-install
           requires:
-            - Install
+            - Lint
       - test_jest:
           name: Test Jest
           context: nodejs-install
           requires:
-            - Install
+            - Lint
       - test_windows:
           name: Test Windows
           context: nodejs-install
           node_version: "8.17.0"
+          requires:
+            - Lint
       - test_jest_windows:
           name: Test Jest Windows
           context: nodejs-install
           node_version: "10.19.0"
+          requires:
+            - Lint
       - release:
           name: Release to GitHub
           context: nodejs-lib-release


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

Fail fast by requiring lint to have succeeded before running tests.

As https://snyk.slack.com/archives/CDSMEJ29E/p1605708656050800, coupling lint failures to tests outcomes can misleadingly mark test jobs in CI as failed when in fact only lint has failed, and tests are fine. This prevents that behaviour