### PR TITLE
No experimental check for platform setting [MYC-117]

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -83,17 +83,22 @@ async function pullWithDockerBinary(
       throw new Error(`The image does not exist for the current platform`);
     }
 
-    if (
-      err.message &&
-      err.message.includes(
-        '"--platform" is only supported on a Docker daemon with experimental features enabled',
-      )
-    ) {
-      throw err;
-    }
-
     if (err.stderr && err.stderr.includes("invalid reference format")) {
       throw new Error(`invalid image format`);
+    }
+
+    if (err.stderr.includes("unknown flag: --platform")) {
+      throw new Error(
+        '"--platform" is only supported on a Docker daemon with version later than 17.09',
+      );
+    }
+
+    if (
+      err.stderr &&
+      err.stderr ===
+        '"--platform" is only supported on a Docker daemon with experimental features enabled'
+    ) {
+      throw new Error(err.stderr);
     }
 
     return pullAndSaveSuccessful;

--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -51,24 +51,16 @@ class Docker {
     return await dockerPull.pull(registry, repo, tag, opt);
   }
 
-  public async isDockerExperimentalEnabled(): Promise<boolean> {
-    const output = await subProcess.execute("docker", ["system", "info"]);
-    return output.stdout.includes("Experimental: true");
-  }
-
-  public async pullCli(targetImage: string, options?: DockerOptions) {
-    let platformOption: string = "";
+  public async pullCli(
+    targetImage: string,
+    options?: DockerOptions,
+  ): Promise<subProcess.CmdOutput> {
+    const opts: string[] = ["pull", targetImage];
     if (options?.platform) {
-      if (await this.isDockerExperimentalEnabled()) {
-        platformOption = `--platform=${options.platform}`;
-      } else {
-        throw new Error(
-          '"--platform" is only supported on a Docker daemon with experimental features enabled',
-        );
-      }
+      opts.push(`--platform=${options.platform}`);
     }
 
-    return subProcess.execute("docker", ["pull", platformOption, targetImage]);
+    return subProcess.execute("docker", opts);
   }
 
   public async save(targetImage: string, destination: string) {

--- a/test/lib/docker.test.ts
+++ b/test/lib/docker.test.ts
@@ -86,8 +86,7 @@ test("save from docker daemon", async (t) => {
 });
 
 test("pullCli", async (t) => {
-  const stub = sinon.stub(subProcess, "execute");
-  stub.resolves({ stdout: "Experimental: true" });
+  const stub = sinon.stub(subProcess, "execute").resolves();
   t.beforeEach(async () => {
     stub.resetHistory();
   });
@@ -103,32 +102,18 @@ test("pullCli", async (t) => {
     const subProcessArgs = stub.getCall(0).args;
     t.same(
       subProcessArgs,
-      ["docker", ["pull", "", targetImage]],
+      ["docker", ["pull", targetImage]],
       "args passed to subProcess.execute as expected",
     );
   });
 
   t.test("with args", async (t) => {
     await docker.pullCli(targetImage, { platform: "linux/arm64/v8" });
-    const subProcessArgs = stub.getCall(1).args;
+    const subProcessArgs = stub.getCall(0).args;
     t.same(
       subProcessArgs,
-      ["docker", ["pull", "--platform=linux/arm64/v8", targetImage]],
+      ["docker", ["pull", targetImage, "--platform=linux/arm64/v8"]],
       "args passed to subProcess.execute as expected",
     );
   });
-
-  t.test(
-    "with platform arg, when no experimental features enabled",
-    async (t) => {
-      stub.resolves({ stdout: "Experimental: false" });
-
-      await t.rejects(
-        async () =>
-          await docker.pullCli(targetImage, { platform: "linux/arm64/v8" }),
-        '"--platform" is only supported on a Docker daemon with experimental features enabled',
-        "throws expected error",
-      );
-    },
-  );
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Mainly removes the check if Docker experimental is enabled if the user specifies a platform. It's not needed anymore as the `--platform` flag for `docker pull` has been graduated to stable. Also some clean-up around that feature.

#### Any background context you want to provide?

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/MYC-117