### PR TITLE
fix: php target file

### DIFF
--- a/lib/analyzer/applications/php.ts
+++ b/lib/analyzer/applications/php.ts
@@ -47,7 +47,7 @@ export async function phpFilesToScannedProjects(
       facts: [depGraphFact, testedFilesFact],
       identity: {
         type: depGraph.pkgManager.name,
-        targetFile: pathPair.manifest,
+        targetFile: pathPair.lock,
       },
     });
   }

--- a/test/system/application-scans/__snapshots__/php.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/php.spec.ts.snap
@@ -651,7 +651,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/app/composer.json",
+        "targetFile": "/app/composer.lock",
         "type": "composer",
       },
       "target": Object {
@@ -1313,7 +1313,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/app/composer.json",
+        "targetFile": "/app/composer.lock",
         "type": "composer",
       },
       "target": Object {


### PR DESCRIPTION


- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
when scanning PHP (composer) manifest files, we need to set the target
file as the lock file rather than the json file, to be consistent with
other ways of creating PHP projects


#### Screenshots
How it should be:
![image](https://user-images.githubusercontent.com/26110560/168599099-c7a1222a-2fc4-4b58-8cf6-8b7cc6e8105a.png)


How it is without this fix
![image](https://user-images.githubusercontent.com/26110560/168599376-97ba0266-cbae-4898-aa94-a81341f155d7.png)
