### PR TITLE
feat: allow base image to be partially missing

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,6 +28,11 @@ export enum HashAlgorithm {
   Sha1 = "sha1",
 }
 
+export enum UnresolvedDockerfileVariableHandling {
+  Abort = "Abort",
+  Continue = "Continue",
+}
+
 export interface ManifestFile {
   name: string;
   path: string;

--- a/test/lib/dockerfile/index.spec.ts
+++ b/test/lib/dockerfile/index.spec.ts
@@ -33,6 +33,8 @@ describe("base image parsing", () => {
     ${"FROM ${A}:${B}"}
     ${"FROM ${A}@${B}"}
     ${"FROM image@${B}"}
+    ${"FROM ${DOCKER_BASE_REGISTRY}/image"}
+    ${"FROM ${DOCKER_BASE_REGISTRY}/image:tag"}
     ${"ARG A" + EOL + "ARG B" + EOL + "FROM ${A}:${B}"}
     ${"ARG A" + EOL + "FROM ${A}:tag"}
     ${"ARG B" + EOL + "FROM alpine:${B}"}
@@ -141,7 +143,7 @@ describe("base image updating", () => {
     it.each`
       scenario                                          | content
       ${"${REPO}:${TAG}"}                               | ${"ARG REPO=repo" + EOL + "ARG TAG=tag" + EOL + "FROM ${REPO}:${TAG}"}
-      ${"${REPO}:${MAJOR}.${MINOR}.${PATCH}-${FLAVOR}"} | ${"ARG REPO=repo" + EOL + "ARG MAJOR=1" + EOL + "ARG MINOR=0" + EOL + "ARG PATCH=0" + EOL + "ARG FLAVOR=slim" + EOL + "FROM ${REPO}:${MAJOR}.${MINOR}.${PATCH}-${SLIM}"}
+      ${"${REPO}:${MAJOR}.${MINOR}.${PATCH}-${FLAVOR}"} | ${"ARG REPO=repo" + EOL + "ARG MAJOR=1" + EOL + "ARG MINOR=0" + EOL + "ARG PATCH=0" + EOL + "ARG FLAVOR=slim" + EOL + "FROM ${REPO}:${MAJOR}.${MINOR}.${PATCH}-${FLAVOR}"}
     `("does not update: $scenario", ({ content }) => {
       const result = updateDockerfileBaseImageName(content, "image:tag0");
       expect(result.error.code).toBe(


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Allow base image to be partially missing

In some cases where the base image in the Dockerfile's FROM instruction contains arguments that are substituted at build-time, we would incorrectly detect the base image as /image:tag which is a bad user experience. We fix this by ensuring that we report the base image only if we can read every variable in the FROM instruction, while keeping the old handling for package instruction parsing.

Co-authored-by:@ahmed-agabani-snyk