### PR TITLE
feat: Add image creation time fact [MAGMA-1271]

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -97,6 +97,7 @@ export async function analyze(
     autoDetectedUserInstructions,
     platform,
     imageLabels,
+    imageCreationTime,
   } = await archiveExtractor.extractImageContent(
     imageType,
     imagePath,
@@ -184,6 +185,7 @@ export async function analyze(
     manifestFiles,
     autoDetectedUserInstructions,
     imageLabels,
+    imageCreationTime,
   };
 }
 

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -77,6 +77,7 @@ export interface StaticAnalysis {
   applicationDependenciesScanResults: AppDepsScanResultWithoutTarget[];
   manifestFiles: ManifestFile[];
   imageLabels?: { [key: string]: string };
+  imageCreationTime?: string;
 }
 
 export interface ArchiveResult {

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -56,6 +56,7 @@ export async function extractImageContent(
           dockerArchive.imageConfig,
         ),
         imageLabels: dockerArchive.imageConfig.config.Labels,
+        imageCreationTime: dockerArchive.imageConfig.created,
       };
   }
 }

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -19,6 +19,7 @@ export interface ExtractionResult {
   autoDetectedUserInstructions?: AutoDetectedUserInstructions;
   platform?: string;
   imageLabels?: { [key: string]: string };
+  imageCreationTime?: string;
 }
 
 export interface ExtractedLayers {
@@ -46,6 +47,7 @@ export interface DockerArchiveImageConfig {
   config: {
     Labels: { [key: string]: string };
   };
+  created: string;
 }
 
 export interface OciArchiveLayer {

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -72,3 +72,8 @@ export interface ImageSizeBytesFact {
   type: "imageSizeBytes";
   data: number;
 }
+
+export interface ImageCreationTimeFact {
+  type: "imageCreationTime";
+  data: string;
+}

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -77,6 +77,14 @@ async function buildResponse(
     additionalOsDepsFacts.push(imageLabels);
   }
 
+  if (depsAnalysis.imageCreationTime) {
+    const imageCreationTimeFact: facts.ImageCreationTimeFact = {
+      type: "imageCreationTime",
+      data: depsAnalysis.imageCreationTime,
+    };
+    additionalOsDepsFacts.push(imageCreationTimeFact);
+  }
+
   if (
     depsAnalysis.rootFsLayers &&
     Array.isArray(depsAnalysis.rootFsLayers) &&

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -34,7 +34,7 @@ async function buildResponse(
     depsAnalysis.packageManager,
   );
 
-  const additionalOsDepsFacts: types.Fact[] = [];
+  const additionalFacts: types.Fact[] = [];
 
   const hashes = depsAnalysis.binaries;
   if (hashes && hashes.length > 0) {
@@ -42,7 +42,7 @@ async function buildResponse(
       type: "keyBinariesHashes",
       data: hashes,
     };
-    additionalOsDepsFacts.push(keyBinariesHashesFact);
+    additionalFacts.push(keyBinariesHashesFact);
   }
 
   if (dockerfileAnalysis !== undefined) {
@@ -50,7 +50,7 @@ async function buildResponse(
       type: "dockerfileAnalysis",
       data: dockerfileAnalysis,
     };
-    additionalOsDepsFacts.push(dockerfileAnalysisFact);
+    additionalFacts.push(dockerfileAnalysisFact);
   }
 
   if (depsAnalysis.imageId) {
@@ -58,7 +58,7 @@ async function buildResponse(
       type: "imageId",
       data: depsAnalysis.imageId,
     };
-    additionalOsDepsFacts.push(imageIdFact);
+    additionalFacts.push(imageIdFact);
   }
 
   if (depsAnalysis.imageLayers && depsAnalysis.imageLayers.length > 0) {
@@ -66,7 +66,7 @@ async function buildResponse(
       type: "imageLayers",
       data: depsAnalysis.imageLayers,
     };
-    additionalOsDepsFacts.push(imageLayersFact);
+    additionalFacts.push(imageLayersFact);
   }
 
   if (depsAnalysis.imageLabels) {
@@ -74,7 +74,7 @@ async function buildResponse(
       type: "imageLabels",
       data: depsAnalysis.imageLabels,
     };
-    additionalOsDepsFacts.push(imageLabels);
+    additionalFacts.push(imageLabels);
   }
 
   if (depsAnalysis.imageCreationTime) {
@@ -82,7 +82,7 @@ async function buildResponse(
       type: "imageCreationTime",
       data: depsAnalysis.imageCreationTime,
     };
-    additionalOsDepsFacts.push(imageCreationTimeFact);
+    additionalFacts.push(imageCreationTimeFact);
   }
 
   if (
@@ -94,7 +94,7 @@ async function buildResponse(
       type: "rootFs",
       data: depsAnalysis.rootFsLayers,
     };
-    additionalOsDepsFacts.push(rootFsFact);
+    additionalFacts.push(rootFsFact);
   }
 
   if (depsAnalysis.depTree.targetOS.prettyName) {
@@ -102,7 +102,7 @@ async function buildResponse(
       type: "imageOsReleasePrettyName",
       data: depsAnalysis.depTree.targetOS.prettyName,
     };
-    additionalOsDepsFacts.push(imageOsReleasePrettyNameFact);
+    additionalFacts.push(imageOsReleasePrettyNameFact);
   }
 
   const manifestFiles =
@@ -114,7 +114,7 @@ async function buildResponse(
       type: "imageManifestFiles",
       data: manifestFiles,
     };
-    additionalOsDepsFacts.push(imageManifestFilesFact);
+    additionalFacts.push(imageManifestFilesFact);
   }
 
   const autoDetectedPackages =
@@ -139,7 +139,7 @@ async function buildResponse(
         dockerfilePackages: autoDetectedPackagesWithChildren!,
       },
     };
-    additionalOsDepsFacts.push(autoDetectedUserInstructionsFact);
+    additionalFacts.push(autoDetectedUserInstructionsFact);
   }
 
   const applicationDependenciesScanResults: types.ScanResult[] = (
@@ -172,7 +172,7 @@ async function buildResponse(
   };
   const scanResults: types.ScanResult[] = [
     {
-      facts: [depGraphFact, ...additionalOsDepsFacts],
+      facts: [depGraphFact, ...additionalFacts],
       target: {
         image: depGraph.rootPkg.name,
       },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -62,7 +62,8 @@ export type FactType =
   | "jarFingerprints"
   | "autoDetectedUserInstructions"
   | "imageLabels"
-  | "imageSizeBytes";
+  | "imageSizeBytes"
+  | "imageCreationTime";
 
 export interface PluginResponse {
   /** The first result is guaranteed to be the OS dependencies scan result. */

--- a/test/lib/extractor/extractor.spec.ts
+++ b/test/lib/extractor/extractor.spec.ts
@@ -44,4 +44,8 @@ describe("extractImageContent", () => {
       maintainer: "NGINX Docker Maintainers <docker-maint@nginx.com>",
     });
   });
+
+  it("extracts image creation time", async () => {
+    expect(typeof extractedContent.imageCreationTime).toEqual("string");
+  });
 });

