### PR TITLE
fix: Fixing the numbers of deps in opensuse-leap:15.1 image

### DIFF
--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -288,5 +288,5 @@ test("able to scan opensuse/leap images", async (t) => {
     "OS image detected",
   );
 
-  t.equal(depGraph.getDepPkgs().length, 125, "expected number of direct deps");
+  t.equal(depGraph.getDepPkgs().length, 124, "expected number of direct deps");
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Something has changed in opensuse-leap:15.1 image and now we find one direct dependency less. 