### PR TITLE
feat: upgrade semver to 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "event-loop-spinner": "^2.0.0",
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
-    "semver": "^6.1.0",
+    "semver": "^7.3.4",
     "snyk-nodejs-lockfile-parser": "1.30.2",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",


### PR DESCRIPTION
https://github.com/npm/node-semver/blob/master/CHANGELOG.md#700

> Refactor module into separate files for better tree-shaking
> Drop support for very old node versions, use const/let, => functions, and classes.

I believe this drops support for node 0.x.
