### PR TITLE
test: fix tests on ARM (MYC-116)

### DIFF
--- a/test/system/index.spec.ts
+++ b/test/system/index.spec.ts
@@ -28,7 +28,13 @@ describe("system tests", () => {
       "695e7fa35b2ea1846732a6c9f8cebec6c941a54d4aafd15a451062ef8be81bfb";
     const img = imgName + ":" + imgTag;
 
-    await subProcess.execute("docker", ["image", "pull", img]);
+    await subProcess.execute("docker", [
+      "image",
+      "pull",
+      img,
+      "--platform",
+      "linux/amd64",
+    ]);
 
     const pluginResult = await plugin.scan({ path: img });
     const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
@@ -47,7 +53,13 @@ describe("system tests", () => {
     const img = imgName + ":" + imgTag;
     const dockerFileLocation = getDockerfileFixturePath("node");
 
-    await subProcess.execute("docker", ["image", "pull", img]);
+    await subProcess.execute("docker", [
+      "image",
+      "pull",
+      img,
+      "--platform",
+      "linux/amd64",
+    ]);
 
     const pluginResponse = await plugin.scan({
       path: img,
@@ -91,7 +103,13 @@ describe("system tests", () => {
     const img = imgName + ":" + imgTag;
     const dockerFileLocation = getDockerfileFixturePath("nginx");
 
-    await subProcess.execute("docker", ["image", "pull", img]);
+    await subProcess.execute("docker", [
+      "image",
+      "pull",
+      img,
+      "--platform",
+      "linux/amd64",
+    ]);
 
     const pluginResponse = await plugin.scan({
       path: img,
@@ -137,7 +155,13 @@ describe("system tests", () => {
     const img = imgName + ":" + imgTag;
     const dockerFileLocation = getDockerfileFixturePath("redis");
 
-    await subProcess.execute("docker", ["image", "pull", img]);
+    await subProcess.execute("docker", [
+      "image",
+      "pull",
+      img,
+      "--platform",
+      "linux/amd64",
+    ]);
 
     const pluginResponse = await plugin.scan({
       path: img,
@@ -200,7 +224,13 @@ describe("system tests", () => {
       const hostAndImgName = "localhost:5000/" + imgName;
       const hostAndImg = hostAndImgName + ":" + imgTag;
 
-      await subProcess.execute("docker", ["image", "pull", img]);
+      await subProcess.execute("docker", [
+        "image",
+        "pull",
+        img,
+        "--platform",
+        "linux/amd64",
+      ]);
       await subProcess.execute("docker", ["tag", img, hostAndImg]);
 
       const pluginResponse = await plugin.scan({
@@ -239,7 +269,7 @@ describe("system tests", () => {
   test("inspect image with sha@256 " + "ubuntu@sha256", async () => {
     const imgName = "ubuntu";
     const imgSha =
-      "@sha256:945039273a7b927869a07b375dc3148de16865de44dec8398672977e050a072e";
+      "@sha256:eb5d7eda6804359e4fc5223a31a2d9caa4c8ea590b14060d81c8bc05b22ca04e";
     const img = imgName + imgSha;
 
     await subProcess.execute("docker", ["image", "pull", img]);
@@ -279,7 +309,13 @@ describe("system tests", () => {
       const hostAndImgName = "localhost:5000/foo/" + imgName;
       const hostAndImg = hostAndImgName + ":" + imgTag;
 
-      await subProcess.execute("docker", ["image", "pull", img]);
+      await subProcess.execute("docker", [
+        "image",
+        "pull",
+        img,
+        "--platform",
+        "linux/amd64",
+      ]);
       await subProcess.execute("docker", ["tag", img, hostAndImg]);
 
       const pluginResponse = await plugin.scan({

--- a/test/system/operating-systems/alpine3.7.spec.ts
+++ b/test/system/operating-systems/alpine3.7.spec.ts
@@ -15,6 +15,7 @@ describe("alpine tests", () => {
     const image = "alpine:3.7.3";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();
@@ -25,6 +26,7 @@ describe("alpine tests", () => {
       "alpine@sha256:92251458088c638061cda8fd8b403b76d661a4dc6b7ee71b6affcf1872557b2b";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();

--- a/test/system/operating-systems/centos7.spec.ts
+++ b/test/system/operating-systems/centos7.spec.ts
@@ -15,6 +15,7 @@ describe("centos tests", () => {
     const image = "centos:7.8.2003";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();
@@ -25,6 +26,7 @@ describe("centos tests", () => {
       "centos@sha256:50b9a3bc27378889210f88d6d0695938e45a912aa99b3fdacfb9a0fef511f15a";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();

--- a/test/system/operating-systems/sles15.spec.ts
+++ b/test/system/operating-systems/sles15.spec.ts
@@ -14,6 +14,7 @@ describe("suse linux enterprise server tests", () => {
     const image = "registry.suse.com/suse/sle15:15.2.8.2.751";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();

--- a/test/system/operating-systems/ubi8.spec.ts
+++ b/test/system/operating-systems/ubi8.spec.ts
@@ -14,6 +14,7 @@ describe("redhat ubi8 tests", () => {
     const image = "registry.access.redhat.com/ubi8/ubi:8.2-347";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();

--- a/test/system/package-managers/apk.spec.ts
+++ b/test/system/package-managers/apk.spec.ts
@@ -10,6 +10,7 @@ describe("apk package manager tests", () => {
     const image = "alpine:3.12.0";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();

--- a/test/system/package-managers/deb.spec.ts
+++ b/test/system/package-managers/deb.spec.ts
@@ -15,6 +15,7 @@ describe("deb package manager tests", () => {
       "debian@sha256:89ff9e144a438f6bdf89fba6a1fdcb614b6d03bc14433bbb937088ca7c7a7b6d";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();

--- a/test/system/package-managers/rpm.spec.ts
+++ b/test/system/package-managers/rpm.spec.ts
@@ -15,6 +15,7 @@ describe("rpm package manager tests", () => {
     const image = "amazonlinux:2.0.20200722.0";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();
@@ -24,6 +25,7 @@ describe("rpm package manager tests", () => {
     const image = "amazonlinux:2022.0.20220504.1";
     const pluginResult = await scan({
       path: image,
+      platform: "linux/amd64",
     });
 
     expect(pluginResult).toMatchSnapshot();

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -21,7 +21,7 @@ test("docker-archive image type throws on bad files", async (t) => {
   );
 });
 
-test("static scan for Identifier type image (nginx:1.19.0)", async (t) => {
+test("image pulled by tag has version set", async (t) => {
   const imageNameAndTag = `nginx:1.19.0`;
 
   const pluginResult = await plugin.scan({
@@ -33,6 +33,22 @@ test("static scan for Identifier type image (nginx:1.19.0)", async (t) => {
   )!.data;
   t.same(depGraph.rootPkg.name, "docker-image|nginx", "Image name matches");
   t.same(depGraph.rootPkg.version, "1.19.0", "Version must not be empty");
+});
+
+test("static scan for Identifier type image (nginx:1.19.0)", async (t) => {
+  // This digest resolves to the `1.19.0` tag. We're using the digest to guarantee we always get the correct
+  // image, no matter on which platform this test is run on.
+  const imageNameAndDigest = `nginx@sha256:0efad4d09a419dc6d574c3c3baacb804a530acd61d5eba72cb1f14e1f5ac0c8f`;
+
+  const pluginResult = await plugin.scan({
+    path: imageNameAndDigest,
+  });
+
+  const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
+    (fact) => fact.type === "depGraph",
+  )!.data;
+  t.same(depGraph.rootPkg.name, "docker-image|nginx", "Image name matches");
+  t.same(depGraph.rootPkg.version, undefined, "Image has no version set"); // because we pull by digest.
   const imageId: string = pluginResult.scanResults[0].facts.find(
     (fact) => fact.type === "imageId",
   )!.data;

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -260,8 +260,10 @@ test("static scanning NGINX with dockerfile analysis matches expected values", a
 
 test("able to scan opensuse/leap images", async (t) => {
   const imgName = "opensuse/leap";
-  const imgTag = "15.1";
-  const img = imgName + ":" + imgTag;
+  // digest corresponds to tag 15.1, but makes the image platform-independent.
+  const imgDigest =
+    "@sha256:2288f0d5caec6a4b7f6b76d7a1ef6cf738f94c8f10941ea1840a365a61ed6219";
+  const img = imgName + imgDigest;
 
   const pluginResult = await plugin.scan({
     path: img,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR improves the unit- and integration-tests and makes them work
on non-AMD64 platforms as well (like Apple's M1). For most tests, it
simply specifies the target platform to always be AMD64. For some
unit-tests, it changes the image tags to instead use the digests of the
AMD64 images.

#### How should this be manually tested?

If you have an M1 or M2 laptop, run `npm run test` locally.

#### What are the relevant tickets?

[MYC-116](https://snyksec.atlassian.net/browse/MYC-116)