### PR TITLE
fix: Handle container test with invalid image [CAP-228]

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -89,6 +89,11 @@ async function pullWithDockerBinary(
     ) {
       throw err;
     }
+
+    if (err.stderr && err.stderr.includes("invalid reference format")) {
+      throw new Error(`invalid image format`);
+    }
+
     return pullAndSaveSuccessful;
   }
 }

--- a/test/lib/analyzer/image-inspector.spec.ts
+++ b/test/lib/analyzer/image-inspector.spec.ts
@@ -4,6 +4,7 @@ import * as tmp from "tmp";
 import { v4 as uuidv4 } from "uuid";
 
 import { DockerPullResult } from "@snyk/snyk-docker-pull";
+import * as plugin from "../../../lib";
 import * as imageInspector from "../../../lib/analyzer/image-inspector";
 import { ArchiveResult } from "../../../lib/analyzer/types";
 import { Docker } from "../../../lib/docker";
@@ -85,6 +86,17 @@ describe("extractImageDetails", () => {
     expect(imageName).toEqual(expected.imageName);
     expect(tag).toEqual(expected.tag);
   });
+  it("should throw an error if the image name has an invalid format", async () => {
+     const imageNameAndTag = "/test:unknown";
+
+     await expect(() =>
+       plugin.scan({
+         path: imageNameAndTag,
+       }),
+     ).rejects.toEqual(
+       new Error("invalid image format"),
+     );
+   });
 });
 
 describe("getImageArchive", () => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Tests Updated

#### What does this PR do?
This PR checks if the image argument passed by the user via the CLI is an existing image and throws an error if it could not be analysed.

#### How should this be manually tested?
From the cli:
$ node dist/cli container test /does-not-exist
$ node dist/cli container test does-not-exist

#### What are the relevant tickets?
See [CAP-228 ](https://snyksec.atlassian.net/browse/CAP-228)