### PR TITLE
fix: bump pull library with fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@snyk/dep-graph": "^1.28.0",
     "@snyk/rpm-parser": "^2.0.0",
-    "@snyk/snyk-docker-pull": "3.6.2",
+    "@snyk/snyk-docker-pull": "^3.6.3",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
     "docker-modem": "2.1.3",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumps pull library, which in turn has a bumped docker-v2 library upgrade, which contains these fixes:

snyk/docker-registry-v2-client#74
Some CRs return a redirect URI with just the path
(without the hostname), which breaks our redirect handling which is
expecting a full URL. This fix adds the hostname and protocol in case
they are missing

snyk/docker-registry-v2-client#75
When the content type is wrongly set to text instead of binary, response
body is returned as string instead of a buffer. This forces a buffer
response
