### PR TITLE
fix: Swap async to sync tmp dir removal

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -25,8 +25,14 @@ async function getInspectResult(
 
 function cleanupCallback(imageFolderPath: string, imageName: string) {
   return () => {
+    const fullImagePath = path.join(imageFolderPath, imageName);
     try {
-      fs.rmSync(imageFolderPath, { recursive: true, force: true });
+      if (fs.existsSync(fullImagePath)) {
+        fs.unlinkSync(fullImagePath);
+      }
+      if (fs.existsSync(imageFolderPath)) {
+        fs.rmdirSync(imageFolderPath);
+      }
     } catch (err) {
       debug(`Can't remove folder ${imageFolderPath}, error: ${err}`);
     }

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -25,13 +25,11 @@ async function getInspectResult(
 
 function cleanupCallback(imageFolderPath: string, imageName: string) {
   return () => {
-    const fullImagePath = path.join(imageFolderPath, imageName);
-    if (fs.existsSync(fullImagePath)) {
-      fs.unlinkSync(fullImagePath);
+    try {
+      fs.rmSync(imageFolderPath, { recursive: true, force: true });
+    } catch (err) {
+      debug(`Can't remove folder ${imageFolderPath}, error: ${err}`);
     }
-    fs.rmdir(imageFolderPath, (err) => {
-      debug(`Can't remove folder ${imageFolderPath}, got error ${err}`);
-    });
   };
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
We're getting intermittent scan failures, where we can't remove the tmp folder cause it has not yet been created. This change might help solving the problem.
Also taking this opportunity to simplify the code, new versions of node now support removal of the whole directory with contents recursively and `force` option will not throw when dir does not exists.