### PR TITLE
refactor: use new rpm parser version

### DIFF
--- a/lib/analyzer/package-managers/rpm.ts
+++ b/lib/analyzer/package-managers/rpm.ts
@@ -8,36 +8,22 @@ import {
 
 export function analyze(
   targetImage: string,
-  rpmDbFilecontent: string,
+  pkgs: PackageInfo[],
 ): Promise<ImagePackagesAnalysis> {
   return Promise.resolve({
     Image: targetImage,
     AnalyzeType: AnalysisType.Rpm,
-    Analysis: parseOutput(rpmDbFilecontent),
+    Analysis: pkgs.map((pkgInfo) => {
+      return {
+        Name: pkgInfo.name,
+        Version: formatRpmPackageVersion(pkgInfo),
+        Source: undefined,
+        Provides: [],
+        Deps: {},
+        AutoInstalled: undefined,
+      };
+    }),
   });
-}
-
-function parseOutput(output: string) {
-  const pkgs: AnalyzedPackageWithVersion[] = [];
-  for (const line of output.split("\n")) {
-    parseLine(line, pkgs);
-  }
-  return pkgs;
-}
-
-function parseLine(text: string, pkgs: AnalyzedPackageWithVersion[]) {
-  const [name, version, size] = text.split("\t");
-  if (name && version && size) {
-    const pkg: AnalyzedPackageWithVersion = {
-      Name: name,
-      Version: version,
-      Source: undefined,
-      Provides: [],
-      Deps: {},
-      AutoInstalled: undefined,
-    };
-    pkgs.push(pkg);
-  }
 }
 
 export function mapRpmSqlitePackages(

--- a/lib/inputs/rpm/static.ts
+++ b/lib/inputs/rpm/static.ts
@@ -1,6 +1,6 @@
 import { getPackages, getPackagesSqlite } from "@snyk/rpm-parser";
 import { PackageInfo } from "@snyk/rpm-parser/lib/rpm/types";
-import { IParserSqliteResponse } from "@snyk/rpm-parser/lib/types";
+import { Response } from "@snyk/rpm-parser/lib/types";
 import * as Debug from "debug";
 import { normalize as normalizePath } from "path";
 import { getContentAsBuffer } from "../../extractor";
@@ -19,10 +19,10 @@ export const getRpmDbFileContentAction: ExtractAction = {
 
 export async function getRpmDbFileContent(
   extractedLayers: ExtractedLayers,
-): Promise<string> {
+): Promise<PackageInfo[]> {
   const rpmDb = getContentAsBuffer(extractedLayers, getRpmDbFileContentAction);
   if (!rpmDb) {
-    return "";
+    return [];
   }
 
   try {
@@ -33,7 +33,7 @@ export async function getRpmDbFileContent(
     return parserResponse.response;
   } catch (error) {
     debug(`An error occurred while analysing RPM packages: ${error}`);
-    return "";
+    return [];
   }
 }
 
@@ -49,7 +49,7 @@ export async function getRpmSqliteDbFileContent(
   }
 
   try {
-    const results: IParserSqliteResponse = await getPackagesSqlite(rpmDb);
+    const results: Response = await getPackagesSqlite(rpmDb);
 
     if (results.error) {
       throw results.error;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@snyk/composer-lockfile-parser": "^1.4.1",
     "@snyk/dep-graph": "^2.3.0",
-    "@snyk/rpm-parser": "^2.3.2",
+    "@snyk/rpm-parser": "3.0.0",
     "@snyk/snyk-docker-pull": "^3.7.5",
     "adm-zip": "^0.5.5",
     "chalk": "^2.4.2",


### PR DESCRIPTION
This commit switches to the new rpm parser that supports modules.

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Switches to the new RPM Parser version with an improved interface.

#### Any background context you want to provide?

The upcoming changes for redhat required a new API, which was the initial motivation for this PR. I've split up the API changes with the module handling now to get this merged earlier.