### PR TITLE
Default nested

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -192,11 +192,9 @@ export async function analyze(
 function getNestedJarsDesiredDepth(options: Partial<PluginOptions>) {
   const nestedJarsOption =
     options["nested-jars-depth"] || options["shaded-jars-depth"];
-  let nestedJarsDepth = 0;
+  let nestedJarsDepth = 1;
   const depthNumber = Number(nestedJarsOption);
-  if (isNaN(depthNumber)) {
-    nestedJarsDepth = isTrue(nestedJarsOption) ? 1 : 0;
-  } else {
+  if (!isNaN(depthNumber) && depthNumber > 1) {
     nestedJarsDepth = depthNumber;
   }
   return nestedJarsDepth;

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -43,11 +43,14 @@ export async function scan(
   }
 
   if (
-    !isNumber(nestedJarsDepth) &&
-    !isTrue(nestedJarsDepth) &&
-    typeof nestedJarsDepth !== "undefined"
+    (!isNumber(nestedJarsDepth) &&
+      !isTrue(nestedJarsDepth) &&
+      typeof nestedJarsDepth !== "undefined") ||
+    Number(nestedJarsDepth) < 1
   ) {
-    throw new Error("--nested-jars-depth accepts only numbers");
+    throw new Error(
+      "--nested-jars-depth accepts only numbers bigger or equal to 1",
+    );
   }
 
   const targetImage = appendLatestTagIfMissing(options.path);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -169,7 +169,8 @@ export interface PluginOptions {
    * How many levels of (nested) JARs we should unpack
    * If a JAR contains other JARs (AKA JAR of JARs), we send back only the children JARs, and don't look for vulns in the parent.
    *
-   * if 0 is provided, it's as if the flag was not provided.
+   * If the flag was not provided but --app-vuls was, we unpack 1 level.
+   * 0 or less cannot be provided, as we always want to unpack at least 1 level of JARs.
    * if n > 0 is provided, we try to unpack n levels of JARs.
    * The default (if flag is provided, but without a number) is 1 level
    *

--- a/test/system/application-scans/java.spec.ts
+++ b/test/system/application-scans/java.spec.ts
@@ -75,13 +75,16 @@ describe("jar binaries scanning", () => {
       });
 
       describe("with default shaded-jars-depth", () => {
+        // Arrange
+        let imageNameAndTag;
         beforeAll(async () => {
-          // Arrange
           fixturePath = getFixture(
             "docker-archives/docker-save/java-uberjar.tar",
           );
-          const imageNameAndTag = `docker-archive:${fixturePath}`;
+          imageNameAndTag = `docker-archive:${fixturePath}`;
+        });
 
+        it("should return nested (second-level) jar in the result", async () => {
           // Act
           pluginResult = await scan({
             path: imageNameAndTag,
@@ -89,10 +92,23 @@ describe("jar binaries scanning", () => {
             "shaded-jars-depth": true,
           });
 
+          // Assert
           fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+          expect(fingerprints).toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
         });
 
-        it("should return nested (second-level) jar in the result", async () => {
+        it("should unpack 1 level of jars if shaded-jars-depth flag is missing", async () => {
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+          });
+
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+
           expect(fingerprints).toContainEqual(
             expect.objectContaining(nestedJar),
           );
@@ -105,35 +121,26 @@ describe("jar binaries scanning", () => {
         );
         const imageNameAndTag = `docker-archive:${fixturePath}`;
 
-        it("should not unpack jars if shaded-jars-depth flag is missing", async () => {
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-          });
-
-          // Assert
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
-          expect(fingerprints).not.toContainEqual(
-            expect.objectContaining(nestedJar),
-          );
+        it("should throw if shaded-jars-depth flag is set to 0", async () => {
+          // Act + Assert
+          await expect(
+            scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "0",
+            }),
+          ).rejects.toThrow();
         });
 
-        it("should not unpack jars if shaded-jars-depth flag is set to 0", async () => {
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "shaded-jars-depth": "0",
-          });
-
-          // Assert
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
-          expect(fingerprints).not.toContainEqual(
-            expect.objectContaining(nestedJar),
-          );
+        it("should throw if shaded-jars-depth flag is set to -1", async () => {
+          // Act + Assert
+          await expect(
+            scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "shaded-jars-depth": "-1",
+            }),
+          ).rejects.toThrow();
         });
 
         it("should throw error if app-vulns flag is missing", async () => {
@@ -428,13 +435,16 @@ describe("jar binaries scanning", () => {
       });
 
       describe("with default nested-jars-depth", () => {
+        // Arrange
+        let imageNameAndTag;
         beforeAll(async () => {
-          // Arrange
           fixturePath = getFixture(
             "docker-archives/docker-save/java-uberjar.tar",
           );
-          const imageNameAndTag = `docker-archive:${fixturePath}`;
+          imageNameAndTag = `docker-archive:${fixturePath}`;
+        });
 
+        it("should return nested (second-level) jar in the result", async () => {
           // Act
           pluginResult = await scan({
             path: imageNameAndTag,
@@ -442,10 +452,23 @@ describe("jar binaries scanning", () => {
             "nested-jars-depth": true,
           });
 
+          // Assert
           fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+
+          expect(fingerprints).toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
         });
 
-        it("should return nested (second-level) jar in the result", async () => {
+        it("should unpack 1 level of jars if nested-jars-depth flag is missing", async () => {
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+          });
+
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+
           expect(fingerprints).toContainEqual(
             expect.objectContaining(nestedJar),
           );
@@ -458,35 +481,26 @@ describe("jar binaries scanning", () => {
         );
         const imageNameAndTag = `docker-archive:${fixturePath}`;
 
-        it("should not unpack jars if nested-jars-depth flag is missing", async () => {
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-          });
-
-          // Assert
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
-          expect(fingerprints).not.toContainEqual(
-            expect.objectContaining(nestedJar),
-          );
+        it("should not unpack jars if nested-jars-depth flag is set to 0", async () => {
+          // Act + Assert
+          await expect(
+            scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "0",
+            }),
+          ).rejects.toThrow();
         });
 
-        it("should not unpack jars if nested-jars-depth flag is set to 0", async () => {
-          // Act
-          pluginResult = await scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "nested-jars-depth": "0",
-          });
-
-          // Assert
-          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
-          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
-          expect(fingerprints).not.toContainEqual(
-            expect.objectContaining(nestedJar),
-          );
+        it("should throw if nested-jars-depth flag is set to -1", async () => {
+          // Act + Assert
+          await expect(
+            scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              "nested-jars-depth": "-1",
+            }),
+          ).rejects.toThrow();
         });
 
         it("should throw error if app-vulns flag is missing", async () => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Step #1 for detecting log4j automatically for customers who scan images with shaded and nested jars.

The end goal is to have always at least 1 level scanned, 

see here https://www.notion.so/snyk/log4shell-shaded-Jar-detection-552bed54e8964a968867c601905f80a0#723610c656e7467684a6cbf62f84322d and here https://snyk.slack.com/archives/C01EPSKVC9L/p1639908202242500?thread_ts=1639765350.234600&cid=C01EPSKVC9L

The first step (in this PR) is making the default level of unpacking 1 (instead of 0, which it once was).

The second step would be to unpack 1 level _more_ than what the customer requested, so we can get the pom.properties (the shaded jars) for that level of nesting. 
