### PR TITLE
chore: Don't return empty labels for oci-archive images

### DIFF
--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -31,7 +31,6 @@ export async function extractImageContent(
         imageId: ociExtractor.getImageIdFromManifest(ociArchive.manifest),
         manifestLayers: ociExtractor.getManifestLayers(ociArchive.manifest),
         extractedLayers: layersWithLatestFileModifications(ociArchive.layers),
-        imageLabels: {},
       };
     default:
       const dockerArchive = await dockerExtractor.extractArchive(

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -18,7 +18,7 @@ export interface ExtractionResult {
   rootFsLayers?: string[];
   autoDetectedUserInstructions?: DockerFileAnalysis;
   platform?: string;
-  imageLabels: { [key: string]: string };
+  imageLabels?: { [key: string]: string };
 }
 
 export interface ExtractedLayers {

--- a/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
@@ -391,10 +391,6 @@ Object {
           "type": "imageLayers",
         },
         Object {
-          "data": Object {},
-          "type": "imageLabels",
-        },
-        Object {
           "data": "Alpine Linux v3.12",
           "type": "imageOsReleasePrettyName",
         },

--- a/test/system/image-type/__snapshots__/oci-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/oci-archive.spec.ts.snap
@@ -369,10 +369,6 @@ Object {
           "type": "imageLayers",
         },
         Object {
-          "data": Object {},
-          "type": "imageLabels",
-        },
-        Object {
           "data": "Alpine Linux v3.12",
           "type": "imageOsReleasePrettyName",
         },


### PR DESCRIPTION
#### What does this PR do?
This is a fixup after #319:
* Update oci-archive extractor not to return empty image labels, because we don't extract them yet.
* For docker-archive, extract labels and always return `imageLabels` fact.

This allows clients to differentiate between these situations:
* `imageLabels` fact is present, data isn't empty: image has labels
* `imageLabels` fact is present, data is empty: image has no labels
* `imageLabels` fact isn't present: we have no information on labels, didn't extract them

Once oci-archive label extraction is implemented, there will be only first two possible situations.
