### PR TITLE
feat: parse go binary and get dependency graph for this binary

### DIFF
--- a/lib/analyzer/applications/types.ts
+++ b/lib/analyzer/applications/types.ts
@@ -1,3 +1,4 @@
+import { Elf } from "../../go-parser/types";
 import { ScanResult } from "../../types";
 
 export interface AppDepsScanResultWithoutTarget
@@ -5,4 +6,8 @@ export interface AppDepsScanResultWithoutTarget
 
 export interface FilePathToContent {
   [filePath: string]: string;
+}
+
+export interface FilePathToElfContent {
+  [filePath: string]: Elf;
 }

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -1,8 +1,11 @@
 import * as Debug from "debug";
-import { DockerFileAnalysis } from "../dockerfile/types";
+import { DockerFileAnalysis } from "../dockerfile";
 import * as archiveExtractor from "../extractor";
-import { getGoModulesContentAction } from "../go-parser";
-import { getFileContent } from "../inputs";
+import {
+  getGoModulesContentAction,
+  goModulesToScannedProjects,
+} from "../go-parser";
+import { getElfFileContent, getFileContent } from "../inputs";
 import {
   getApkDbFileContent,
   getApkDbFileContentAction,
@@ -149,10 +152,14 @@ export async function analyze(
       getFileContent(extractedLayers, getJarFileContentAction.actionName),
       targetImage,
     );
+    const goModulesScanResult = await goModulesToScannedProjects(
+      getElfFileContent(extractedLayers, getGoModulesContentAction.actionName),
+    );
 
     applicationDependenciesScanResults.push(
       ...nodeDependenciesScanResults,
       ...jarFingerprintScanResults,
+      ...goModulesScanResult,
     );
   }
 

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -1,7 +1,12 @@
 import { ImageType } from "../types";
 import * as dockerExtractor from "./docker-archive";
 import * as ociExtractor from "./oci-archive";
-import { ExtractAction, ExtractedLayers, ExtractionResult } from "./types";
+import {
+  ExtractAction,
+  ExtractedLayers,
+  ExtractionResult,
+  FileContent,
+} from "./types";
 
 /**
  * Given a path on the file system to a image archive, open it up to inspect the layers
@@ -68,11 +73,11 @@ function layersWithLatestFileModifications(
   return extractedLayers;
 }
 
-function isBufferType(type: string | Buffer): type is Buffer {
+function isBufferType(type: FileContent): type is Buffer {
   return (type as Buffer).buffer !== undefined;
 }
 
-function isStringType(type: string | Buffer): type is string {
+function isStringType(type: FileContent): type is string {
   return (type as string).substring !== undefined;
 }
 
@@ -95,7 +100,7 @@ export function getContentAsString(
 function getContent(
   extractedLayers: ExtractedLayers,
   extractAction: ExtractAction,
-): string | Buffer | undefined {
+): FileContent | undefined {
   const fileNames = Object.keys(extractedLayers);
   const fileNamesProducedByTheExtractAction = fileNames.filter(
     (name) => extractAction.actionName in extractedLayers[name],

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -1,11 +1,14 @@
 import { Readable } from "stream";
+import { Elf } from "../go-parser/types";
 
 export type ExtractCallback = (
   dataStream: Readable,
   streamSize?: number,
 ) => Promise<string | Buffer>;
 
-export type FileNameAndContent = Record<string, string | Buffer>;
+export type FileContent = string | Buffer | Elf;
+
+export type FileNameAndContent = Record<string, FileContent>;
 
 export interface ExtractionResult {
   imageId: string;

--- a/lib/go-parser/parser.ts
+++ b/lib/go-parser/parser.ts
@@ -1,0 +1,97 @@
+import * as depGraph from "@snyk/dep-graph";
+import { eventLoopSpinner } from "event-loop-spinner";
+
+import { DEP_GRAPH_TYPE } from "./";
+import { parserStrTab } from "./str-tab-parser";
+import { Elf, GoPackage, PackageVersionTable } from "./types";
+import { extractModulesFromBinary } from "./version-parser";
+
+/**
+ * Parse `.strtab` to get Go packages
+ * Parse `.go.buildinfo` to get addresses
+ * to go modules and their versions
+ * @param goBinary
+ */
+export async function parseGoBinary(
+  goBinary: Elf,
+): Promise<depGraph.DepGraph | undefined> {
+  // Non-stripped binaries contain data on ".strtab" section
+  const strTab = goBinary.body.sections.find(
+    (section) => section.name === ".strtab",
+  );
+
+  // TODO: stripped binaries are not supported in this iteration
+  if (!strTab) {
+    return undefined;
+  }
+
+  const { name, modules } = extractModulesFromBinary(goBinary);
+  const packages: GoPackage[] = parserStrTab(strTab.data);
+
+  // If there is no packages or modules, return empty result
+  if (Object.keys(modules).length === 0 || packages.length === 0) {
+    return undefined;
+  }
+
+  const packageVersionTable: PackageVersionTable = matchModuleToPackage(
+    modules,
+    packages,
+  );
+  return await createDepGraph(name, packageVersionTable);
+}
+
+/**
+ * Package name consist of module name and path to package.
+ * This function matches package to modules and their versions
+ * @param moduleVersionTable
+ * @param packages
+ */
+function matchModuleToPackage(
+  moduleVersionTable: any,
+  packages: GoPackage[],
+): PackageVersionTable {
+  const resultTable: PackageVersionTable = {};
+  for (const pack of packages) {
+    let moduleVersion = moduleVersionTable[pack];
+
+    if (!moduleVersion) {
+      const [packageModule] = Object.keys(moduleVersionTable)
+        // Find all modules that this package can be from
+        .filter((moduleName) => pack.startsWith(moduleName))
+        // The longest string will be the closest match
+        .sort((a, b) => b.length - a.length);
+
+      if (!packageModule || !moduleVersionTable[packageModule]) {
+        continue;
+      }
+
+      moduleVersion = moduleVersionTable[packageModule];
+    }
+
+    resultTable[pack] = moduleVersion;
+  }
+
+  return resultTable;
+}
+
+async function createDepGraph(
+  name: string,
+  packageVersionTable: PackageVersionTable,
+): Promise<depGraph.DepGraph> {
+  const goModulesDepGraph = new depGraph.DepGraphBuilder(
+    { name: DEP_GRAPH_TYPE },
+    { name },
+  );
+
+  for (const [name, version] of Object.entries(packageVersionTable)) {
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+
+    const nodeId = `${name}@${version}`;
+    goModulesDepGraph.addPkgNode({ name, version }, nodeId);
+    goModulesDepGraph.connectDep(goModulesDepGraph.rootNodeId, nodeId);
+  }
+
+  return goModulesDepGraph.build();
+}

