### PR TITLE
fix: Catch errors with admzip

### DIFF
--- a/lib/analyzer/applications/java.ts
+++ b/lib/analyzer/applications/java.ts
@@ -108,6 +108,8 @@ function unpackJarsTraverse({
   dependencies?: JarDep[];
 }): JarBuffer[] {
   let isFatJar: boolean = false;
+  let zip;
+  let zipEntries;
 
   if (unpackedLevels >= desiredLevelsOfUnpacking) {
     jarBuffers.push({
@@ -116,8 +118,18 @@ function unpackJarsTraverse({
       dependencies,
     });
   } else {
-    const zip = new admzip(jarBuffer);
-    const zipEntries = zip.getEntries();
+    try {
+      zip = new admzip(jarBuffer);
+      zipEntries = zip.getEntries();
+    } catch (err) {
+      jarBuffers.push({
+        location: jarPath,
+        digest: jarBuffer,
+        dependencies,
+      });
+
+      return jarBuffers;
+    }
 
     // technically the level should be increased only if a JAR is found, but increasing here to make
     // sure it states the level, and not counting all the jars found, regardless of level.

--- a/test/lib/analyzer/java.spec.ts
+++ b/test/lib/analyzer/java.spec.ts
@@ -9,26 +9,46 @@ import {
 import { getTextFromFixture } from "../../util";
 
 describe("jarFilesToScannedProjects function", () => {
+  // Arrange
+  const bufferedDigest = Buffer.from(
+    "485de3a253e23f645037828c07f1d7f1af40763a",
+  );
+  let hashedBuffer = crypto.createHash("sha1");
+  hashedBuffer.setEncoding("hex");
+  hashedBuffer.update(bufferedDigest);
+  hashedBuffer.end();
+  hashedBuffer = hashedBuffer.read().toString("hex");
+
+  const filePathToContent = {
+    "/libs/another_dir/test.jar": bufferedDigest,
+  };
+
   it("should return expected scannedProject[] result", async () => {
-    // Arrange
-    const bufferedDigest = Buffer.from(
-      "485de3a253e23f645037828c07f1d7f1af40763a",
-    );
-    let hashedBuffer = crypto.createHash("sha1");
-    hashedBuffer.setEncoding("hex");
-    hashedBuffer.update(bufferedDigest);
-    hashedBuffer.end();
-    hashedBuffer = hashedBuffer.read().toString("hex");
-
-    const filePathToContent = {
-      "/libs/another_dir/test.jar": bufferedDigest,
-    };
-
     // Act
     const result = await jarFilesToScannedProjects(
       filePathToContent,
       "image-name",
       0, // we don't want to unpack any fat jars
+    );
+
+    // Assert
+    expect(result[0].facts[0].type).toEqual("jarFingerprints");
+    expect(result[0].facts[0].data.fingerprints[0].location).toEqual(
+      "/libs/another_dir/test.jar",
+    );
+    expect(result[0].facts[0].data.fingerprints[0].digest).toEqual(
+      hashedBuffer,
+    );
+    expect(result[0].identity.type).toEqual("maven");
+    expect(result[0].identity.targetFile).toEqual("/libs/another_dir");
+  });
+
+  it("should catch errors with admzip and continue", async () => {
+    // Act
+    const result = await jarFilesToScannedProjects(
+      filePathToContent,
+      "image-name",
+      1, // we want to ensure unpacking to "trip" admzip
     );
 
     // Assert


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This PR catches any errors coming from admzip and continues
with the next JAR. The JAR that causes unzip errors will still
be included in the fingerprints as expected.

#### What are the relevant tickets?

