### PR TITLE
fix: unify error message formatting

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -59,11 +59,7 @@ async function pullWithDockerBinary(
     await docker.save(targetImage, saveLocation);
     return (pullAndSaveSuccessful = true);
   } catch (err) {
-    debug(
-      `couldn't pull ${targetImage} using docker binary: ${JSON.stringify(
-        err,
-      )}`,
-    );
+    debug(`couldn't pull ${targetImage} using docker binary: ${err}`);
 
     if (
       err.stderr &&
@@ -319,7 +315,7 @@ function isLocalImageSameArchitecture(
     // Note: this is using the same flag/input pattern as the new Docker buildx: eg. linux/arm64/v8
     platformArchitecture = platformOption.split("/")[1];
   } catch (error) {
-    debug(`Error parsing platform flag: '${JSON.stringify(error)}'`);
+    debug(`Error parsing platform flag: '${error}'`);
     return false;
   }
 

--- a/lib/analyzer/os-release/static.ts
+++ b/lib/analyzer/os-release/static.ts
@@ -59,7 +59,7 @@ export async function detect(
     try {
       osRelease = await handler(osReleaseFile);
     } catch (err) {
-      debug("Malformed OS release file", JSON.stringify(err));
+      debug(`Malformed OS release file: ${err}`);
     }
     if (osRelease) {
       break;

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -159,7 +159,7 @@ export async function analyze(
       dockerfileAnalysis,
     );
   } catch (err) {
-    debug(`Could not detect OS release: ${JSON.stringify(err)}`);
+    debug(`Could not detect OS release: ${err}`);
     throw new Error("Failed to detect OS release");
   }
 
@@ -173,7 +173,7 @@ export async function analyze(
       aptDistrolessAnalyze(targetImage, distrolessAptFiles),
     ]);
   } catch (err) {
-    debug(`Could not detect installed OS packages: ${JSON.stringify(err)}`);
+    debug(`Could not detect installed OS packages: ${err}`);
     throw new Error("Failed to detect installed OS packages");
   }
 

--- a/lib/extractor/docker-archive/layer.ts
+++ b/lib/extractor/docker-archive/layer.ts
@@ -66,9 +66,7 @@ export async function extractArchive(
         );
       } catch (error) {
         debug(
-          `Error getting layers and manifest content from docker archive: '${JSON.stringify(
-            error,
-          )}'`,
+          `Error getting layers and manifest content from docker archive: ${error}`,
         );
         reject(new Error("Invalid Docker archive"));
       }

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -46,8 +46,7 @@ export async function extractImageLayer(
           } catch (error) {
             // An ExtractAction has thrown an uncaught exception, likely a bug in the code!
             debug(
-              "Exception thrown while applying callbacks during image layer extraction",
-              JSON.stringify(error),
+              `Exception thrown while applying callbacks during image layer extraction: ${error}`,
             );
             reject(error);
           }

--- a/lib/extractor/oci-archive/layer.ts
+++ b/lib/extractor/oci-archive/layer.ts
@@ -95,9 +95,7 @@ export async function extractArchive(
         );
       } catch (error) {
         debug(
-          `Error getting layers and manifest content from oci archive: '${JSON.stringify(
-            error,
-          )}'`,
+          `Error getting layers and manifest content from oci archive: '${error}'`,
         );
         reject(new Error("Invalid OCI archive"));
       }

--- a/lib/inputs/rpm/static.ts
+++ b/lib/inputs/rpm/static.ts
@@ -32,11 +32,7 @@ export async function getRpmDbFileContent(
     }
     return parserResponse.response;
   } catch (error) {
-    debug(
-      `An error occurred while analysing RPM packages: ${JSON.stringify(
-        error,
-      )}`,
-    );
+    debug(`An error occurred while analysing RPM packages: ${error}`);
     return "";
   }
 }
@@ -60,11 +56,7 @@ export async function getRpmSqliteDbFileContent(
     }
     return results.response;
   } catch (error) {
-    debug(
-      `An error occurred while analysing RPM packages: ${JSON.stringify(
-        error,
-      )}`,
-    );
+    debug(`An error occurred while analysing RPM packages: ${error}`);
     return [];
   }
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This commit removes all occurrences of printed errors that are being formatted with `JSON.stringify()`, as that formats the error to an empty object `{}`, which is not helpful.

It also removes calls to `debug` with `error` as the second argument, and embeds them into the string. This is purely to make all our error messages look the same.
