### PR TITLE
Append latest if an image without a tag was provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ package-lock.json
 yarn.lock
 .DS_Store
 test/fixtures/ls-output/xxx.txt
+.nyc_output/
 
 # Diagnostic reports (https://nodejs.org/api/report.html) 
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -26,10 +26,10 @@ export async function scan(
 
   mergeEnvVarsIntoCredentials(options);
 
-  const targetImage = options.path;
-  if (!targetImage) {
+  if (!options.path) {
     throw new Error("No image identifier or path provided");
   }
+  const targetImage = appendLatestTagIfMissing(options.path);
 
   const dockerfilePath = options.file;
   const dockerfileAnalysis = await readDockerfileAndAnalyse(dockerfilePath);
@@ -136,4 +136,14 @@ async function imageIdentifierAnalysis(
 
 function isTrue(value?: boolean | string): boolean {
   return String(value).toLowerCase() === "true";
+}
+
+export function appendLatestTagIfMissing(targetImage: string): string {
+  if (
+    getImageType(targetImage) === ImageType.Identifier &&
+    !targetImage.includes(":")
+  ) {
+    return `${targetImage}:latest`;
+  }
+  return targetImage;
 }

--- a/test/lib/scan.spec.ts
+++ b/test/lib/scan.spec.ts
@@ -1,4 +1,7 @@
-import { mergeEnvVarsIntoCredentials } from "../../lib/scan";
+import {
+  appendLatestTagIfMissing,
+  mergeEnvVarsIntoCredentials,
+} from "../../lib/scan";
 
 describe("mergeEnvVarsIntoCredentials", () => {
   const oldEnvVars = { ...process.env };
@@ -71,4 +74,36 @@ describe("mergeEnvVarsIntoCredentials", () => {
 
       expect(options.password).toEqual(expectedPassword);
     });
+});
+
+describe("appendLatestTagIfMissing", () => {
+  it("does not append latest to docker archive path", () => {
+    const dockerArchivePath = "docker-archive:some/path/image.tar";
+    expect(appendLatestTagIfMissing(dockerArchivePath)).toEqual(
+      dockerArchivePath,
+    );
+  });
+
+  it("does not append latest to docker archive path", () => {
+    const ociArchivePath = "oci-archive:some/path/image.tar";
+    expect(appendLatestTagIfMissing(ociArchivePath)).toEqual(ociArchivePath);
+  });
+
+  it("does not append latest if tag exists", () => {
+    const imageWithTag = "image:sometag";
+    expect(appendLatestTagIfMissing(imageWithTag)).toEqual(imageWithTag);
+  });
+
+  it("does not modify targetImage with sha", () => {
+    const imageWithSha =
+      "snyk container test nginx@sha256:56ea7092e72db3e9f84d58d583370d59b842de02ea9e1f836c3f3afc7ce408c1";
+    expect(appendLatestTagIfMissing(imageWithSha)).toEqual(imageWithSha);
+  });
+
+  it("appends latest if no tag exists", () => {
+    const imageWithoutTag = "image";
+    expect(appendLatestTagIfMissing(imageWithoutTag)).toEqual(
+      `${imageWithoutTag}:latest`,
+    );
+  });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Most of the docker commands implicitly add `latest` to images without tags. In case of `docker save`, the behavior is not the same and can result in performance issues as well as inconsistent results.

#### How should this be manually tested?

Using `scan` with/without latest tag, with multiple different images from the same repo, should result in the same `scanResults`