--- a/lib/go-parser/str-tab-parser.ts
+++ b/lib/go-parser/str-tab-parser.ts
@@ -1,0 +1,27 @@
+import { GoPackage } from "./types";
+
+/**
+ * Because 3rd party imports in Go look like URLs (github.com/bla/bla)
+ * we try to match lines that have URL-like type of string and ends with `..inittask` string
+ * `.inittask` is internal Go mechanism to initialize modules
+ */
+const INIT_TASK_LINE_REGEXP = /^\w+\.\w+\/.+\.\.inittask$/;
+
+/**
+ * Get all lines in `.strtab` that ends with `..inittask`
+ * `..inittask` is internal go function to init the package
+ * Also lines need to be decoded, cos it might contain HTML encoded symbols
+ * @param strTabSectionBuffer
+ */
+export function parserStrTab(strTabSectionBuffer: Buffer): GoPackage[] {
+  return (
+    strTabSectionBuffer
+      .toString()
+      // Lines in a strTab are terminated by \u0000 (NULL) symbol
+      .split("\0")
+      // Get only lines that look like go packages
+      .filter((line) => line.match(INIT_TASK_LINE_REGEXP))
+      // Remove trailing `..inittask` from go package
+      .map((line) => decodeURIComponent(line.replace("..inittask", "")))
+  );
+}

--- a/lib/go-parser/types.ts
+++ b/lib/go-parser/types.ts
@@ -1,0 +1,46 @@
+export interface Elf {
+  body: {
+    programs: ElfProgram[];
+    sections: ElfSection[];
+  };
+}
+
+export interface ElfProgram {
+  type: string;
+  offset: number;
+  vaddr: number;
+  filesz: number;
+  flags: {
+    w?: boolean;
+  };
+  data: Buffer;
+}
+
+export interface ElfSection {
+  name: string;
+  addr: number;
+  off: number;
+  size: number;
+  data: Buffer;
+}
+
+export type ReadPtrFunc = (Buffer) => number;
+
+export interface PackageVersionTable {
+  [key: string]: string;
+}
+
+export type GoPackage = string;
+
+export interface GoVersionsResult {
+  mod: string;
+  version: string;
+}
+
+export interface GoModulesResult {
+  goVersion: string;
+  name: string;
+  modules: {
+    [key: string]: string;
+  };
+}

