### PR TITLE
feat: Return jar dependecies from pom files

### DIFF
--- a/lib/analyzer/applications/types.ts
+++ b/lib/analyzer/applications/types.ts
@@ -13,6 +13,18 @@ export interface FilePathToBuffer {
 export interface JarBuffer {
   location: string;
   digest: Buffer;
+  dependencies: JarDep[];
+}
+export interface JarDep {
+  parentName?: string;
+  name?: string;
+  version?: string;
+}
+
+export interface PomProperties {
+  groupId?: string;
+  artifactId?: string;
+  version?: string;
 }
 
 export interface FilePathToElfContent {

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -1,5 +1,5 @@
 import { AutoDetectedUserInstructions, ManifestFile } from "../types";
-import { AppDepsScanResultWithoutTarget } from "./applications/types";
+import { AppDepsScanResultWithoutTarget, JarDep } from "./applications/types";
 
 export interface AnalyzedPackage {
   Name: string;
@@ -54,6 +54,7 @@ export interface IAptFiles {
 export interface JarFingerprint {
   location: string;
   digest: string;
+  dependencies: JarDep[];
 }
 
 export interface StaticAnalysis {

--- a/test/fixtures/pom-properties/incomplete.pom.properties
+++ b/test/fixtures/pom-properties/incomplete.pom.properties
@@ -1,0 +1,3 @@
+# Incomplete pom.properties file: missing required field
+groupId=org.test
+artifactId=org.test.unversioned

--- a/test/fixtures/pom-properties/invalid.pom.properties
+++ b/test/fixtures/pom-properties/invalid.pom.properties
@@ -1,0 +1,2 @@
+# Invalid pom.properties file
+testName:invalid

--- a/test/fixtures/pom-properties/valid.pom.properties
+++ b/test/fixtures/pom-properties/valid.pom.properties
@@ -1,0 +1,4 @@
+# Comment line
+artifactId=org.test.dependency
+groupId=org.test
+version=1.0.0

--- a/test/lib/analyzer/java.spec.ts
+++ b/test/lib/analyzer/java.spec.ts
@@ -1,6 +1,13 @@
 import { Buffer } from "buffer";
 import * as crypto from "crypto";
-import { jarFilesToScannedProjects } from "../../../lib/analyzer/applications/java";
+import { __metadata } from "tslib";
+import {
+  getDependencyFromPomProperties,
+  jarFilesToScannedProjects,
+  parsePomProperties,
+} from "../../../lib/analyzer/applications/java";
+import { getTextFromFixture } from "../../util";
+
 describe("jarFilesToScannedProjects function", () => {
   it("should return expected scannedProject[] result", async () => {
     // Arrange
@@ -34,5 +41,64 @@ describe("jarFilesToScannedProjects function", () => {
     );
     expect(result[0].identity.type).toEqual("maven");
     expect(result[0].identity.targetFile).toEqual("/libs/another_dir");
+  });
+});
+
+describe("parsePomProperties function", () => {
+  describe("with a valid pom.properties dependency file", () => {
+    const fixture = getTextFromFixture("pom-properties/valid.pom.properties");
+    const path = "/path/to/package-dependency-1.0.0.jar";
+    const parsed = parsePomProperties(fixture);
+
+    it("parsed output includes all required properties", () => {
+      expect(parsed).toEqual(
+        expect.objectContaining({
+          name: "org.test.dependency",
+          parentName: "org.test",
+          version: "1.0.0",
+        }),
+      );
+    });
+
+    it("ignores superfluous lines in pom.properties", () => {
+      expect(Object.keys(parsed)).toHaveLength(3);
+    });
+  });
+
+  describe("with an invalid pom.properties dependency file", () => {
+    it("returns null", () => {
+      const fixture = getTextFromFixture(
+        "pom-properties/invalid.pom.properties",
+      );
+      const path = "/path/to/org.test.dependency-1.0.0.jar";
+      const dep = getDependencyFromPomProperties(fixture, path);
+      expect(dep).toBeNull();
+    });
+  });
+});
+
+describe("getDependencyFromPomProperties function", () => {
+  const fixture = getTextFromFixture("pom-properties/valid.pom.properties");
+  const path = "/path/to/package-dependency-1.0.0.jar";
+  const dep = parsePomProperties(fixture);
+
+  it("returns a dep as expected", () => {
+    const dep = getDependencyFromPomProperties(fixture, path);
+    expect(dep).not.toBeNull();
+  });
+
+  it("returns null when the dependency references the JAR", () => {
+    const path = "/path/to/org.test.dependency-1.0.0.jar";
+    const dep = getDependencyFromPomProperties(fixture, path);
+    expect(dep).toBeNull();
+  });
+
+  it("returns null when the pom.properties file has a required field missing", () => {
+    const fixture = getTextFromFixture(
+      "pom-properties/incomplete.pom.properties",
+    );
+    const path = "/path/to/org.test.dependency-1.0.0.jar";
+    const dep = getDependencyFromPomProperties(fixture, path);
+    expect(dep).toBeNull();
   });
 });

--- a/test/system/application-scans/__snapshots__/java.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/java.spec.ts.snap
@@ -75,6 +75,7 @@ Object {
           "data": Object {
             "fingerprints": Array [
               Object {
+                "dependencies": Array [],
                 "digest": "485de3a253e23f645037828c07f1d7f1af40763a",
                 "location": "/app/activation-1.1.1.jar",
               },
@@ -103,10 +104,12 @@ Object {
           "data": Object {
             "fingerprints": Array [
               Object {
+                "dependencies": Array [],
                 "digest": "2fa68c05f54f1bba9559dd571eb81959081f1895",
                 "location": "/libs/aopalliance-repackaged-2.5.0.jar",
               },
               Object {
+                "dependencies": Array [],
                 "digest": "55762d3191a8d6610ef46d11e8cb70c7667342a3",
                 "location": "/libs/audience-annotations-0.5.0.jar",
               },

--- a/test/util/index.ts
+++ b/test/util/index.ts
@@ -13,6 +13,11 @@ export function getFixture(fixturePath: string | string[]): string {
 }
 
 export function getObjFromFixture(fixturePath) {
+  const text = getTextFromFixture(fixturePath);
+  return JSON.parse(text);
+}
+
+export function getTextFromFixture(fixturePath) {
   const path = getFixture(fixturePath);
-  return JSON.parse(readFileSync(path, { encoding: "utf-8" }));
+  return readFileSync(path, { encoding: "utf-8" });
 }

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -75,6 +75,7 @@ Object {
           "data": Object {
             "fingerprints": Array [
               Object {
+                "dependencies": Array [],
                 "digest": "485de3a253e23f645037828c07f1d7f1af40763a",
                 "location": "\\\\app\\\\activation-1.1.1.jar",
               },
@@ -103,10 +104,12 @@ Object {
           "data": Object {
             "fingerprints": Array [
               Object {
+                "dependencies": Array [],
                 "digest": "2fa68c05f54f1bba9559dd571eb81959081f1895",
                 "location": "\\\\libs\\\\aopalliance-repackaged-2.5.0.jar",
               },
               Object {
+                "dependencies": Array [],
                 "digest": "55762d3191a8d6610ef46d11e8cb70c7667342a3",
                 "location": "\\\\libs\\\\audience-annotations-0.5.0.jar",
               },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Extract information from unpacked JAR pom files and pass the discovered dependencies to maven to be added to the depGraph. This information will be used to query the vulnDB to find possible vulns for the packages from jar pom files.
