### PR TITLE
fix: remove unnecessary async keyword from extractImageDetails

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -107,7 +107,7 @@ async function pullFromContainerRegistry(
   username: string | undefined,
   password: string | undefined,
 ): Promise<void> {
-  const { hostname, imageName, tag } = await extractImageDetails(targetImage);
+  const { hostname, imageName, tag } = extractImageDetails(targetImage);
   debug(
     `Attempting to pull: registry: ${hostname}, image: ${imageName}, tag: ${tag}`,
   );
@@ -237,7 +237,7 @@ async function getImageArchive(
   };
 }
 
-async function extractImageDetails(targetImage: string): Promise<ImageDetails> {
+function extractImageDetails(targetImage: string): ImageDetails {
   let remainder: string;
   let hostname: string;
   let imageName: string;

--- a/test/lib/analyzer/image-inspector.spec.ts
+++ b/test/lib/analyzer/image-inspector.spec.ts
@@ -75,12 +75,12 @@ describe("extractImageDetails", () => {
       imageName: "foo/bar",
       tag: "sha256:8756a25c4c5e902c4fe20322cc69d510a0517b51eab630c614efbd612ed568bf",
     }}
-  `("extract details for $image", async ({ image, expected }) => {
+  `("extract details for $image", ({ image, expected }) => {
     const {
       hostname,
       imageName,
       tag,
-    } = await imageInspector.extractImageDetails(image);
+    } = imageInspector.extractImageDetails(image);
     expect(hostname).toEqual(expected.hostname);
     expect(imageName).toEqual(expected.imageName);
     expect(tag).toEqual(expected.tag);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Removes the async keywork from the function extractImageDetails which doesn't use await inside it.