### PR TITLE
fix: split auto detected user instructions and dockerfile analysis type

### DIFF
--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -1,5 +1,4 @@
-import { DockerFileAnalysis } from "../dockerfile";
-import { ManifestFile } from "../types";
+import { AutoDetectedUserInstructions, ManifestFile } from "../types";
 import { AppDepsScanResultWithoutTarget } from "./applications/types";
 
 export interface AnalyzedPackage {
@@ -74,7 +73,7 @@ export interface StaticAnalysis {
   binaries: string[];
   imageLayers: string[];
   rootFsLayers?: string[];
-  autoDetectedUserInstructions?: DockerFileAnalysis;
+  autoDetectedUserInstructions?: AutoDetectedUserInstructions;
   applicationDependenciesScanResults: AppDepsScanResultWithoutTarget[];
   manifestFiles: ManifestFile[];
   imageLabels?: { [key: string]: string };

--- a/lib/extractor/docker-archive/index.ts
+++ b/lib/extractor/docker-archive/index.ts
@@ -3,7 +3,7 @@ import {
   getLayersFromPackages,
   getPackagesFromRunInstructions,
 } from "../../dockerfile/instruction-parser";
-import { HashAlgorithm } from "../../types";
+import { AutoDetectedUserInstructions, HashAlgorithm } from "../../types";
 
 import { DockerArchiveImageConfig, DockerArchiveManifest } from "../types";
 export { extractArchive } from "./layer";
@@ -45,7 +45,9 @@ export function getPlatformFromConfig(
     : undefined;
 }
 
-export function getDetectedLayersInfoFromConfig(imageConfig) {
+export function getDetectedLayersInfoFromConfig(
+  imageConfig,
+): AutoDetectedUserInstructions {
   const runInstructions = getUserInstructionLayersFromConfig(imageConfig)
     .filter((instruction) => !instruction.empty_layer && instruction.created_by)
     .map((instruction) => instruction.created_by.replace("# buildkit", ""));

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -1,6 +1,6 @@
 import { Readable } from "stream";
-import { DockerFileAnalysis } from "../dockerfile";
 import { Elf } from "../go-parser/types";
+import { AutoDetectedUserInstructions } from "../types";
 
 export type ExtractCallback = (
   dataStream: Readable,
@@ -16,7 +16,7 @@ export interface ExtractionResult {
   manifestLayers: string[];
   extractedLayers: ExtractedLayers;
   rootFsLayers?: string[];
-  autoDetectedUserInstructions?: DockerFileAnalysis;
+  autoDetectedUserInstructions?: AutoDetectedUserInstructions;
   platform?: string;
   imageLabels?: { [key: string]: string };
 }

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -1,7 +1,7 @@
 import { DepGraph } from "@snyk/dep-graph";
 import { JarFingerprint } from "./analyzer/types";
 import { DockerFileAnalysis } from "./dockerfile/types";
-import { ManifestFile } from "./types";
+import { AutoDetectedUserInstructions, ManifestFile } from "./types";
 
 export interface DepGraphFact {
   type: "depGraph";
@@ -30,7 +30,7 @@ export interface RootFsFact {
 
 export interface AutoDetectedUserInstructionsFact {
   type: "autoDetectedUserInstructions";
-  data: DockerFileAnalysis;
+  data: AutoDetectedUserInstructions;
 }
 export interface ImageIdFact {
   type: "imageId";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,6 +10,7 @@ import { UpdateDockerfileBaseImageNameErrorCode } from "./dockerfile/types";
 import * as facts from "./facts";
 import { scan } from "./scan";
 import {
+  AutoDetectedUserInstructions,
   ContainerTarget,
   Fact,
   FactType,
@@ -32,6 +33,7 @@ export {
   FactType,
   ManifestFile,
   analyseDockerfile,
+  AutoDetectedUserInstructions,
   DockerFileAnalysis,
   updateDockerfileBaseImageName,
   UpdateDockerfileBaseImageNameErrorCode,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,10 @@
 import { DepGraphData } from "@snyk/dep-graph";
 
-import { DockerFileAnalysis, DockerFilePackages } from "./dockerfile/types";
+import {
+  DockerFileAnalysis,
+  DockerFileLayers,
+  DockerFilePackages,
+} from "./dockerfile/types";
 
 export enum ImageType {
   Identifier, // e.g. "nginx:latest"
@@ -71,6 +75,11 @@ export interface ScanResult {
   identity: Identity;
   /** Facts are the collection of things you found. */
   facts: Fact[];
+}
+
+export interface AutoDetectedUserInstructions {
+  dockerfilePackages: DockerFilePackages;
+  dockerfileLayers: DockerFileLayers;
 }
 
 export interface ContainerTarget {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Updates domain to reflect that AutoDetectedUserInstructions does not have a base image.
This is preparation for adding parsing errors to DockerFileAnalysis.