--- a/test/lib/facts.spec.ts
+++ b/test/lib/facts.spec.ts
@@ -47,6 +47,10 @@ describe("Facts", () => {
       type: "autoDetectedUserInstructions",
       data: {} as any,
     };
+    const imageCreationTimeFact: facts.ImageCreationTimeFact = {
+      type: "imageCreationTime",
+      data: "",
+    };
 
     // This would catch compilation errors.
     const allFacts: Fact[] = [
@@ -61,6 +65,7 @@ describe("Facts", () => {
       rootFsFact,
       testedFilesFact,
       autoDetectedUserInstructionsFact,
+      imageCreationTimeFact,
     ];
     expect(allFacts).toBeDefined();
 

--- a/test/system/app-os/__snapshots__/globs.spec.ts.snap
+++ b/test/system/app-os/__snapshots__/globs.spec.ts.snap
@@ -1872,6 +1872,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-11-17T20:20:58.91197757Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:114ca5b7280f3b49e94a67659890aadde83d58a8bde0d9020b2bc8c902c3b9de",
           ],

--- a/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
@@ -380,6 +380,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2020-10-18T21:48:52.642510942Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:50644c29ef5a27c9a40c393a73ece2479de78325cae7d762ef3cdc19bf42dd0a",
             "sha256:c1df98c53fe381ef0bd5d7712600a9c4e8e7ac6debbfb0cd3a4c50a4e2e6c5c0",

--- a/test/system/application-scans/__snapshots__/java.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/java.spec.ts.snap
@@ -49,6 +49,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-03-24T13:05:21.8612979Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:05356880e40587a7dedbdcb39f8a9f99f2f48e094c7e1d2fae64f4774cc7a4aa",
           ],

--- a/test/system/application-scans/__snapshots__/node.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/node.spec.ts.snap
@@ -1610,6 +1610,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-04-21T18:22:56.403210733Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:2943de48ac85f6eaeecbf35ed894375b5001e9001fd908e40d8e577b77e6bfeb",
           ],

