### PR TITLE
chore: pin semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
       - run: npm run build
       - run:
           name: Release on GitHub
-          command: npx semantic-release
+          command: npx semantic-release@19.0.5
 
 workflows:
   version: 2


### PR DESCRIPTION
v20 requires node >=18
