### PR TITLE
fix: export functions and types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,12 @@
+import { Binary } from "./analyzer/types";
 import { display } from "./display";
 import * as dockerFile from "./dockerfile";
+import {
+  analyseDockerfile,
+  DockerFileAnalysis,
+  updateDockerfileBaseImageName,
+} from "./dockerfile";
+import { UpdateDockerfileBaseImageNameErrorCode } from "./dockerfile/types";
 import * as facts from "./facts";
 import { scan } from "./scan";
 import {
@@ -24,4 +31,9 @@ export {
   Fact,
   FactType,
   ManifestFile,
+  analyseDockerfile,
+  DockerFileAnalysis,
+  updateDockerfileBaseImageName,
+  UpdateDockerfileBaseImageNameErrorCode,
+  Binary,
 };


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
It exports functions and types that are used in Docker Deps

#### Any background context you want to provide?
Docker Deps is importing some function functions and types from the `dist` folder. Because these functions and types were not being properly exported in Snyk Docker Plugin. 

[CAP-219](https://snyksec.atlassian.net/browse/CAP-219)