--- a/test/system/bugs/__snapshots__/rpm-transitive-dependencies.spec.ts.snap
+++ b/test/system/bugs/__snapshots__/rpm-transitive-dependencies.spec.ts.snap
@@ -2540,6 +2540,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2020-06-17T09:15:02.8859064Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:edf3aa290fb3c255a84fe836109093fbfeef65c08544f655fad8d6afb53868ba",
             "sha256:14bfd933344aa23b1df9e553b6729cdb312cb9d33436cc6984c867db7018e695",

--- a/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
@@ -7845,6 +7845,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-11-02T15:40:18.22876599Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:2c833f307fd8f18a378b71d3c43c575fabdb88955a2198662938ac2a08a99928",
             "sha256:5f349fdc9028f7edde7f8d4c487d59b3e4b9d66a367dc85492fc7a81abf57b41",

--- a/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
@@ -1767,6 +1767,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2019-09-12T14:37:49.527989907Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:2db44bce66cde56fca25aeeb7d09dc924b748e3adfe58c9cc3eb2bd2f68a1b68",
             "sha256:16d1b1dd2a23a7a79426299fde8be361194007dfebb3438f96735755283becf8",

--- a/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
@@ -1767,6 +1767,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2019-08-15T21:22:39.878636802Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:1c95c77433e8d7bf0f519c9d8c9ca967e2603f0defbf379130d9a841cca2e28e",
             "sha256:002a63507c1caa5cc0e1af10e5b888f6ba20d06275e989a452581d789a48948e",

--- a/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
+++ b/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
@@ -55,6 +55,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-03-24T13:05:21.8612979Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:05356880e40587a7dedbdcb39f8a9f99f2f48e094c7e1d2fae64f4774cc7a4aa",
           ],
@@ -1844,6 +1848,10 @@ Object {
             "1ec0a1574e1b795732f45c4f2eb9e447d7052a176f4c97bb1c68d78b17a72b25.tar",
           ],
           "type": "imageLayers",
