### PR TITLE
fix: bring back option for nested-jars-depth=0

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -194,7 +194,7 @@ function getNestedJarsDesiredDepth(options: Partial<PluginOptions>) {
     options["nested-jars-depth"] || options["shaded-jars-depth"];
   let nestedJarsDepth = 1;
   const depthNumber = Number(nestedJarsOption);
-  if (!isNaN(depthNumber) && depthNumber > 1) {
+  if (!isNaN(depthNumber) && depthNumber >= 0) {
     nestedJarsDepth = depthNumber;
   }
   return nestedJarsDepth;

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -46,10 +46,10 @@ export async function scan(
     (!isNumber(nestedJarsDepth) &&
       !isTrue(nestedJarsDepth) &&
       typeof nestedJarsDepth !== "undefined") ||
-    Number(nestedJarsDepth) < 1
+    Number(nestedJarsDepth) < 0
   ) {
     throw new Error(
-      "--nested-jars-depth accepts only numbers bigger or equal to 1",
+      "--nested-jars-depth accepts only numbers bigger than or equal to 0",
     );
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,7 +171,7 @@ export interface PluginOptions {
    * If a JAR contains other JARs (AKA JAR of JARs), we send back only the children JARs, and don't look for vulns in the parent.
    *
    * If the flag was not provided but --app-vuls was, we unpack 1 level.
-   * 0 or less cannot be provided, as we always want to unpack at least 1 level of JARs.
+   * If 0 is provided, we do not unpack any JARs
    * if n > 0 is provided, we try to unpack n levels of JARs.
    * The default (if flag is provided, but without a number) is 1 level
    *

--- a/test/system/application-scans/java.spec.ts
+++ b/test/system/application-scans/java.spec.ts
@@ -121,15 +121,20 @@ describe("jar binaries scanning", () => {
         );
         const imageNameAndTag = `docker-archive:${fixturePath}`;
 
-        it("should throw if shaded-jars-depth flag is set to 0", async () => {
-          // Act + Assert
-          await expect(
-            scan({
-              path: imageNameAndTag,
-              "app-vulns": true,
-              "shaded-jars-depth": "0",
-            }),
-          ).rejects.toThrow();
+        it("should not unpack jars if shaded-jars-depth flag is set to 0", async () => {
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+            "shaded-jars-depth": "0",
+          });
+
+          // Assert
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
+          expect(fingerprints).not.toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
         });
 
         it("should throw if shaded-jars-depth flag is set to -1", async () => {
@@ -482,14 +487,19 @@ describe("jar binaries scanning", () => {
         const imageNameAndTag = `docker-archive:${fixturePath}`;
 
         it("should not unpack jars if nested-jars-depth flag is set to 0", async () => {
-          // Act + Assert
-          await expect(
-            scan({
-              path: imageNameAndTag,
-              "app-vulns": true,
-              "nested-jars-depth": "0",
-            }),
-          ).rejects.toThrow();
+          // Act
+          pluginResult = await scan({
+            path: imageNameAndTag,
+            "app-vulns": true,
+            "nested-jars-depth": "0",
+          });
+
+          // Assert
+          fingerprints = pluginResult.scanResults[1].facts[0].data.fingerprints;
+          expect(fingerprints).toContainEqual(expect.objectContaining(fatJar));
+          expect(fingerprints).not.toContainEqual(
+            expect.objectContaining(nestedJar),
+          );
         });
 
         it("should throw if nested-jars-depth flag is set to -1", async () => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Allowing the CLI users to opt-out and use `--nested-jars-depth=0` to not unpack any levels of JARs.