### PR TITLE
fix: Restore system proxy configuration if available

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -12,11 +12,23 @@ function execute(
   args: string[],
   options?,
 ): Promise<CmdOutput> {
-  const spawnOptions: any = { shell: true };
+  const spawnOptions: any = { shell: true, env: process.env };
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
   args = quoteAll(args, spawnOptions);
+
+  // Before spawning an external process, we look if we need to restore the system proxy configuration,
+  // which overides the cli internal proxy configuration.
+  if (process.env.SNYK_SYSTEM_HTTP_PROXY !== undefined) {
+    spawnOptions.env.HTTP_PROXY = process.env.SNYK_SYSTEM_HTTP_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_HTTPS_PROXY !== undefined) {
+    spawnOptions.env.HTTPS_PROXY = process.env.SNYK_SYSTEM_HTTPS_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_NO_PROXY !== undefined) {
+    spawnOptions.env.NO_PROXY = process.env.SNYK_SYSTEM_NO_PROXY;
+  }
 
   return new Promise((resolve, reject) => {
     let stdout = "";


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
The Extensible CLI uses an internal proxy/gateway to forward traffic to snyk.io. Some external tools like docker would by default also pass their traffic through the internal proxy. In case of docker this can cause different issues, which is why this PR restores the system proxy configuration before spawning the docker client.

#### Where should the reviewer start?
lib/sub-process.ts

#### What are the relevant tickets?
HMMR-627

