### PR TITLE
fix: bump rpm parser

### DIFF
--- a/lib/inputs/rpm/static.ts
+++ b/lib/inputs/rpm/static.ts
@@ -2,17 +2,12 @@ import { getPackages, getPackagesSqlite } from "@snyk/rpm-parser";
 import { PackageInfo } from "@snyk/rpm-parser/lib/rpm/types";
 import { IParserSqliteResponse } from "@snyk/rpm-parser/lib/types";
 import * as Debug from "debug";
-import { writeFile as writeFileFs } from "fs";
 import { normalize as normalizePath } from "path";
-import { fileSync } from "tmp";
-import { promisify } from "util";
 import { getContentAsBuffer } from "../../extractor";
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToBuffer } from "../../stream-utils";
 
 const debug = Debug("snyk");
-
-const writeFile = promisify(writeFileFs);
 
 export const getRpmDbFileContentAction: ExtractAction = {
   actionName: "rpm-db",
@@ -58,14 +53,8 @@ export async function getRpmSqliteDbFileContent(
   }
 
   try {
-    const tempFileObj = fileSync();
-    await writeFile(tempFileObj.fd, rpmDb);
+    const results: IParserSqliteResponse = await getPackagesSqlite(rpmDb);
 
-    const results: IParserSqliteResponse = await getPackagesSqlite(
-      tempFileObj.name,
-    );
-
-    tempFileObj.removeCallback(); // removing the temp file created after processing
     if (results.error) {
       throw results.error;
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@snyk/composer-lockfile-parser": "^1.4.1",
     "@snyk/dep-graph": "^1.28.0",
-    "@snyk/rpm-parser": "^2.3.0",
+    "@snyk/rpm-parser": "^2.3.1",
     "@snyk/snyk-docker-pull": "^3.7.2",
     "adm-zip": "^0.5.5",
     "chalk": "^2.4.2",


### PR DESCRIPTION

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

`rpm-parser` now using `sql.js` instead of `sqlite` due to limitations in Snyk CLI. 
Mainly removals since it supports opening the DB from Buffer. 
