### PR TITLE
fix: skip CGo binaries without PCLNTable

### DIFF
--- a/lib/go-parser/go-binary.ts
+++ b/lib/go-parser/go-binary.ts
@@ -18,8 +18,14 @@ export class GoBinary {
     const pclnTab = goElfBinary.body.sections.find(
       (section) => section.name === ".gopclntab",
     );
+
+    // some CGo built binaries might not contain a pclnTab, which means we
+    // cannot scan the files.
+    // TODO: from a technical perspective, it would be enough to only report the
+    // modules, as the only remediation path is to upgrade a full module
+    // anyways. From a product perspective, it's not clear (yet).
     if (pclnTab === undefined) {
-      throw Error("no pcln table found in Go binary");
+      throw Error("no pcln table present in Go binary");
     }
 
     this.matchFilesToModules(new LineTable(pclnTab.data).go12MapFiles());

--- a/tslint.json
+++ b/tslint.json
@@ -1,13 +1,11 @@
 {
   "defaultSeverity": "error",
-  "extends": [
-    "tslint:recommended",
-    "tslint-config-prettier"
-  ],
+  "extends": ["tslint:recommended", "tslint-config-prettier"],
   "rules": {
     "no-shadowed-variable": false,
     "interface-name": false,
     "object-literal-sort-keys": false,
-    "no-bitwise": false
+    "no-bitwise": false,
+    "max-classes-per-file": false
   }
 }


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Some CGo-built binaries might not contain a pcln table, as is described in [Building a better Go linker](https://docs.google.com/document/d/1D13QhciikbdLtaI67U6Ble5d_1nsI4befEd6_k1z91U/view):

> For “cgo” binaries, which may make arbitrary use of C libraries, the
Go linker links all of the Go code into a single native object file and then invokes the system linker to produce the final binary.

One example and the reason why we have found this issue is containerd, that is built with CGo enabled.

I do not know how exactly to build a Go binary without a PCLN table, but somehow it must be possible :-)

So far, we have thrown an error and thus exited the scan if the PCLN table was missing in a Go binary, because we did not expect this case to exist. Now that we know it exists, this commit fixes that behaviour and simply skips the binary in the scan.

