### PR TITLE
[RUN-1271] Feat/identify go binaries

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -1,6 +1,7 @@
 import * as Debug from "debug";
 import { DockerFileAnalysis } from "../dockerfile/types";
 import * as archiveExtractor from "../extractor";
+import { getGoModulesContentAction } from "../go-parser";
 import { getFileContent } from "../inputs";
 import {
   getApkDbFileContent,
@@ -74,7 +75,11 @@ export async function analyze(
 
   if (appScan) {
     staticAnalysisActions.push(
-      ...[getNodeAppFileContentAction, getJarFileContentAction],
+      ...[
+        getNodeAppFileContentAction,
+        getJarFileContentAction,
+        getGoModulesContentAction,
+      ],
     );
   }
 

--- a/lib/extractor/callbacks.ts
+++ b/lib/extractor/callbacks.ts
@@ -7,7 +7,6 @@ export async function applyCallbacks(
   fileContentStream: Readable,
 ): Promise<FileNameAndContent> {
   const result: FileNameAndContent = {};
-
   const actionsToAwait = matchedActions.map((action) => {
     // Using a pass through allows us to read the stream multiple times.
     const streamCopy = new PassThrough();
@@ -22,11 +21,17 @@ export async function applyCallbacks(
 
     return promise.then((content) => {
       // Assign the result once the Promise is complete.
-      result[action.actionName] = content;
+      if (content) {
+        result[action.actionName] = content;
+      }
     });
   });
 
   await Promise.all(actionsToAwait);
 
   return result;
+}
+
+export function isResultEmpty(result: FileNameAndContent): boolean {
+  return Object.keys(result).length === 0;
 }

--- a/lib/extractor/callbacks.ts
+++ b/lib/extractor/callbacks.ts
@@ -5,6 +5,7 @@ import { ExtractAction, FileNameAndContent } from "./types";
 export async function applyCallbacks(
   matchedActions: ExtractAction[],
   fileContentStream: Readable,
+  streamSize?: number,
 ): Promise<FileNameAndContent> {
   const result: FileNameAndContent = {};
   const actionsToAwait = matchedActions.map((action) => {
@@ -15,7 +16,7 @@ export async function applyCallbacks(
     // Queue the promise but don't await on it yet: we want consumers to start around the same time.
     const promise =
       action.callback !== undefined
-        ? action.callback(streamCopy)
+        ? action.callback(streamCopy, streamSize)
         : // If no callback was provided for this action then return as string by default.
           streamToString(streamCopy);
 

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -26,7 +26,11 @@ export async function extractImageLayer(
           action.filePathMatches(absoluteFileName),
         );
         if (matchedActions.length > 0) {
-          const callbackResult = await applyCallbacks(matchedActions, stream);
+          const callbackResult = await applyCallbacks(
+            matchedActions,
+            stream,
+            headers.size,
+          );
 
           if (!isResultEmpty(callbackResult)) {
             result[absoluteFileName] = callbackResult;

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -2,7 +2,7 @@ import * as gunzip from "gunzip-maybe";
 import * as path from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
-import { applyCallbacks } from "./callbacks";
+import { applyCallbacks, isResultEmpty } from "./callbacks";
 import { ExtractAction, ExtractedLayers } from "./types";
 
 /**
@@ -26,10 +26,11 @@ export async function extractImageLayer(
           action.filePathMatches(absoluteFileName),
         );
         if (matchedActions.length > 0) {
-          result[absoluteFileName] = await applyCallbacks(
-            matchedActions,
-            stream,
-          );
+          const callbackResult = await applyCallbacks(matchedActions, stream);
+
+          if (!isResultEmpty(callbackResult)) {
+            result[absoluteFileName] = callbackResult;
+          }
         }
       }
 

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -2,6 +2,7 @@ import { Readable } from "stream";
 
 export type ExtractCallback = (
   dataStream: Readable,
+  streamSize?: number,
 ) => Promise<string | Buffer>;
 
 export type FileNameAndContent = Record<string, string | Buffer>;

--- a/lib/go-parser/index.ts
+++ b/lib/go-parser/index.ts
@@ -1,0 +1,115 @@
+import * as elf from "elfy";
+import * as path from "path";
+import { Readable } from "stream";
+import { ExtractAction } from "../extractor/types";
+
+const ignoredPaths = [
+  path.normalize("/boot"),
+  path.normalize("/dev"),
+  path.normalize("/etc"),
+  path.normalize("/home"),
+  path.normalize("/media"),
+  path.normalize("/mnt"),
+  path.normalize("/proc"),
+  path.normalize("/root"),
+  path.normalize("/run"),
+  path.normalize("/sbin"),
+  path.normalize("/sys"),
+  path.normalize("/tmp"),
+  path.normalize("/var"),
+];
+
+function filePathMatches(filePath: string): boolean {
+  const dirName = path.dirname(filePath);
+  return (
+    !path.parse(filePath).ext &&
+    !ignoredPaths.some((ignorePath) => dirName.startsWith(ignorePath))
+  );
+}
+
+export const getGoModulesContentAction: ExtractAction = {
+  actionName: "gomodules",
+  filePathMatches,
+  callback: findGoBinaries,
+};
+
+async function findGoBinaries(
+  stream: Readable,
+  streamSize?: number,
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const encoding = "binary";
+    const buildIdMagic = "Go";
+    const elfHeaderMagic = "\x7FELF";
+    const buildInfoMagic = "\xff Go buildinf:";
+    const elfBuildInfoSize = 64 * 1024; // ELF section headers and so ".go.buildinfo" & ".note.go.buildid" blobs are available in the first 64kb
+
+    const buffer: Buffer = Buffer.alloc(streamSize ?? elfBuildInfoSize);
+    let bytesWritten = 0;
+
+    stream.on("end", () => {
+      // Discard
+      if (bytesWritten === 0) {
+        return resolve();
+      }
+
+      const binaryFile = elf.parse(buffer);
+
+      const goBuildInfo = binaryFile.body.sections.find(
+        (section) => section.name === ".go.buildinfo",
+      );
+      // Could be found in file headers
+      const goBuildId = binaryFile.body.sections.find(
+        (section) => section.name === ".note.go.buildid",
+      );
+
+      if (!goBuildInfo && !goBuildId) {
+        return resolve();
+      } else if (goBuildInfo) {
+        const info = goBuildInfo.data
+          .slice(0, buildInfoMagic.length)
+          .toString(encoding);
+
+        if (info === buildInfoMagic) {
+          return resolve(binaryFile);
+        }
+
+        return resolve();
+      } else if (goBuildId) {
+        const strings = goBuildId.data
+          .toString()
+          .split(/\0+/g)
+          .filter(Boolean);
+        const go = strings[strings.length - 2];
+        const buildIdParts = strings[strings.length - 1].split("/");
+
+        // Build ID's precise form is actionID/[.../]contentID.
+        // Usually the buildID is simply actionID/contentID, but with exceptions.
+        // https://github.com/golang/go/blob/master/src/cmd/go/internal/work/buildid.go#L23
+        if (go === buildIdMagic && buildIdParts.length >= 2) {
+          return resolve(binaryFile);
+        }
+
+        return resolve();
+      }
+    });
+
+    stream.on("error", (error) => {
+      reject(error);
+    });
+
+    stream.once("data", (chunk) => {
+      const first4Bytes = chunk.toString(encoding, 0, 4);
+
+      if (first4Bytes === elfHeaderMagic) {
+        Buffer.from(chunk).copy(buffer, bytesWritten, 0);
+        bytesWritten += chunk.length;
+        // Listen to next chunks only if it's an ELF executable
+        stream.addListener("data", (chunk) => {
+          Buffer.from(chunk).copy(buffer, bytesWritten, 0);
+          bytesWritten += chunk.length;
+        });
+      }
+    });
+  });
+}

--- a/lib/inputs/file-pattern/static.ts
+++ b/lib/inputs/file-pattern/static.ts
@@ -34,7 +34,8 @@ export function generateExtractAction(
   return {
     actionName: "find-files-by-pattern",
     filePathMatches: generatePathMatcher(globsInclude, globsExclude),
-    callback: (dataStream) => streamToString(dataStream, "base64"),
+    callback: (dataStream, streamSize) =>
+      streamToString(dataStream, streamSize, "base64"),
   };
 }
 

--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -11,6 +11,7 @@ type SupportedEncodings = "utf8" | "base64";
 
 export async function streamToString(
   stream: Readable,
+  streamSize?: number,
   encoding: SupportedEncodings = "utf8",
 ): Promise<string> {
   const chunks: string[] = [];

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",
     "dockerfile-ast": "0.0.30",
+    "elfy": "^1.0.0",
     "event-loop-spinner": "^2.0.0",
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
@@ -45,7 +46,7 @@
     "uuid": "^8.2.0"
   },
   "devDependencies": {
-    "@types/node": "8.10.48",
+    "@types/node": "8.10.66",
     "@types/sinon": "5.0.5",
     "@types/tar-stream": "^1.6.1",
     "@types/tmp": "^0.2.0",

--- a/test/lib/stream-utils.test.ts
+++ b/test/lib/stream-utils.test.ts
@@ -21,7 +21,7 @@ test("stream-utils.streamToString(base64)", async (t) => {
   const fixture = getFixture("small-sample-text.txt");
   const fileStream = createReadStream(fixture);
 
-  const fileContent = await streamToString(fileStream, "base64");
+  const fileContent = await streamToString(fileStream, undefined, "base64");
   const expectedContent = readFileSync(fixture, { encoding: "base64" });
 
   t.same(fileContent, expectedContent, "Returned the expected string");


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
refactor: Extract only not empty layers
    
    Before, applyCallbacks result was always defined, because we were matching on file path. For Go modules parsing, we also match on the filepath, but now the callback function does not necessarily return a result and we are filtering the undefined results out.

 feat: Identify go binaries
    
    We're identifying go binaries which are ELF executables, which are then returned as extractedLayers. No results from go modules are being processed into a scanResult yet.

#### Where should the reviewer start?
Commit by commit, the first one is a refactor and the second one we're adding go binaries extraction.

https://snyksec.atlassian.net/browse/RUN-1271
