### PR TITLE
fix: downgrade minimum nodejs version to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "npm run build"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=12"
   },
   "dependencies": {
     "@snyk/composer-lockfile-parser": "^1.4.1",

--- a/test/lib/analyzer/image-inspector.spec.ts
+++ b/test/lib/analyzer/image-inspector.spec.ts
@@ -16,7 +16,7 @@ function rmdirRecursive(customPath: string[]): void {
   }
 
   const joinedPath = path.join(...customPath);
-  fs.rmSync(joinedPath, { recursive: true, force: true });
+  fs.rmdirSync(joinedPath, { recursive: true });
 }
 
 // prettier-ignore


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Since Snyk's CLI current minimum supported version is 12, the plugin
should also support that version. Then only piece of code that was using
a Node >= 14 code was the use of `rmSync` in one of the tests, and this
was adjusted here.
