### PR TITLE
feat: add alias nested-jars-depth in addition to shaded-jars-depth

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -155,7 +155,7 @@ export async function analyze(
       getFileContent(extractedLayers, getNodeAppFileContentAction.actionName),
     );
 
-    const desiredLevelsOfUnpacking = getShadedJarsDesiredDepth(options);
+    const desiredLevelsOfUnpacking = getNestedJarsDesiredDepth(options);
 
     const jarFingerprintScanResults = await jarFilesToScannedProjects(
       getBufferContent(extractedLayers, getJarFileContentAction.actionName),
@@ -189,15 +189,17 @@ export async function analyze(
   };
 }
 
-function getShadedJarsDesiredDepth(options: Partial<PluginOptions>) {
-  let shadedJarsDepth = 0;
-  const depthNumber = Number(options["shaded-jars-depth"]);
+function getNestedJarsDesiredDepth(options: Partial<PluginOptions>) {
+  const nestedJarsOption =
+    options["nested-jars-depth"] || options["shaded-jars-depth"];
+  let nestedJarsDepth = 0;
+  const depthNumber = Number(nestedJarsOption);
   if (isNaN(depthNumber)) {
-    shadedJarsDepth = isTrue(options["shaded-jars-depth"]) ? 1 : 0;
+    nestedJarsDepth = isTrue(nestedJarsOption) ? 1 : 0;
   } else {
-    shadedJarsDepth = depthNumber;
+    nestedJarsDepth = depthNumber;
   }
-  return shadedJarsDepth;
+  return nestedJarsDepth;
 }
 
 function shouldCheckForGlobs(globsToFind: {

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -31,20 +31,23 @@ export async function scan(
     throw new Error("No image identifier or path provided");
   }
 
-  const shadedJarsDepth = options["shaded-jars-depth"];
+  const nestedJarsDepth =
+    options["nested-jars-depth"] || options["shaded-jars-depth"];
   if (
-    (isTrue(shadedJarsDepth) || isNumber(shadedJarsDepth)) &&
+    (isTrue(nestedJarsDepth) || isNumber(nestedJarsDepth)) &&
     !isTrue(options["app-vulns"])
   ) {
-    throw new Error("To use shaded-jars-depth, you must also use app-vulns");
+    throw new Error(
+      "To use --nested-jars-depth, you must also use --app-vulns",
+    );
   }
 
   if (
-    !isNumber(shadedJarsDepth) &&
-    !isTrue(shadedJarsDepth) &&
-    typeof shadedJarsDepth !== "undefined"
+    !isNumber(nestedJarsDepth) &&
+    !isTrue(nestedJarsDepth) &&
+    typeof nestedJarsDepth !== "undefined"
   ) {
-    throw new Error("shaded-jars-depth accepts only numbers");
+    throw new Error("--nested-jars-depth accepts only numbers");
   }
 
   const targetImage = appendLatestTagIfMissing(options.path);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -166,15 +166,21 @@ export interface PluginOptions {
   "app-vulns": boolean | string;
 
   /**
-   * How many levels are nested jars we should unpack
-   * If jar contains other jars (AKA fat-jar or shaded-jar), we send back only the children jars, and don't look for vulns in the parent.
+   * How many levels of (nested) JARs we should unpack
+   * If a JAR contains other JARs (AKA JAR of JARs), we send back only the children JARs, and don't look for vulns in the parent.
    *
    * if 0 is provided, it's as if the flag was not provided.
-   * if n > 0 is provided, we try to unpack n levels of jars.
+   * if n > 0 is provided, we try to unpack n levels of JARs.
    * The default (if flag is provided, but without a number) is 1 level
    *
    * Must always come with app-vulns
+   *
+   * Alias: shaded-jars-depth
+   * TODO remove shaded-jars-depth
+   * A shaded JAR is when you unpack all JAR files, then repack them into a single JAR, while
+   * renaming (i.e., "shading") all packages of all dependencies.
    */
+  "nested-jars-depth": boolean | string;
   "shaded-jars-depth": boolean | string;
 
   /** The default is "false". */

--- a/test/system/application-scans/java.spec.ts
+++ b/test/system/application-scans/java.spec.ts
@@ -28,142 +28,15 @@ describe("jar binaries scanning", () => {
       digest: expect.any(String),
     };
 
-    describe("with all needed CLI flags (app-vulns and shaded-jars-depth)", () => {
-      beforeAll(async () => {
-        // Arrange
-        fixturePath = getFixture(
-          "docker-archives/docker-save/java-uberjar.tar",
-        );
-        const imageNameAndTag = `docker-archive:${fixturePath}`;
-
-        // Act
-        pluginResult = await scan({
-          path: imageNameAndTag,
-          "app-vulns": true,
-          "shaded-jars-depth": "1",
-        });
-
-        fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-      });
-
-      it("should return two results", async () => {
-        expect(fingerprints).toHaveLength(2);
-      });
-
-      it("should return nested (second-level) jar in the result", async () => {
-        expect(fingerprints).toContainEqual(expect.objectContaining(nestedJar));
-      });
-
-      it("should not return a first-level jar that have nested jars in it (uber jar)", async () => {
-        expect(fingerprints).not.toContainEqual(
-          expect.objectContaining(fatJar),
-        );
-      });
-
-      it("should return first-level jars that have no nested jars in it", async () => {
-        expect(fingerprints).toContainEqual(
-          expect.objectContaining({
-            location: "/j2objc-annotations-1.3.jar",
-            digest: expect.any(String),
-          }),
-        );
-      });
-    });
-
-    describe("with default shaded-jars-depth", () => {
-      beforeAll(async () => {
-        // Arrange
-        fixturePath = getFixture(
-          "docker-archives/docker-save/java-uberjar.tar",
-        );
-        const imageNameAndTag = `docker-archive:${fixturePath}`;
-
-        // Act
-        pluginResult = await scan({
-          path: imageNameAndTag,
-          "app-vulns": true,
-          "shaded-jars-depth": true,
-        });
-
-        fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-      });
-
-      it("should return nested (second-level) jar in the result", async () => {
-        expect(fingerprints).toContainEqual(expect.objectContaining(nestedJar));
-      });
-    });
-
-    describe("with missing CLI flags", () => {
-      fixturePath = getFixture("docker-archives/docker-save/java-uberjar.tar");
-      const imageNameAndTag = `docker-archive:${fixturePath}`;
-
-      it("should not unpack jars if shaded-jars-depth flag is missing", async () => {
-        // Act
-        pluginResult = await scan({
-          path: imageNameAndTag,
-          "app-vulns": true,
-        });
-
-        // Assert
-        fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-        expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
-        expect(fingerprints).not.toContainEqual(
-          expect.objectContaining(nestedJar),
-        );
-      });
-
-      it("should not unpack jars if shaded-jars-depth flag is set to 0", async () => {
-        // Act
-        pluginResult = await scan({
-          path: imageNameAndTag,
-          "app-vulns": true,
-          "shaded-jars-depth": "0",
-        });
-
-        // Assert
-        fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-        expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
-        expect(fingerprints).not.toContainEqual(
-          expect.objectContaining(nestedJar),
-        );
-      });
-
-      it("should throw error if app-vulns flag is missing", async () => {
-        // Act
-        await expect(
-          scan({
-            path: imageNameAndTag,
-            "shaded-jars-depth": "1",
-          }),
-        ).rejects.toThrow();
-      });
-
-      it("should throw error if shaded-jars-depth is not a number", async () => {
-        // Act
-        await expect(
-          scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "shaded-jars-depth": "NotANumber!",
-          }),
-        ).rejects.toThrow();
-      });
-
-      describe("multi-level jars", () => {
-        let imageNameAndTag;
+    // TODO: deprecate --shaded-jars-depth and leave only --nested-jars-depth
+    describe("--shaded-jars-depth", () => {
+      describe("with all needed CLI flags (app-vulns and shaded-jars-depth)", () => {
         beforeAll(async () => {
           // Arrange
           fixturePath = getFixture(
-            "docker-archives/docker-save/3-level-jar.tar",
+            "docker-archives/docker-save/java-uberjar.tar",
           );
-          imageNameAndTag = `docker-archive:${fixturePath}`;
-        });
-
-        it("should return partial scan if shaded-jars-depth=1", async () => {
-          const level2JarFingerprint = {
-            location: "/level-3-jar.jar/level-2-jar.jar",
-            digest: expect.any(String),
-          };
+          const imageNameAndTag = `docker-archive:${fixturePath}`;
 
           // Act
           pluginResult = await scan({
@@ -173,161 +46,658 @@ describe("jar binaries scanning", () => {
           });
 
           fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-
-          expect(fingerprints).toHaveLength(1);
-          expect(fingerprints).toContainEqual(
-            expect.objectContaining(level2JarFingerprint),
-          );
         });
 
-        it("should return full scan if shaded-jars-depth=2, because unpacking 2 levels will reveal the third", async () => {
-          const deepestLevelJarFingerprint = {
-            location:
-              "/level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
-            digest: expect.any(String),
-          };
-
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "shaded-jars-depth": "2",
-          });
-
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-
-          expect(fingerprints).toHaveLength(1);
-          expect(fingerprints).toContainEqual(
-            expect.objectContaining(deepestLevelJarFingerprint),
-          );
-        });
-
-        it("should return full scan if shaded-jars-depth=4, because there are only 3 levels of jars", async () => {
-          const deepestLevelJarFingerprint = {
-            location:
-              "/level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
-            digest: expect.any(String),
-          };
-
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "shaded-jars-depth": "4",
-          });
-
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-
-          expect(fingerprints).toHaveLength(1);
-          expect(fingerprints).toContainEqual(
-            expect.objectContaining(deepestLevelJarFingerprint),
-          );
-        });
-
-        it("should handle sibling uber jars", async () => {
-          // Arrange
-          fixturePath = getFixture(
-            "docker-archives/docker-save/sibling-uberjars-deepest-first.tar",
-          );
-          imageNameAndTag = `docker-archive:${fixturePath}`;
-          const threeLevelFingerprint = {
-            location:
-              "/A-level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
-            digest: expect.any(String),
-          };
-          const twoLevelFingerprint = {
-            location: "/B-uber-jar.jar/guava-30.1-jre.jar",
-            digest: expect.any(String),
-          };
-          const flatFingerprint = {
-            location: "/C-j2objc-annotations-1.3.jar",
-            digest: expect.any(String),
-          };
-
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "shaded-jars-depth": "4",
-          });
-
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-
-          // Assert
-          expect(fingerprints).toHaveLength(3);
-          expect(fingerprints).toContainEqual(
-            expect.objectContaining(threeLevelFingerprint),
-          );
-          expect(fingerprints).toContainEqual(
-            expect.objectContaining(twoLevelFingerprint),
-          );
-          expect(fingerprints).toContainEqual(
-            expect.objectContaining(flatFingerprint),
-          );
-        });
-
-        // TODO CAP-447
-        it.skip("should return correct levels unpacked for sibling jars, where the last is the deepest", async () => {
-          // Arrange
-          fixturePath = getFixture(
-            "docker-archives/docker-save/sibling-uberjars-shallowest-first.tar",
-          );
-          imageNameAndTag = `docker-archive:${fixturePath}`;
-        });
-
-        // TODO CAP-447
-        it.skip("should return correct levels unpacked for sibling jars, where the first is the deepest", async () => {
-          // Arrange
-          fixturePath = getFixture(
-            "docker-archives/docker-save/sibling-uberjars-deepest-first.tar",
-          );
-          imageNameAndTag = `docker-archive:${fixturePath}`;
-
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "shaded-jars-depth": "2",
-          });
-
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-          // tslint:disable-next-line:no-console
-          console.log("🚀 ~ fingerprints", fingerprints);
-        });
-
-        it("should return correct result for top level jar that container 2 uberjars within it", async () => {
-          // Arrange
-          fixturePath = getFixture("docker-archives/docker-save/top-level.tar");
-          imageNameAndTag = `docker-archive:${fixturePath}`;
-
-          const firstSibling = {
-            digest: expect.any(String),
-            location:
-              "/top-level.jar/A-level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
-          };
-          const secondSibling = {
-            digest: expect.any(String),
-            location:
-              "/top-level.jar/A-level-3-jar.jar/B-uber-jar.jar/guava-30.1-jre.jar",
-          };
-
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "shaded-jars-depth": "4",
-          });
-
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-
-          // Assert
+        it("should return two results", async () => {
           expect(fingerprints).toHaveLength(2);
+        });
+
+        it("should return nested (second-level) jar in the result", async () => {
           expect(fingerprints).toContainEqual(
-            expect.objectContaining(firstSibling),
+            expect.objectContaining(nestedJar),
           );
+        });
+
+        it("should not return a first-level jar that have nested jars in it (uber jar)", async () => {
+          expect(fingerprints).not.toContainEqual(
+            expect.objectContaining(fatJar),
+          );
+        });
+
+        it("should return first-level jars that have no nested jars in it", async () => {
           expect(fingerprints).toContainEqual(
-            expect.objectContaining(secondSibling),
+            expect.objectContaining({
+              location: "/j2objc-annotations-1.3.jar",
+              digest: expect.any(String),
+            }),
           );
+        });
+      });
+
+      describe("with default shaded-jars-depth", () => {
+        beforeAll(async () => {
+          // Arrange
+          fixturePath = getFixture(
+            "docker-archives/docker-save/java-uberjar.tar",
+          );
+          const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+            "shaded-jars-depth": true,
+          });
+
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+        });
+
+        it("should return nested (second-level) jar in the result", async () => {
+          expect(fingerprints).toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
+        });
+      });
+
+      describe("with missing CLI flags", () => {
+        fixturePath = getFixture(
+          "docker-archives/docker-save/java-uberjar.tar",
+        );
+        const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+        it("should not unpack jars if shaded-jars-depth flag is missing", async () => {
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+          });
+
+          // Assert
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
+          expect(fingerprints).not.toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
+        });
+
+        it("should not unpack jars if shaded-jars-depth flag is set to 0", async () => {
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+            "shaded-jars-depth": "0",
+          });
+
+          // Assert
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
+          expect(fingerprints).not.toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
+        });
+
+        it("should throw error if app-vulns flag is missing", async () => {
+          // Act
+          await expect(
+            scan({
+              path: imageNameAndTag,
+              "shaded-jars-depth": "1",
+            }),
+          ).rejects.toThrow();
+        });
+
+        it("should throw error if shaded-jars-depth is not a number", async () => {
+          // Act
+          await expect(
+            scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "NotANumber!",
+            }),
+          ).rejects.toThrow();
+        });
+
+        describe("multi-level jars", () => {
+          let imageNameAndTag;
+          beforeAll(async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/3-level-jar.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+          });
+
+          it("should return partial scan if shaded-jars-depth=1", async () => {
+            const level2JarFingerprint = {
+              location: "/level-3-jar.jar/level-2-jar.jar",
+              digest: expect.any(String),
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "1",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            expect(fingerprints).toHaveLength(1);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(level2JarFingerprint),
+            );
+          });
+
+          it("should return full scan if shaded-jars-depth=2, because unpacking 2 levels will reveal the third", async () => {
+            const deepestLevelJarFingerprint = {
+              location:
+                "/level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+              digest: expect.any(String),
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "2",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            expect(fingerprints).toHaveLength(1);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(deepestLevelJarFingerprint),
+            );
+          });
+
+          it("should return full scan if shaded-jars-depth=4, because there are only 3 levels of jars", async () => {
+            const deepestLevelJarFingerprint = {
+              location:
+                "/level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+              digest: expect.any(String),
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "4",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            expect(fingerprints).toHaveLength(1);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(deepestLevelJarFingerprint),
+            );
+          });
+
+          it("should handle sibling uber jars", async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/sibling-uberjars-deepest-first.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+            const threeLevelFingerprint = {
+              location:
+                "/A-level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+              digest: expect.any(String),
+            };
+            const twoLevelFingerprint = {
+              location: "/B-uber-jar.jar/guava-30.1-jre.jar",
+              digest: expect.any(String),
+            };
+            const flatFingerprint = {
+              location: "/C-j2objc-annotations-1.3.jar",
+              digest: expect.any(String),
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "4",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            // Assert
+            expect(fingerprints).toHaveLength(3);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(threeLevelFingerprint),
+            );
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(twoLevelFingerprint),
+            );
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(flatFingerprint),
+            );
+          });
+
+          // TODO CAP-447
+          it.skip("should return correct levels unpacked for sibling jars, where the last is the deepest", async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/sibling-uberjars-shallowest-first.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+          });
+
+          // TODO CAP-447
+          it.skip("should return correct levels unpacked for sibling jars, where the first is the deepest", async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/sibling-uberjars-deepest-first.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "2",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+            // tslint:disable-next-line:no-console
+            console.log("🚀 ~ fingerprints", fingerprints);
+          });
+
+          it("should return correct result for top level jar that container 2 uberjars within it", async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/top-level.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+
+            const firstSibling = {
+              digest: expect.any(String),
+              location:
+                "/top-level.jar/A-level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+            };
+            const secondSibling = {
+              digest: expect.any(String),
+              location:
+                "/top-level.jar/A-level-3-jar.jar/B-uber-jar.jar/guava-30.1-jre.jar",
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "4",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            // Assert
+            expect(fingerprints).toHaveLength(2);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(firstSibling),
+            );
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(secondSibling),
+            );
+          });
+        });
+      });
+    });
+
+    describe("--nested-jars-depth", () => {
+      it("should take the value of nested-jars-depth over shaded-jars-depth", async () => {
+        // Arrange
+        fixturePath = getFixture("docker-archives/docker-save/3-level-jar.tar");
+        const imageNameAndTag = `docker-archive:${fixturePath}`;
+        const level2JarFingerprint = {
+          location: "/level-3-jar.jar/level-2-jar.jar",
+          digest: expect.any(String),
+        };
+        const deepestLevelJarFingerprint = {
+          location:
+            "/level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+          digest: expect.any(String),
+        };
+
+        // Act
+        pluginResult = await scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "nested-jars-depth": "1",
+          "shaded-jars-depth": "2",
+        });
+
+        fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+        expect(fingerprints).toHaveLength(1);
+        expect(fingerprints).toContainEqual(
+          expect.objectContaining(level2JarFingerprint),
+        );
+        expect(fingerprints).not.toContainEqual(
+          expect.objectContaining(deepestLevelJarFingerprint),
+        );
+      });
+
+      describe("with all needed CLI flags (app-vulns and shaded-jars-depth)", () => {
+        beforeAll(async () => {
+          // Arrange
+          fixturePath = getFixture(
+            "docker-archives/docker-save/java-uberjar.tar",
+          );
+          const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+            "shaded-jars-depth": "1",
+          });
+
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+        });
+
+        it("should return two results", async () => {
+          expect(fingerprints).toHaveLength(2);
+        });
+
+        it("should return nested (second-level) jar in the result", async () => {
+          expect(fingerprints).toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
+        });
+
+        it("should not return a first-level jar that have nested jars in it (uber jar)", async () => {
+          expect(fingerprints).not.toContainEqual(
+            expect.objectContaining(fatJar),
+          );
+        });
+
+        it("should return first-level jars that have no nested jars in it", async () => {
+          expect(fingerprints).toContainEqual(
+            expect.objectContaining({
+              location: "/j2objc-annotations-1.3.jar",
+              digest: expect.any(String),
+            }),
+          );
+        });
+      });
+
+      describe("with default nested-jars-depth", () => {
+        beforeAll(async () => {
+          // Arrange
+          fixturePath = getFixture(
+            "docker-archives/docker-save/java-uberjar.tar",
+          );
+          const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+            "nested-jars-depth": true,
+          });
+
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+        });
+
+        it("should return nested (second-level) jar in the result", async () => {
+          expect(fingerprints).toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
+        });
+      });
+
+      describe("with missing CLI flags", () => {
+        fixturePath = getFixture(
+          "docker-archives/docker-save/java-uberjar.tar",
+        );
+        const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+        it("should not unpack jars if nested-jars-depth flag is missing", async () => {
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+          });
+
+          // Assert
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
+          expect(fingerprints).not.toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
+        });
+
+        it("should not unpack jars if nested-jars-depth flag is set to 0", async () => {
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+            "nested-jars-depth": "0",
+          });
+
+          // Assert
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
+          expect(fingerprints).not.toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
+        });
+
+        it("should throw error if app-vulns flag is missing", async () => {
+          // Act
+          await expect(
+            scan({
+              path: imageNameAndTag,
+              "nested-jars-depth": "1",
+            }),
+          ).rejects.toThrow();
+        });
+
+        it("should throw error if nested-jars-depth is not a number", async () => {
+          // Act
+          await expect(
+            scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "NotANumber!",
+            }),
+          ).rejects.toThrow();
+        });
+
+        describe("multi-level jars", () => {
+          let imageNameAndTag;
+          beforeAll(async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/3-level-jar.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+          });
+
+          it("should return partial scan if nested-jars-depth=1", async () => {
+            const level2JarFingerprint = {
+              location: "/level-3-jar.jar/level-2-jar.jar",
+              digest: expect.any(String),
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "1",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            expect(fingerprints).toHaveLength(1);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(level2JarFingerprint),
+            );
+          });
+
+          it("should return full scan if nested-jars-depth=2, because unpacking 2 levels will reveal the third", async () => {
+            const deepestLevelJarFingerprint = {
+              location:
+                "/level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+              digest: expect.any(String),
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "2",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            expect(fingerprints).toHaveLength(1);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(deepestLevelJarFingerprint),
+            );
+          });
+
+          it("should return full scan if nested-jars-depth=4, because there are only 3 levels of jars", async () => {
+            const deepestLevelJarFingerprint = {
+              location:
+                "/level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+              digest: expect.any(String),
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "4",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            expect(fingerprints).toHaveLength(1);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(deepestLevelJarFingerprint),
+            );
+          });
+
+          it("should handle sibling uber jars", async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/sibling-uberjars-deepest-first.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+            const threeLevelFingerprint = {
+              location:
+                "/A-level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+              digest: expect.any(String),
+            };
+            const twoLevelFingerprint = {
+              location: "/B-uber-jar.jar/guava-30.1-jre.jar",
+              digest: expect.any(String),
+            };
+            const flatFingerprint = {
+              location: "/C-j2objc-annotations-1.3.jar",
+              digest: expect.any(String),
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "4",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            // Assert
+            expect(fingerprints).toHaveLength(3);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(threeLevelFingerprint),
+            );
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(twoLevelFingerprint),
+            );
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(flatFingerprint),
+            );
+          });
+
+          // TODO CAP-447
+          it.skip("should return correct levels unpacked for sibling jars, where the last is the deepest", async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/sibling-uberjars-shallowest-first.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+          });
+
+          // TODO CAP-447
+          it.skip("should return correct levels unpacked for sibling jars, where the first is the deepest", async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/sibling-uberjars-deepest-first.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "2",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+            // tslint:disable-next-line:no-console
+            console.log("🚀 ~ fingerprints", fingerprints);
+          });
+
+          it("should return correct result for top level jar that container 2 uberjars within it", async () => {
+            // Arrange
+            fixturePath = getFixture(
+              "docker-archives/docker-save/top-level.tar",
+            );
+            imageNameAndTag = `docker-archive:${fixturePath}`;
+
+            const firstSibling = {
+              digest: expect.any(String),
+              location:
+                "/top-level.jar/A-level-3-jar.jar/level-2-jar.jar/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+            };
+            const secondSibling = {
+              digest: expect.any(String),
+              location:
+                "/top-level.jar/A-level-3-jar.jar/B-uber-jar.jar/guava-30.1-jre.jar",
+            };
+
+            // Act
+            pluginResult = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "4",
+            });
+
+            fingerprints =
+              pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+            // Assert
+            expect(fingerprints).toHaveLength(2);
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(firstSibling),
+            );
+            expect(fingerprints).toContainEqual(
+              expect.objectContaining(secondSibling),
+            );
+          });
         });
       });
     });


### PR DESCRIPTION
we realized that "shaded-jars" to speak about "nested jars" (jars inside jar)  is not the correct term.

We don't want to break backwards compatibility, so adding the alias. in the future we will only document
--nested-jars-depth, and will ask those who use --shaded to switch.

> **uber jar** is also known as **fat jar** i.e. **jar with dependencies.**There are three common methods for constructing an uber jar:
>

> **Unshaded:** Unpack all JAR files, then repack them into a single JAR. Works with Java's default class loader. Tools [maven-assembly-plugin](http://maven.apache.org/plugins/maven-assembly-plugin/)
>

> **Shaded:** Same as unshaded, but rename (i.e., "shade") all **packages** of all dependencies. Works with Java's default class loader. Avoids some (not all) dependency version clashes. Tools [maven-shade-plugin](http://maven.apache.org/plugins/maven-shade-plugin/)
>

> **JAR of JARs:** The final JAR file contains the other JAR files embedded within. Avoids dependency version clashes. All resource files are preserved. Tools: [Eclipse JAR File Exporter](http://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fref-export-jar.htm)
>

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team