### PR TITLE
RUN-2459 fix: pass image with digest via options for kubernetes monitor

### DIFF
--- a/lib/extractor/image.ts
+++ b/lib/extractor/image.ts
@@ -1,4 +1,6 @@
-export { ImageName, ImageDigest };
+import { PluginOptions } from "../types";
+
+export { ImageName, ImageDigest, getImageNames };
 class ImageName {
   public name: string;
   public tag?: string;
@@ -129,4 +131,29 @@ class ImageDigest {
   public toString(): string {
     return this.alg + ":" + this.hex;
   }
+}
+
+function getImageNames(
+  options?: Partial<PluginOptions>,
+  imageName?: ImageName,
+): string[] {
+  if (imageName) {
+    return imageName.getAllNames();
+  }
+
+  const names: string[] = [];
+  if (options?.imageNameAndTag) {
+    const imageName = new ImageName(options.imageNameAndTag);
+    names.push(...imageName.getAllNames());
+  }
+
+  if (
+    options?.imageNameAndDigest &&
+    options?.imageNameAndDigest !== options?.imageNameAndTag
+  ) {
+    const imageName = new ImageName(options.imageNameAndDigest);
+    names.push(...imageName.getAllNames());
+  }
+
+  return names;
 }

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -6,7 +6,6 @@ import * as facts from "./facts";
 
 import { instructionDigest } from "./dockerfile";
 import { DockerFileAnalysis, DockerFilePackages } from "./dockerfile/types";
-import { ImageName } from "./extractor/image";
 import * as types from "./types";
 
 export { buildResponse };
@@ -18,7 +17,7 @@ async function buildResponse(
   },
   dockerfileAnalysis: DockerFileAnalysis | undefined,
   excludeBaseImageVulns: boolean,
-  imageName?: ImageName,
+  names?: string[],
 ): Promise<types.PluginResponse> {
   const deps = depsAnalysis.depTree.dependencies;
   const dockerfilePkgs = collectDockerfilePkgs(dockerfileAnalysis, deps);
@@ -182,8 +181,7 @@ async function buildResponse(
     data: depGraph,
   };
 
-  if (imageName) {
-    const names = imageName.getAllNames();
+  if (names) {
     if (names.length > 0) {
       const imageNameInfo = { names };
       const imageNamesFact: facts.ImageNamesFact = {

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -2,7 +2,7 @@ import * as analyzer from "./analyzer";
 import { StaticAnalysis } from "./analyzer/types";
 import { buildTree } from "./dependency-tree";
 import { DockerFileAnalysis } from "./dockerfile/types";
-import { ImageName } from "./extractor/image";
+import { getImageNames, ImageName } from "./extractor/image";
 import { isTrue } from "./option-utils";
 import { parseAnalysisResults } from "./parser";
 import { buildResponse } from "./response-builder";
@@ -51,10 +51,13 @@ export async function analyzeStatically(
   };
 
   const excludeBaseImageVulns = isTrue(options["exclude-base-image-vulns"]);
+
+  const names = getImageNames(options, imageName);
+
   return buildResponse(
     analysis,
     dockerfileAnalysis,
     excludeBaseImageVulns,
-    imageName,
+    names,
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -151,6 +151,14 @@ export interface PluginOptions {
   imageNameAndTag: string;
 
   /**
+   * WARNING! This is NOT used by the Snyk CLI!
+   *
+   * It is used by K8s-Monitor to preserve the imageNameAndDigest if we can extract this
+   * information from the workload metadata when scanning archives.
+   */
+  imageNameAndDigest: string;
+
+  /**
    * Provide patterns on which to match for detecting package manager manifest files.
    * Used for the APP+OS deps feature, not by the CLI.
    */

--- a/test/lib/extractor/image.spec.ts
+++ b/test/lib/extractor/image.spec.ts
@@ -1,4 +1,4 @@
-import { ImageName } from "../../../lib/extractor/image";
+import { getImageNames, ImageName } from "../../../lib/extractor/image";
 
 const imageCases = [
   ["nginx:latest", {}, "nginx", "latest", ["nginx:latest"]],
@@ -75,5 +75,56 @@ describe("ImageName class can handle given inputs", () => {
         message: expect.stringContaining("unsupported digest algorithm"),
       }),
     );
+  });
+});
+
+describe("getImageNames can handle given inputs", () => {
+  test("getImageNames return an array with name and tag when only imageNameAndTag option was provided", () => {
+    const names = getImageNames({ imageNameAndTag: "nginx:latest" }, undefined);
+    expect(names).toEqual(["nginx:latest"]);
+  });
+
+  test("getImageNames return an array with two elements when only imageNameAndTag and imageNameAndDigest options were provided", () => {
+    const names = getImageNames(
+      {
+        imageNameAndTag: "nginx:latest",
+        imageNameAndDigest:
+          "nginx@sha256:a29baa1d6820ccfc12f25dd9b4de24b998cab06826df2704fc8182e437147a5b",
+      },
+      undefined,
+    );
+    expect(names).toEqual([
+      "nginx:latest",
+      "nginx@sha256:a29baa1d6820ccfc12f25dd9b4de24b998cab06826df2704fc8182e437147a5b",
+    ]);
+  });
+
+  test("getImageNames return an array with one elements when imageNameAndTag and imageNameAndDigest options are the same", () => {
+    const names = getImageNames(
+      {
+        imageNameAndTag:
+          "nginx@sha256:a29baa1d6820ccfc12f25dd9b4de24b998cab06826df2704fc8182e437147a5b",
+        imageNameAndDigest:
+          "nginx@sha256:a29baa1d6820ccfc12f25dd9b4de24b998cab06826df2704fc8182e437147a5b",
+      },
+      undefined,
+    );
+    expect(names).toEqual([
+      "nginx@sha256:a29baa1d6820ccfc12f25dd9b4de24b998cab06826df2704fc8182e437147a5b",
+    ]);
+  });
+
+  test("getImageNames return an array when an imageName instance was provided", () => {
+    const image = "nginx:latest";
+    const digest = {
+      manifest:
+        "sha256:9604d5d228cf1ba638a767b0d879b600cf288c5aecd68c8b35e30911aadf0dab",
+    };
+    const imageName = new ImageName(image, digest);
+    const names = getImageNames(undefined, imageName);
+    expect(names).toEqual([
+      "nginx:latest",
+      "nginx@sha256:9604d5d228cf1ba638a767b0d879b600cf288c5aecd68c8b35e30911aadf0dab",
+    ]);
   });
 });

--- a/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
@@ -8118,6 +8118,14 @@ Object {
           },
           "type": "autoDetectedUserInstructions",
         },
+        Object {
+          "data": Object {
+            "names": Array [
+              "snyk/runtime-fixtures:dockergoof",
+            ],
+          },
+          "type": "imageNames",
+        },
       ],
       "identity": Object {
         "args": Object {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Pass the image name with digest via options for Kubernetes Monitor, so we can add that into the imageName facts.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-2459

#### Screenshots


#### Additional questions
