### PR TITLE
fix: amending condition for 'manifest unknown' errors

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -76,7 +76,14 @@ async function pullWithDockerBinary(
       throw new Error(`Operating system is not supported`);
     }
 
-    if (err.stderr && err.stderr.includes("no matching manifest for")) {
+    const unknownManifestConditions = [
+      "no matching manifest for",
+      "manifest unknown",
+    ];
+    if (
+      err.stderr &&
+      unknownManifestConditions.some((value) => err.stderr.includes(value))
+    ) {
       if (platform) {
         throw new Error(`The image does not exist for ${platform}`);
       }

--- a/test/windows/plugin.spec.ts
+++ b/test/windows/plugin.spec.ts
@@ -78,8 +78,8 @@ describe("windows scanning", () => {
     ]);
   });
 
-  it("can static scan for Identifier type image (nginx:1.19.0)", async () => {
-    const imageNameAndTag = "nginx:1.19.0";
+  it("can static scan for Identifier type image (nginx:1.19.11)", async () => {
+    const imageNameAndTag = "nginx:1.19.11";
 
     await expect(() =>
       plugin.scan({


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This commit amends the condition used to check against `err.stderr` from the docker daemon, based on the latest response (assume it must have changed), when the manifest for a given image or tag cannot be found. It ensures that the errors is not treated as a generic error and will not fall back to use `snyk-docker-pull` and fail with invalid credentials error when using the docker binary.

#### Any background context you want to provide?
https://snyk.zendesk.com/agent/tickets/32820
