### PR TITLE
refactor: jar extract action to return a Buffer

### DIFF
--- a/lib/analyzer/applications/java.ts
+++ b/lib/analyzer/applications/java.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
+import { bufferToSha1 } from "../../buffer-utils";
 import { JarFingerprintsFact } from "../../facts";
-import { bufferToSha1 } from "../../stream-utils";
 import { JarBuffer } from "./types";
 import { AppDepsScanResultWithoutTarget, FilePathToBuffer } from "./types";
 

--- a/lib/analyzer/applications/types.ts
+++ b/lib/analyzer/applications/types.ts
@@ -7,6 +7,13 @@ export interface AppDepsScanResultWithoutTarget
 export interface FilePathToContent {
   [filePath: string]: string;
 }
+export interface FilePathToBuffer {
+  [filePath: string]: Buffer;
+}
+export interface JarBuffer {
+  location: string;
+  digest: Buffer;
+}
 
 export interface FilePathToElfContent {
   [filePath: string]: Elf;

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -5,7 +5,7 @@ import {
   getGoModulesContentAction,
   goModulesToScannedProjects,
 } from "../go-parser";
-import { getElfFileContent, getFileContent } from "../inputs";
+import { getBufferContent, getElfFileContent, getFileContent } from "../inputs";
 import {
   getApkDbFileContent,
   getApkDbFileContentAction,
@@ -151,7 +151,7 @@ export async function analyze(
       getFileContent(extractedLayers, getNodeAppFileContentAction.actionName),
     );
     const jarFingerprintScanResults = await jarFilesToScannedProjects(
-      getFileContent(extractedLayers, getJarFileContentAction.actionName),
+      getBufferContent(extractedLayers, getJarFileContentAction.actionName),
       targetImage,
     );
     const goModulesScanResult = await goModulesToScannedProjects(

--- a/lib/buffer-utils.ts
+++ b/lib/buffer-utils.ts
@@ -1,0 +1,12 @@
+import * as crypto from "crypto";
+import { HashAlgorithm } from "./types";
+
+const HASH_ENCODING = "hex";
+
+export function bufferToSha1(buffer: Buffer): string {
+  const hash = crypto.createHash(HashAlgorithm.Sha1);
+  hash.setEncoding(HASH_ENCODING);
+  hash.update(buffer);
+  hash.end();
+  return hash.read().toString(HASH_ENCODING);
+}

--- a/lib/inputs/index.ts
+++ b/lib/inputs/index.ts
@@ -1,4 +1,5 @@
 import {
+  FilePathToBuffer,
   FilePathToContent,
   FilePathToElfContent,
 } from "../analyzer/applications/types";
@@ -47,6 +48,27 @@ export function getElfFileContent(
         throw new Error("elf file expected to contain programs and sections");
       }
 
+      foundAppFiles[filePath] = extractedLayers[filePath][actionName];
+    }
+  }
+
+  return foundAppFiles;
+}
+
+export function getBufferContent(
+  extractedLayers: ExtractedLayers,
+  searchedAction: string,
+): FilePathToBuffer {
+  const foundAppFiles = {};
+
+  for (const filePath of Object.keys(extractedLayers)) {
+    for (const actionName of Object.keys(extractedLayers[filePath])) {
+      if (actionName !== searchedAction) {
+        continue;
+      }
+      if (!Buffer.isBuffer(extractedLayers[filePath][actionName])) {
+        throw new Error("expected Buffer");
+      }
       foundAppFiles[filePath] = extractedLayers[filePath][actionName];
     }
   }

--- a/lib/inputs/index.ts
+++ b/lib/inputs/index.ts
@@ -6,6 +6,10 @@ import {
 import { ExtractedLayers, FileContent } from "../extractor/types";
 import { Elf } from "../go-parser/types";
 
+function isStringType(type: FileContent) {
+  return typeof type === "string";
+}
+
 export function getFileContent(
   extractedLayers: ExtractedLayers,
   searchedAction: string,
@@ -17,7 +21,7 @@ export function getFileContent(
       if (actionName !== searchedAction) {
         continue;
       }
-      if (!(typeof extractedLayers[filePath][actionName] === "string")) {
+      if (!isStringType(extractedLayers[filePath][actionName])) {
         throw new Error("expected string");
       }
       foundAppFiles[filePath] = extractedLayers[filePath][actionName];
@@ -55,6 +59,10 @@ export function getElfFileContent(
   return foundAppFiles;
 }
 
+function isTypeBuffer(type: FileContent) {
+  return Buffer.isBuffer(type);
+}
+
 export function getBufferContent(
   extractedLayers: ExtractedLayers,
   searchedAction: string,
@@ -66,7 +74,7 @@ export function getBufferContent(
       if (actionName !== searchedAction) {
         continue;
       }
-      if (!Buffer.isBuffer(extractedLayers[filePath][actionName])) {
+      if (!isTypeBuffer(extractedLayers[filePath][actionName])) {
         throw new Error("expected Buffer");
       }
       foundAppFiles[filePath] = extractedLayers[filePath][actionName];

--- a/lib/inputs/java/static.ts
+++ b/lib/inputs/java/static.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { ExtractAction } from "../../extractor/types";
-import { streamToSha1 } from "../../stream-utils";
+import { streamToBuffer } from "../../stream-utils";
 
 const ignoredPaths = ["/usr/lib", "gradle/cache"];
 
@@ -17,5 +17,5 @@ function filePathMatches(filePath: string): boolean {
 export const getJarFileContentAction: ExtractAction = {
   actionName: "jar",
   filePathMatches,
-  callback: streamToSha1,
+  callback: streamToBuffer,
 };

--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -70,3 +70,11 @@ export async function streamToJson<T>(stream: Readable): Promise<T> {
   const file = await streamToString(stream);
   return JSON.parse(file);
 }
+
+export function bufferToSha1(buffer: Buffer): string {
+  const hash = crypto.createHash(HashAlgorithm.Sha1);
+  hash.setEncoding(HASH_ENCODING);
+  hash.update(buffer);
+  hash.end();
+  return hash.read().toString(HASH_ENCODING);
+}

--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -70,11 +70,3 @@ export async function streamToJson<T>(stream: Readable): Promise<T> {
   const file = await streamToString(stream);
   return JSON.parse(file);
 }
-
-export function bufferToSha1(buffer: Buffer): string {
-  const hash = crypto.createHash(HashAlgorithm.Sha1);
-  hash.setEncoding(HASH_ENCODING);
-  hash.update(buffer);
-  hash.end();
-  return hash.read().toString(HASH_ENCODING);
-}

--- a/test/lib/analyzer/java.spec.ts
+++ b/test/lib/analyzer/java.spec.ts
@@ -1,21 +1,35 @@
+import { Buffer } from "buffer";
+import * as crypto from "crypto";
 import { jarFilesToScannedProjects } from "../../../lib/analyzer/applications/java";
-
 describe("jarFilesToScannedProjects function", () => {
   it("should return expected scannedProject[] result", async () => {
+    // Arrange
+    const bufferedDigest = Buffer.from(
+      "485de3a253e23f645037828c07f1d7f1af40763a",
+    );
+    let hashedBuffer = crypto.createHash("sha1");
+    hashedBuffer.setEncoding("hex");
+    hashedBuffer.update(bufferedDigest);
+    hashedBuffer.end();
+    hashedBuffer = hashedBuffer.read().toString("hex");
+
     const filePathToContent = {
-      "/libs/another_dir/test.jar": "485de3a253e23f645037828c07f1d7f1af40763a",
+      "/libs/another_dir/test.jar": bufferedDigest,
     };
 
+    // Act
     const result = await jarFilesToScannedProjects(
       filePathToContent,
       "image-name",
     );
+
+    // Assert
     expect(result[0].facts[0].type).toEqual("jarFingerprints");
     expect(result[0].facts[0].data.fingerprints[0].location).toEqual(
       "/libs/another_dir/test.jar",
     );
     expect(result[0].facts[0].data.fingerprints[0].digest).toEqual(
-      "485de3a253e23f645037828c07f1d7f1af40763a",
+      hashedBuffer,
     );
     expect(result[0].identity.type).toEqual("maven");
     expect(result[0].identity.targetFile).toEqual("/libs/another_dir");

--- a/test/lib/buffer-utils.spec.ts
+++ b/test/lib/buffer-utils.spec.ts
@@ -1,0 +1,25 @@
+import { Buffer } from "buffer";
+import * as crypto from "crypto";
+import { bufferToSha1 } from "../../lib/buffer-utils";
+
+describe("buffer-utils", () => {
+  describe("bufferToSha1", () => {
+    it("should convert Buffer to sha1", () => {
+      // Arrange
+      const textToConvert = "hello world";
+      let hashedText = crypto.createHash("sha1");
+      hashedText.setEncoding("hex");
+      hashedText.update(textToConvert);
+      hashedText.end();
+      hashedText = hashedText.read().toString("hex");
+
+      const bufferedText = Buffer.from(textToConvert);
+
+      // Act
+      const result = bufferToSha1(bufferedText);
+
+      // Assert
+      expect(result).toEqual(hashedText);
+    });
+  });
+});

--- a/test/lib/inputs/index.spec.ts
+++ b/test/lib/inputs/index.spec.ts
@@ -1,0 +1,110 @@
+import {
+  getBufferContent,
+  getElfFileContent,
+  getFileContent,
+} from "../../../lib/inputs";
+
+describe("lib/inputs", () => {
+  describe("getBufferContent", () => {
+    it("should return 2 results if both are of type Buffer", () => {
+      // Arrange
+      const dummyExtractedLayers = {
+        "foo/bar.jar": { jar: Buffer.from("hello world") },
+        "bla/yada.jar": { jar: Buffer.from("hello again") },
+      };
+
+      // Act
+      const result = getBufferContent(dummyExtractedLayers, "jar");
+
+      // Assert
+      expect(result).toEqual(
+        expect.objectContaining({
+          "foo/bar.jar": expect.any(Buffer),
+          "bla/yada.jar": expect.any(Buffer),
+        }),
+      );
+    });
+
+    it("should throw if one of the types is not a buffer", () => {
+      // Arrange
+      const dummyExtractedLayers = {
+        "foo/bar.jar": { jar: Buffer.from("hello world") },
+        "bla/yada.jar": { jar: "not a buffer!" },
+      };
+
+      // Act and Assert
+      expect(() => getBufferContent(dummyExtractedLayers, "jar")).toThrowError(
+        "expected Buffer",
+      );
+    });
+  });
+
+  describe("getFileContent", () => {
+    it("should return 2 results if both are of type string", () => {
+      // Arrange
+      const dummyExtractedLayers = {
+        "foo/bar": { "node-app-files": "hello world" },
+        "bla/yada": { "node-app-files": "hello again" },
+      };
+
+      // Act
+      const result = getFileContent(dummyExtractedLayers, "node-app-files");
+
+      // Assert
+      expect(result).toEqual(
+        expect.objectContaining({
+          "foo/bar": expect.any(String),
+          "bla/yada": expect.any(String),
+        }),
+      );
+    });
+
+    it("should throw if one of the types is not a string", () => {
+      // Arrange
+      const dummyExtractedLayers = {
+        "foo/bar": { "node-app-files": "hello world" },
+        "bla/yada": { "node-app-files": Buffer.from("not a string!") },
+      };
+
+      // Act and Assert
+      expect(() =>
+        getFileContent(dummyExtractedLayers, "node-app-files"),
+      ).toThrowError("expected string");
+    });
+  });
+
+  describe("getElfFileContent", () => {
+    it("should return 2 results if both are of type Elf", () => {
+      // Arrange
+
+      const dummyExtractedLayers = {
+        "foo/bar": { gomodules: { body: { programs: [], sections: [] } } },
+        "bla/yada": { gomodules: { body: { programs: [], sections: [] } } },
+      };
+
+      // Act
+      const result = getElfFileContent(dummyExtractedLayers, "gomodules");
+
+      // Assert
+      expect(result).toEqual(
+        expect.objectContaining({
+          "foo/bar": expect.any(Object),
+          "bla/yada": expect.any(Object),
+        }),
+      );
+    });
+
+    it("should throw if one of the types is not an Elf", () => {
+      // Arrange
+      const dummyExtractedLayers = {
+        "foo/bar": { gomodules: { body: { programs: [], sections: [] } } },
+        "bla/yada": { gomodules: { body: { programs: ["no sections"] } } },
+      };
+
+      // Act and Assert
+      expect(() =>
+        getElfFileContent(dummyExtractedLayers as any, "gomodules"),
+      ).toThrowError("elf file expected to contain programs and sections");
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Return a Buffer rather than sha from the extract actions, and only convert to sha during later processing.

This is required before will are able to extend the later processing with unpacking the jar within the next task

#### Where should the reviewer start?
can be reviewed commit-by-commit. main changes are in first commit, and later commits are more refactoring and tests.

#### How should this be manually tested?
run a scan on image with jars, note that output should be the same on master and on this branch.

#### Any background context you want to provide?
Part of "UberJars" work to support nested jars.

#### What are the relevant tickets?
CAP-409

