### PR TITLE
fix: python site-package location

### DIFF
--- a/lib/inputs/python/static.ts
+++ b/lib/inputs/python/static.ts
@@ -5,7 +5,7 @@ import { streamToString } from "../../stream-utils";
 
 const poetryManifestFiles = ["pyproject.toml", "poetry.lock"];
 const pipManifestFiles = ["requirements.txt"];
-const pythonMetadataFilesRegex = /\/usr\/local\/lib\/python.*?\/site-packages\/.*?\.dist-info\/METADATA/;
+const pythonMetadataFilesRegex = /\/lib\/python.*?\/site-packages\/.*?\.dist-info\/METADATA/;
 
 function poetryFilePathMatches(filePath: string): boolean {
   const fileName = basename(filePath);

--- a/test/lib/analyzer/python-pip-analyzer.spec.ts
+++ b/test/lib/analyzer/python-pip-analyzer.spec.ts
@@ -37,6 +37,33 @@ describe("pip analyzer", () => {
     expect(res[0].facts[0].data._depPkgsList).toHaveLength(8);
   });
 
+  it("correctly creates a dep graph when metadata files are in a different location", async () => {
+    const basePath = getFixture(`/python/ok`);
+    const filePathToContent = {
+      "/app/requirements.txt": readFileSync(
+        path.join(basePath, "requirements.txt"),
+      ).toString(),
+    };
+    const sitePackages = readdirSync(path.join(basePath, "site-packages"), {
+      withFileTypes: true,
+    });
+    for (const packageEntity of sitePackages) {
+      if (packageEntity.isDirectory()) {
+        filePathToContent[
+          `/usr/lib/python2.7/site-packages/${packageEntity.name}/METADATA`
+        ] = readFileSync(
+          path.join(basePath, `site-packages/${packageEntity.name}/METADATA`),
+        ).toString();
+      }
+    }
+    const res = await pipFilesToScannedProjects(filePathToContent);
+    expect(res[0].identity).toMatchObject({
+      type: "pip",
+      targetFile: "/app/requirements.txt",
+    });
+    expect(res[0].facts[0].data._depPkgsList).toHaveLength(8);
+  });
+
   it("correctly creates a dep graph from a requirements file and missing metadata", async () => {
     const filePathToContent = prepareFiles("missing-deps");
     const res = await pipFilesToScannedProjects(filePathToContent);

--- a/test/system/operating-systems/oraclelinux8.2.spec.ts
+++ b/test/system/operating-systems/oraclelinux8.2.spec.ts
@@ -15,6 +15,7 @@ describe("oracle linux tests", () => {
       "oraclelinux@sha256:652409ec0fd4e79b07ecf82e35ebf50277be69f6b8e873129a55a0bdedf827d0";
     const pluginResult = await scan({
       path: image,
+      "exclude-app-vulns": true,
     });
 
     expect(pluginResult).toMatchSnapshot();


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
The site-packages directory can be found in various locations depending
on python version and usage of virtual environment. This fix allows more
flexibility in finding it
