### PR TITLE
fix: Bump docker-pull version to 3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@snyk/dep-graph": "^1.28.0",
     "@snyk/rpm-parser": "^2.0.0",
-    "@snyk/snyk-docker-pull": "^3.6.3",
+    "@snyk/snyk-docker-pull": "^3.7.1",
     "adm-zip": "^0.5.5",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",


### PR DESCRIPTION
This PR is bumping docker-pull version to @snyk/snyk-docker-pull@3.7.1, which removes the optimization that chooses when to accept manifest list content type and instead always accept it, to tackle snyk/snyk#2359 - needed for ECR.

See as well: https://github.com/snyk/docker-registry-v2-client/pull/84