### PR TITLE
fix: allow base image to be partially missing

### DIFF
--- a/lib/dockerfile/instruction-parser.ts
+++ b/lib/dockerfile/instruction-parser.ts
@@ -97,22 +97,29 @@ function getInstructionExpandVariables(
   text?: string,
 ): string {
   let str = text || instruction.toString();
-  const variables = instruction.getVariables();
-  const resolvedVariables = variables.reduce((resolvedVars, variable) => {
+  const resolvedVariables = {};
+
+  for (const variable of instruction.getVariables()) {
     const line = variable.getRange().start.line;
     const name = variable.getName();
-    resolvedVars[name] = dockerfile.resolveVariable(name, line);
-    return resolvedVars;
-  }, {});
+    resolvedVariables[name] = dockerfile.resolveVariable(name, line);
+  }
+
   for (const variable of Object.keys(resolvedVariables)) {
+    if (!resolvedVariables[variable]) {
+      str = "";
+      break;
+    }
+
     // The $ is a special regexp character that should be escaped with a backslash
     // Support both notations either with $variable_name or ${variable_name}
     // The global search "g" flag is used to match and replace all occurrences
     str = str.replace(
       RegExp(`\\$\{${variable}\}|\\$${variable}`, "g"),
-      resolvedVariables[variable] || "",
+      resolvedVariables[variable],
     );
   }
+
   return str;
 }
 

--- a/test/lib/dockerfile/index.spec.ts
+++ b/test/lib/dockerfile/index.spec.ts
@@ -33,6 +33,8 @@ describe("base image parsing", () => {
     ${"FROM ${A}:${B}"}
     ${"FROM ${A}@${B}"}
     ${"FROM image@${B}"}
+    ${"FROM ${DOCKER_BASE_REGISTRY}/image"}
+    ${"FROM ${DOCKER_BASE_REGISTRY}/image:tag"}
     ${"ARG A" + EOL + "ARG B" + EOL + "FROM ${A}:${B}"}
     ${"ARG A" + EOL + "FROM ${A}:tag"}
     ${"ARG B" + EOL + "FROM alpine:${B}"}
@@ -141,7 +143,7 @@ describe("base image updating", () => {
     it.each`
       scenario                                          | content
       ${"${REPO}:${TAG}"}                               | ${"ARG REPO=repo" + EOL + "ARG TAG=tag" + EOL + "FROM ${REPO}:${TAG}"}
-      ${"${REPO}:${MAJOR}.${MINOR}.${PATCH}-${FLAVOR}"} | ${"ARG REPO=repo" + EOL + "ARG MAJOR=1" + EOL + "ARG MINOR=0" + EOL + "ARG PATCH=0" + EOL + "ARG FLAVOR=slim" + EOL + "FROM ${REPO}:${MAJOR}.${MINOR}.${PATCH}-${SLIM}"}
+      ${"${REPO}:${MAJOR}.${MINOR}.${PATCH}-${FLAVOR}"} | ${"ARG REPO=repo" + EOL + "ARG MAJOR=1" + EOL + "ARG MINOR=0" + EOL + "ARG PATCH=0" + EOL + "ARG FLAVOR=slim" + EOL + "FROM ${REPO}:${MAJOR}.${MINOR}.${PATCH}-${FLAVOR}"}
     `("does not update: $scenario", ({ content }) => {
       const result = updateDockerfileBaseImageName(content, "image:tag0");
       expect(result.error.code).toBe(


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Allow base image to be partially missing

In some cases where the base image in the Dockerfile's FROM instruction contains arguments that are substituted at build-time, we would incorrectly detect the base image as /image:tag which is a bad user experience. We fix this by ensuring that we report the base image only if we can read every variable in the FROM instruction.

kudos to one and only @ahmed-agabani-snyk 