### PR TITLE
fix: ensure large objects are not loaded in memory when parsing them

### DIFF
--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -3,6 +3,7 @@ import { Readable } from "stream";
 import { HashAlgorithm } from "./types";
 
 const HASH_ENCODING = "hex";
+const MEGABYTE = 1 * 1024 * 1024;
 
 /**
  * https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
@@ -66,7 +67,29 @@ export async function streamToSha1(stream: Readable): Promise<string> {
   return streamToHash(stream, HashAlgorithm.Sha1);
 }
 
+/**
+ * Reads up to 2 megabytes from the stream and tries to JSON.parse the result.
+ * Will reject if an error occurs from within the stream or when parsing cannot be done.
+ */
 export async function streamToJson<T>(stream: Readable): Promise<T> {
-  const file = await streamToString(stream);
-  return JSON.parse(file);
+  return new Promise<T>((resolve, reject) => {
+    const chunks: string[] = [];
+    let bytes = 0;
+    stream.on("end", () => {
+      try {
+        resolve(JSON.parse(chunks.join("")));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    stream.on("error", (error) => reject(error));
+    stream.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes <= 2 * MEGABYTE) {
+        chunks.push(chunk.toString("utf8"));
+      } else {
+        reject(new Error("The stream is too large to parse as JSON"));
+      }
+    });
+  });
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Whenever we attempted to parse oci-archive files, we first loaded any file we encountered in memory fully before we JSON-parsed it.
Some files may be really large and may consume lots of memory.

Introduce a hard limit to read only up to 2 MiB of the file and to attempt to parse the result.

