### PR TITLE
test: show bug with being unable to scan CentOS 6 images

### DIFF
--- a/test/system/bugs/centos6.spec.ts
+++ b/test/system/bugs/centos6.spec.ts
@@ -1,0 +1,23 @@
+import { scan } from "../../../lib";
+import { execute } from "../../../lib/sub-process";
+
+describe("BUG: CentOS 6 image cannot be scanned", () => {
+  afterAll(async () => {
+    await execute("docker", [
+      "image",
+      "rm",
+      "dokken/centos-6@sha256:494b9b280814f1e661597b48e229156e4dccb60dce198d9210f7572ff22626d2",
+    ]).catch();
+  });
+
+  it("cannot scan a centos6-based image", async () => {
+    const imagePath =
+      "dokken/centos-6@sha256:494b9b280814f1e661597b48e229156e4dccb60dce198d9210f7572ff22626d2";
+
+    await expect(async () =>
+      scan({
+        path: imagePath,
+      }),
+    ).rejects.toThrow("Failed to detect OS release");
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This bug happens because the image in question has 2 OS release files - lsb_release and centos_release.
Our detection logic runs the LSB parser first. Unfortunately, in this specific image lsb_release is malformed and does not contain enough information about the OS release. The real OS release data is in centos_release, but our parser throws an error before examining it.


#### What are the relevant tickets?

[Jira ticket #9475](https://snyk.zendesk.com/agent/tickets/9475)

I'll create the follow up fix for this :) 
