### PR TITLE
Fix/try catch go parsing

### DIFF
--- a/test/system/application-scans/gomodules.spec.ts
+++ b/test/system/application-scans/gomodules.spec.ts
@@ -23,7 +23,7 @@ describe("gomodules binaries scanning", () => {
     expect(pluginResult).toMatchSnapshot();
   });
 
-  it("throws an uncaught exception when a binary cannot be parsed", async () => {
+  it("throws an error when a Go binary cannot be parsed", async () => {
     const elfParseMock = jest.spyOn(elf, "parse").mockImplementation(() => {
       throw new Error("Cannot read property 'type' of undefined");
     });
@@ -31,18 +31,12 @@ describe("gomodules binaries scanning", () => {
     const fixturePath = getFixture("docker-archives/docker-save/yq.tar");
     const imageNameAndTag = `docker-archive:${fixturePath}`;
 
-    try {
-      const pluginResult = await scan({
+    await expect(() =>
+      scan({
         path: imageNameAndTag,
         "app-vulns": true,
-      });
-      expect(pluginResult).toEqual<PluginResponse>({
-        scanResults: expect.any(Array),
-      });
-    } catch (error) {
-      // This won't be executed!
-      expect(error).toBeDefined();
-    }
+      }),
+    ).rejects.toThrow("Error reading tar archive");
 
     elfParseMock.mockRestore();
   });

--- a/test/system/application-scans/gomodules.spec.ts
+++ b/test/system/application-scans/gomodules.spec.ts
@@ -1,7 +1,13 @@
-import { scan } from "../../../lib";
+import * as elf from "elfy";
+
+import { PluginResponse, scan } from "../../../lib";
 import { getFixture } from "../../util";
 
 describe("gomodules binaries scanning", () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
   it("should return expected result", async () => {
     // Arrange
     const fixturePath = getFixture("docker-archives/docker-save/yq.tar");
@@ -15,5 +21,29 @@ describe("gomodules binaries scanning", () => {
 
     // Assert
     expect(pluginResult).toMatchSnapshot();
+  });
+
+  it("throws an uncaught exception when a binary cannot be parsed", async () => {
+    const elfParseMock = jest.spyOn(elf, "parse").mockImplementation(() => {
+      throw new Error("Cannot read property 'type' of undefined");
+    });
+
+    const fixturePath = getFixture("docker-archives/docker-save/yq.tar");
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+    try {
+      const pluginResult = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+      });
+      expect(pluginResult).toEqual<PluginResponse>({
+        scanResults: expect.any(Array),
+      });
+    } catch (error) {
+      // This won't be executed!
+      expect(error).toBeDefined();
+    }
+
+    elfParseMock.mockRestore();
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Ensure to capture and rethrow errors from image layer parsing.

Right now any errors that occur during image layer parsing are not properly caught (because they occur either in an async or EventEmitter context) and result in uncaught exceptions.

One of these places is the Go binaries parser, which we now properly try-catch and reject the promise that wraps it.
Additionally we need to try-catch the image layer parsing process as a whole, which was missing before.

#### Any background context you want to provide?

[Alerts in Slack](https://snyk.slack.com/archives/C01KWP7CKQC/p1612857668002100) and [discussion](https://snyk.slack.com/archives/C01KWP7CKQC/p1612857959002400)
[Node.js documentation on error propagation and interception](https://nodejs.org/docs/latest/api/errors.html#errors_error_propagation_and_interception)

