### PR TITLE
fix: Upgrading CircleCI build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   resource_class: small
   docker:
-    - image: circleci/node:14
+    - image: cimg/node:14.18
   working_directory: ~/snyk-docker-plugin
 
 windows_defaults: &windows_defaults
@@ -102,8 +102,6 @@ jobs:
       - notify_slack_on_failure
   test:
     <<: *defaults
-    docker:
-      - image: circleci/node:14
     steps:
       - checkout
       - setup_remote_docker
@@ -125,8 +123,6 @@ jobs:
   test_jest:
     <<: *defaults
     resource_class: medium
-    docker:
-      - image: circleci/node:14
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This PR upgrades the legacy CircleCI convenience image circleci/node
to the next-gen cimg/node image for the build pipeline. The image is
tagged at 14.18.

#### Any background context you want to provide?
[https://circleci.com/docs/2.0/next-gen-migration-guide/](https://circleci.com/docs/2.0/next-gen-migration-guide/)
[https://circleci.com/developer/images/image/cimg/node](https://circleci.com/developer/images/image/cimg/node)


#### What are the relevant tickets?
See [[CAP-432](https://snyksec.atlassian.net/browse/CAP-432)]