--- a/lib/go-parser/version-parser.ts
+++ b/lib/go-parser/version-parser.ts
@@ -1,0 +1,226 @@
+import {
+  Elf,
+  ElfProgram,
+  GoModulesResult,
+  GoVersionsResult,
+  ReadPtrFunc,
+} from "./types";
+
+/**
+ * Create same output as `go version -m binary-file` does
+ * @param binary
+ */
+export function extractModulesFromBinary(binary: Elf): GoModulesResult {
+  const { version: goVersion, mod } = findVers(binary);
+  const { name, modules } = prepareGoDependencies(mod);
+
+  return { goVersion, name, modules };
+}
+
+/**
+ * Normalize versions to align with `snyk-go-parser`
+ * @param mod
+ */
+function prepareGoDependencies(
+  mod: string,
+): Omit<GoModulesResult, "goVersion"> {
+  if (!mod) {
+    return { name: "", modules: {} };
+  }
+
+  const [, mainModuleLine, ...versionsLines] = mod.split("\n");
+  const [, name] = mainModuleLine.split("\t");
+  const modules = versionsLines.reduce((accum, curr) => {
+    // Skip If for some reason after splitting there is a empty line
+    if (!curr) {
+      return accum;
+    }
+
+    const [, name, ver] = curr.split("\t");
+    // Versions in Go have trailing 'v'
+    let version = ver.substring(1);
+    // In versions with hash, we only care about hash
+    // v0.0.0-20200905004654-be1d3432aa8f => #be1d3432aa8f
+    version = version.includes("-")
+      ? `#${version.substring(version.lastIndexOf("-") + 1)}`
+      : version;
+
+    accum[name] = version;
+    return accum;
+  }, {});
+
+  return { name, modules };
+}
+
+// Source
+// https://github.com/golang/go/blob/46f99ce7ea97d11b0a1a079da8dda0f51df2a2d2/src/cmd/go/internal/version/version.go#L146
+/**
+ * Function finds and returns the Go version and
+ * module version information in the executable binary
+ * @param binary
+ */
+function findVers(binary: Elf): GoVersionsResult {
+  const result = {
+    version: "",
+    mod: "",
+  };
+
+  const text = dataStart(binary);
+  let data = readData(binary.body.programs, text, 64 * 1024) || Buffer.from([]);
+
+  for (
+    ;
+    !data.toString("binary").startsWith("\xff Go buildinf:");
+    data = data.slice(32)
+  ) {
+    if (data.length < 32) {
+      return result;
+    }
+  }
+
+  const ptrSize = data[14];
+  const bigEndian = data[15] !== 0;
+
+  let readPtr: ReadPtrFunc;
+  if (ptrSize === 4) {
+    if (bigEndian) {
+      readPtr = (buffer) => buffer.readInt32BE(0);
+    } else {
+      readPtr = (buffer) => buffer.readInt32LE(0);
+    }
+  } else {
+    if (bigEndian) {
+      readPtr = (buffer) => Number(buffer.readBigInt64BE());
+    } else {
+      readPtr = (buffer) => Number(buffer.readBigInt64LE());
+    }
+  }
+
+  // The build info blob left by the linker is identified by
+  // a 16-byte header, consisting of buildInfoMagic (14 bytes),
+  // the binary's pointer size (1 byte),
+  // and whether the binary is big endian (1 byte).
+  // Now we attempt to read info after metadata.
+  // From 16th byte to 16th + ptrSize there is a header that points
+  // to go version
+  const version: string = readString(
+    binary,
+    ptrSize,
+    readPtr,
+    readPtr(data.slice(16, 16 + ptrSize)),
+  );
+
+  if (version === "") {
+    return result;
+  }
+
+  result.version = version;
+
+  // Go version header was right after metadata.
+  // Modules header right after go version
+  // Read next `ptrSize` bytes, this point to the
+  // place where modules info is stored
+  const mod: string = readString(
+    binary,
+    ptrSize,
+    readPtr,
+    readPtr(data.slice(16 + ptrSize, 16 + 2 * ptrSize)),
+  );
+
+  // This verifies that what we got are actually go modules
+  // First 16 bytes are unicodes as last 16
+  // Mirrors go version source code
+  if (mod.length >= 33 && mod[mod.length - 17] === "\n") {
+    result.mod = mod.slice(16, mod.length - 16);
+  } else {
+    result.mod = "";
+  }
+
+  return result;
+}
+
+// Source
+// https://github.com/golang/go/blob/46f99ce7ea97d11b0a1a079da8dda0f51df2a2d2/src/cmd/go/internal/version/exe.go#L105
+/**
+ * Find start of section that contains module version data
+ * @param binary
+ */
+function dataStart(binary: Elf): number {
+  for (const section of binary.body.sections) {
+    if (section.name === ".go.buildinfo") {
+      return section.addr;
+    }
+  }
+
+  for (const program of binary.body.programs) {
+    if (program.type === "load" && program.flags.w === true) {
+      return program.vaddr;
+    }
+  }
+
+  return 0;
+}
+
+// Source
+// https://github.com/golang/go/blob/46f99ce7ea97d11b0a1a079da8dda0f51df2a2d2/src/cmd/go/internal/version/exe.go#L87
+/**
+ * Read at most `size` of bytes from `program` that contains byte at `addr`
+ * @param programs
+ * @param addr
+ * @param size
+ */
+function readData(
+  programs: ElfProgram[],
+  addr: number,
+  size: number,
+): Buffer | undefined {
+  for (const program of programs) {
+    const vaddr = program.vaddr;
+    const filesz = program.filesz;
+    if (vaddr <= addr && addr <= vaddr + filesz - 1) {
+      let n = vaddr + filesz - addr;
+
+      if (n > size) {
+        n = size;
+      }
+
+      const from = addr - vaddr; // offset from the beginning of the program
+
+      return program.data.slice(from, from + n);
+    }
+  }
+
+  return undefined;
+}
+
+// Source
+// https://github.com/golang/go/blob/46f99ce7ea97d11b0a1a079da8dda0f51df2a2d2/src/cmd/go/internal/version/version.go#L189
+/**
+ * Function returns the string at address addr in the executable x
+ * @param binaryFile
+ * @param ptrSize
+ * @param readPtr
+ * @param addr
+ */
+function readString(
+  binaryFile: Elf,
+  ptrSize: number,
+  readPtr: ReadPtrFunc,
+  addr: number,
+): string {
+  const hdr = readData(binaryFile.body.programs, addr, 2 * ptrSize);
+  if (!hdr || hdr.length < 2 * ptrSize) {
+    return "";
+  }
+
+  const dataAddr = readPtr(hdr);
+  const dataLen = readPtr(hdr.slice(ptrSize));
+
+  const data = readData(binaryFile.body.programs, dataAddr, dataLen);
+
+  if (!data || data.length < dataLen) {
+    return "";
+  }
+
+  return data.toString("binary");
+}

