### PR TITLE
chore: uses team-lumos context in build pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,11 +207,14 @@ workflows:
     jobs:
       - install:
           name: Install
-          context: nodejs-install
+          context: 
+            - nodejs-install
+            - team-lumos
       - lint:
           name: Lint
           context:
             - nodejs-install
+            - team-lumos
             - snyk-bot-slack
           requires:
             - Install
@@ -229,6 +232,7 @@ workflows:
           name: Test
           context:
             - nodejs-install
+            - team-lumos
             - snyk-bot-slack
           requires:
             - Build
@@ -238,6 +242,7 @@ workflows:
           name: Test Windows
           context:
             - nodejs-install
+            - team-lumos
             - snyk-bot-slack
           node_version: "12"
           requires:
@@ -248,6 +253,7 @@ workflows:
           name: Test Jest Windows
           context:
             - nodejs-install
+            - team-lumos
             - snyk-bot-slack
           node_version: "12"
           requires:
@@ -258,6 +264,7 @@ workflows:
           name: Build CLI with changes
           context:
             - nodejs-install
+            - team-lumos
             - snyk-bot-slack
           requires:
             - Build
@@ -267,6 +274,7 @@ workflows:
           name: Release to GitHub
           context:
             - nodejs-lib-release
+            - team-lumos
             - snyk-bot-slack
           filters:
             branches:
@@ -289,12 +297,16 @@ workflows:
     jobs:
       - install:
           name: Install
-          context: nodejs-install
+          context: 
+            - nodejs-install
+            - team-lumos
           post-steps:
             - *slack-fail-notify
       - build_and_test_latest_go_binary:
           name: Build Go binary
-          context: nodejs-install
+          context: 
+            - nodejs-install
+            - team-lumos
           requires:
             - Install
           post-steps:


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

### What this does

As part of the decommissioning of the `snyksec` GH account, a new `team-lumos` context has been created to allow team specific control over service accounts; namely the use of `GH_TOKEN` and `NPM_TOKEN` env vars used in nodejs install and release jobs.

### Notes for the reviewer

The new context has been added, in addition, to existing contexts, where the `GH_TOKEN` is required. Also changed the context from `snyk-lumos` to `team-lumos` for Snyk tests as it makes more sense to manage a single context for our pipelines.

### More information

- [Jira Ticket](https://snyksec.atlassian.net/browse/LUM-280)