+        },
+        Object {
+          "data": "2020-02-24T11:06:57.2049514Z",
+          "type": "imageCreationTime",
         },
         Object {
           "data": Array [

--- a/test/system/operating-systems/__snapshots__/alpine3.7.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/alpine3.7.spec.ts.snap
@@ -351,6 +351,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2019-03-07T22:19:53.447205048Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:3fc64803ca2de7279269048fe2b8b3c73d4536448c87c32375b2639ac168a48b",
           ],
@@ -724,6 +728,10 @@ Object {
             "9dc84fbaf586a6da942b080c52689ac0cd8266ae7971ffd8e62729542e21c52c/layer.tar",
           ],
           "type": "imageLayers",
+        },
+        Object {
+          "data": "2019-03-07T22:19:53.447205048Z",
+          "type": "imageCreationTime",
         },
         Object {
           "data": Array [

--- a/test/system/operating-systems/__snapshots__/busybox1.32.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/busybox1.32.spec.ts.snap
@@ -49,6 +49,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-09-09T01:38:21.750425221Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:e8e544649a797bb64853d4b70feaea366aedb53658277861b685dd0a3e76343a",
           ],

--- a/test/system/operating-systems/__snapshots__/centos6.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/centos6.spec.ts.snap
@@ -3008,6 +3008,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2021-03-13T00:03:32.777698465Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:af6bf1987c2eb07d73f33836b0d8fd825d7c785273526b077e46780e8b4b2ae9",
             "sha256:282064e8c74ac642a58047db969497eeae247fb78e8e9c7c7cd0452b3063a11b",

--- a/test/system/operating-systems/__snapshots__/centos7.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/centos7.spec.ts.snap
@@ -2269,6 +2269,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2020-05-05T21:20:34.898381457Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:fb82b029bea0a2a3b6a62a9c1e47e57fae2a82f629b2d1a346da4fc8fb53a0b6",
           ],
@@ -4560,6 +4564,10 @@ Object {
             "org.opencontainers.image.vendor": "CentOS",
           },
           "type": "imageLabels",
+        },
+        Object {
+          "data": "2020-05-05T21:20:34.898381457Z",
+          "type": "imageCreationTime",
         },
         Object {
           "data": Array [

--- a/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
@@ -1652,6 +1652,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-09-10T00:30:05.463804767Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:b323b70996e4f6d603c331669ac44cf6234a2e22002d3686e9c88398c6911c25",
           ],

--- a/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
@@ -157,6 +157,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "1970-01-01T00:00:00Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:79d541cda6cb9a0c0e4aaa62aaea1f85b6b56544b5ad25e1e3369525ec0bf670",
             "sha256:236f427c513a1d6f359c493154ef41bb0d768e0d0396599e0625a5f6fee476d7",

--- a/test/system/operating-systems/__snapshots__/oraclelinux8.2.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/oraclelinux8.2.spec.ts.snap
@@ -2791,6 +2791,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2020-09-15T21:21:13.371332071Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:8f5b0a4c155316ae86167c983db7048fe2db2e9691093b35377eaf9d9b28ecc9",
           ],

--- a/test/system/operating-systems/__snapshots__/scratch.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/scratch.spec.ts.snap
@@ -49,6 +49,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-09-26T20:05:17.6183383Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:030010b308e3e918de7f8e174a741c7e2f780e37e83fb529c27bcfbaceebfe45",
           ],

--- a/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
@@ -1886,6 +1886,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2020-09-22T16:49:18Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:0f350a1ede685e83e2220dd2ad17b7b1247cfa80eb6a9f0bbfed83d1e544ed45",
           ],

--- a/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
@@ -2761,6 +2761,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2020-09-01T19:44:12.470032Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:ccf04fbd6e1943f648d1c2980e96038edc02b543c597556098ab2bcaa4fd1fa8",
             "sha256:b7b591e3443f17f9d8272b8d118b6c031ca826deb09d4b44f296ba934f1b6e57",

--- a/test/system/package-managers/__snapshots__/apk.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/apk.spec.ts.snap
@@ -369,6 +369,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-05-29T21:19:46.363518345Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:50644c29ef5a27c9a40c393a73ece2479de78325cae7d762ef3cdc19bf42dd0a",
           ],

--- a/test/system/package-managers/__snapshots__/deb.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/deb.spec.ts.snap
@@ -1761,6 +1761,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-09-10T00:29:31.920948309Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:69215f34c115201c526c8a6552b88e87d18e24d5387322154838f64ed6029683",
           ],

--- a/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
@@ -1610,6 +1610,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-07-31T22:19:46.006726038Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:50c3cd23142638cd1a726e8d788baa9353907479df6e6501edcee6fa4f7820ba",
           ],

