### PR TITLE
fix: Update snyk-docker-pull to improve performance [DC-1219]

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@snyk/dep-graph": "^1.28.0",
     "@snyk/rpm-parser": "^2.0.0",
-    "@snyk/snyk-docker-pull": "3.2.5",
+    "@snyk/snyk-docker-pull": "3.2.6",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR updates snyk-docker-pull which has an updated version of docker-registry-v2-client, as latest update in docker-registry-v2-client includes a performance improvement that reduces the amount of API calls in getManifest, in some scenarios.

#### Any background context you want to provide?

More information about the improvement can be found in the docker-registry-v2-client PR: https://github.com/snyk/docker-registry-v2-client/pull/63

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/DC-1219

