### PR TITLE
fix: Update snyk-docker-pull to v3.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@snyk/dep-graph": "^1.28.0",
     "@snyk/rpm-parser": "^2.0.0",
-    "@snyk/snyk-docker-pull": "3.2.6",
+    "@snyk/snyk-docker-pull": "3.2.8",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Update snyk-docker-pull to update docker-registry-v2-client to enable setting needle default timeout through environment variable.

#### Any background context you want to provide?

https://github.com/snyk/docker-registry-v2-client/pull/64

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/DC-1162