--- a/test/system/platforms/__snapshots__/amd.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/amd.spec.ts.snap
@@ -1796,6 +1796,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-10-13T22:07:24.375626298Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:d0fe97fa8b8cefdffcef1d62b65aba51a6c87b6679628a2b50fc6a7a579f764c",
             "sha256:832f21763c8e6b070314e619ebb9ba62f815580da6d0eaec8a1b080bd01575f7",
@@ -3666,6 +3670,10 @@ Object {
             "4baee5ef150aea0d65b6db15f11077ca8f6c4484e159d8671b52f4926b4d2d1b/layer.tar",
           ],
           "type": "imageLayers",
+        },
+        Object {
+          "data": "2020-10-13T22:07:24.375626298Z",
+          "type": "imageCreationTime",
         },
         Object {
           "data": Array [

--- a/test/system/platforms/__snapshots__/arm.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/arm.spec.ts.snap
@@ -970,6 +970,10 @@ Object {
           "type": "imageLabels",
         },
         Object {
+          "data": "2020-08-14T01:03:03.653764393Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:e2f13739ad415e6f8d9f73253910e4984563a1ec98bd0e0af715fc2c74dfe84b",
             "sha256:00e7d2cc2a5924431554f4bf5f0661d4c10e2b83b7cc7b3ae49273a219b16f45",

--- a/test/system/platforms/__snapshots__/ppc64le.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/ppc64le.spec.ts.snap
@@ -789,6 +789,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-10-02T02:54:58.006860434Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:5a8b4ad4d2fdb56c18f5b1e532f17ef33e6404c83dc1581a3adddf99dcd9d51c",
             "sha256:76daf675c598f6bb12a85310d25f6cc070e3c4fd460b4b396ba9ee1dc52356ef",
@@ -1684,6 +1688,10 @@ Object {
             "885fefe7dada53ec94b4674e544466c4bb2ef1905fa769618b1bf9c277e4e75b/layer.tar",
           ],
           "type": "imageLayers",
+        },
+        Object {
+          "data": "2020-10-02T02:54:58.006860434Z",
+          "type": "imageCreationTime",
         },
         Object {
           "data": Array [

--- a/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
+++ b/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
@@ -405,6 +405,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2019-01-31T23:49:56.027143164Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:767f936afb51c8a3ad9a96592a4be092048bb70f2ca410028a0b3f64b826acbb",
             "sha256:52506d3645613bb715039c51c2076e89b1a370042b044bf8023968180cc71277",
@@ -905,6 +909,10 @@ Object {
             "93e33f1be740ed7d552b1f02a7d766f8a51704e9b889e8c70e293b2b3b8d74a5/layer.tar",
           ],
           "type": "imageLayers",
+        },
+        Object {
+          "data": "2019-01-31T23:49:56.027143164Z",
+          "type": "imageCreationTime",
         },
         Object {
           "data": Array [

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -49,6 +49,10 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": "2020-01-03T01:21:37.263809283Z",
+          "type": "imageCreationTime",
+        },
+        Object {
           "data": Array [
             "sha256:9c27e219663c25e0f28493790cc0b88bc973ba3b1686355f221c38a36978ac63",
           ],
@@ -1737,6 +1741,10 @@ Object {
             "2943de48ac85f6eaeecbf35ed894375b5001e9001fd908e40d8e577b77e6bfeb.tar",
           ],
           "type": "imageLayers",
+        },
+        Object {
+          "data": "2020-04-21T18:22:56.403210733Z",
+          "type": "imageCreationTime",
         },
         Object {
           "data": Array [


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR adds image creation time fact.

#### Where should the reviewer start?

I'd suggest to start in extractImageContent function

#### Any background context you want to provide?

As part of the rule-based auto-import from container registries, we would like to base some of the import rules on the image creation time, found in the image config. 
Since the image creation time is not a required field in the [spec](https://github.com/opencontainers/image-spec/blob/main/config.md#properties), we would like to examine what is the
percentage of images that have this information missing. Adding this attribute as a fact will allow us to collect this information.


#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/MAGMA-1271