--- a/lib/inputs/index.ts
+++ b/lib/inputs/index.ts
@@ -1,9 +1,14 @@
-import { ExtractedLayers } from "../extractor/types";
+import {
+  FilePathToContent,
+  FilePathToElfContent,
+} from "../analyzer/applications/types";
+import { ExtractedLayers, FileContent } from "../extractor/types";
+import { Elf } from "../go-parser/types";
 
 export function getFileContent(
   extractedLayers: ExtractedLayers,
   searchedAction: string,
-): { [fileName: string]: string } {
+): FilePathToContent {
   const foundAppFiles = {};
 
   for (const filePath of Object.keys(extractedLayers)) {
@@ -14,6 +19,34 @@ export function getFileContent(
       if (!(typeof extractedLayers[filePath][actionName] === "string")) {
         throw new Error("expected string");
       }
+      foundAppFiles[filePath] = extractedLayers[filePath][actionName];
+    }
+  }
+
+  return foundAppFiles;
+}
+
+function isElfType(type: FileContent): type is Elf {
+  const elf = type as Elf;
+  return !!(elf.body && elf.body.programs && elf.body.sections);
+}
+
+export function getElfFileContent(
+  extractedLayers: ExtractedLayers,
+  searchedAction: string,
+): FilePathToElfContent {
+  const foundAppFiles = {};
+
+  for (const filePath of Object.keys(extractedLayers)) {
+    for (const actionName of Object.keys(extractedLayers[filePath])) {
+      if (actionName !== searchedAction) {
+        continue;
+      }
+
+      if (!isElfType(extractedLayers[filePath][actionName])) {
+        throw new Error("elf file expected to contain programs and sections");
+      }
+
       foundAppFiles[filePath] = extractedLayers[filePath][actionName];
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "prettier --check \"{lib,test}/**/*.ts\" && tslint --format stylish \"{lib,test}/**/*.ts\"",
     "format": "prettier --loglevel warn --write '{lib,test}/**/*.ts' && tslint --fix --format stylish '{lib,test}/**/*.ts'",
     "test": "npm run lint && npm run unit-test",
-    "test-jest": "jest --bail --logHeapUsage",
+    "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage",
     "test-windows": "npm run lint && tap test/windows/**/*.test.ts -R=spec --timeout=300",
-    "test-jest-windows": "jest --bail --config test/windows/jest.config.js --logHeapUsage",
+    "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
     "unit-test": "tap test/**/*.test.ts -R=spec --timeout=300",
     "prepare": "npm run build"
   },

--- a/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
@@ -1,0 +1,679 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gomodules binaries scanning should return expected result 1`] = `
+Object {
+  "scanResults": Array [
+    Object {
+      "facts": Array [
+        Object {
+          "data": Object {
+            "graph": Object {
+              "nodes": Array [
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+                    },
+                    Object {
+                      "nodeId": "alpine-keys/alpine-keys@2.2-r0",
+                    },
+                    Object {
+                      "nodeId": "apk-tools/apk-tools@2.10.5-r1",
+                    },
+                    Object {
+                      "nodeId": "busybox/busybox@1.31.1-r16|2",
+                    },
+                    Object {
+                      "nodeId": "busybox/ssl_client@1.31.1-r16",
+                    },
+                    Object {
+                      "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2",
+                    },
+                    Object {
+                      "nodeId": "libc-dev/libc-utils@0.7.2-r3",
+                    },
+                    Object {
+                      "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|2",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                    Object {
+                      "nodeId": "musl/musl-utils@1.1.24-r8|2",
+                    },
+                    Object {
+                      "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|2",
+                    },
+                    Object {
+                      "nodeId": "openssl/libssl1.1@1.1.1g-r0|2",
+                    },
+                    Object {
+                      "nodeId": "pax-utils/scanelf@1.2.6-r0|2",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib@1.2.11-r3|2",
+                    },
+                  ],
+                  "nodeId": "root-node",
+                  "pkgId": "docker-image|yq.tar@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "busybox/busybox@1.31.1-r16|1",
+                  "pkgId": "busybox/busybox@1.31.1-r16",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                  ],
+                  "nodeId": "busybox/busybox@1.31.1-r16|2",
+                  "pkgId": "busybox/busybox@1.31.1-r16",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "musl/musl@1.1.24-r8",
+                  "pkgId": "musl/musl@1.1.24-r8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "busybox/busybox@1.31.1-r16|1",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                  ],
+                  "nodeId": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+                  "pkgId": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "alpine-keys/alpine-keys@2.2-r0",
+                  "pkgId": "alpine-keys/alpine-keys@2.2-r0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+                  "pkgId": "openssl/libcrypto1.1@1.1.1g-r0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                  ],
+                  "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|2",
+                  "pkgId": "openssl/libcrypto1.1@1.1.1g-r0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "openssl/libssl1.1@1.1.1g-r0|1",
+                  "pkgId": "openssl/libssl1.1@1.1.1g-r0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                    Object {
+                      "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+                    },
+                  ],
+                  "nodeId": "openssl/libssl1.1@1.1.1g-r0|2",
+                  "pkgId": "openssl/libssl1.1@1.1.1g-r0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib@1.2.11-r3|1",
+                  "pkgId": "zlib/zlib@1.2.11-r3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                  ],
+                  "nodeId": "zlib/zlib@1.2.11-r3|2",
+                  "pkgId": "zlib/zlib@1.2.11-r3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                    Object {
+                      "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+                    },
+                    Object {
+                      "nodeId": "openssl/libssl1.1@1.1.1g-r0|1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib@1.2.11-r3|1",
+                    },
+                  ],
+                  "nodeId": "apk-tools/apk-tools@2.10.5-r1",
+                  "pkgId": "apk-tools/apk-tools@2.10.5-r1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|1",
+                  "pkgId": "libtls-standalone/libtls-standalone@2.9.1-r1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                    Object {
+                      "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+                    },
+                    Object {
+                      "nodeId": "openssl/libssl1.1@1.1.1g-r0|1",
+                    },
+                  ],
+                  "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|2",
+                  "pkgId": "libtls-standalone/libtls-standalone@2.9.1-r1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|1",
+                    },
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                  ],
+                  "nodeId": "busybox/ssl_client@1.31.1-r16",
+                  "pkgId": "busybox/ssl_client@1.31.1-r16",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2",
+                  "pkgId": "ca-certificates/ca-certificates-bundle@20191127-r2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "musl/musl-utils@1.1.24-r8|1",
+                  "pkgId": "musl/musl-utils@1.1.24-r8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                    Object {
+                      "nodeId": "pax-utils/scanelf@1.2.6-r0|1",
+                    },
+                  ],
+                  "nodeId": "musl/musl-utils@1.1.24-r8|2",
+                  "pkgId": "musl/musl-utils@1.1.24-r8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl-utils@1.1.24-r8|1",
+                    },
+                  ],
+                  "nodeId": "libc-dev/libc-utils@0.7.2-r3",
+                  "pkgId": "libc-dev/libc-utils@0.7.2-r3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pax-utils/scanelf@1.2.6-r0|1",
+                  "pkgId": "pax-utils/scanelf@1.2.6-r0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "musl/musl@1.1.24-r8",
+                    },
+                  ],
+                  "nodeId": "pax-utils/scanelf@1.2.6-r0|2",
+                  "pkgId": "pax-utils/scanelf@1.2.6-r0",
+                },
+              ],
+              "rootNodeId": "root-node",
+            },
+            "pkgManager": Object {
+              "name": "apk",
+              "repositories": Array [
+                Object {
+                  "alias": "alpine:3.12.0",
+                },
+              ],
+            },
+            "pkgs": Array [
+              Object {
+                "id": "docker-image|yq.tar@",
+                "info": Object {
+                  "name": "docker-image|yq.tar",
+                  "version": undefined,
+                },
+              },
+              Object {
+                "id": "busybox/busybox@1.31.1-r16",
+                "info": Object {
+                  "name": "busybox/busybox",
+                  "version": "1.31.1-r16",
+                },
+              },
+              Object {
+                "id": "musl/musl@1.1.24-r8",
+                "info": Object {
+                  "name": "musl/musl",
+                  "version": "1.1.24-r8",
+                },
+              },
+              Object {
+                "id": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+                "info": Object {
+                  "name": "alpine-baselayout/alpine-baselayout",
+                  "version": "3.2.0-r6",
+                },
+              },
+              Object {
+                "id": "alpine-keys/alpine-keys@2.2-r0",
+                "info": Object {
+                  "name": "alpine-keys/alpine-keys",
+                  "version": "2.2-r0",
+                },
+              },
+              Object {
+                "id": "openssl/libcrypto1.1@1.1.1g-r0",
+                "info": Object {
+                  "name": "openssl/libcrypto1.1",
+                  "version": "1.1.1g-r0",
+                },
+              },
+              Object {
+                "id": "openssl/libssl1.1@1.1.1g-r0",
+                "info": Object {
+                  "name": "openssl/libssl1.1",
+                  "version": "1.1.1g-r0",
+                },
+              },
+              Object {
+                "id": "zlib/zlib@1.2.11-r3",
+                "info": Object {
+                  "name": "zlib/zlib",
+                  "version": "1.2.11-r3",
+                },
+              },
+              Object {
+                "id": "apk-tools/apk-tools@2.10.5-r1",
+                "info": Object {
+                  "name": "apk-tools/apk-tools",
+                  "version": "2.10.5-r1",
+                },
+              },
+              Object {
+                "id": "libtls-standalone/libtls-standalone@2.9.1-r1",
+                "info": Object {
+                  "name": "libtls-standalone/libtls-standalone",
+                  "version": "2.9.1-r1",
+                },
+              },
+              Object {
+                "id": "busybox/ssl_client@1.31.1-r16",
+                "info": Object {
+                  "name": "busybox/ssl_client",
+                  "version": "1.31.1-r16",
+                },
+              },
+              Object {
+                "id": "ca-certificates/ca-certificates-bundle@20191127-r2",
+                "info": Object {
+                  "name": "ca-certificates/ca-certificates-bundle",
+                  "version": "20191127-r2",
+                },
+              },
+              Object {
+                "id": "musl/musl-utils@1.1.24-r8",
+                "info": Object {
+                  "name": "musl/musl-utils",
+                  "version": "1.1.24-r8",
+                },
+              },
+              Object {
+                "id": "libc-dev/libc-utils@0.7.2-r3",
+                "info": Object {
+                  "name": "libc-dev/libc-utils",
+                  "version": "0.7.2-r3",
+                },
+              },
+              Object {
+                "id": "pax-utils/scanelf@1.2.6-r0",
+                "info": Object {
+                  "name": "pax-utils/scanelf",
+                  "version": "1.2.6-r0",
+                },
+              },
+            ],
+            "schemaVersion": "1.2.0",
+          },
+          "type": "depGraph",
+        },
+        Object {
+          "data": "0809facff9bd760673e046192ad24a2ee08d451f6dbb6c22552293dc4b15e734",
+          "type": "imageId",
+        },
+        Object {
+          "data": Array [
+            "50644c29ef5a27c9a40c393a73ece2479de78325cae7d762ef3cdc19bf42dd0a.tar",
+            "c1df98c53fe381ef0bd5d7712600a9c4e8e7ac6debbfb0cd3a4c50a4e2e6c5c0.tar",
+            "c1df98c53fe381ef0bd5d7712600a9c4e8e7ac6debbfb0cd3a4c50a4e2e6c5c0.tar",
+            "d24888289f050c75a92d33b77c3a052154ed2c4f61e084b7e63cd007bc8bfb00.tar",
+          ],
+          "type": "imageLayers",
+        },
+        Object {
+          "data": Array [
+            "sha256:50644c29ef5a27c9a40c393a73ece2479de78325cae7d762ef3cdc19bf42dd0a",
+            "sha256:c1df98c53fe381ef0bd5d7712600a9c4e8e7ac6debbfb0cd3a4c50a4e2e6c5c0",
+            "sha256:c1df98c53fe381ef0bd5d7712600a9c4e8e7ac6debbfb0cd3a4c50a4e2e6c5c0",
+            "sha256:d24888289f050c75a92d33b77c3a052154ed2c4f61e084b7e63cd007bc8bfb00",
+          ],
+          "type": "rootFs",
+        },
+        Object {
+          "data": "Alpine Linux v3.12",
+          "type": "imageOsReleasePrettyName",
+        },
+      ],
+      "identity": Object {
+        "args": Object {
+          "platform": "linux/amd64",
+        },
+        "type": "apk",
+      },
+      "target": Object {
+        "image": "docker-image|yq.tar",
+      },
+    },
+    Object {
+      "facts": Array [
+        Object {
+          "data": Object {
+            "graph": Object {
+              "nodes": Array [
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "github.com/kylelemons/godebug/diff@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "github.com/pkg/errors@0.9.1",
+                    },
+                    Object {
+                      "nodeId": "github.com/spf13/cobra@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "gopkg.in/op/go-logging.v1@#b2cb9fa56473",
+                    },
+                    Object {
+                      "nodeId": "gopkg.in/yaml.v3@#eeeca48fe776",
+                    },
+                    Object {
+                      "nodeId": "github.com/fatih/color@1.9.0",
+                    },
+                    Object {
+                      "nodeId": "github.com/goccy/go-yaml/lexer@1.8.1",
+                    },
+                    Object {
+                      "nodeId": "github.com/goccy/go-yaml/printer@1.8.1",
+                    },
+                    Object {
+                      "nodeId": "github.com/spf13/pflag@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "github.com/mattn/go-colorable@0.1.7",
+                    },
+                    Object {
+                      "nodeId": "github.com/mattn/go-isatty@0.0.12",
+                    },
+                    Object {
+                      "nodeId": "github.com/goccy/go-yaml/scanner@1.8.1",
+                    },
+                    Object {
+                      "nodeId": "github.com/goccy/go-yaml/token@1.8.1",
+                    },
+                    Object {
+                      "nodeId": "github.com/goccy/go-yaml/ast@1.8.1",
+                    },
+                    Object {
+                      "nodeId": "golang.org/x/sys/unix@#be1d3432aa8f",
+                    },
+                    Object {
+                      "nodeId": "golang.org/x/xerrors@#5ec99f83aff1",
+                    },
+                  ],
+                  "nodeId": "root-node",
+                  "pkgId": "github.com/mikefarah/yq/v3@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/kylelemons/godebug/diff@1.1.0",
+                  "pkgId": "github.com/kylelemons/godebug/diff@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/pkg/errors@0.9.1",
+                  "pkgId": "github.com/pkg/errors@0.9.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/spf13/cobra@1.0.0",
+                  "pkgId": "github.com/spf13/cobra@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gopkg.in/op/go-logging.v1@#b2cb9fa56473",
+                  "pkgId": "gopkg.in/op/go-logging.v1@#b2cb9fa56473",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gopkg.in/yaml.v3@#eeeca48fe776",
+                  "pkgId": "gopkg.in/yaml.v3@#eeeca48fe776",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/fatih/color@1.9.0",
+                  "pkgId": "github.com/fatih/color@1.9.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/goccy/go-yaml/lexer@1.8.1",
+                  "pkgId": "github.com/goccy/go-yaml/lexer@1.8.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/goccy/go-yaml/printer@1.8.1",
+                  "pkgId": "github.com/goccy/go-yaml/printer@1.8.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/spf13/pflag@1.0.5",
+                  "pkgId": "github.com/spf13/pflag@1.0.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/mattn/go-colorable@0.1.7",
+                  "pkgId": "github.com/mattn/go-colorable@0.1.7",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/mattn/go-isatty@0.0.12",
+                  "pkgId": "github.com/mattn/go-isatty@0.0.12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/goccy/go-yaml/scanner@1.8.1",
+                  "pkgId": "github.com/goccy/go-yaml/scanner@1.8.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/goccy/go-yaml/token@1.8.1",
+                  "pkgId": "github.com/goccy/go-yaml/token@1.8.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "github.com/goccy/go-yaml/ast@1.8.1",
+                  "pkgId": "github.com/goccy/go-yaml/ast@1.8.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "golang.org/x/sys/unix@#be1d3432aa8f",
+                  "pkgId": "golang.org/x/sys/unix@#be1d3432aa8f",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "golang.org/x/xerrors@#5ec99f83aff1",
+                  "pkgId": "golang.org/x/xerrors@#5ec99f83aff1",
+                },
+              ],
+              "rootNodeId": "root-node",
+            },
+            "pkgManager": Object {
+              "name": "gomodules",
+            },
+            "pkgs": Array [
+              Object {
+                "id": "github.com/mikefarah/yq/v3@",
+                "info": Object {
+                  "name": "github.com/mikefarah/yq/v3",
+                },
+              },
+              Object {
+                "id": "github.com/kylelemons/godebug/diff@1.1.0",
+                "info": Object {
+                  "name": "github.com/kylelemons/godebug/diff",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "github.com/pkg/errors@0.9.1",
+                "info": Object {
+                  "name": "github.com/pkg/errors",
+                  "version": "0.9.1",
+                },
+              },
+              Object {
+                "id": "github.com/spf13/cobra@1.0.0",
+                "info": Object {
+                  "name": "github.com/spf13/cobra",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "gopkg.in/op/go-logging.v1@#b2cb9fa56473",
+                "info": Object {
+                  "name": "gopkg.in/op/go-logging.v1",
+                  "version": "#b2cb9fa56473",
+                },
+              },
+              Object {
+                "id": "gopkg.in/yaml.v3@#eeeca48fe776",
+                "info": Object {
+                  "name": "gopkg.in/yaml.v3",
+                  "version": "#eeeca48fe776",
+                },
+              },
+              Object {
+                "id": "github.com/fatih/color@1.9.0",
+                "info": Object {
+                  "name": "github.com/fatih/color",
+                  "version": "1.9.0",
+                },
+              },
+              Object {
+                "id": "github.com/goccy/go-yaml/lexer@1.8.1",
+                "info": Object {
+                  "name": "github.com/goccy/go-yaml/lexer",
+                  "version": "1.8.1",
+                },
+              },
+              Object {
+                "id": "github.com/goccy/go-yaml/printer@1.8.1",
+                "info": Object {
+                  "name": "github.com/goccy/go-yaml/printer",
+                  "version": "1.8.1",
+                },
+              },
+              Object {
+                "id": "github.com/spf13/pflag@1.0.5",
+                "info": Object {
+                  "name": "github.com/spf13/pflag",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "github.com/mattn/go-colorable@0.1.7",
+                "info": Object {
+                  "name": "github.com/mattn/go-colorable",
+                  "version": "0.1.7",
+                },
+              },
+              Object {
+                "id": "github.com/mattn/go-isatty@0.0.12",
+                "info": Object {
+                  "name": "github.com/mattn/go-isatty",
+                  "version": "0.0.12",
+                },
+              },
+              Object {
+                "id": "github.com/goccy/go-yaml/scanner@1.8.1",
+                "info": Object {
+                  "name": "github.com/goccy/go-yaml/scanner",
+                  "version": "1.8.1",
+                },
+              },
+              Object {
+                "id": "github.com/goccy/go-yaml/token@1.8.1",
+                "info": Object {
+                  "name": "github.com/goccy/go-yaml/token",
+                  "version": "1.8.1",
+                },
+              },
+              Object {
+                "id": "github.com/goccy/go-yaml/ast@1.8.1",
+                "info": Object {
+                  "name": "github.com/goccy/go-yaml/ast",
+                  "version": "1.8.1",
+                },
+              },
+              Object {
+                "id": "golang.org/x/sys/unix@#be1d3432aa8f",
+                "info": Object {
+                  "name": "golang.org/x/sys/unix",
+                  "version": "#be1d3432aa8f",
+                },
+              },
+              Object {
+                "id": "golang.org/x/xerrors@#5ec99f83aff1",
+                "info": Object {
+                  "name": "golang.org/x/xerrors",
+                  "version": "#5ec99f83aff1",
+                },
+              },
+            ],
+            "schemaVersion": "1.2.0",
+          },
+          "type": "depGraph",
+        },
+      ],
+      "identity": Object {
+        "targetFile": "/usr/bin/yq",
+        "type": "gomodules",
+      },
+      "target": Object {
+        "image": "docker-image|yq.tar",
+      },
+    },
+  ],
+}
+`;

--- a/test/system/application-scans/gomodules.spec.ts
+++ b/test/system/application-scans/gomodules.spec.ts
@@ -1,0 +1,19 @@
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
+
+describe("gomodules binaries scanning", () => {
+  it("should return expected result", async () => {
+    // Arrange
+    const fixturePath = getFixture("docker-archives/docker-save/yq.tar");
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+    // Act
+    const pluginResult = await scan({
+      path: imageNameAndTag,
+      "app-vulns": true,
+    });
+
+    // Assert
+    expect(pluginResult).toMatchSnapshot();
+  });
+});

--- a/test/system/application-scans/java.spec.ts
+++ b/test/system/application-scans/java.spec.ts
@@ -1,13 +1,9 @@
-import { join as pathJoin } from "path";
-import { scan } from "../../../lib/index";
-
-function getFixture(fixturePath: string): string {
-  return pathJoin(__dirname, "../../fixtures/docker-archives", fixturePath);
-}
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
 
 describe("jar binaries scanning", () => {
   it("should return expected result", async () => {
-    const fixturePath = getFixture("docker-save/java.tar");
+    const fixturePath = getFixture("docker-archives/docker-save/java.tar");
     const imageNameAndTag = `docker-archive:${fixturePath}`;
 
     const pluginResult = await scan({

--- a/test/system/application-scans/node.spec.ts
+++ b/test/system/application-scans/node.spec.ts
@@ -1,9 +1,5 @@
-import { join as pathJoin } from "path";
-import { scan } from "../../../lib/index";
-
-function getFixture(fixturePath: string): string {
-  return pathJoin(__dirname, "../../fixtures", fixturePath);
-}
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
 
 describe("node application scans", () => {
   it("should correctly return applications as multiple scan results", async () => {

--- a/test/system/bugs/rpm-transitive-dependencies.spec.ts
+++ b/test/system/bugs/rpm-transitive-dependencies.spec.ts
@@ -1,10 +1,6 @@
-import { join as pathJoin } from "path";
 import { scan } from "../../../lib";
 import { DockerFileAnalysis } from "../../../lib/dockerfile";
-
-function getFixture(fixturePath) {
-  return pathJoin(__dirname, "../../fixtures", fixturePath);
-}
+import { getFixture } from "../../util";
 
 /**
  * The following bug proves that RPM packages do not have transitive dependencies.

--- a/test/system/flags/image-name-and-tag.spec.ts
+++ b/test/system/flags/image-name-and-tag.spec.ts
@@ -1,10 +1,6 @@
 import { DepGraph } from "@snyk/dep-graph";
-import { join as pathJoin } from "path";
-import { scan } from "../../../lib/index";
-
-function getFixture(fixturePath: string): string {
-  return pathJoin(__dirname, "../../fixtures", fixturePath);
-}
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
 
 describe("imageNameAndTag tests", () => {
   it("it overrides name and version when reading a docker archive", async () => {

--- a/test/system/image-type/compressed-archive.spec.ts
+++ b/test/system/image-type/compressed-archive.spec.ts
@@ -1,10 +1,7 @@
 import { DepGraph } from "@snyk/dep-graph";
-import { join as pathJoin } from "path";
-import { scan } from "../../../lib/index";
 
-function getFixture(fixturePath: string): string {
-  return pathJoin(__dirname, "../../fixtures", fixturePath);
-}
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
 
 describe("compressed archive scanning", () => {
   it("should correctly scan a compressed archive", async () => {

--- a/test/system/image-type/docker-archive.spec.ts
+++ b/test/system/image-type/docker-archive.spec.ts
@@ -1,9 +1,5 @@
-import { join as pathJoin } from "path";
-import { scan } from "../../../lib/index";
-
-function getFixture(fixturePath: string): string {
-  return pathJoin(__dirname, "../../fixtures", fixturePath);
-}
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
 
 describe("docker archive scanning", () => {
   it("should correctly scan a docker archive", async () => {

--- a/test/system/image-type/oci-archive.spec.ts
+++ b/test/system/image-type/oci-archive.spec.ts
@@ -1,9 +1,5 @@
-import { join as pathJoin } from "path";
-import { scan } from "../../../lib/index";
-
-function getFixture(fixturePath: string): string {
-  return pathJoin(__dirname, "../../fixtures", fixturePath);
-}
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
 
 describe("oci archive scanning", () => {
   it("should correctly scan an oci archive", async () => {

--- a/test/system/key-binaries-hashes/hashes.spec.ts
+++ b/test/system/key-binaries-hashes/hashes.spec.ts
@@ -1,13 +1,11 @@
-import { join as pathJoin } from "path";
-import { scan } from "../../../lib/index";
-
-function getFixture(fixturePath: string): string {
-  return pathJoin(__dirname, "../../fixtures/docker-archives", fixturePath);
-}
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
 
 describe("key binaries hashes scanning", () => {
   it("should correctly scan node key binaries hashes", async () => {
-    const fixturePath = getFixture("skopeo-copy/nodes-fake-multi.tar");
+    const fixturePath = getFixture(
+      "docker-archives/skopeo-copy/nodes-fake-multi.tar",
+    );
     const imageNameAndTag = `docker-archive:${fixturePath}`;
 
     const pluginResult = await scan({
@@ -18,7 +16,7 @@ describe("key binaries hashes scanning", () => {
   });
 
   it("should correctly scan java key binaries hashes", async () => {
-    const fixturePath = getFixture("docker-save/openjdk.tar");
+    const fixturePath = getFixture("docker-archives/docker-save/openjdk.tar");
     const imageNameAndTag = `docker-archive:${fixturePath}`;
 
     const pluginResult = await scan({

--- a/test/util/index.ts
+++ b/test/util/index.ts
@@ -1,0 +1,12 @@
+import { join } from "path";
+
+export function getFixture(fixturePath: string | string[]): string {
+  if (typeof fixturePath === "string") {
+    if (fixturePath.includes("/")) {
+      fixturePath = fixturePath.split("/").filter(Boolean); // if it started or ended with /
+    } else {
+      fixturePath = [fixturePath];
+    }
+  }
+  return join(__dirname, "..", "fixtures", ...fixturePath);
+}

--- a/test/windows/application-scans.spec.ts
+++ b/test/windows/application-scans.spec.ts
@@ -1,13 +1,11 @@
-import { join as pathJoin } from "path";
-import { scan } from "../../lib/index";
-
-function getFixture(fixturePath: string): string {
-  return pathJoin(__dirname, "../fixtures/docker-archives", fixturePath);
-}
+import { scan } from "../../lib";
+import { getFixture } from "../util";
 
 describe("scanning a container image with 2 applications", () => {
   it("should return expected result", async () => {
-    const fixturePath = getFixture("skopeo-copy/rpm-npm-yarn.tar");
+    const fixturePath = getFixture(
+      "docker-archives/skopeo-copy/rpm-npm-yarn.tar",
+    );
     const imageNameAndTag = `docker-archive:${fixturePath}`;
 
     const pluginResult = await scan({
@@ -21,7 +19,9 @@ describe("scanning a container image with 2 applications", () => {
 
 describe("jar binaries scanning", () => {
   it("should return expected result", async () => {
-    const fixturePath = getFixture("docker-save/java-windows.tar");
+    const fixturePath = getFixture(
+      "docker-archives/docker-save/java-windows.tar",
+    );
     const imageNameAndTag = `docker-archive:${fixturePath}`;
 
     const pluginResult = await scan({

--- a/test/windows/plugin.spec.ts
+++ b/test/windows/plugin.spec.ts
@@ -2,10 +2,7 @@ import { DepGraph } from "@snyk/dep-graph";
 import * as path from "path";
 
 import * as plugin from "../../lib";
-
-function getFixture(fixturePath): string {
-  return path.join(__dirname, "../fixtures", fixturePath);
-}
+import { getFixture } from "../util";
 
 describe("windows scanning", () => {
   it("can scan docker-archive image type", async () => {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add support to scan `non-stripped` Go binaries

Algorythm: 
1. Find binaries in the image
2. Check if the binary is ELF executable.
3. Get relevant ELF sections and programs.
4. Parse them.
5. Build DepGraph
 