### PR TITLE
Chore/performance measure script

### DIFF
--- a/scripts/scan-performance.ts
+++ b/scripts/scan-performance.ts
@@ -1,0 +1,59 @@
+#! /usr/bin/env ts-node
+
+// tslint:disable:no-console
+
+import { scan } from "../lib/scan";
+
+process.on("uncaughtException", (err) => {
+  console.log("UNCAUGHT EXCEPTION! %s", err);
+  process.exit(1);
+});
+
+const DEFAULT_NUMBER_OF_RUNS = 10;
+
+async function main() {
+  try {
+    validateArgs();
+
+    const imageToScan = process.argv[2];
+    const numberOfRuns = Number(process.argv[3]) || DEFAULT_NUMBER_OF_RUNS;
+    console.log(`scanning ${imageToScan}`);
+    const startTime = Date.now();
+
+    for (let i = 0; i < numberOfRuns; i++) {
+      console.log(`scan # ${i}`);
+      await scan({
+        "app-vulns": true,
+        path: `docker-archive:${imageToScan}`,
+      });
+    }
+
+    console.log(
+      `average time per complete scan: ${(Date.now() - startTime) /
+        numberOfRuns}`,
+    );
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+function validateArgs() {
+  if (process.argv.length < 3 || !process.argv[2].endsWith(".tar")) {
+    throw new Error(
+      `First argument must be a path to a saved image, .tar file`,
+    );
+  }
+
+  if (!(process.argv[3] && !isNaN(Number(process.argv[3])))) {
+    throw new Error(
+      `Invalid argument '${process.argv[3]}' expected a number (number of runs).`,
+    );
+  }
+}
+
+main()
+  .then(() => "Done!" && process.exit(0))
+  .catch((err) => {
+    console.log(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
We want to measure the performance of image scans that contain jars, with and without code we're about to add that unpacks fat jars (one level or even more, indefinitely, which is what SFDC want).

this PR has a 

Two things to note:
* ~I added the time check in `static-analyzer.ts`, *around* jarFingerprintScanResults and not *in* it, because I thought it would be easier with the code changes we want to make. this file wont have to change.~   removed commit
* I used Date.now and not performance.now because when running the script locally I got an error `ReferenceError: performance is not defined`. this can probably be solved, but as far as I understand the difference between Date and performance is the accuracy, milliseconds vs microsecond, and I wonder if we need such persicion here. please let me know what you think!

#### Where should the reviewer start?
I split this PR to 2 commits, in case we'd want only the script, and not taint the code with console.logs.

#### How should this be manually tested?
How to run:
`npx ts-node scripts/scan-performance.ts PATH_TO_IMAGE NUM_OF_RUNS`

NUM_OF_RUNS is optional, default it 10

#### What are the relevant tickets?
CAP-411

