### PR TITLE
chore: align ci test flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,25 +180,24 @@ workflows:
       - build:
           name: Build
           requires:
-            - Install
+            - Lint
       - test:
           name: Test
           context: nodejs-install
           requires:
-            - Install
-      - test_jest:
-          name: Test Jest
-          context: nodejs-install
-          requires:
-            - Install
+            - Build
       - test_windows:
           name: Test Windows
           context: nodejs-install
           node_version: "10.19.0"
+          requires:
+            - Build
       - test_jest_windows:
           name: Test Jest Windows
           context: nodejs-install
           node_version: "10.19.0"
+          requires:
+            - Build
       - release:
           name: Release to GitHub
           context: nodejs-lib-release
@@ -211,3 +210,4 @@ workflows:
             - Build
             - Test
             - Test Windows
+            - Test Jest Windows


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- removed the test-jest job from the test and release workflow, since
  `test-jest` is already a part of the `test` script, and it's redundant
  to run it twice.
- only run tests after lint and build are done to avoid running the
  tests on a broken code

