### PR TITLE
fix: fallback to other archive extractor in case of failure

### DIFF
--- a/test/lib/extractor/extractor.spec.ts
+++ b/test/lib/extractor/extractor.spec.ts
@@ -67,10 +67,10 @@ describe("extractImageContent", () => {
       await expect(extractImageContent(0, fixture, [])).resolves.not.toThrow();
     });
 
-    it("throws InvalidArchive error when type is set to docker-archive", async () => {
+    it("successfully extracts the archive when image type is set to docker-archive", async () => {
       await expect(
         extractImageContent(ImageType.DockerArchive, fixture, []),
-      ).rejects.toThrow(InvalidArchiveError);
+      ).resolves.not.toThrow();
     });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

Attempt to extract oci archive even if the use specified that the archive is a docker archive.
The user of the plugin doesn't necessarily know the archive type. 
Changed to always attempt to use the OCI extractor if the Docker extractor failed. 

