### PR TITLE
Use ENV for credentials for downloading images on CLI

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -9,12 +9,22 @@ import { getArchivePath, getImageType } from "./image-type";
 import * as staticModule from "./static";
 import { ImageType, PluginOptions, PluginResponse } from "./types";
 
+// Registry credentials may also be provided by env vars. When both are set, flags take precedence.
+export function mergeEnvVarsIntoCredentials(
+  options: Partial<PluginOptions>,
+): void {
+  options.username = options.username || process.env.SNYK_REGISTRY_USERNAME;
+  options.password = options.password || process.env.SNYK_REGISTRY_PASSWORD;
+}
+
 export async function scan(
   options?: Partial<PluginOptions>,
 ): Promise<PluginResponse> {
   if (!options) {
     throw new Error("No plugin options provided");
   }
+
+  mergeEnvVarsIntoCredentials(options);
 
   const targetImage = options.path;
   if (!targetImage) {

--- a/test/lib/scan.spec.ts
+++ b/test/lib/scan.spec.ts
@@ -1,0 +1,74 @@
+import { mergeEnvVarsIntoCredentials } from "../../lib/scan";
+
+describe("mergeEnvVarsIntoCredentials", () => {
+  const oldEnvVars = { ...process.env };
+  const FLAG_USER = "flagUser";
+  const ENV_VAR_USER = "envVarUser";
+  const FLAG_PASSWORD = "flagPassword";
+  const ENV_VAR_PASSWORD = "envVarPassword";
+
+  beforeEach(() => {
+    delete process.env.SNYK_REGISTRY_USERNAME;
+    delete process.env.SNYK_REGISTRY_PASSWORD;
+  });
+
+  afterEach(() => {
+    process.env = { ...oldEnvVars };
+  });
+
+  // prettier-ignore
+  it.each`
+    
+    usernameFlag | usernameEnvVar  |  expectedUsername 
+    
+    ${undefined} | ${undefined}    |  ${undefined}
+    ${FLAG_USER} | ${undefined}    |  ${FLAG_USER}   
+    ${undefined} | ${ENV_VAR_USER} |  ${ENV_VAR_USER}
+    ${FLAG_USER} | ${ENV_VAR_USER} |  ${FLAG_USER}
+        
+  `("should set username to $expectedUsername when flag is $usernameFlag and envvar is $usernameEnvVar",
+  ({
+        usernameFlag,
+        usernameEnvVar,
+        expectedUsername,
+      }) => {
+        if (usernameEnvVar) {
+            process.env.SNYK_REGISTRY_USERNAME = usernameEnvVar;
+        }
+        const options = {
+            username: usernameFlag,
+        };
+
+        mergeEnvVarsIntoCredentials(options);
+
+        expect(options.username).toEqual(expectedUsername);
+  });
+
+  // prettier-ignore
+  it.each`
+    
+    passwordFlag     | passwordEnvVar      |  expectedPassword 
+    
+    ${undefined}     | ${undefined}        | ${undefined}
+    ${FLAG_PASSWORD} | ${undefined}        | ${FLAG_PASSWORD}   
+    ${undefined}     | ${ENV_VAR_PASSWORD} | ${ENV_VAR_PASSWORD}
+    ${FLAG_PASSWORD} | ${ENV_VAR_PASSWORD} | ${FLAG_PASSWORD}
+        
+  `("should set password to $expectedPassword when flag is $passwordFlag and envvar is $passwordEnvVar",
+    ({
+       passwordFlag,
+       passwordEnvVar,
+       expectedPassword,
+     }) => {
+      if (passwordEnvVar) {
+        process.env.SNYK_REGISTRY_PASSWORD = passwordEnvVar;
+      }
+      const options = {
+        password: passwordFlag,
+      };
+
+      mergeEnvVarsIntoCredentials(options);
+
+      expect(options.password).toEqual(expectedPassword);
+    });
+});

--- a/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
+++ b/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
@@ -1,6 +1,437 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`username and password authentication should correctly authenticate to the container registry when username and password are provided 1`] = `
+exports[`username and password authentication should correctly authenticate to the container registry when username and password are provided as SNYK env vars and not as flags 1`] = `
+Object {
+  "scanResults": Array [
+    Object {
+      "facts": Array [
+        Object {
+          "data": Object {
+            "graph": Object {
+              "nodes": Array [
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "alpine-baselayout/alpine-baselayout@3.1.0-r0",
+                    },
+                    Object {
+                      "nodeId": "alpine-keys/alpine-keys@2.1-r1",
+                    },
+                    Object {
+                      "nodeId": "apk-tools/apk-tools@2.10.1-r0",
+                    },
+                    Object {
+                      "nodeId": "busybox/busybox@1.28.4-r3|2",
+                    },
+                    Object {
+                      "nodeId": "busybox/ssl_client@1.28.4-r3",
+                    },
+                    Object {
+                      "nodeId": "gcc/libgcc@6.4.0-r9",
+                    },
+                    Object {
+                      "nodeId": "gcc/libstdc++@6.4.0-r9|2",
+                    },
+                    Object {
+                      "nodeId": "libc-dev/libc-utils@0.7.1-r0",
+                    },
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libcrypto@2.7.4-r0|2",
+                    },
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libssl@2.7.4-r0|2",
+                    },
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libtls@2.7.4-r0|2",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                    Object {
+                      "nodeId": "musl/musl-utils@1.1.19-r10|2",
+                    },
+                    Object {
+                      "nodeId": "pax-utils/scanelf@1.2.3-r0|2",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib@1.2.11-r1|2",
+                    },
+                  ],
+                  "nodeId": "root-node",
+                  "pkgId": "docker-image|snykgoof/dockerhub-goof@alpine",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "busybox/busybox@1.28.4-r3|1",
+                  "pkgId": "busybox/busybox@1.28.4-r3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "busybox/busybox@1.28.4-r3|2",
+                  "pkgId": "busybox/busybox@1.28.4-r3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "musl/musl@1.1.19-r10",
+                  "pkgId": "musl/musl@1.1.19-r10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "busybox/busybox@1.28.4-r3|1",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "alpine-baselayout/alpine-baselayout@3.1.0-r0",
+                  "pkgId": "alpine-baselayout/alpine-baselayout@3.1.0-r0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "alpine-keys/alpine-keys@2.1-r1",
+                  "pkgId": "alpine-keys/alpine-keys@2.1-r1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libressl/libressl2.7-libcrypto@2.7.4-r0|1",
+                  "pkgId": "libressl/libressl2.7-libcrypto@2.7.4-r0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "libressl/libressl2.7-libcrypto@2.7.4-r0|2",
+                  "pkgId": "libressl/libressl2.7-libcrypto@2.7.4-r0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libressl/libressl2.7-libssl@2.7.4-r0|1",
+                  "pkgId": "libressl/libressl2.7-libssl@2.7.4-r0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libcrypto@2.7.4-r0|1",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "libressl/libressl2.7-libssl@2.7.4-r0|2",
+                  "pkgId": "libressl/libressl2.7-libssl@2.7.4-r0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib@1.2.11-r1|1",
+                  "pkgId": "zlib/zlib@1.2.11-r1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "zlib/zlib@1.2.11-r1|2",
+                  "pkgId": "zlib/zlib@1.2.11-r1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libcrypto@2.7.4-r0|1",
+                    },
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libssl@2.7.4-r0|1",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib@1.2.11-r1|1",
+                    },
+                  ],
+                  "nodeId": "apk-tools/apk-tools@2.10.1-r0",
+                  "pkgId": "apk-tools/apk-tools@2.10.1-r0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libressl/libressl2.7-libtls@2.7.4-r0|1",
+                  "pkgId": "libressl/libressl2.7-libtls@2.7.4-r0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libcrypto@2.7.4-r0|1",
+                    },
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libssl@2.7.4-r0|1",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "libressl/libressl2.7-libtls@2.7.4-r0|2",
+                  "pkgId": "libressl/libressl2.7-libtls@2.7.4-r0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libressl/libressl2.7-libtls@2.7.4-r0|1",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "busybox/ssl_client@1.28.4-r3",
+                  "pkgId": "busybox/ssl_client@1.28.4-r3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "gcc/libstdc++@6.4.0-r9|1",
+                  "pkgId": "gcc/libstdc++@6.4.0-r9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc/libstdc++@6.4.0-r9|2",
+                  "pkgId": "gcc/libstdc++@6.4.0-r9",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "gcc/libstdc++@6.4.0-r9|1",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "gcc/libgcc@6.4.0-r9",
+                  "pkgId": "gcc/libgcc@6.4.0-r9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "musl/musl-utils@1.1.19-r10|1",
+                  "pkgId": "musl/musl-utils@1.1.19-r10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                    Object {
+                      "nodeId": "pax-utils/scanelf@1.2.3-r0|1",
+                    },
+                  ],
+                  "nodeId": "musl/musl-utils@1.1.19-r10|2",
+                  "pkgId": "musl/musl-utils@1.1.19-r10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl-utils@1.1.19-r10|1",
+                    },
+                  ],
+                  "nodeId": "libc-dev/libc-utils@0.7.1-r0",
+                  "pkgId": "libc-dev/libc-utils@0.7.1-r0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pax-utils/scanelf@1.2.3-r0|1",
+                  "pkgId": "pax-utils/scanelf@1.2.3-r0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.19-r10",
+                    },
+                  ],
+                  "nodeId": "pax-utils/scanelf@1.2.3-r0|2",
+                  "pkgId": "pax-utils/scanelf@1.2.3-r0",
+                },
+              ],
+              "rootNodeId": "root-node",
+            },
+            "pkgManager": Object {
+              "name": "apk",
+              "repositories": Array [
+                Object {
+                  "alias": "alpine:3.8.2",
+                },
+              ],
+            },
+            "pkgs": Array [
+              Object {
+                "id": "docker-image|snykgoof/dockerhub-goof@alpine",
+                "info": Object {
+                  "name": "docker-image|snykgoof/dockerhub-goof",
+                  "version": "alpine",
+                },
+              },
+              Object {
+                "id": "busybox/busybox@1.28.4-r3",
+                "info": Object {
+                  "name": "busybox/busybox",
+                  "version": "1.28.4-r3",
+                },
+              },
+              Object {
+                "id": "musl/musl@1.1.19-r10",
+                "info": Object {
+                  "name": "musl/musl",
+                  "version": "1.1.19-r10",
+                },
+              },
+              Object {
+                "id": "alpine-baselayout/alpine-baselayout@3.1.0-r0",
+                "info": Object {
+                  "name": "alpine-baselayout/alpine-baselayout",
+                  "version": "3.1.0-r0",
+                },
+              },
+              Object {
+                "id": "alpine-keys/alpine-keys@2.1-r1",
+                "info": Object {
+                  "name": "alpine-keys/alpine-keys",
+                  "version": "2.1-r1",
+                },
+              },
+              Object {
+                "id": "libressl/libressl2.7-libcrypto@2.7.4-r0",
+                "info": Object {
+                  "name": "libressl/libressl2.7-libcrypto",
+                  "version": "2.7.4-r0",
+                },
+              },
+              Object {
+                "id": "libressl/libressl2.7-libssl@2.7.4-r0",
+                "info": Object {
+                  "name": "libressl/libressl2.7-libssl",
+                  "version": "2.7.4-r0",
+                },
+              },
+              Object {
+                "id": "zlib/zlib@1.2.11-r1",
+                "info": Object {
+                  "name": "zlib/zlib",
+                  "version": "1.2.11-r1",
+                },
+              },
+              Object {
+                "id": "apk-tools/apk-tools@2.10.1-r0",
+                "info": Object {
+                  "name": "apk-tools/apk-tools",
+                  "version": "2.10.1-r0",
+                },
+              },
+              Object {
+                "id": "libressl/libressl2.7-libtls@2.7.4-r0",
+                "info": Object {
+                  "name": "libressl/libressl2.7-libtls",
+                  "version": "2.7.4-r0",
+                },
+              },
+              Object {
+                "id": "busybox/ssl_client@1.28.4-r3",
+                "info": Object {
+                  "name": "busybox/ssl_client",
+                  "version": "1.28.4-r3",
+                },
+              },
+              Object {
+                "id": "gcc/libstdc++@6.4.0-r9",
+                "info": Object {
+                  "name": "gcc/libstdc++",
+                  "version": "6.4.0-r9",
+                },
+              },
+              Object {
+                "id": "gcc/libgcc@6.4.0-r9",
+                "info": Object {
+                  "name": "gcc/libgcc",
+                  "version": "6.4.0-r9",
+                },
+              },
+              Object {
+                "id": "musl/musl-utils@1.1.19-r10",
+                "info": Object {
+                  "name": "musl/musl-utils",
+                  "version": "1.1.19-r10",
+                },
+              },
+              Object {
+                "id": "libc-dev/libc-utils@0.7.1-r0",
+                "info": Object {
+                  "name": "libc-dev/libc-utils",
+                  "version": "0.7.1-r0",
+                },
+              },
+              Object {
+                "id": "pax-utils/scanelf@1.2.3-r0",
+                "info": Object {
+                  "name": "pax-utils/scanelf",
+                  "version": "1.2.3-r0",
+                },
+              },
+            ],
+            "schemaVersion": "1.2.0",
+          },
+          "type": "depGraph",
+        },
+        Object {
+          "data": Array [
+            "0fc4cab19958b98d637fefa8a81af2fb42aec5a9dcad2f636aad4a58a665181c",
+          ],
+          "type": "keyBinariesHashes",
+        },
+        Object {
+          "data": "ebbf98230a821f1795b10c4df40ce81b1905e47d625cb9b4b0c7c617acb85e53",
+          "type": "imageId",
+        },
+        Object {
+          "data": Array [
+            "169185f82c45a6eb72e0ca4ee66152626e7ace92a0cbc53624fb46d0a553f0bd/layer.tar",
+            "80e1b3e484f00bce3ac164eb0d744be783f154f356f79491f2a0236a1a6ecae8/layer.tar",
+            "93e33f1be740ed7d552b1f02a7d766f8a51704e9b889e8c70e293b2b3b8d74a5/layer.tar",
+          ],
+          "type": "imageLayers",
+        },
+        Object {
+          "data": Array [
+            "sha256:767f936afb51c8a3ad9a96592a4be092048bb70f2ca410028a0b3f64b826acbb",
+            "sha256:52506d3645613bb715039c51c2076e89b1a370042b044bf8023968180cc71277",
+            "sha256:bc39a721343bd8a32be9237b976929718f7b0e66bdc8834d8f8cb79c80d7d08f",
+          ],
+          "type": "rootFs",
+        },
+        Object {
+          "data": "Alpine Linux v3.8",
+          "type": "imageOsReleasePrettyName",
+        },
+      ],
+      "identity": Object {
+        "args": Object {
+          "platform": "linux/amd64",
+        },
+        "type": "apk",
+      },
+      "target": Object {
+        "image": "docker-image|snykgoof/dockerhub-goof",
+      },
+    },
+  ],
+}
+`;
+
+exports[`username and password authentication should correctly authenticate to the container registry when username and password are provided as flags 1`] = `
 Object {
   "scanResults": Array [
     Object {

--- a/test/system/registry-authentication/username-password.spec.ts
+++ b/test/system/registry-authentication/username-password.spec.ts
@@ -2,11 +2,35 @@ import { EOL } from "os";
 import { scan } from "../../../lib/index";
 
 describe("username and password authentication", () => {
-  it("should correctly authenticate to the container registry when username and password are provided", async () => {
+  const oldSnykRegistryUsernameEnvVar = process.env.SNYK_REGISTRY_USERNAME;
+  const oldSnykRegistryPasswordEnvVar = process.env.SNYK_REGISTRY_PASSWORD;
+
+  afterAll(() => {
+    // return SNYK credential env vars to previous state
+    if (oldSnykRegistryUsernameEnvVar !== undefined) {
+      process.env.SNYK_REGISTRY_USERNAME = oldSnykRegistryUsernameEnvVar;
+    }
+    if (oldSnykRegistryPasswordEnvVar !== undefined) {
+      process.env.SNYK_REGISTRY_PASSWPRD = oldSnykRegistryPasswordEnvVar;
+    }
+  });
+
+  it("should correctly authenticate to the container registry when username and password are provided as flags", async () => {
     const pluginResult = await scan({
       path: process.env.DOCKER_HUB_PRIVATE_IMAGE,
       username: process.env.DOCKER_HUB_USERNAME,
       password: process.env.DOCKER_HUB_PASSWORD,
+    });
+
+    expect(pluginResult).toMatchSnapshot();
+  });
+
+  it("should correctly authenticate to the container registry when username and password are provided as SNYK env vars and not as flags", async () => {
+    process.env.SNYK_REGISTRY_USERNAME = process.env.DOCKER_HUB_USERNAME;
+    process.env.SNYK_REGISTRY_PASSWORD = process.env.DOCKER_HUB_PASSWORD;
+
+    const pluginResult = await scan({
+      path: process.env.DOCKER_HUB_PRIVATE_IMAGE,
     });
 
     expect(pluginResult).toMatchSnapshot();


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

[RUN-1041] Setting SNYK_REGISTRY_USERNAME and/or SNYK_REGISTRY_PASSWORD environment variables allows these credentials to be used to log in to remote registries. The existing --username and --password flags, if present, take precedence

Documentation updates will follow in a separate PR

[RUN-1041]: https://snyksec.atlassian.net/browse/RUN-1041