### PR TITLE
feat: Add hash algorithm prefix ('sha256:') to docker imageId [RHINO-45]

### DIFF
--- a/lib/extractor/docker-archive/index.ts
+++ b/lib/extractor/docker-archive/index.ts
@@ -3,6 +3,7 @@ import {
   getLayersFromPackages,
   getPackagesFromRunInstructions,
 } from "../../dockerfile/instruction-parser";
+import { HashAlgorithm } from "../../types";
 
 import { DockerArchiveImageConfig, DockerArchiveManifest } from "../types";
 export { extractArchive } from "./layer";
@@ -15,7 +16,12 @@ export function getImageIdFromManifest(
   manifest: DockerArchiveManifest,
 ): string {
   try {
-    return manifest.Config.split(".")[0];
+    const imageId = manifest.Config.split(".")[0];
+    if (imageId.includes(":")) {
+      // imageId includes the algorithm prefix
+      return imageId;
+    }
+    return `${HashAlgorithm.Sha256}:${imageId}`;
   } catch (err) {
     throw new Error("Failed to extract image ID from archive manifest");
   }

--- a/test/lib/extractor/docker-archive/index.spec.ts
+++ b/test/lib/extractor/docker-archive/index.spec.ts
@@ -1,0 +1,36 @@
+import { getImageIdFromManifest } from "../../../../lib/extractor/docker-archive";
+import { DockerArchiveManifest } from "../../../../lib/extractor/types";
+
+describe("getImageIdFromManifest", () => {
+  describe("when manifest config string contains algorithm prefix", () => {
+    it("returns the imageId with prefix", () => {
+      const manifest: DockerArchiveManifest = {
+        Config:
+          "sha256:2565821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538.json",
+        RepoTags: [],
+        Layers: [],
+      };
+
+      const imageId = getImageIdFromManifest(manifest);
+      expect(imageId).toEqual(
+        "sha256:2565821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538",
+      );
+    });
+  });
+
+  describe("when manifest config string does not contain algorithm prefix", () => {
+    it("returns the imageId with prefix", () => {
+      const manifest: DockerArchiveManifest = {
+        Config:
+          "2565821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538.json",
+        RepoTags: [],
+        Layers: [],
+      };
+
+      const imageId = getImageIdFromManifest(manifest);
+      expect(imageId).toEqual(
+        "sha256:2565821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538",
+      );
+    });
+  });
+});

--- a/test/system/app-os/__snapshots__/globs.spec.ts.snap
+++ b/test/system/app-os/__snapshots__/globs.spec.ts.snap
@@ -1862,7 +1862,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "ef05c61d51129e3866d5b71b4f44864919dd2b9e5f2644f0a511703182acf8f9",
+          "data": "sha256:ef05c61d51129e3866d5b71b4f44864919dd2b9e5f2644f0a511703182acf8f9",
           "type": "imageId",
         },
         Object {

--- a/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
@@ -359,7 +359,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "0809facff9bd760673e046192ad24a2ee08d451f6dbb6c22552293dc4b15e734",
+          "data": "sha256:0809facff9bd760673e046192ad24a2ee08d451f6dbb6c22552293dc4b15e734",
           "type": "imageId",
         },
         Object {

--- a/test/system/application-scans/__snapshots__/java.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/java.spec.ts.snap
@@ -39,7 +39,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "e997a24cd4633de60213a23debcfb37dcc9fa6578a112976fc80aaa094ea1f59",
+          "data": "sha256:e997a24cd4633de60213a23debcfb37dcc9fa6578a112976fc80aaa094ea1f59",
           "type": "imageId",
         },
         Object {

--- a/test/system/application-scans/__snapshots__/node.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/node.spec.ts.snap
@@ -1600,7 +1600,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "7f335821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538",
+          "data": "sha256:7f335821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538",
           "type": "imageId",
         },
         Object {

--- a/test/system/bugs/__snapshots__/rpm-transitive-dependencies.spec.ts.snap
+++ b/test/system/bugs/__snapshots__/rpm-transitive-dependencies.spec.ts.snap
@@ -2510,7 +2510,7 @@ Object {
           "type": "dockerfileAnalysis",
         },
         Object {
-          "data": "01bf7139aec575f3d93dd55f96e1bccdde090142c9501882c4bcc48685bb9f7b",
+          "data": "sha256:01bf7139aec575f3d93dd55f96e1bccdde090142c9501882c4bcc48685bb9f7b",
           "type": "imageId",
         },
         Object {

--- a/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
@@ -7769,7 +7769,7 @@ Object {
           "type": "dockerfileAnalysis",
         },
         Object {
-          "data": "1c13388e727de4695a7507d4695d21be94009d9bcacf54c9cc0e370c86f6d8ef",
+          "data": "sha256:1c13388e727de4695a7507d4695d21be94009d9bcacf54c9cc0e370c86f6d8ef",
           "type": "imageId",
         },
         Object {

--- a/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
@@ -1751,7 +1751,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "ab56bba91343aafcdd94b7a44b42e12f32719b9a2b8579e93017c1280f48e8f3",
+          "data": "sha256:ab56bba91343aafcdd94b7a44b42e12f32719b9a2b8579e93017c1280f48e8f3",
           "type": "imageId",
         },
         Object {

--- a/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
@@ -1751,7 +1751,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "5a3221f0137beb960c34b9cf4455424b6210160fd618c5e79401a07d6e5a2ced",
+          "data": "sha256:5a3221f0137beb960c34b9cf4455424b6210160fd618c5e79401a07d6e5a2ced",
           "type": "imageId",
         },
         Object {

--- a/test/system/index.spec.ts
+++ b/test/system/index.spec.ts
@@ -62,7 +62,7 @@ describe("system tests", () => {
     )!.data;
 
     expect(imageId).toEqual(
-      "00165cd5d0c00321af529a74915a9a7fe5cc9759ebca8e86ad38191933f551e8",
+      "sha256:00165cd5d0c00321af529a74915a9a7fe5cc9759ebca8e86ad38191933f551e8",
     );
     expect(pluginResponse.scanResults[0].identity.type).toEqual("deb");
     expect(pluginResponse.scanResults[0].identity.type).toEqual(
@@ -109,7 +109,7 @@ describe("system tests", () => {
     )!.data;
 
     expect(imageId).toEqual(
-      "7f70b30f2cc66b5e23308fb20c6e57dc1ea0c47950cca797831b705177c6b8ce",
+      "sha256:7f70b30f2cc66b5e23308fb20c6e57dc1ea0c47950cca797831b705177c6b8ce",
     );
     expect(pluginResponse.scanResults[0].identity.type).toEqual("deb");
 
@@ -163,7 +163,7 @@ describe("system tests", () => {
     )!.data;
 
     expect(imageId).toEqual(
-      "ca0b6709748d024a67c502558ea88dc8a1f8a858d380f5ddafa1504126a3b018",
+      "sha256:ca0b6709748d024a67c502558ea88dc8a1f8a858d380f5ddafa1504126a3b018",
     );
     expect(pluginResponse.scanResults[0].identity.type).toEqual("apk");
 
@@ -218,7 +218,7 @@ describe("system tests", () => {
       )!.data;
 
       expect(imageId).toEqual(
-        "ca0b6709748d024a67c502558ea88dc8a1f8a858d380f5ddafa1504126a3b018",
+        "sha256:ca0b6709748d024a67c502558ea88dc8a1f8a858d380f5ddafa1504126a3b018",
       );
       expect(pluginResponse.scanResults[0].identity.type).toEqual("apk");
 
@@ -255,7 +255,7 @@ describe("system tests", () => {
     )!.data;
 
     expect(imageId).toEqual(
-      "20bb25d32758db4f91b18a9581794cfaa6a8c5fbad80093e9a9e42211e131a48",
+      "sha256:20bb25d32758db4f91b18a9581794cfaa6a8c5fbad80093e9a9e42211e131a48",
     );
     expect(pluginResponse.scanResults[0].identity.type).toEqual("deb");
 
@@ -294,7 +294,7 @@ describe("system tests", () => {
       )!.data;
 
       expect(imageId).toEqual(
-        "ca0b6709748d024a67c502558ea88dc8a1f8a858d380f5ddafa1504126a3b018",
+        "sha256:ca0b6709748d024a67c502558ea88dc8a1f8a858d380f5ddafa1504126a3b018",
       );
       expect(pluginResponse.scanResults[0].identity.type).toEqual("apk");
 

--- a/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
+++ b/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
@@ -45,7 +45,7 @@ Object {
           "type": "keyBinariesHashes",
         },
         Object {
-          "data": "e997a24cd4633de60213a23debcfb37dcc9fa6578a112976fc80aaa094ea1f59",
+          "data": "sha256:e997a24cd4633de60213a23debcfb37dcc9fa6578a112976fc80aaa094ea1f59",
           "type": "imageId",
         },
         Object {
@@ -1835,7 +1835,7 @@ Object {
           "type": "keyBinariesHashes",
         },
         Object {
-          "data": "c23a5744368857498ede92ce059cbf481800bb870931de9d11dfea764db02889",
+          "data": "sha256:c23a5744368857498ede92ce059cbf481800bb870931de9d11dfea764db02889",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/alpine3.7.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/alpine3.7.spec.ts.snap
@@ -341,7 +341,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "6d1ef012b5674ad8a127ecfa9b5e6f5178d171b90ee462846974177fd9bdd39f",
+          "data": "sha256:6d1ef012b5674ad8a127ecfa9b5e6f5178d171b90ee462846974177fd9bdd39f",
           "type": "imageId",
         },
         Object {
@@ -716,7 +716,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "6d1ef012b5674ad8a127ecfa9b5e6f5178d171b90ee462846974177fd9bdd39f",
+          "data": "sha256:6d1ef012b5674ad8a127ecfa9b5e6f5178d171b90ee462846974177fd9bdd39f",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/busybox1.32.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/busybox1.32.spec.ts.snap
@@ -39,7 +39,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "9f00140cde00e263233ec6214cd1d8b8a0f9f92c1834d5dc842d2e184e807b29",
+          "data": "sha256:9f00140cde00e263233ec6214cd1d8b8a0f9f92c1834d5dc842d2e184e807b29",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/centos6.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/centos6.spec.ts.snap
@@ -2980,7 +2980,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "37eec09741b0048d83af1a40ac621bb5f591f28e8f322317ffe22a41dc7ffadd",
+          "data": "sha256:37eec09741b0048d83af1a40ac621bb5f591f28e8f322317ffe22a41dc7ffadd",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/centos7.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/centos7.spec.ts.snap
@@ -2245,7 +2245,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "afb6fca791e071c66276202f8efca5ce3d3dc4fb218bcddff1bc565d981ddd1e",
+          "data": "sha256:afb6fca791e071c66276202f8efca5ce3d3dc4fb218bcddff1bc565d981ddd1e",
           "type": "imageId",
         },
         Object {
@@ -4538,7 +4538,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "afb6fca791e071c66276202f8efca5ce3d3dc4fb218bcddff1bc565d981ddd1e",
+          "data": "sha256:afb6fca791e071c66276202f8efca5ce3d3dc4fb218bcddff1bc565d981ddd1e",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
@@ -1642,7 +1642,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "27f9bc730bd1a6a041e45fadd7150e936d585df1521b852d73e441bc1fd1f25f",
+          "data": "sha256:27f9bc730bd1a6a041e45fadd7150e936d585df1521b852d73e441bc1fd1f25f",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
@@ -146,7 +146,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "c2987b6738086b576c4bdca35a4e9caa748367d33a2a7a066404822e3778facb",
+          "data": "sha256:c2987b6738086b576c4bdca35a4e9caa748367d33a2a7a066404822e3778facb",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/oraclelinux8.2.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/oraclelinux8.2.spec.ts.snap
@@ -2770,7 +2770,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "c23ddcc8aacfa4742804c99faabc26042a1864254af7107dbb5126628a18f3d7",
+          "data": "sha256:c23ddcc8aacfa4742804c99faabc26042a1864254af7107dbb5126628a18f3d7",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/scratch.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/scratch.spec.ts.snap
@@ -39,7 +39,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "3e9c14093f51ff6402e39c4fbe3bfa08773bbc63db8bce4e948cd85f88a59f6d",
+          "data": "sha256:3e9c14093f51ff6402e39c4fbe3bfa08773bbc63db8bce4e948cd85f88a59f6d",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
@@ -1855,7 +1855,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "1a30717f94468b0f6c1e3e75832f80d3de00f729b96702a1091229b644dd265d",
+          "data": "sha256:1a30717f94468b0f6c1e3e75832f80d3de00f729b96702a1091229b644dd265d",
           "type": "imageId",
         },
         Object {

--- a/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
@@ -2725,7 +2725,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "ecbc6f53bba0d1923ca9e92b3f747da8353a070fccbae93625bd8b47dbee772e",
+          "data": "sha256:ecbc6f53bba0d1923ca9e92b3f747da8353a070fccbae93625bd8b47dbee772e",
           "type": "imageId",
         },
         Object {

--- a/test/system/package-managers/__snapshots__/apk.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/apk.spec.ts.snap
@@ -359,7 +359,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e",
+          "data": "sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e",
           "type": "imageId",
         },
         Object {

--- a/test/system/package-managers/__snapshots__/deb.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/deb.spec.ts.snap
@@ -1751,7 +1751,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "da838f7eb4f84536cf176bcbfed3c6f846f3cb18ae9c3c7befae1e8cd345aa19",
+          "data": "sha256:da838f7eb4f84536cf176bcbfed3c6f846f3cb18ae9c3c7befae1e8cd345aa19",
           "type": "imageId",
         },
         Object {

--- a/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
@@ -1600,7 +1600,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "ba2cc467a2bce7ffc9e2d6e38a87f6ec89c1c93bc83ff575e8021bb592f9ad2e",
+          "data": "sha256:ba2cc467a2bce7ffc9e2d6e38a87f6ec89c1c93bc83ff575e8021bb592f9ad2e",
           "type": "imageId",
         },
         Object {

--- a/test/system/platforms/__snapshots__/amd.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/amd.spec.ts.snap
@@ -1781,7 +1781,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "bd571e6529f32461648680c82e2540f9db4b3bb92709ae5d19dd347531c98f19",
+          "data": "sha256:bd571e6529f32461648680c82e2540f9db4b3bb92709ae5d19dd347531c98f19",
           "type": "imageId",
         },
         Object {
@@ -3645,7 +3645,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "bd571e6529f32461648680c82e2540f9db4b3bb92709ae5d19dd347531c98f19",
+          "data": "sha256:bd571e6529f32461648680c82e2540f9db4b3bb92709ae5d19dd347531c98f19",
           "type": "imageId",
         },
         Object {

--- a/test/system/platforms/__snapshots__/arm.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/arm.spec.ts.snap
@@ -950,7 +950,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "068614b905e936c8385dfe78226faa7329858b327edb0236eadd1f1c7d0903f8",
+          "data": "sha256:068614b905e936c8385dfe78226faa7329858b327edb0236eadd1f1c7d0903f8",
           "type": "imageId",
         },
         Object {

--- a/test/system/platforms/__snapshots__/ppc64le.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/ppc64le.spec.ts.snap
@@ -770,7 +770,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "fe64ed5afe5d5b2838dea115bd245cadccf97fdc8f3b9e90ccb3a4cc235cf5bc",
+          "data": "sha256:fe64ed5afe5d5b2838dea115bd245cadccf97fdc8f3b9e90ccb3a4cc235cf5bc",
           "type": "imageId",
         },
         Object {
@@ -1652,7 +1652,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "fe64ed5afe5d5b2838dea115bd245cadccf97fdc8f3b9e90ccb3a4cc235cf5bc",
+          "data": "sha256:fe64ed5afe5d5b2838dea115bd245cadccf97fdc8f3b9e90ccb3a4cc235cf5bc",
           "type": "imageId",
         },
         Object {

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -38,7 +38,7 @@ test("static scan for Identifier type image (nginx:1.19.0)", async (t) => {
   )!.data;
   t.same(
     imageId,
-    "2622e6cca7ebbb6e310743abce3fc47335393e79171b9d76ba9d4f446ce7b163",
+    "sha256:2622e6cca7ebbb6e310743abce3fc47335393e79171b9d76ba9d4f446ce7b163",
     "The image ID matches",
   );
   t.same(

--- a/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
+++ b/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
@@ -393,7 +393,7 @@ Object {
           "type": "keyBinariesHashes",
         },
         Object {
-          "data": "ebbf98230a821f1795b10c4df40ce81b1905e47d625cb9b4b0c7c617acb85e53",
+          "data": "sha256:ebbf98230a821f1795b10c4df40ce81b1905e47d625cb9b4b0c7c617acb85e53",
           "type": "imageId",
         },
         Object {
@@ -881,7 +881,7 @@ Object {
           "type": "keyBinariesHashes",
         },
         Object {
-          "data": "ebbf98230a821f1795b10c4df40ce81b1905e47d625cb9b4b0c7c617acb85e53",
+          "data": "sha256:ebbf98230a821f1795b10c4df40ce81b1905e47d625cb9b4b0c7c617acb85e53",
           "type": "imageId",
         },
         Object {

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -110,7 +110,7 @@ test("static analysis works for scratch images", async (t) => {
 
   t.equals(
     imageId,
-    "6d5fcfe5ff170471fcc3c8b47631d6d71202a1fd44cf3c147e50c8de21cf0648",
+    "sha256:6d5fcfe5ff170471fcc3c8b47631d6d71202a1fd44cf3c147e50c8de21cf0648",
     "image ID identified correctly",
   );
   t.equals(

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -39,7 +39,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "bf756fb1ae65adf866bd8c456593cd24beb6a0a061dedf42b26a993176745f6b",
+          "data": "sha256:bf756fb1ae65adf866bd8c456593cd24beb6a0a061dedf42b26a993176745f6b",
           "type": "imageId",
         },
         Object {
@@ -1721,7 +1721,7 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "7f335821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538",
+          "data": "sha256:7f335821efb5e5b95b36541004fa0287732a11f97a4a0ff807cc065746f82538",
           "type": "imageId",
         },
         Object {

--- a/test/windows/plugin.spec.ts
+++ b/test/windows/plugin.spec.ts
@@ -23,7 +23,7 @@ describe("windows scanning", () => {
       (fact) => fact.type === "imageId",
     )!.data;
     expect(imageId).toEqual(
-      "5a3221f0137beb960c34b9cf4455424b6210160fd618c5e79401a07d6e5a2ced",
+      "sha256:5a3221f0137beb960c34b9cf4455424b6210160fd618c5e79401a07d6e5a2ced",
     );
     expect(pluginResult.scanResults[0].identity.type).toEqual("deb");
     expect(

--- a/test/windows/static.test.ts
+++ b/test/windows/static.test.ts
@@ -41,7 +41,7 @@ test("static analysis builds the expected response", async (t) => {
   )!.data;
   t.same(
     skopeoCopyImageId,
-    "ab56bba91343aafcdd94b7a44b42e12f32719b9a2b8579e93017c1280f48e8f3",
+    "sha256:ab56bba91343aafcdd94b7a44b42e12f32719b9a2b8579e93017c1280f48e8f3",
     "The image ID matches",
   );
   t.same(
@@ -156,7 +156,7 @@ test("static analysis works for scratch images", async (t) => {
   )!.data;
   t.equals(
     imageId,
-    "6d5fcfe5ff170471fcc3c8b47631d6d71202a1fd44cf3c147e50c8de21cf0648",
+    "sha256:6d5fcfe5ff170471fcc3c8b47631d6d71202a1fd44cf3c147e50c8de21cf0648",
     "image ID identified correctly",
   );
   const imageLayers: string = pluginResultWithSkopeoCopy.scanResults[0].facts.find(


### PR DESCRIPTION
The prefix is added to the imageId to 

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This PR adds the hash algorithm prefix (sha256:) to the docker imageId.

#### Where should the reviewer start?
Start the review in lib/extractor/docker-archive/index.ts getImageIdFromManifest() funciton.

#### Any background context you want to provide?

This PR aligns with the id shown in 'docker manifest' and 'docker images --no-trunc' commands, and in v2 API get manifest. It aligns with the OCI [spec](https://github.com/opencontainers/image-spec/blob/master/config.md#imageid) and the imageId returned from OCI images.

#### What are the relevant tickets?

The imageId prefix is added as part of the work for querying images scan history by their imageId in Snyk's external API: [RHINO-45](https://snyksec.atlassian.net/browse/RHINO-45)
