### PR TITLE
fix: Added filtering history entries with no "created_by"

### DIFF
--- a/lib/extractor/docker-archive/index.ts
+++ b/lib/extractor/docker-archive/index.ts
@@ -41,7 +41,7 @@ export function getPlatformFromConfig(
 
 export function getDetectedLayersInfoFromConfig(imageConfig) {
   const runInstructions = getUserInstructionLayersFromConfig(imageConfig)
-    .filter((instruction) => !instruction.empty_layer)
+    .filter((instruction) => !instruction.empty_layer && instruction.created_by)
     .map((instruction) => instruction.created_by.replace("# buildkit", ""));
 
   const dockerfilePackages = getPackagesFromRunInstructions(runInstructions);


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
For docker archives we extract auto detected user instructions from the image config. Some of the entries are missing "created_by" so we were throwing an error - this PR is fixing that.

