### PR TITLE
fix: only log when an error occurs on rmdir

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -30,7 +30,9 @@ function cleanupCallback(imageFolderPath: string, imageName: string) {
       fs.unlinkSync(fullImagePath);
     }
     fs.rmdir(imageFolderPath, (err) => {
-      debug(`Can't remove folder ${imageFolderPath}, got error ${err}`);
+      if (err !== null) {
+        debug(`Can't remove folder ${imageFolderPath}, got error ${err}`);
+      }
     });
   };
 }


### PR DESCRIPTION


- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
We constantly log that we can't remove folder even in case there was no
error removing the folder. This adds a null check for the callback
error.

