### PR TITLE
fix: Update snyk-docker-pull to fix exception [DC-1219]

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@snyk/dep-graph": "^1.28.0",
     "@snyk/rpm-parser": "^2.0.0",
-    "@snyk/snyk-docker-pull": "3.2.3",
+    "@snyk/snyk-docker-pull": "3.2.5",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Updated snyk-docker-pull which has an updated version of docker-registry-v2-client that fixed an issue when getting multiarch manifest by its digest returning a manifest list, which resulted in a 'cannot read property of undefined' exception, when trying to access the manifest.config.digest object (as there is no config object in manifest list).

The latest fix in the v2-client lib makes sure the getManifest always returns a manifest.v2 object rather than a list (in case a list is returned by the API call the default linux/amd64 arch is chosen and returned by it).

#### What are the relevant tickets?

An open ticket in snyk CLI: https://github.com/snyk/snyk/issues/1892
Internal Jira ticket: https://snyksec.atlassian.net/browse/DC-1219 

#### Relevant Pull Requests

https://github.com/snyk/docker-registry-v2-client/pull/62
https://github.com/snyk/snyk-docker-pull/pull/89
