### PR TITLE
test: fix regression test shell issues

### DIFF
--- a/.circleci/build-go-binary-latest.sh
+++ b/.circleci/build-go-binary-latest.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -ex
+set -eux
 
 cd ~/snyk-docker-plugin/test/fixtures/go-binaries/source
 ./build.sh latest

--- a/test/fixtures/go-binaries/source/build.sh
+++ b/test/fixtures/go-binaries/source/build.sh
@@ -3,17 +3,17 @@
 # Simply call this script with no arguments. Needs Docker to be installed.
 # The binaries here are used for the symbol parser and the Go version extraction test.
 
-set -ex
+set -eux
 
 versions="1.13.15 1.16.15 1.18.5 1.19.0"
 # let the user overwrite the versions to build.
 if [ "$#" -gt 0 ]; then
-    versions="$@"
+    versions="$*"
 fi;
 
 for version in $versions; do 
     # the "latest" builds need an "alpine" tag (there's no "latest-alpine" tag).
-    if [ "$version" == "latest" ]; then
+    if [ "$version" = "latest" ]; then
         tag="alpine"
         version="latest"
     else


### PR DESCRIPTION
`==` is a bashism, `=` is the shell equivalent. Interestingly, when run
on MacOS, `==` works as well, which is why local testing didn't bring up
this issue.

Further, `@*` concatenates the array of arguments into a single variable
seperated by the `IFS`, which is a space. So the end result should be
the same.

These changes have been tested in the same Docker image that is used in
CI.

Also, the `-u` flag has been added to the `set` command so that the script fails on any error. This is useful because so far, CI failed due to `golang:latest-alpine` not being a valid image. This image name was only created because the if-check didn't succeed due to the syntax error.

With the `-u` flag, this would have exited earlier and would have made the issue more obvious as well.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

