### PR TITLE
fix: upgrade typescript dependency

### DIFF
--- a/lib/go-parser/index.ts
+++ b/lib/go-parser/index.ts
@@ -63,7 +63,7 @@ async function findGoBinaries(
       try {
         // Discard
         if (bytesWritten === 0) {
-          return resolve();
+          return resolve(undefined);
         }
 
         const binaryFile = elf.parse(buffer);
@@ -81,12 +81,12 @@ async function findGoBinaries(
         );
 
         if (!goBuildInfo && !goBuildId) {
-          return resolve();
+          return resolve(undefined);
         } else if (interp) {
           // Compiled using cgo
           // we wouldn't be able to extract modules
           // TODO: cgo-compiled binaries are not supported in this iteration
-          return resolve();
+          return resolve(undefined);
         } else if (goBuildInfo) {
           const info = goBuildInfo.data
             .slice(0, buildInfoMagic.length)
@@ -96,7 +96,7 @@ async function findGoBinaries(
             return resolve(binaryFile);
           }
 
-          return resolve();
+          return resolve(undefined);
         } else if (goBuildId) {
           const strings = goBuildId.data
             .toString()
@@ -112,12 +112,12 @@ async function findGoBinaries(
             return resolve(binaryFile);
           }
 
-          return resolve();
+          return resolve(undefined);
         }
       } catch (error) {
         // catching exception during elf file parse shouldn't fail the archive iteration
         // it either we recognize file as binary or not
-        return resolve();
+        return resolve(undefined);
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -64,10 +64,12 @@
     "tsc-watch": "^4.2.8",
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "4.0.3"
+    "typescript": "^4.6.4"
   },
   "release": {
-    "branches": ["main"],
+    "branches": [
+      "main"
+    ],
     "verifyConditions": [
       "@semantic-release/github"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
+    "useUnknownInCatchVariables": false,
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Build started failing all of a sudden, probably because we have no
package-lock file in this project. To fix the tsc build problem, this
commit upgrades typescript, and replaces empty `resolve` statements to
`resolve(undefined)`, since otherwise it throws a type error.
