### PR TITLE
fix: upgrade snyk-nodejs-lockfile-parser from 1.36.0 to 1.37.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^7.3.4",
-    "snyk-nodejs-lockfile-parser": "1.36.0",
+    "snyk-nodejs-lockfile-parser": "1.37.2",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",
     "tslib": "^1",


### PR DESCRIPTION

- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This PR upgrades the version of snyk-nodejs-lockfile-parser from 1.36.0 to 1.37.2. 
This is done to support deeply out of sync lockfiles, added in v1.37.0.

#### Any background context you want to provide?

https://snyk.slack.com/archives/C01EPSMGZML/p1639590254212300


