### PR TITLE
feat: remove gunzip-maybe and use Node.js streams

### DIFF
--- a/lib/extractor/docker-archive/layer.ts
+++ b/lib/extractor/docker-archive/layer.ts
@@ -1,10 +1,9 @@
 import * as Debug from "debug";
 import { createReadStream } from "fs";
-import * as gunzip from "gunzip-maybe";
 import { basename, normalize as normalizePath } from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
-import { streamToJson } from "../../stream-utils";
+import { pipeDecompressedStream, streamToJson } from "../../stream-utils";
 import { extractImageLayer } from "../layer";
 import {
   DockerArchiveManifest,
@@ -76,9 +75,8 @@ export async function extractArchive(
 
     tarExtractor.on("error", (error) => reject(error));
 
-    createReadStream(dockerArchiveFilesystemPath)
-      .pipe(gunzip())
-      .pipe(tarExtractor);
+    const dockerArchiveStream = createReadStream(dockerArchiveFilesystemPath);
+    pipeDecompressedStream(dockerArchiveStream, tarExtractor);
   });
 }
 

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -1,8 +1,8 @@
 import * as Debug from "debug";
-import * as gunzip from "gunzip-maybe";
 import * as path from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
+import { pipeDecompressedStream } from "../stream-utils";
 import { applyCallbacks, isResultEmpty } from "./callbacks";
 import { ExtractAction, ExtractedLayers } from "./types";
 
@@ -61,6 +61,6 @@ export async function extractImageLayer(
 
     tarExtractor.on("error", (error) => reject(error));
 
-    layerTarStream.pipe(gunzip()).pipe(tarExtractor);
+    pipeDecompressedStream(layerTarStream, tarExtractor);
   });
 }

--- a/lib/extractor/oci-archive/layer.ts
+++ b/lib/extractor/oci-archive/layer.ts
@@ -1,10 +1,9 @@
 import * as Debug from "debug";
 import { createReadStream } from "fs";
-import * as gunzip from "gunzip-maybe";
 import { normalize as normalizePath, sep as pathSeparator } from "path";
 import { PassThrough } from "stream";
 import { extract, Extract } from "tar-stream";
-import { streamToJson } from "../../stream-utils";
+import { pipeDecompressedStream, streamToJson } from "../../stream-utils";
 import { extractImageLayer } from "../layer";
 import {
   ExtractAction,
@@ -103,9 +102,8 @@ export async function extractArchive(
       reject(error);
     });
 
-    createReadStream(ociArchiveFilesystemPath)
-      .pipe(gunzip())
-      .pipe(tarExtractor);
+    const ociArchiveStream = createReadStream(ociArchiveFilesystemPath);
+    pipeDecompressedStream(ociArchiveStream, tarExtractor);
   });
 }
 

--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -1,9 +1,11 @@
 import * as crypto from "crypto";
-import { Readable } from "stream";
+import { Readable, Writable } from "stream";
+import { createGunzip, createInflate } from "zlib";
 import { HashAlgorithm } from "./types";
 
 const HASH_ENCODING = "hex";
 const MEGABYTE = 1 * 1024 * 1024;
+const GZIP_HEADERS_SIZE_BYTES = 3;
 
 /**
  * https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
@@ -21,7 +23,7 @@ export async function streamToString(
       resolve(chunks.join(""));
     });
     stream.on("error", (error) => reject(error));
-    stream.on("data", (chunk) => {
+    stream.on("data", (chunk: Buffer) => {
       chunks.push(chunk.toString(encoding));
     });
   });
@@ -83,7 +85,7 @@ export async function streamToJson<T>(stream: Readable): Promise<T> {
       }
     });
     stream.on("error", (error) => reject(error));
-    stream.on("data", (chunk) => {
+    stream.on("data", (chunk: Buffer) => {
       bytes += chunk.length;
       if (bytes <= 2 * MEGABYTE) {
         chunks.push(chunk.toString("utf8"));
@@ -92,4 +94,60 @@ export async function streamToJson<T>(stream: Readable): Promise<T> {
       }
     });
   });
+}
+
+/**
+ * Decompresses a source stream (if compressed) and pipes it to a destination stream.
+ */
+export function pipeDecompressedStream(
+  source: Readable,
+  destination: Writable,
+): void {
+  let header = Buffer.alloc(0);
+
+  // Collect enough bytes to be able to inspect the start of the stream to understand how it is compressed.
+  const bytesCollector = (chunk: Buffer) => {
+    header = Buffer.concat([header, chunk]);
+    if (header.length < GZIP_HEADERS_SIZE_BYTES) {
+      // Continue collecting data until we have enough
+      return;
+    }
+
+    // Stop collecting individual chunks of data because we will pipe the stream from now on.
+    source.off("data", bytesCollector);
+
+    if (isGzipHeader(header)) {
+      const gunzip = createGunzip();
+      gunzip.write(header);
+      source.pipe(gunzip).pipe(destination);
+    } else if (isDeflateHeader(header)) {
+      const inflate = createInflate();
+      inflate.write(header);
+      source.pipe(inflate).pipe(destination);
+    } else {
+      destination.write(header);
+      source.pipe(destination);
+    }
+  };
+
+  source.on("data", bytesCollector);
+  // If the stream was shorter than expected, we need to write what we have collected to the destination stream.
+  // Otherwise we risk the destination hanging forever waiting on data.
+  source.on("end", () => {
+    if (header.length < GZIP_HEADERS_SIZE_BYTES) {
+      destination.write(header);
+      destination.emit("finish");
+    }
+  });
+}
+
+function isGzipHeader(buffer: Buffer): boolean {
+  return buffer[0] === 0x1f && buffer[1] === 0x8b && buffer[2] === 0x08;
+}
+
+function isDeflateHeader(buffer: Buffer): boolean {
+  return (
+    buffer[0] === 0x78 &&
+    (buffer[1] === 1 || buffer[1] === 0x9c || buffer[1] === 0xda)
+  );
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "dockerfile-ast": "0.2.1",
     "elfy": "^1.0.0",
     "event-loop-spinner": "^2.0.0",
-    "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^7.3.4",
     "snyk-nodejs-lockfile-parser": "1.37.3",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

While analyzing a performance issue, noticed that the CPU usage is pretty high. The flame graph / stack trace showed a subdependency of gunzip-maybe to be the main reason.
Switching to Node.js streams yields a slight performance improvement (tested with the latest Redis OCI archive):
- Before: 1.18s user 0.20s system 132% cpu 1.041 total
- After: 1.02s user 0.19s system 126% cpu 0.963 total
