### PR TITLE
feat: scan image config for oci archives to get rootFs, platform, etc.

### DIFF
--- a/lib/extractor/docker-archive/index.ts
+++ b/lib/extractor/docker-archive/index.ts
@@ -5,7 +5,7 @@ import {
 } from "../../dockerfile/instruction-parser";
 import { AutoDetectedUserInstructions, HashAlgorithm } from "../../types";
 
-import { DockerArchiveImageConfig, DockerArchiveManifest } from "../types";
+import { DockerArchiveManifest, ImageConfig } from "../types";
 export { extractArchive } from "./layer";
 
 export function getManifestLayers(manifest: DockerArchiveManifest) {
@@ -27,9 +27,7 @@ export function getImageIdFromManifest(
   }
 }
 
-export function getRootFsLayersFromConfig(
-  imageConfig: DockerArchiveImageConfig,
-): string[] {
+export function getRootFsLayersFromConfig(imageConfig: ImageConfig): string[] {
   try {
     return imageConfig.rootfs.diff_ids;
   } catch (err) {
@@ -38,7 +36,7 @@ export function getRootFsLayersFromConfig(
 }
 
 export function getPlatformFromConfig(
-  imageConfig: DockerArchiveImageConfig,
+  imageConfig: ImageConfig,
 ): string | undefined {
   return imageConfig.os && imageConfig.architecture
     ? `${imageConfig.os}/${imageConfig.architecture}`

--- a/lib/extractor/docker-archive/layer.ts
+++ b/lib/extractor/docker-archive/layer.ts
@@ -7,11 +7,11 @@ import { extract, Extract } from "tar-stream";
 import { streamToJson } from "../../stream-utils";
 import { extractImageLayer } from "../layer";
 import {
-  DockerArchiveImageConfig,
   DockerArchiveManifest,
   ExtractAction,
   ExtractedLayers,
   ExtractedLayersAndManifest,
+  ImageConfig,
 } from "../types";
 
 const debug = Debug("snyk");
@@ -30,7 +30,7 @@ export async function extractArchive(
     const tarExtractor: Extract = extract();
     const layers: Record<string, ExtractedLayers> = {};
     let manifest: DockerArchiveManifest;
-    let imageConfig: DockerArchiveImageConfig;
+    let imageConfig: ImageConfig;
 
     tarExtractor.on("entry", async (header, stream, next) => {
       if (header.type === "file") {
@@ -51,7 +51,7 @@ export async function extractArchive(
           );
           manifest = manifestArray[0];
         } else if (isImageConfigFile(normalizedName)) {
-          imageConfig = await getManifestFile<DockerArchiveImageConfig>(stream);
+          imageConfig = await getManifestFile<ImageConfig>(stream);
         }
       }
 
@@ -84,7 +84,7 @@ export async function extractArchive(
 
 function getLayersContentAndArchiveManifest(
   manifest: DockerArchiveManifest,
-  imageConfig: DockerArchiveImageConfig,
+  imageConfig: ImageConfig,
   layers: Record<string, ExtractedLayers>,
 ): ExtractedLayersAndManifest {
   // skip (ignore) non-existent layers

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -31,6 +31,14 @@ export async function extractImageContent(
         imageId: ociExtractor.getImageIdFromManifest(ociArchive.manifest),
         manifestLayers: ociExtractor.getManifestLayers(ociArchive.manifest),
         extractedLayers: layersWithLatestFileModifications(ociArchive.layers),
+        rootFsLayers: dockerExtractor.getRootFsLayersFromConfig(
+          ociArchive.imageConfig,
+        ),
+        autoDetectedUserInstructions: dockerExtractor.getDetectedLayersInfoFromConfig(
+          ociArchive.imageConfig,
+        ),
+        platform: dockerExtractor.getPlatformFromConfig(ociArchive.imageConfig),
+        imageLabels: ociArchive.imageConfig.config.Labels,
       };
     default:
       const dockerArchive = await dockerExtractor.extractArchive(

--- a/lib/extractor/oci-archive/layer.ts
+++ b/lib/extractor/oci-archive/layer.ts
@@ -7,9 +7,9 @@ import { extract, Extract } from "tar-stream";
 import { streamToJson } from "../../stream-utils";
 import { extractImageLayer } from "../layer";
 import {
-  DockerArchiveImageConfig,
   ExtractAction,
   ExtractedLayers,
+  ImageConfig,
   OciArchiveManifest,
   OciImageIndex,
   OciManifestInfo,
@@ -29,14 +29,14 @@ export async function extractArchive(
 ): Promise<{
   layers: ExtractedLayers[];
   manifest: OciArchiveManifest;
-  imageConfig: DockerArchiveImageConfig;
+  imageConfig: ImageConfig;
 }> {
   return new Promise((resolve, reject) => {
     const tarExtractor: Extract = extract();
 
     const layers: Record<string, ExtractedLayers> = {};
     const manifests: Record<string, OciArchiveManifest> = {};
-    let imageConfig: DockerArchiveImageConfig | undefined;
+    let imageConfig: ImageConfig | undefined;
     let imageIndex: OciImageIndex | undefined;
 
     tarExtractor.on("entry", async (header, stream, next) => {
@@ -112,12 +112,12 @@ export async function extractArchive(
 function getLayersContentAndArchiveManifest(
   imageIndex: OciImageIndex | undefined,
   manifestCollection: Record<string, OciArchiveManifest>,
-  imageConfig: DockerArchiveImageConfig | undefined,
+  imageConfig: ImageConfig | undefined,
   layers: Record<string, ExtractedLayers>,
 ): {
   layers: ExtractedLayers[];
   manifest: OciArchiveManifest;
-  imageConfig: DockerArchiveImageConfig;
+  imageConfig: ImageConfig;
 } {
   // filter empty layers
   // get the layers content without the name
@@ -174,7 +174,7 @@ function isArchiveManifest(manifest: any): manifest is OciArchiveManifest {
   );
 }
 
-function isImageConfigFile(json: any): json is DockerArchiveImageConfig {
+function isImageConfigFile(json: any): json is ImageConfig {
   return json !== undefined && json.architecture && json.rootfs;
 }
 

--- a/lib/extractor/oci-archive/layer.ts
+++ b/lib/extractor/oci-archive/layer.ts
@@ -7,6 +7,7 @@ import { extract, Extract } from "tar-stream";
 import { streamToJson } from "../../stream-utils";
 import { extractImageLayer } from "../layer";
 import {
+  DockerArchiveImageConfig,
   ExtractAction,
   ExtractedLayers,
   OciArchiveManifest,
@@ -28,12 +29,14 @@ export async function extractArchive(
 ): Promise<{
   layers: ExtractedLayers[];
   manifest: OciArchiveManifest;
+  imageConfig: DockerArchiveImageConfig;
 }> {
   return new Promise((resolve, reject) => {
     const tarExtractor: Extract = extract();
 
     const layers: Record<string, ExtractedLayers> = {};
     const manifests: Record<string, OciArchiveManifest> = {};
+    let imageConfig: DockerArchiveImageConfig | undefined;
     let imageIndex: OciImageIndex | undefined;
 
     tarExtractor.on("entry", async (header, stream, next) => {
@@ -63,6 +66,8 @@ export async function extractArchive(
           const digest = `${hashName}:${hashValue}`;
           if (isArchiveManifest(manifest)) {
             manifests[digest] = manifest;
+          } else if (isImageConfigFile(manifest)) {
+            imageConfig = manifest;
           }
           if (layer !== undefined) {
             layers[digest] = layer as ExtractedLayers;
@@ -77,7 +82,12 @@ export async function extractArchive(
     tarExtractor.on("finish", () => {
       try {
         resolve(
-          getLayersContentAndArchiveManifest(imageIndex, manifests, layers),
+          getLayersContentAndArchiveManifest(
+            imageIndex,
+            manifests,
+            imageConfig,
+            layers,
+          ),
         );
       } catch (error) {
         debug(
@@ -102,8 +112,13 @@ export async function extractArchive(
 function getLayersContentAndArchiveManifest(
   imageIndex: OciImageIndex | undefined,
   manifestCollection: Record<string, OciArchiveManifest>,
+  imageConfig: DockerArchiveImageConfig | undefined,
   layers: Record<string, ExtractedLayers>,
-): { layers: ExtractedLayers[]; manifest: OciArchiveManifest } {
+): {
+  layers: ExtractedLayers[];
+  manifest: OciArchiveManifest;
+  imageConfig: DockerArchiveImageConfig;
+} {
   // filter empty layers
   // get the layers content without the name
   // reverse layers order from last to first
@@ -119,9 +134,14 @@ function getLayersContentAndArchiveManifest(
     throw new Error("We found no layers in the provided image");
   }
 
+  if (imageConfig === undefined) {
+    throw new Error("Could not find the image config in the provided image");
+  }
+
   return {
     layers: filteredLayers,
     manifest,
+    imageConfig,
   };
 }
 
@@ -152,6 +172,10 @@ function isArchiveManifest(manifest: any): manifest is OciArchiveManifest {
   return (
     manifest !== undefined && manifest.layers && manifest.layers.length >= 0
   );
+}
+
+function isImageConfigFile(json: any): json is DockerArchiveImageConfig {
+  return json !== undefined && json.architecture && json.rootfs;
 }
 
 function isImageIndexFile(name: string): boolean {

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -28,7 +28,7 @@ export interface ExtractedLayers {
 export interface ExtractedLayersAndManifest {
   layers: ExtractedLayers[];
   manifest: DockerArchiveManifest;
-  imageConfig: DockerArchiveImageConfig;
+  imageConfig: ImageConfig;
 }
 
 export interface DockerArchiveManifest {
@@ -39,7 +39,7 @@ export interface DockerArchiveManifest {
   Layers: string[];
 }
 
-export interface DockerArchiveImageConfig {
+export interface ImageConfig {
   architecture: string;
   os: string;
   rootfs: { diff_ids: string[] };

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^7.3.4",
-    "snyk-nodejs-lockfile-parser": "1.36.0",
+    "snyk-nodejs-lockfile-parser": "1.37.3",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",
     "tslib": "^1",

--- a/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
@@ -395,12 +395,20 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": Array [
+            "sha256:50644c29ef5a27c9a40c393a73ece2479de78325cae7d762ef3cdc19bf42dd0a",
+          ],
+          "type": "rootFs",
+        },
+        Object {
           "data": "Alpine Linux v3.12",
           "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
-        "args": undefined,
+        "args": Object {
+          "platform": "linux/amd64",
+        },
         "type": "apk",
       },
       "target": Object {

--- a/test/system/image-type/__snapshots__/oci-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/oci-archive.spec.ts.snap
@@ -369,12 +369,20 @@ Object {
           "type": "imageLayers",
         },
         Object {
+          "data": Array [
+            "sha256:50644c29ef5a27c9a40c393a73ece2479de78325cae7d762ef3cdc19bf42dd0a",
+          ],
+          "type": "rootFs",
+        },
+        Object {
           "data": "Alpine Linux v3.12",
           "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
-        "args": undefined,
+        "args": Object {
+          "platform": "linux/amd64",
+        },
         "type": "apk",
       },
       "target": Object {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

The OCI Archive scanning was not collecting the image config, so we were missing lots of good information from the image, such as root fs layers, auto-detected user instructions, platform, and image labels. The config is now properly detected and we can read this data.

