### PR TITLE
feat: new @snyk/dep-graph (no more node 8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@snyk/composer-lockfile-parser": "^1.4.1",
-    "@snyk/dep-graph": "^1.28.0",
+    "@snyk/dep-graph": "^2.3.0",
     "@snyk/rpm-parser": "^2.3.1",
     "@snyk/snyk-docker-pull": "^3.7.2",
     "adm-zip": "^0.5.5",
@@ -41,7 +41,7 @@
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
     "semver": "^7.3.4",
-    "snyk-nodejs-lockfile-parser": "1.37.3",
+    "snyk-nodejs-lockfile-parser": "1.40.0",
     "tar-stream": "^2.1.0",
     "tmp": "^0.2.1",
     "tslib": "^1",
@@ -64,7 +64,7 @@
     "tsc-watch": "^4.2.8",
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^4.6.4"
+    "typescript": "~4.7.3"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
### What this does

Upgrade to the recent version of @snyk/dep-graph, which has dropped support for node 8, which we haven't cared about for a long time.