### PR TITLE
feat: include upstream/source name and version in purl

### DIFF
--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -9,6 +9,7 @@ export interface AnalyzedPackage {
   Name: string;
   Version?: string;
   Source?: string;
+  SourceVersion?: string;
   Provides: string[];
   Deps: {
     [name: string]: any;

--- a/lib/dependency-tree/index.ts
+++ b/lib/dependency-tree/index.ts
@@ -124,6 +124,7 @@ export function buildTree(
       const pkg = {
         name: depFullName(depInfo),
         version: depInfo.Version,
+        sourceVersion: depInfo.SourceVersion,
       };
       metaSubtree.dependencies[pkg.name] = pkg;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1448,9 +1448,9 @@
       }
     },
     "@snyk/dep-graph": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.6.1.tgz",
-      "integrity": "sha512-8N+wgLCUDGbyjDpHSpPICM+elcJ06WKFRl/1nVe6OE9dFBpjC64wtFohQgQDlazPxQC2eOLqImR8QlwNQ6hoDQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.7.0.tgz",
+      "integrity": "sha512-sdT56r9RFHL80HX0NqpIJOjhNNksHplnMwwrfRB24opdLa0/k3GilPcWreKJgs25A2610JVSBY9s6AfrNr1ReA==",
       "requires": {
         "event-loop-spinner": "^2.1.0",
         "lodash.clone": "^4.5.0",
@@ -1474,9 +1474,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-          "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+          "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         }
       }
     },
@@ -2115,7 +2115,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "arg": {
@@ -2135,7 +2135,7 @@
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true
     },
     "arr-flatten": {
@@ -2147,7 +2147,7 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true
     },
     "array-buffer-byte-length": {
@@ -2163,7 +2163,7 @@
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
       "dev": true
     },
     "array-ify": {
@@ -2180,7 +2180,7 @@
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true
     },
     "arrify": {
@@ -2205,13 +2205,13 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true
     },
     "async": {
@@ -2231,7 +2231,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "atob": {
@@ -2249,7 +2249,7 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true
     },
     "aws4": {
@@ -2424,7 +2424,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -2469,7 +2469,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -2527,7 +2527,7 @@
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
       "requires": {
         "pako": "~0.2.0"
       }
@@ -2585,7 +2585,7 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==",
       "dev": true
     },
     "cache-base": {
@@ -2728,7 +2728,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
     "chalk": {
@@ -2794,7 +2794,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -2834,7 +2834,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -2846,7 +2846,7 @@
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
@@ -2864,7 +2864,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "color-support": {
       "version": "1.1.3",
@@ -2890,7 +2890,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "compare-func": {
@@ -2912,7 +2912,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "conventional-changelog-angular": {
       "version": "5.0.13",
@@ -2969,7 +2969,7 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
     },
     "core-util-is": {
@@ -3115,7 +3115,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -3150,7 +3150,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "decamelize-keys": {
@@ -3213,7 +3213,7 @@
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "integrity": "sha512-B0n2zDIXpzLzKeoEozorDSa1cHc1t0NjmxP0zuAxbizNU2MBqYJJKYXrrFdKuQliojXynrxgd7l4ahfg/+aA5g==",
       "dev": true,
       "requires": {
         "strip-bom": "^3.0.0"
@@ -3222,7 +3222,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
           "dev": true
         }
       }
@@ -3285,7 +3285,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "detect-newline": {
@@ -3413,7 +3413,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
@@ -3457,7 +3457,7 @@
     "endian-reader": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/endian-reader/-/endian-reader-0.3.0.tgz",
-      "integrity": "sha1-hOykNrgK7Q0GOcRykTOLky7+UKA="
+      "integrity": "sha512-zPlHN59VLEjeJtpEU41ti/i7ZvTbwclvUN2M8anCsI3tOC/3mq6WNTJEKi49A5eLGvDkA0975LZb67Xwp7u4xQ=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3547,7 +3547,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "escodegen": {
       "version": "2.0.0",
@@ -3603,7 +3603,7 @@
     "event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
       "dev": true,
       "requires": {
         "duplexer": "~0.1.1",
@@ -3618,7 +3618,7 @@
     "events-to-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "integrity": "sha512-inRWzRY7nG+aXZxBzEqYKB3HPgwflZRopAjDCHv0whhRx+MTUr1ei0ICZUypdyE0HRm4L2d5VEcIqLD6yl+BFA==",
       "dev": true
     },
     "exec-sh": {
@@ -3655,13 +3655,13 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
       "dev": true,
       "requires": {
         "debug": "^2.3.3",
@@ -3685,7 +3685,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -3694,7 +3694,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -3703,7 +3703,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -3830,7 +3830,7 @@
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -3867,7 +3867,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -3876,7 +3876,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -3916,7 +3916,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -3946,7 +3946,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastq": {
@@ -4026,7 +4026,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
           "dev": true
         },
         "pify": {
@@ -4065,7 +4065,7 @@
     "findit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
-      "integrity": "sha1-ZQnwEmr0wXhVHPqZOU4DLhOk1W4=",
+      "integrity": "sha512-ENZS237/Hr8bjczn5eKuBohLgaD0JyUd0arxretR1f9RO46vZHA1b2y0VorgGV3WaOT3c+78P8h7v4JGJ1i/rg==",
       "dev": true
     },
     "flow-parser": {
@@ -4108,13 +4108,13 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true
     },
     "foreground-child": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "integrity": "sha512-3TOY+4TKV0Ml83PXJQY+JFQaHNV38lzQDIzzXYg1kWdBLenGgoZhAs0CKgzI31vi2pWEpQMq/Yi4bpKwCPkw7g==",
       "dev": true,
       "requires": {
         "cross-spawn": "^4",
@@ -4124,7 +4124,7 @@
         "cross-spawn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -4153,7 +4153,7 @@
         "yallist": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
           "dev": true
         }
       }
@@ -4161,7 +4161,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true
     },
     "form-data": {
@@ -4178,7 +4178,7 @@
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
@@ -4187,7 +4187,7 @@
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "dev": true
     },
     "fs-constants": {
@@ -4198,7 +4198,7 @@
     "fs-exists-cached": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
-      "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
+      "integrity": "sha512-kSxoARUDn4F2RPXX48UXnaFKwVU7Ivd/6qpzZL29MCDmr9sTvybv4gFCp+qaI4fM9m0z9fgz/yJvi56GAz+BZg==",
       "dev": true
     },
     "fs-extra": {
@@ -4215,7 +4215,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -4313,13 +4313,13 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4448,7 +4448,7 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true,
       "optional": true
     },
@@ -4468,7 +4468,7 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true
     },
     "har-validator": {
@@ -4524,7 +4524,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -4557,7 +4557,7 @@
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
       "dev": true,
       "requires": {
         "get-value": "^2.0.6",
@@ -4568,7 +4568,7 @@
     "has-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
@@ -4578,7 +4578,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -4587,7 +4587,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -4598,7 +4598,7 @@
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4609,7 +4609,7 @@
     "hasha": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "integrity": "sha512-w0Kz8lJFBoyaurBiNrIvxPqr/gJ6fOfSkpAPOepN3oECqGJag37xPbOv57izi/KP8auHgNYxn5fXtAb+1LsJ6w==",
       "dev": true,
       "requires": {
         "is-stream": "^1.0.1"
@@ -4666,7 +4666,7 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -4748,7 +4748,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -4759,7 +4759,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4795,7 +4795,7 @@
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
@@ -4804,7 +4804,7 @@
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4826,7 +4826,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "is-bigint": {
@@ -4889,7 +4889,7 @@
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
@@ -4898,7 +4898,7 @@
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4918,7 +4918,7 @@
     "is-deflate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
-      "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
+      "integrity": "sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -4949,13 +4949,13 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -4980,7 +4980,7 @@
     "is-gzip": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+      "integrity": "sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ=="
     },
     "is-negative-zero": {
       "version": "2.0.2",
@@ -5097,7 +5097,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-weakref": {
@@ -5128,23 +5128,23 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -5217,7 +5217,7 @@
         "path-key": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
           "dev": true
         },
         "rimraf": {
@@ -5238,7 +5238,7 @@
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -5247,7 +5247,7 @@
         "shebang-regex": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
           "dev": true
         },
         "uuid": {
@@ -6869,7 +6869,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
     "jsdom": {
@@ -6957,7 +6957,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "json5": {
@@ -7023,7 +7023,7 @@
     "lcov-parse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
       "dev": true
     },
     "leven": {
@@ -7035,7 +7035,7 @@
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -7051,7 +7051,7 @@
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -7063,7 +7063,7 @@
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
           "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
@@ -7073,7 +7073,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
           "dev": true
         }
       }
@@ -7131,7 +7131,7 @@
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "lodash.foreach": {
@@ -7142,7 +7142,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "lodash.has": {
       "version": "4.5.2",
@@ -7330,7 +7330,7 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true
     },
     "map-obj": {
@@ -7342,13 +7342,13 @@
     "map-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
@@ -7532,7 +7532,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "needle": {
@@ -7594,19 +7594,19 @@
     "node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
+      "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
       "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
     "node-modules-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "integrity": "sha512-JMaRS9L4wSRIR+6PTVEikTrq/lMGEZR43a48ETeilY0Q0iMwVnccMFrUM1k+tNzmYuIU0Vh710bCUqHX+/+ctQ==",
       "dev": true
     },
     "node-notifier": {
@@ -7857,7 +7857,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "istanbul-lib-coverage": {
@@ -7984,7 +7984,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
           "dev": true
         },
         "path-type": {
@@ -7999,7 +7999,7 @@
             "pify": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
               "dev": true
             }
           }
@@ -8013,7 +8013,7 @@
         "read-pkg": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
           "dev": true,
           "requires": {
             "load-json-file": "^4.0.0",
@@ -8155,13 +8155,13 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -8172,7 +8172,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -8181,7 +8181,7 @@
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -8208,7 +8208,7 @@
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
@@ -8228,7 +8228,7 @@
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -8237,7 +8237,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
@@ -8274,13 +8274,13 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true
     },
     "own-or": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
-      "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+      "integrity": "sha512-NfZr5+Tdf6MB8UI9GLvKRs4cXY8/yB0w3xtt84xFdWy8hkGjn+JFc60VhzS/hFRfbyxFcGYMTjnF4Me+RbbqrA==",
       "dev": true
     },
     "own-or-env": {
@@ -8306,7 +8306,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "dev": true
     },
     "p-limit": {
@@ -8352,14 +8352,14 @@
       }
     },
     "packageurl-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.0.0.tgz",
-      "integrity": "sha512-06kNFU+yB2pjDf5JyXouQeKfwSScGP8hrZK6VgB+W4SlVy4y5yB4vl+AVmh3R0GBNd+fBt0dEiSx3HKmuchuJQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.0.2.tgz",
+      "integrity": "sha512-fWC4ZPxo80qlh3xN5FxfIoQD3phVY4+EyzTIqyksjhKNDmaicdpxSvkWwIrYTtv9C1/RcUN6pxaTwGmj2NzS6A=="
     },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -8399,7 +8399,7 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "dev": true
     },
     "path-exists": {
@@ -8411,7 +8411,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -8436,7 +8436,7 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
           "dev": true
         }
       }
@@ -8449,7 +8449,7 @@
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
       "dev": true,
       "requires": {
         "through": "~2.3"
@@ -8468,7 +8468,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "dev": true
     },
     "picocolors": {
@@ -8517,13 +8517,13 @@
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true
     },
     "prettier": {
@@ -8627,7 +8627,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
     "psl": {
@@ -8822,7 +8822,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -8831,7 +8831,7 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "dev": true
     },
     "repeat-element": {
@@ -8843,7 +8843,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true
     },
     "request": {
@@ -8906,7 +8906,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-from-string": {
@@ -8970,7 +8970,7 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "dev": true
     },
     "responselike": {
@@ -9022,7 +9022,7 @@
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
       "dev": true,
       "requires": {
         "ret": "~0.1.10"
@@ -9092,7 +9092,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -9131,7 +9131,7 @@
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -9143,7 +9143,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -9163,7 +9163,7 @@
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -9172,7 +9172,7 @@
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -9210,7 +9210,7 @@
         "normalize-path": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
           "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
@@ -9265,7 +9265,7 @@
         "to-regex-range": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -9308,7 +9308,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "set-value": {
@@ -9326,7 +9326,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -9449,7 +9449,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -9458,7 +9458,7 @@
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
@@ -9467,13 +9467,13 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
           "dev": true
         }
       }
@@ -9492,7 +9492,7 @@
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -9541,7 +9541,7 @@
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -9753,7 +9753,7 @@
     "split": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
       "dev": true,
       "requires": {
         "through": "2"
@@ -9785,7 +9785,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "sql.js": {
       "version": "1.8.0",
@@ -9840,7 +9840,7 @@
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "dev": true,
       "requires": {
         "define-property": "^0.2.5",
@@ -9850,7 +9850,7 @@
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -9866,7 +9866,7 @@
     "stream-combiner": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
       "dev": true,
       "requires": {
         "duplexer": "~0.1.1"
@@ -10010,7 +10010,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
       "dev": true
     },
     "strip-final-newline": {
@@ -11393,7 +11393,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "through2": {
@@ -11451,13 +11451,13 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
@@ -11466,7 +11466,7 @@
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -11668,7 +11668,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -11677,12 +11677,12 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -11768,7 +11768,7 @@
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
       "dev": true,
       "requires": {
         "has-value": "^0.3.1",
@@ -11778,7 +11778,7 @@
         "has-value": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
           "dev": true,
           "requires": {
             "get-value": "^2.0.3",
@@ -11789,7 +11789,7 @@
             "isobject": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
               "dev": true,
               "requires": {
                 "isarray": "1.0.0"
@@ -11800,7 +11800,7 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
           "dev": true
         }
       }
@@ -11827,7 +11827,7 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "dev": true
     },
     "url-parse": {
@@ -11849,7 +11849,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "8.3.2",
@@ -11899,7 +11899,7 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -12020,7 +12020,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "which-typed-array": {
@@ -12083,7 +12083,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -12140,7 +12140,7 @@
     "yapool": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
-      "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
+      "integrity": "sha512-RONBZndo8Lo8pKPfORRxr2DIk2NZKIml654o4kaIu7RXVxQCKsAN6AqrcoZsI3h+2H5YO2mD/04Wy4LbAgd+Pg==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@snyk/composer-lockfile-parser": "^1.4.1",
-    "@snyk/dep-graph": "^2.6.1",
+    "@snyk/dep-graph": "^2.7.0",
     "@snyk/docker-registry-v2-client": "^2.10.0",
     "@snyk/rpm-parser": "3.1.0",
     "@snyk/snyk-docker-pull": "^3.9.0",
@@ -44,7 +44,7 @@
     "event-loop-spinner": "^2.0.0",
     "gunzip-maybe": "^1.4.2",
     "mkdirp": "^1.0.4",
-    "packageurl-js": "^1.0.0",
+    "packageurl-js": "^1.0.2",
     "semver": "^7.5.1",
     "shescape": "1.6.6",
     "snyk-nodejs-lockfile-parser": "^1.49.0",

--- a/test/lib/analyzer/package-managers/apt.spec.ts
+++ b/test/lib/analyzer/package-managers/apt.spec.ts
@@ -1,0 +1,42 @@
+import { purl } from "../../../../lib/analyzer/package-managers/apt";
+import type { AnalyzedPackageWithVersion } from "../../../../lib/analyzer/types";
+
+describe("purl()", () => {
+  it.each([
+    [{ Name: undefined, Version: undefined }],
+    [{ Name: "foo", Version: undefined }],
+    [{ Name: undefined, Version: "bar" }],
+  ])("does not build a purl if Name or Version is missing: %s", (pkg) => {
+    expect(purl(pkg as unknown as AnalyzedPackageWithVersion)).toBeUndefined();
+  });
+
+  it("constructs a purl with name and version", () => {
+    expect(
+      purl({
+        Name: "bar",
+        Version: "1.2.3-4",
+      } as unknown as AnalyzedPackageWithVersion),
+    ).toEqual("pkg:deb/bar@1.2.3-4");
+  });
+
+  it("constructs a purl with source name", () => {
+    expect(
+      purl({
+        Source: "foo",
+        Name: "bar",
+        Version: "1.2.3-4",
+      } as unknown as AnalyzedPackageWithVersion),
+    ).toEqual("pkg:deb/bar@1.2.3-4?upstream=foo");
+  });
+
+  it("constructs a purl with upstream name and version", () => {
+    expect(
+      purl({
+        Source: "foo",
+        SourceVersion: "5.6.7+8",
+        Name: "bar",
+        Version: "1.2.3-4",
+      } as unknown as AnalyzedPackageWithVersion),
+    ).toEqual("pkg:deb/bar@1.2.3-4?upstream=foo%405.6.7%2B8");
+  });
+});

--- a/test/system/app-os/__snapshots__/globs.spec.ts.snap
+++ b/test/system/app-os/__snapshots__/globs.spec.ts.snap
@@ -1216,6 +1216,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
+                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1223,6 +1224,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
+                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1230,6 +1232,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
+                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1237,6 +1240,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1244,6 +1248,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1251,6 +1256,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1258,6 +1264,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1265,6 +1272,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1272,6 +1280,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1279,6 +1288,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1286,6 +1296,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1293,6 +1304,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.118",
                   "version": "3.118",
                 },
               },
@@ -1300,6 +1312,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1307,6 +1320,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
+                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1314,6 +1328,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1321,6 +1336,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
                   "version": "1.8.4-5",
                 },
               },
@@ -1328,6 +1344,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@241-7~deb10u4?upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1335,6 +1352,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@241-7~deb10u4?upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1342,6 +1360,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2.1",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2.1?upstream=apt",
                   "version": "1.8.2.1",
                 },
               },
@@ -1349,6 +1368,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
                   "version": "2019.1",
                 },
               },
@@ -1356,6 +1376,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1363,6 +1384,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1370,6 +1392,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
+                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1377,6 +1400,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
+                  "purl": "pkg:deb/libidn2-0@2.0.5-1%2Bdeb10u1?upstream=libidn2",
                   "version": "2.0.5-1+deb10u1",
                 },
               },
@@ -1384,6 +1408,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.13-3",
                   "version": "4.13-3",
                 },
               },
@@ -1391,6 +1416,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
+                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1398,6 +1424,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1405,6 +1432,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
+                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1412,6 +1440,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
+                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1419,6 +1448,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1426,6 +1456,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
+                  "purl": "pkg:deb/libgnutls30@3.6.7-4%2Bdeb10u5?upstream=gnutls28",
                   "version": "3.6.7-4+deb10u5",
                 },
               },
@@ -1433,6 +1464,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
+                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1440,6 +1472,7 @@ Object {
                 "id": "apt@1.8.2.1",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.8.2.1",
                   "version": "1.8.2.1",
                 },
               },
@@ -1447,6 +1480,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1454,6 +1488,7 @@ Object {
                 "id": "base-files@10.3+deb10u6",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u6",
                   "version": "10.3+deb10u6",
                 },
               },
@@ -1461,6 +1496,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1468,6 +1504,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.46",
                   "version": "3.5.46",
                 },
               },
@@ -1475,6 +1512,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.6.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -1482,6 +1520,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
+                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1489,6 +1528,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@5.0-4",
                   "version": "5.0-4",
                 },
               },
@@ -1496,6 +1536,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.30-3",
                   "version": "8.30-3",
                 },
               },
@@ -1503,6 +1544,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.10.2-5",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1510,6 +1552,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
                 },
               },
@@ -1517,6 +1560,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
+                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1524,6 +1568,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
+                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1531,6 +1576,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1538,6 +1584,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1545,6 +1592,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1552,6 +1600,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u3",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1559,6 +1608,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1566,6 +1616,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1573,6 +1624,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@3.3-1",
                   "version": "3.3-1",
                 },
               },
@@ -1580,6 +1632,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.9-3",
                   "version": "1.9-3",
                 },
               },
@@ -1587,6 +1640,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.21",
                   "version": "3.21",
                 },
               },
@@ -1594,6 +1648,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1601,6 +1656,7 @@ Object {
                 "id": "elfutils/libelf1@0.176-1.1",
                 "info": Object {
                   "name": "elfutils/libelf1",
+                  "purl": "pkg:deb/libelf1@0.176-1.1?upstream=elfutils",
                   "version": "0.176-1.1",
                 },
               },
@@ -1608,6 +1664,7 @@ Object {
                 "id": "iptables/libxtables12@1.8.2-4",
                 "info": Object {
                   "name": "iptables/libxtables12",
+                  "purl": "pkg:deb/libxtables12@1.8.2-4?upstream=iptables",
                   "version": "1.8.2-4",
                 },
               },
@@ -1615,6 +1672,7 @@ Object {
                 "id": "libcap2@1:2.25-2",
                 "info": Object {
                   "name": "libcap2",
+                  "purl": "pkg:deb/libcap2@1:2.25-2",
                   "version": "1:2.25-2",
                 },
               },
@@ -1622,6 +1680,7 @@ Object {
                 "id": "libcap2/libcap2-bin@1:2.25-2",
                 "info": Object {
                   "name": "libcap2/libcap2-bin",
+                  "purl": "pkg:deb/libcap2-bin@1:2.25-2?upstream=libcap2",
                   "version": "1:2.25-2",
                 },
               },
@@ -1629,6 +1688,7 @@ Object {
                 "id": "libmnl/libmnl0@1.0.4-2",
                 "info": Object {
                   "name": "libmnl/libmnl0",
+                  "purl": "pkg:deb/libmnl0@1.0.4-2?upstream=libmnl",
                   "version": "1.0.4-2",
                 },
               },
@@ -1636,6 +1696,7 @@ Object {
                 "id": "iproute2@4.20.0-2",
                 "info": Object {
                   "name": "iproute2",
+                  "purl": "pkg:deb/iproute2@4.20.0-2",
                   "version": "4.20.0-2",
                 },
               },
@@ -1643,6 +1704,7 @@ Object {
                 "id": "iputils/iputils-ping@3:20180629-2+deb10u1",
                 "info": Object {
                   "name": "iputils/iputils-ping",
+                  "purl": "pkg:deb/iputils-ping@3:20180629-2%2Bdeb10u1?upstream=iputils",
                   "version": "3:20180629-2+deb10u1",
                 },
               },
@@ -1755,6 +1817,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
+                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1762,6 +1825,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1769,6 +1833,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1776,6 +1841,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1783,6 +1849,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.7-1",
                   "version": "4.7-1",
                 },
               },
@@ -1790,6 +1857,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1797,6 +1865,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1804,6 +1873,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1811,6 +1881,7 @@ Object {
                 "id": "tzdata@2020d-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2020d-0%2Bdeb10u1",
                   "version": "2020d-0+deb10u1",
                 },
               },
@@ -1818,6 +1889,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1825,6 +1897,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1832,6 +1905,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1839,6 +1913,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1846,6 +1921,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
+                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1853,6 +1929,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
@@ -4922,6 +4922,7 @@ Object {
                 "id": "acl@2.2.52-2",
                 "info": Object {
                   "name": "acl",
+                  "purl": "pkg:deb/acl@2.2.52-2",
                   "version": "2.2.52-2",
                 },
               },
@@ -4929,6 +4930,7 @@ Object {
                 "id": "apt/libapt-pkg4.12@1.0.9.8.4",
                 "info": Object {
                   "name": "apt/libapt-pkg4.12",
+                  "purl": "pkg:deb/libapt-pkg4.12@1.0.9.8.4?upstream=apt",
                   "version": "1.0.9.8.4",
                 },
               },
@@ -4936,6 +4938,7 @@ Object {
                 "id": "debian-archive-keyring@2017.5~deb8u1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2017.5~deb8u1",
                   "version": "2017.5~deb8u1",
                 },
               },
@@ -4943,6 +4946,7 @@ Object {
                 "id": "gnupg@1.4.18-7+deb8u4",
                 "info": Object {
                   "name": "gnupg",
+                  "purl": "pkg:deb/gnupg@1.4.18-7%2Bdeb8u4",
                   "version": "1.4.18-7+deb8u4",
                 },
               },
@@ -4950,6 +4954,7 @@ Object {
                 "id": "apt@1.0.9.8.4",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.0.9.8.4",
                   "version": "1.0.9.8.4",
                 },
               },
@@ -4957,6 +4962,7 @@ Object {
                 "id": "libsigsegv/libsigsegv2@2.10-4+b1",
                 "info": Object {
                   "name": "libsigsegv/libsigsegv2",
+                  "purl": "pkg:deb/libsigsegv2@2.10-4%2Bb1?upstream=libsigsegv%402.10-4",
                   "version": "2.10-4+b1",
                 },
               },
@@ -4964,6 +4970,7 @@ Object {
                 "id": "m4@1.4.17-4",
                 "info": Object {
                   "name": "m4",
+                  "purl": "pkg:deb/m4@1.4.17-4",
                   "version": "1.4.17-4",
                 },
               },
@@ -4971,6 +4978,7 @@ Object {
                 "id": "gdbm/libgdbm3@1.8.3-13.1",
                 "info": Object {
                   "name": "gdbm/libgdbm3",
+                  "purl": "pkg:deb/libgdbm3@1.8.3-13.1?upstream=gdbm",
                   "version": "1.8.3-13.1",
                 },
               },
@@ -4978,6 +4986,7 @@ Object {
                 "id": "perl/perl-modules@5.20.2-3+deb8u10",
                 "info": Object {
                   "name": "perl/perl-modules",
+                  "purl": "pkg:deb/perl-modules@5.20.2-3%2Bdeb8u10?upstream=perl",
                   "version": "5.20.2-3+deb8u10",
                 },
               },
@@ -4985,6 +4994,7 @@ Object {
                 "id": "perl@5.20.2-3+deb8u10",
                 "info": Object {
                   "name": "perl",
+                  "purl": "pkg:deb/perl@5.20.2-3%2Bdeb8u10",
                   "version": "5.20.2-3+deb8u10",
                 },
               },
@@ -4992,6 +5002,7 @@ Object {
                 "id": "autoconf@2.69-8",
                 "info": Object {
                   "name": "autoconf",
+                  "purl": "pkg:deb/autoconf@2.69-8",
                   "version": "2.69-8",
                 },
               },
@@ -4999,6 +5010,7 @@ Object {
                 "id": "autotools-dev@20140911.1",
                 "info": Object {
                   "name": "autotools-dev",
+                  "purl": "pkg:deb/autotools-dev@20140911.1",
                   "version": "20140911.1",
                 },
               },
@@ -5006,6 +5018,7 @@ Object {
                 "id": "automake-1.14/automake@1:1.14.1-4+deb8u1",
                 "info": Object {
                   "name": "automake-1.14/automake",
+                  "purl": "pkg:deb/automake@1:1.14.1-4%2Bdeb8u1?upstream=automake-1.14",
                   "version": "1:1.14.1-4+deb8u1",
                 },
               },
@@ -5013,6 +5026,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.192",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.192?upstream=cdebconf",
                   "version": "0.192",
                 },
               },
@@ -5020,6 +5034,7 @@ Object {
                 "id": "base-passwd@3.5.37",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.37",
                   "version": "3.5.37",
                 },
               },
@@ -5027,6 +5042,7 @@ Object {
                 "id": "base-files@8+deb8u10",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@8%2Bdeb8u10",
                   "version": "8+deb8u10",
                 },
               },
@@ -5034,6 +5050,7 @@ Object {
                 "id": "dash/dash@0.5.7-4+b1",
                 "info": Object {
                   "name": "dash/dash",
+                  "purl": "pkg:deb/dash@0.5.7-4%2Bb1?upstream=dash%400.5.7-4",
                   "version": "0.5.7-4+b1",
                 },
               },
@@ -5041,6 +5058,7 @@ Object {
                 "id": "ncurses/libncurses5@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libncurses5",
+                  "purl": "pkg:deb/libncurses5@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -5048,6 +5066,7 @@ Object {
                 "id": "bash@4.3-11+deb8u1",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@4.3-11%2Bdeb8u1",
                   "version": "4.3-11+deb8u1",
                 },
               },
@@ -5055,6 +5074,7 @@ Object {
                 "id": "bzip2/bzip2@1.0.6-7+b3",
                 "info": Object {
                   "name": "bzip2/bzip2",
+                  "purl": "pkg:deb/bzip2@1.0.6-7%2Bb3?upstream=bzip2%401.0.6-7",
                   "version": "1.0.6-7+b3",
                 },
               },
@@ -5062,6 +5082,7 @@ Object {
                 "id": "bzip2/libbz2-dev@1.0.6-7+b3",
                 "info": Object {
                   "name": "bzip2/libbz2-dev",
+                  "purl": "pkg:deb/libbz2-dev@1.0.6-7%2Bb3?upstream=bzip2%401.0.6-7",
                   "version": "1.0.6-7+b3",
                 },
               },
@@ -5069,6 +5090,7 @@ Object {
                 "id": "python2.7/libpython2.7-stdlib@2.7.9-2+deb8u1",
                 "info": Object {
                   "name": "python2.7/libpython2.7-stdlib",
+                  "purl": "pkg:deb/libpython2.7-stdlib@2.7.9-2%2Bdeb8u1?upstream=python2.7",
                   "version": "2.7.9-2+deb8u1",
                 },
               },
@@ -5076,6 +5098,7 @@ Object {
                 "id": "python-defaults/libpython-stdlib@2.7.9-1",
                 "info": Object {
                   "name": "python-defaults/libpython-stdlib",
+                  "purl": "pkg:deb/libpython-stdlib@2.7.9-1?upstream=python-defaults",
                   "version": "2.7.9-1",
                 },
               },
@@ -5083,6 +5106,7 @@ Object {
                 "id": "python2.7/python2.7-minimal@2.7.9-2+deb8u1",
                 "info": Object {
                   "name": "python2.7/python2.7-minimal",
+                  "purl": "pkg:deb/python2.7-minimal@2.7.9-2%2Bdeb8u1?upstream=python2.7",
                   "version": "2.7.9-2+deb8u1",
                 },
               },
@@ -5090,6 +5114,7 @@ Object {
                 "id": "python-defaults/python-minimal@2.7.9-1",
                 "info": Object {
                   "name": "python-defaults/python-minimal",
+                  "purl": "pkg:deb/python-minimal@2.7.9-1?upstream=python-defaults",
                   "version": "2.7.9-1",
                 },
               },
@@ -5097,6 +5122,7 @@ Object {
                 "id": "mime-support@3.58",
                 "info": Object {
                   "name": "mime-support",
+                  "purl": "pkg:deb/mime-support@3.58",
                   "version": "3.58",
                 },
               },
@@ -5104,6 +5130,7 @@ Object {
                 "id": "ncurses/libncursesw5@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libncursesw5",
+                  "purl": "pkg:deb/libncursesw5@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -5111,6 +5138,7 @@ Object {
                 "id": "openssl/libssl1.0.0@1.0.1t-1+deb8u8",
                 "info": Object {
                   "name": "openssl/libssl1.0.0",
+                  "purl": "pkg:deb/libssl1.0.0@1.0.1t-1%2Bdeb8u8?upstream=openssl",
                   "version": "1.0.1t-1+deb8u8",
                 },
               },
@@ -5118,6 +5146,7 @@ Object {
                 "id": "python2.7/libpython2.7-minimal@2.7.9-2+deb8u1",
                 "info": Object {
                   "name": "python2.7/libpython2.7-minimal",
+                  "purl": "pkg:deb/libpython2.7-minimal@2.7.9-2%2Bdeb8u1?upstream=python2.7",
                   "version": "2.7.9-2+deb8u1",
                 },
               },
@@ -5125,6 +5154,7 @@ Object {
                 "id": "readline6/readline-common@6.3-8",
                 "info": Object {
                   "name": "readline6/readline-common",
+                  "purl": "pkg:deb/readline-common@6.3-8?upstream=readline6",
                   "version": "6.3-8",
                 },
               },
@@ -5132,6 +5162,7 @@ Object {
                 "id": "readline6/libreadline6@6.3-8+b3",
                 "info": Object {
                   "name": "readline6/libreadline6",
+                  "purl": "pkg:deb/libreadline6@6.3-8%2Bb3?upstream=readline6%406.3-8",
                   "version": "6.3-8+b3",
                 },
               },
@@ -5139,6 +5170,7 @@ Object {
                 "id": "sqlite3/libsqlite3-0@3.8.7.1-1+deb8u2",
                 "info": Object {
                   "name": "sqlite3/libsqlite3-0",
+                  "purl": "pkg:deb/libsqlite3-0@3.8.7.1-1%2Bdeb8u2?upstream=sqlite3",
                   "version": "3.8.7.1-1+deb8u2",
                 },
               },
@@ -5146,6 +5178,7 @@ Object {
                 "id": "python2.7@2.7.9-2+deb8u1",
                 "info": Object {
                   "name": "python2.7",
+                  "purl": "pkg:deb/python2.7@2.7.9-2%2Bdeb8u1",
                   "version": "2.7.9-2+deb8u1",
                 },
               },
@@ -5153,6 +5186,7 @@ Object {
                 "id": "python-defaults/python@2.7.9-1",
                 "info": Object {
                   "name": "python-defaults/python",
+                  "purl": "pkg:deb/python@2.7.9-1?upstream=python-defaults",
                   "version": "2.7.9-1",
                 },
               },
@@ -5160,6 +5194,7 @@ Object {
                 "id": "six/python-six@1.8.0-1",
                 "info": Object {
                   "name": "six/python-six",
+                  "purl": "pkg:deb/python-six@1.8.0-1?upstream=six",
                   "version": "1.8.0-1",
                 },
               },
@@ -5167,6 +5202,7 @@ Object {
                 "id": "configobj/python-configobj@5.0.6-1",
                 "info": Object {
                   "name": "configobj/python-configobj",
+                  "purl": "pkg:deb/python-configobj@5.0.6-1?upstream=configobj",
                   "version": "5.0.6-1",
                 },
               },
@@ -5174,6 +5210,7 @@ Object {
                 "id": "bzr/python-bzrlib@2.6.0+bzr6595-6+deb8u1",
                 "info": Object {
                   "name": "bzr/python-bzrlib",
+                  "purl": "pkg:deb/python-bzrlib@2.6.0%2Bbzr6595-6%2Bdeb8u1?upstream=bzr",
                   "version": "2.6.0+bzr6595-6+deb8u1",
                 },
               },
@@ -5181,6 +5218,7 @@ Object {
                 "id": "bzr@2.6.0+bzr6595-6+deb8u1",
                 "info": Object {
                   "name": "bzr",
+                  "purl": "pkg:deb/bzr@2.6.0%2Bbzr6595-6%2Bdeb8u1",
                   "version": "2.6.0+bzr6595-6+deb8u1",
                 },
               },
@@ -5188,6 +5226,7 @@ Object {
                 "id": "openssl@1.0.1t-1+deb8u8",
                 "info": Object {
                   "name": "openssl",
+                  "purl": "pkg:deb/openssl@1.0.1t-1%2Bdeb8u8",
                   "version": "1.0.1t-1+deb8u8",
                 },
               },
@@ -5195,6 +5234,7 @@ Object {
                 "id": "ca-certificates@20141019+deb8u3",
                 "info": Object {
                   "name": "ca-certificates",
+                  "purl": "pkg:deb/ca-certificates@20141019%2Bdeb8u3",
                   "version": "20141019+deb8u3",
                 },
               },
@@ -5202,6 +5242,7 @@ Object {
                 "id": "cryptsetup/libcryptsetup4@2:1.6.6-5",
                 "info": Object {
                   "name": "cryptsetup/libcryptsetup4",
+                  "purl": "pkg:deb/libcryptsetup4@2:1.6.6-5?upstream=cryptsetup",
                   "version": "2:1.6.6-5",
                 },
               },
@@ -5209,6 +5250,7 @@ Object {
                 "id": "krb5/libgssapi-krb5-2@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libgssapi-krb5-2",
+                  "purl": "pkg:deb/libgssapi-krb5-2@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -5216,6 +5258,7 @@ Object {
                 "id": "krb5/libkrb5-3@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkrb5-3",
+                  "purl": "pkg:deb/libkrb5-3@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -5223,6 +5266,7 @@ Object {
                 "id": "libidn/libidn11@1.29-1+deb8u2",
                 "info": Object {
                   "name": "libidn/libidn11",
+                  "purl": "pkg:deb/libidn11@1.29-1%2Bdeb8u2?upstream=libidn",
                   "version": "1.29-1+deb8u2",
                 },
               },
@@ -5230,6 +5274,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.17-3",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.17-3?upstream=libgpg-error",
                   "version": "1.17-3",
                 },
               },
@@ -5237,6 +5282,7 @@ Object {
                 "id": "libgcrypt20@1.6.3-2+deb8u4",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.6.3-2%2Bdeb8u4",
                   "version": "1.6.3-2+deb8u4",
                 },
               },
@@ -5244,6 +5290,7 @@ Object {
                 "id": "libssh2/libssh2-1@1.4.3-4.1+deb8u1",
                 "info": Object {
                   "name": "libssh2/libssh2-1",
+                  "purl": "pkg:deb/libssh2-1@1.4.3-4.1%2Bdeb8u1?upstream=libssh2",
                   "version": "1.4.3-4.1+deb8u1",
                 },
               },
@@ -5251,6 +5298,7 @@ Object {
                 "id": "openldap/libldap-2.4-2@2.4.40+dfsg-1+deb8u3",
                 "info": Object {
                   "name": "openldap/libldap-2.4-2",
+                  "purl": "pkg:deb/libldap-2.4-2@2.4.40%2Bdfsg-1%2Bdeb8u3?upstream=openldap",
                   "version": "2.4.40+dfsg-1+deb8u3",
                 },
               },
@@ -5258,6 +5306,7 @@ Object {
                 "id": "gnutls28/libgnutls-deb0-28@3.3.8-6+deb8u7",
                 "info": Object {
                   "name": "gnutls28/libgnutls-deb0-28",
+                  "purl": "pkg:deb/libgnutls-deb0-28@3.3.8-6%2Bdeb8u7?upstream=gnutls28",
                   "version": "3.3.8-6+deb8u7",
                 },
               },
@@ -5265,6 +5314,7 @@ Object {
                 "id": "nettle/libhogweed2@2.7.1-5+deb8u2",
                 "info": Object {
                   "name": "nettle/libhogweed2",
+                  "purl": "pkg:deb/libhogweed2@2.7.1-5%2Bdeb8u2?upstream=nettle",
                   "version": "2.7.1-5+deb8u2",
                 },
               },
@@ -5272,6 +5322,7 @@ Object {
                 "id": "nettle/libnettle4@2.7.1-5+deb8u2",
                 "info": Object {
                   "name": "nettle/libnettle4",
+                  "purl": "pkg:deb/libnettle4@2.7.1-5%2Bdeb8u2?upstream=nettle",
                   "version": "2.7.1-5+deb8u2",
                 },
               },
@@ -5279,6 +5330,7 @@ Object {
                 "id": "rtmpdump/librtmp1@2.4+20150115.gita107cef-1+deb8u1",
                 "info": Object {
                   "name": "rtmpdump/librtmp1",
+                  "purl": "pkg:deb/librtmp1@2.4%2B20150115.gita107cef-1%2Bdeb8u1?upstream=rtmpdump",
                   "version": "2.4+20150115.gita107cef-1+deb8u1",
                 },
               },
@@ -5286,6 +5338,7 @@ Object {
                 "id": "curl/libcurl3@7.38.0-4+deb8u11",
                 "info": Object {
                   "name": "curl/libcurl3",
+                  "purl": "pkg:deb/libcurl3@7.38.0-4%2Bdeb8u11?upstream=curl",
                   "version": "7.38.0-4+deb8u11",
                 },
               },
@@ -5293,6 +5346,7 @@ Object {
                 "id": "curl@7.38.0-4+deb8u11",
                 "info": Object {
                   "name": "curl",
+                  "purl": "pkg:deb/curl@7.38.0-4%2Bdeb8u11",
                   "version": "7.38.0-4+deb8u11",
                 },
               },
@@ -5300,6 +5354,7 @@ Object {
                 "id": "curl/libcurl4-openssl-dev@7.38.0-4+deb8u11",
                 "info": Object {
                   "name": "curl/libcurl4-openssl-dev",
+                  "purl": "pkg:deb/libcurl4-openssl-dev@7.38.0-4%2Bdeb8u11?upstream=curl",
                   "version": "7.38.0-4+deb8u11",
                 },
               },
@@ -5307,6 +5362,7 @@ Object {
                 "id": "db5.3/libdb5.3-dev@5.3.28-9+deb8u1",
                 "info": Object {
                   "name": "db5.3/libdb5.3-dev",
+                  "purl": "pkg:deb/libdb5.3-dev@5.3.28-9%2Bdeb8u1?upstream=db5.3",
                   "version": "5.3.28-9+deb8u1",
                 },
               },
@@ -5314,6 +5370,7 @@ Object {
                 "id": "db-defaults/libdb-dev@5.3.0+b1",
                 "info": Object {
                   "name": "db-defaults/libdb-dev",
+                  "purl": "pkg:deb/libdb-dev@5.3.0%2Bb1?upstream=db-defaults%405.3.0",
                   "version": "5.3.0+b1",
                 },
               },
@@ -5321,6 +5378,7 @@ Object {
                 "id": "liblocale-gettext-perl/liblocale-gettext-perl@1.05-8+b1",
                 "info": Object {
                   "name": "liblocale-gettext-perl/liblocale-gettext-perl",
+                  "purl": "pkg:deb/liblocale-gettext-perl@1.05-8%2Bb1?upstream=liblocale-gettext-perl%401.05-8",
                   "version": "1.05-8+b1",
                 },
               },
@@ -5328,6 +5386,7 @@ Object {
                 "id": "libtext-charwidth-perl/libtext-charwidth-perl@0.04-7+b3",
                 "info": Object {
                   "name": "libtext-charwidth-perl/libtext-charwidth-perl",
+                  "purl": "pkg:deb/libtext-charwidth-perl@0.04-7%2Bb3?upstream=libtext-charwidth-perl%400.04-7",
                   "version": "0.04-7+b3",
                 },
               },
@@ -5335,6 +5394,7 @@ Object {
                 "id": "libtext-iconv-perl/libtext-iconv-perl@1.7-5+b2",
                 "info": Object {
                   "name": "libtext-iconv-perl/libtext-iconv-perl",
+                  "purl": "pkg:deb/libtext-iconv-perl@1.7-5%2Bb2?upstream=libtext-iconv-perl%401.7-5",
                   "version": "1.7-5+b2",
                 },
               },
@@ -5342,6 +5402,7 @@ Object {
                 "id": "libtext-wrapi18n-perl@0.06-7",
                 "info": Object {
                   "name": "libtext-wrapi18n-perl",
+                  "purl": "pkg:deb/libtext-wrapi18n-perl@0.06-7",
                   "version": "0.06-7",
                 },
               },
@@ -5349,6 +5410,7 @@ Object {
                 "id": "debconf/debconf-i18n@1.5.56+deb8u1",
                 "info": Object {
                   "name": "debconf/debconf-i18n",
+                  "purl": "pkg:deb/debconf-i18n@1.5.56%2Bdeb8u1?upstream=debconf",
                   "version": "1.5.56+deb8u1",
                 },
               },
@@ -5356,6 +5418,7 @@ Object {
                 "id": "gnupg/gpgv@1.4.18-7+deb8u4",
                 "info": Object {
                   "name": "gnupg/gpgv",
+                  "purl": "pkg:deb/gpgv@1.4.18-7%2Bdeb8u4?upstream=gnupg",
                   "version": "1.4.18-7+deb8u4",
                 },
               },
@@ -5363,6 +5426,7 @@ Object {
                 "id": "diffutils/diffutils@1:3.3-1+b1",
                 "info": Object {
                   "name": "diffutils/diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.3-1%2Bb1?upstream=diffutils%401%3A3.3-1",
                   "version": "1:3.3-1+b1",
                 },
               },
@@ -5370,6 +5434,7 @@ Object {
                 "id": "mawk@1.3.3-17",
                 "info": Object {
                   "name": "mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17",
                   "version": "1.3.3-17",
                 },
               },
@@ -5377,6 +5442,7 @@ Object {
                 "id": "binutils@2.25-5+deb8u1",
                 "info": Object {
                   "name": "binutils",
+                  "purl": "pkg:deb/binutils@2.25-5%2Bdeb8u1",
                   "version": "2.25-5+deb8u1",
                 },
               },
@@ -5384,6 +5450,7 @@ Object {
                 "id": "libtimedate-perl@2.3000-2",
                 "info": Object {
                   "name": "libtimedate-perl",
+                  "purl": "pkg:deb/libtimedate-perl@2.3000-2",
                   "version": "2.3000-2",
                 },
               },
@@ -5391,6 +5458,7 @@ Object {
                 "id": "dpkg/libdpkg-perl@1.17.27",
                 "info": Object {
                   "name": "dpkg/libdpkg-perl",
+                  "purl": "pkg:deb/libdpkg-perl@1.17.27?upstream=dpkg",
                   "version": "1.17.27",
                 },
               },
@@ -5398,6 +5466,7 @@ Object {
                 "id": "make-dfsg/make@4.0-8.1",
                 "info": Object {
                   "name": "make-dfsg/make",
+                  "purl": "pkg:deb/make@4.0-8.1?upstream=make-dfsg",
                   "version": "4.0-8.1",
                 },
               },
@@ -5405,6 +5474,7 @@ Object {
                 "id": "patch@2.7.5-1",
                 "info": Object {
                   "name": "patch",
+                  "purl": "pkg:deb/patch@2.7.5-1",
                   "version": "2.7.5-1",
                 },
               },
@@ -5412,6 +5482,7 @@ Object {
                 "id": "xz-utils/xz-utils@5.1.1alpha+20120614-2+b3",
                 "info": Object {
                   "name": "xz-utils/xz-utils",
+                  "purl": "pkg:deb/xz-utils@5.1.1alpha%2B20120614-2%2Bb3?upstream=xz-utils%405.1.1alpha%2B20120614-2",
                   "version": "5.1.1alpha+20120614-2+b3",
                 },
               },
@@ -5419,6 +5490,7 @@ Object {
                 "id": "dpkg/dpkg-dev@1.17.27",
                 "info": Object {
                   "name": "dpkg/dpkg-dev",
+                  "purl": "pkg:deb/dpkg-dev@1.17.27?upstream=dpkg",
                   "version": "1.17.27",
                 },
               },
@@ -5426,6 +5498,7 @@ Object {
                 "id": "e2fsprogs/e2fslibs@1.42.12-2+b1",
                 "info": Object {
                   "name": "e2fsprogs/e2fslibs",
+                  "purl": "pkg:deb/e2fslibs@1.42.12-2%2Bb1?upstream=e2fsprogs%401.42.12-2",
                   "version": "1.42.12-2+b1",
                 },
               },
@@ -5433,6 +5506,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.42.12-2+b1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.42.12-2%2Bb1?upstream=e2fsprogs%401.42.12-2",
                   "version": "1.42.12-2+b1",
                 },
               },
@@ -5440,6 +5514,7 @@ Object {
                 "id": "util-linux@2.25.2-6",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.25.2-6",
                   "version": "2.25.2-6",
                 },
               },
@@ -5447,6 +5522,7 @@ Object {
                 "id": "util-linux/libblkid1@2.25.2-6",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.25.2-6?upstream=util-linux",
                   "version": "2.25.2-6",
                 },
               },
@@ -5454,6 +5530,7 @@ Object {
                 "id": "e2fsprogs/e2fsprogs@1.42.12-2+b1",
                 "info": Object {
                   "name": "e2fsprogs/e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.42.12-2%2Bb1?upstream=e2fsprogs%401.42.12-2",
                   "version": "1.42.12-2+b1",
                 },
               },
@@ -5461,6 +5538,7 @@ Object {
                 "id": "file@1:5.22+15-2+deb8u3",
                 "info": Object {
                   "name": "file",
+                  "purl": "pkg:deb/file@1:5.22%2B15-2%2Bdeb8u3",
                   "version": "1:5.22+15-2+deb8u3",
                 },
               },
@@ -5468,6 +5546,7 @@ Object {
                 "id": "findutils/findutils@4.4.2-9+b1",
                 "info": Object {
                   "name": "findutils/findutils",
+                  "purl": "pkg:deb/findutils@4.4.2-9%2Bb1?upstream=findutils%404.4.2-9",
                   "version": "4.4.2-9+b1",
                 },
               },
@@ -5475,6 +5554,7 @@ Object {
                 "id": "gcc-4.8/gcc-4.8-base@4.8.4-1",
                 "info": Object {
                   "name": "gcc-4.8/gcc-4.8-base",
+                  "purl": "pkg:deb/gcc-4.8-base@4.8.4-1?upstream=gcc-4.8",
                   "version": "4.8.4-1",
                 },
               },
@@ -5482,6 +5562,7 @@ Object {
                 "id": "gcc-4.9@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9",
+                  "purl": "pkg:deb/gcc-4.9@4.9.2-10%2Bdeb8u1",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5489,6 +5570,7 @@ Object {
                 "id": "cloog/libcloog-isl4@0.18.2-1+b2",
                 "info": Object {
                   "name": "cloog/libcloog-isl4",
+                  "purl": "pkg:deb/libcloog-isl4@0.18.2-1%2Bb2?upstream=cloog%400.18.2-1",
                   "version": "0.18.2-1+b2",
                 },
               },
@@ -5496,6 +5578,7 @@ Object {
                 "id": "gcc-4.9/libgcc-4.9-dev@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libgcc-4.9-dev",
+                  "purl": "pkg:deb/libgcc-4.9-dev@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5503,6 +5586,7 @@ Object {
                 "id": "gcc-4.9/libstdc++-4.9-dev@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libstdc++-4.9-dev",
+                  "purl": "pkg:deb/libstdc%2B%2B-4.9-dev@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5510,6 +5594,7 @@ Object {
                 "id": "isl/libisl10@0.12.2-2",
                 "info": Object {
                   "name": "isl/libisl10",
+                  "purl": "pkg:deb/libisl10@0.12.2-2?upstream=isl",
                   "version": "0.12.2-2",
                 },
               },
@@ -5517,6 +5602,7 @@ Object {
                 "id": "mpclib3/libmpc3@1.0.2-1",
                 "info": Object {
                   "name": "mpclib3/libmpc3",
+                  "purl": "pkg:deb/libmpc3@1.0.2-1?upstream=mpclib3",
                   "version": "1.0.2-1",
                 },
               },
@@ -5524,6 +5610,7 @@ Object {
                 "id": "mpfr4/libmpfr4@3.1.2-2",
                 "info": Object {
                   "name": "mpfr4/libmpfr4",
+                  "purl": "pkg:deb/libmpfr4@3.1.2-2?upstream=mpfr4",
                   "version": "3.1.2-2",
                 },
               },
@@ -5531,6 +5618,7 @@ Object {
                 "id": "gcc-4.9/g++-4.9@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/g++-4.9",
+                  "purl": "pkg:deb/g%2B%2B-4.9@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5538,6 +5626,7 @@ Object {
                 "id": "gcc-defaults/cpp@4:4.9.2-2",
                 "info": Object {
                   "name": "gcc-defaults/cpp",
+                  "purl": "pkg:deb/cpp@4:4.9.2-2?upstream=gcc-defaults%401.136",
                   "version": "4:4.9.2-2",
                 },
               },
@@ -5545,6 +5634,7 @@ Object {
                 "id": "gcc-defaults/gcc@4:4.9.2-2",
                 "info": Object {
                   "name": "gcc-defaults/gcc",
+                  "purl": "pkg:deb/gcc@4:4.9.2-2?upstream=gcc-defaults%401.136",
                   "version": "4:4.9.2-2",
                 },
               },
@@ -5552,6 +5642,7 @@ Object {
                 "id": "gcc-defaults/g++@4:4.9.2-2",
                 "info": Object {
                   "name": "gcc-defaults/g++",
+                  "purl": "pkg:deb/g%2B%2B@4:4.9.2-2?upstream=gcc-defaults%401.136",
                   "version": "4:4.9.2-2",
                 },
               },
@@ -5559,6 +5650,7 @@ Object {
                 "id": "gdbm/libgdbm-dev@1.8.3-13.1",
                 "info": Object {
                   "name": "gdbm/libgdbm-dev",
+                  "purl": "pkg:deb/libgdbm-dev@1.8.3-13.1?upstream=gdbm",
                   "version": "1.8.3-13.1",
                 },
               },
@@ -5566,6 +5658,7 @@ Object {
                 "id": "geoip/libgeoip1@1.6.2-4",
                 "info": Object {
                   "name": "geoip/libgeoip1",
+                  "purl": "pkg:deb/libgeoip1@1.6.2-4?upstream=geoip",
                   "version": "1.6.2-4",
                 },
               },
@@ -5573,6 +5666,7 @@ Object {
                 "id": "geoip/geoip-bin@1.6.2-4",
                 "info": Object {
                   "name": "geoip/geoip-bin",
+                  "purl": "pkg:deb/geoip-bin@1.6.2-4?upstream=geoip",
                   "version": "1.6.2-4",
                 },
               },
@@ -5580,6 +5674,7 @@ Object {
                 "id": "geoip/libgeoip-dev@1.6.2-4",
                 "info": Object {
                   "name": "geoip/libgeoip-dev",
+                  "purl": "pkg:deb/libgeoip-dev@1.6.2-4?upstream=geoip",
                   "version": "1.6.2-4",
                 },
               },
@@ -5587,6 +5682,7 @@ Object {
                 "id": "curl/libcurl3-gnutls@7.38.0-4+deb8u11",
                 "info": Object {
                   "name": "curl/libcurl3-gnutls",
+                  "purl": "pkg:deb/libcurl3-gnutls@7.38.0-4%2Bdeb8u11?upstream=curl",
                   "version": "7.38.0-4+deb8u11",
                 },
               },
@@ -5594,6 +5690,7 @@ Object {
                 "id": "git/git-man@1:2.1.4-2.1+deb8u6",
                 "info": Object {
                   "name": "git/git-man",
+                  "purl": "pkg:deb/git-man@1:2.1.4-2.1%2Bdeb8u6?upstream=git",
                   "version": "1:2.1.4-2.1+deb8u6",
                 },
               },
@@ -5601,6 +5698,7 @@ Object {
                 "id": "liberror-perl@0.17-1.1",
                 "info": Object {
                   "name": "liberror-perl",
+                  "purl": "pkg:deb/liberror-perl@0.17-1.1",
                   "version": "0.17-1.1",
                 },
               },
@@ -5608,6 +5706,7 @@ Object {
                 "id": "git@1:2.1.4-2.1+deb8u6",
                 "info": Object {
                   "name": "git",
+                  "purl": "pkg:deb/git@1:2.1.4-2.1%2Bdeb8u6",
                   "version": "1:2.1.4-2.1+deb8u6",
                 },
               },
@@ -5615,6 +5714,7 @@ Object {
                 "id": "glib2.0/libglib2.0-dev@2.42.1-1+b1",
                 "info": Object {
                   "name": "glib2.0/libglib2.0-dev",
+                  "purl": "pkg:deb/libglib2.0-dev@2.42.1-1%2Bb1?upstream=glib2.0%402.42.1-1",
                   "version": "2.42.1-1+b1",
                 },
               },
@@ -5622,6 +5722,7 @@ Object {
                 "id": "glibc/libc-bin@2.19-18+deb8u10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.19-18%2Bdeb8u10?upstream=glibc",
                   "version": "2.19-18+deb8u10",
                 },
               },
@@ -5629,6 +5730,7 @@ Object {
                 "id": "libusb/libusb-0.1-4@2:0.1.12-25",
                 "info": Object {
                   "name": "libusb/libusb-0.1-4",
+                  "purl": "pkg:deb/libusb-0.1-4@2:0.1.12-25?upstream=libusb",
                   "version": "2:0.1.12-25",
                 },
               },
@@ -5636,6 +5738,7 @@ Object {
                 "id": "grep@2.20-4.1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@2.20-4.1",
                   "version": "2.20-4.1",
                 },
               },
@@ -5643,6 +5746,7 @@ Object {
                 "id": "gzip@1.6-4",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.6-4",
                   "version": "1.6-4",
                 },
               },
@@ -5650,6 +5754,7 @@ Object {
                 "id": "hostname@3.15",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.15",
                   "version": "3.15",
                 },
               },
@@ -5657,6 +5762,7 @@ Object {
                 "id": "hicolor-icon-theme@0.13-1",
                 "info": Object {
                   "name": "hicolor-icon-theme",
+                  "purl": "pkg:deb/hicolor-icon-theme@0.13-1",
                   "version": "0.13-1",
                 },
               },
@@ -5664,6 +5770,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6.q16-2@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6.q16-2",
+                  "purl": "pkg:deb/libmagickcore-6.q16-2@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5671,6 +5778,7 @@ Object {
                 "id": "imagemagick/libmagickwand-6.q16-2@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickwand-6.q16-2",
+                  "purl": "pkg:deb/libmagickwand-6.q16-2@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5678,6 +5786,7 @@ Object {
                 "id": "imagemagick/imagemagick-6.q16@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/imagemagick-6.q16",
+                  "purl": "pkg:deb/imagemagick-6.q16@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5685,6 +5794,7 @@ Object {
                 "id": "imagemagick@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick",
+                  "purl": "pkg:deb/imagemagick@8:6.8.9.9-5%2Bdeb8u12",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5692,6 +5802,7 @@ Object {
                 "id": "djvulibre/libdjvulibre21@3.5.25.4-4+b1",
                 "info": Object {
                   "name": "djvulibre/libdjvulibre21",
+                  "purl": "pkg:deb/libdjvulibre21@3.5.25.4-4%2Bb1?upstream=djvulibre%403.5.25.4-4",
                   "version": "3.5.25.4-4+b1",
                 },
               },
@@ -5699,6 +5810,7 @@ Object {
                 "id": "libjpeg-turbo/libjpeg62-turbo-dev@1:1.3.1-12",
                 "info": Object {
                   "name": "libjpeg-turbo/libjpeg62-turbo-dev",
+                  "purl": "pkg:deb/libjpeg62-turbo-dev@1:1.3.1-12?upstream=libjpeg-turbo",
                   "version": "1:1.3.1-12",
                 },
               },
@@ -5706,6 +5818,7 @@ Object {
                 "id": "libjpeg-turbo/libjpeg-dev@1:1.3.1-12",
                 "info": Object {
                   "name": "libjpeg-turbo/libjpeg-dev",
+                  "purl": "pkg:deb/libjpeg-dev@1:1.3.1-12?upstream=libjpeg-turbo",
                   "version": "1:1.3.1-12",
                 },
               },
@@ -5713,6 +5826,7 @@ Object {
                 "id": "djvulibre/libdjvulibre-dev@3.5.25.4-4+b1",
                 "info": Object {
                   "name": "djvulibre/libdjvulibre-dev",
+                  "purl": "pkg:deb/libdjvulibre-dev@3.5.25.4-4%2Bb1?upstream=djvulibre%403.5.25.4-4",
                   "version": "3.5.25.4-4+b1",
                 },
               },
@@ -5720,6 +5834,7 @@ Object {
                 "id": "libpng/libpng12-dev@1.2.50-2+deb8u3",
                 "info": Object {
                   "name": "libpng/libpng12-dev",
+                  "purl": "pkg:deb/libpng12-dev@1.2.50-2%2Bdeb8u3?upstream=libpng",
                   "version": "1.2.50-2+deb8u3",
                 },
               },
@@ -5727,6 +5842,7 @@ Object {
                 "id": "freetype/libfreetype6-dev@2.5.2-3+deb8u2",
                 "info": Object {
                   "name": "freetype/libfreetype6-dev",
+                  "purl": "pkg:deb/libfreetype6-dev@2.5.2-3%2Bdeb8u2?upstream=freetype",
                   "version": "2.5.2-3+deb8u2",
                 },
               },
@@ -5734,6 +5850,7 @@ Object {
                 "id": "expat/libexpat1-dev@2.1.0-6+deb8u4",
                 "info": Object {
                   "name": "expat/libexpat1-dev",
+                  "purl": "pkg:deb/libexpat1-dev@2.1.0-6%2Bdeb8u4?upstream=expat",
                   "version": "2.1.0-6+deb8u4",
                 },
               },
@@ -5741,6 +5858,7 @@ Object {
                 "id": "graphviz/libcdt5@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libcdt5",
+                  "purl": "pkg:deb/libcdt5@2.38.0-7?upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -5748,6 +5866,7 @@ Object {
                 "id": "graphviz/libcgraph6@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libcgraph6",
+                  "purl": "pkg:deb/libcgraph6@2.38.0-7?upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -5755,6 +5874,7 @@ Object {
                 "id": "graphviz/libpathplan4@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libpathplan4",
+                  "purl": "pkg:deb/libpathplan4@2.38.0-7?upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -5762,6 +5882,7 @@ Object {
                 "id": "graphviz/libxdot4@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libxdot4",
+                  "purl": "pkg:deb/libxdot4@2.38.0-7?upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -5769,6 +5890,7 @@ Object {
                 "id": "libvpx/libvpx1@1.3.0-3+deb8u1",
                 "info": Object {
                   "name": "libvpx/libvpx1",
+                  "purl": "pkg:deb/libvpx1@1.3.0-3%2Bdeb8u1?upstream=libvpx",
                   "version": "1.3.0-3+deb8u1",
                 },
               },
@@ -5776,6 +5898,7 @@ Object {
                 "id": "libxpm/libxpm4@1:3.5.12-0+deb8u1",
                 "info": Object {
                   "name": "libxpm/libxpm4",
+                  "purl": "pkg:deb/libxpm4@1:3.5.12-0%2Bdeb8u1?upstream=libxpm",
                   "version": "1:3.5.12-0+deb8u1",
                 },
               },
@@ -5783,6 +5906,7 @@ Object {
                 "id": "libgd2/libgd3@2.1.0-5+deb8u11",
                 "info": Object {
                   "name": "libgd2/libgd3",
+                  "purl": "pkg:deb/libgd3@2.1.0-5%2Bdeb8u11?upstream=libgd2",
                   "version": "2.1.0-5+deb8u11",
                 },
               },
@@ -5790,6 +5914,7 @@ Object {
                 "id": "libtool/libltdl7@2.4.2-1.11+b1",
                 "info": Object {
                   "name": "libtool/libltdl7",
+                  "purl": "pkg:deb/libltdl7@2.4.2-1.11%2Bb1?upstream=libtool%402.4.2-1.11",
                   "version": "2.4.2-1.11+b1",
                 },
               },
@@ -5797,6 +5922,7 @@ Object {
                 "id": "pango1.0/libpangocairo-1.0-0@1.36.8-3",
                 "info": Object {
                   "name": "pango1.0/libpangocairo-1.0-0",
+                  "purl": "pkg:deb/libpangocairo-1.0-0@1.36.8-3?upstream=pango1.0",
                   "version": "1.36.8-3",
                 },
               },
@@ -5804,6 +5930,7 @@ Object {
                 "id": "pango1.0/libpangoft2-1.0-0@1.36.8-3",
                 "info": Object {
                   "name": "pango1.0/libpangoft2-1.0-0",
+                  "purl": "pkg:deb/libpangoft2-1.0-0@1.36.8-3?upstream=pango1.0",
                   "version": "1.36.8-3",
                 },
               },
@@ -5811,6 +5938,7 @@ Object {
                 "id": "graphviz/libgvc6@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libgvc6",
+                  "purl": "pkg:deb/libgvc6@2.38.0-7?upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -5818,6 +5946,7 @@ Object {
                 "id": "graphviz/libgvpr2@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libgvpr2",
+                  "purl": "pkg:deb/libgvpr2@2.38.0-7?upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -5825,6 +5954,7 @@ Object {
                 "id": "libtool/libltdl-dev@2.4.2-1.11+b1",
                 "info": Object {
                   "name": "libtool/libltdl-dev",
+                  "purl": "pkg:deb/libltdl-dev@2.4.2-1.11%2Bb1?upstream=libtool%402.4.2-1.11",
                   "version": "2.4.2-1.11+b1",
                 },
               },
@@ -5832,6 +5962,7 @@ Object {
                 "id": "graphviz/libgraphviz-dev@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libgraphviz-dev",
+                  "purl": "pkg:deb/libgraphviz-dev@2.38.0-7?upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -5839,6 +5970,7 @@ Object {
                 "id": "imagemagick/imagemagick-common@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/imagemagick-common",
+                  "purl": "pkg:deb/imagemagick-common@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5846,6 +5978,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6-arch-config@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6-arch-config",
+                  "purl": "pkg:deb/libmagickcore-6-arch-config@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5853,6 +5986,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6-headers@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6-headers",
+                  "purl": "pkg:deb/libmagickcore-6-headers@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5860,6 +5994,7 @@ Object {
                 "id": "gcc-4.9/libgomp1@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libgomp1",
+                  "purl": "pkg:deb/libgomp1@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5867,6 +6002,7 @@ Object {
                 "id": "fftw3/libfftw3-double3@3.3.4-2",
                 "info": Object {
                   "name": "fftw3/libfftw3-double3",
+                  "purl": "pkg:deb/libfftw3-double3@3.3.4-2?upstream=fftw3",
                   "version": "3.3.4-2",
                 },
               },
@@ -5874,6 +6010,7 @@ Object {
                 "id": "lcms2/liblcms2-2@2.6-3+deb8u1",
                 "info": Object {
                   "name": "lcms2/liblcms2-2",
+                  "purl": "pkg:deb/liblcms2-2@2.6-3%2Bdeb8u1?upstream=lcms2",
                   "version": "2.6-3+deb8u1",
                 },
               },
@@ -5881,6 +6018,7 @@ Object {
                 "id": "liblqr/liblqr-1-0@0.4.2-2",
                 "info": Object {
                   "name": "liblqr/liblqr-1-0",
+                  "purl": "pkg:deb/liblqr-1-0@0.4.2-2?upstream=liblqr",
                   "version": "0.4.2-2",
                 },
               },
@@ -5888,6 +6026,7 @@ Object {
                 "id": "libxml2@2.9.1+dfsg1-5+deb8u6",
                 "info": Object {
                   "name": "libxml2",
+                  "purl": "pkg:deb/libxml2@2.9.1%2Bdfsg1-5%2Bdeb8u6",
                   "version": "2.9.1+dfsg1-5+deb8u6",
                 },
               },
@@ -5895,6 +6034,7 @@ Object {
                 "id": "djvulibre/libdjvulibre-text@3.5.25.4-4",
                 "info": Object {
                   "name": "djvulibre/libdjvulibre-text",
+                  "purl": "pkg:deb/libdjvulibre-text@3.5.25.4-4?upstream=djvulibre",
                   "version": "3.5.25.4-4",
                 },
               },
@@ -5902,6 +6042,7 @@ Object {
                 "id": "gdk-pixbuf/libgdk-pixbuf2.0-common@2.31.1-2+deb8u7",
                 "info": Object {
                   "name": "gdk-pixbuf/libgdk-pixbuf2.0-common",
+                  "purl": "pkg:deb/libgdk-pixbuf2.0-common@2.31.1-2%2Bdeb8u7?upstream=gdk-pixbuf",
                   "version": "2.31.1-2+deb8u7",
                 },
               },
@@ -5909,6 +6050,7 @@ Object {
                 "id": "jasper/libjasper1@1.900.1-debian1-2.4+deb8u3",
                 "info": Object {
                   "name": "jasper/libjasper1",
+                  "purl": "pkg:deb/libjasper1@1.900.1-debian1-2.4%2Bdeb8u3?upstream=jasper",
                   "version": "1.900.1-debian1-2.4+deb8u3",
                 },
               },
@@ -5916,6 +6058,7 @@ Object {
                 "id": "gdk-pixbuf/libgdk-pixbuf2.0-0@2.31.1-2+deb8u7",
                 "info": Object {
                   "name": "gdk-pixbuf/libgdk-pixbuf2.0-0",
+                  "purl": "pkg:deb/libgdk-pixbuf2.0-0@2.31.1-2%2Bdeb8u7?upstream=gdk-pixbuf",
                   "version": "2.31.1-2+deb8u7",
                 },
               },
@@ -5923,6 +6066,7 @@ Object {
                 "id": "libcroco/libcroco3@0.6.8-3+b1",
                 "info": Object {
                   "name": "libcroco/libcroco3",
+                  "purl": "pkg:deb/libcroco3@0.6.8-3%2Bb1?upstream=libcroco%400.6.8-3",
                   "version": "0.6.8-3+b1",
                 },
               },
@@ -5930,6 +6074,7 @@ Object {
                 "id": "librsvg/librsvg2-2@2.40.5-1+deb8u2",
                 "info": Object {
                   "name": "librsvg/librsvg2-2",
+                  "purl": "pkg:deb/librsvg2-2@2.40.5-1%2Bdeb8u2?upstream=librsvg",
                   "version": "2.40.5-1+deb8u2",
                 },
               },
@@ -5937,6 +6082,7 @@ Object {
                 "id": "libwmf/libwmf0.2-7@0.2.8.4-10.3+deb8u2",
                 "info": Object {
                   "name": "libwmf/libwmf0.2-7",
+                  "purl": "pkg:deb/libwmf0.2-7@0.2.8.4-10.3%2Bdeb8u2?upstream=libwmf",
                   "version": "0.2.8.4-10.3+deb8u2",
                 },
               },
@@ -5944,6 +6090,7 @@ Object {
                 "id": "ilmbase/libilmbase6@1.0.1-6.1",
                 "info": Object {
                   "name": "ilmbase/libilmbase6",
+                  "purl": "pkg:deb/libilmbase6@1.0.1-6.1?upstream=ilmbase",
                   "version": "1.0.1-6.1",
                 },
               },
@@ -5951,6 +6098,7 @@ Object {
                 "id": "openexr/libopenexr6@1.6.1-8",
                 "info": Object {
                   "name": "openexr/libopenexr6",
+                  "purl": "pkg:deb/libopenexr6@1.6.1-8?upstream=openexr",
                   "version": "1.6.1-8",
                 },
               },
@@ -5958,6 +6106,7 @@ Object {
                 "id": "graphite2/libgraphite2-3@1.3.10-1~deb8u1",
                 "info": Object {
                   "name": "graphite2/libgraphite2-3",
+                  "purl": "pkg:deb/libgraphite2-3@1.3.10-1~deb8u1?upstream=graphite2",
                   "version": "1.3.10-1~deb8u1",
                 },
               },
@@ -5965,6 +6114,7 @@ Object {
                 "id": "harfbuzz/libharfbuzz0b@0.9.35-2",
                 "info": Object {
                   "name": "harfbuzz/libharfbuzz0b",
+                  "purl": "pkg:deb/libharfbuzz0b@0.9.35-2?upstream=harfbuzz",
                   "version": "0.9.35-2",
                 },
               },
@@ -5972,6 +6122,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6.q16-2-extra@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6.q16-2-extra",
+                  "purl": "pkg:deb/libmagickcore-6.q16-2-extra@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5979,6 +6130,7 @@ Object {
                 "id": "jasper/libjasper-dev@1.900.1-debian1-2.4+deb8u3",
                 "info": Object {
                   "name": "jasper/libjasper-dev",
+                  "purl": "pkg:deb/libjasper-dev@1.900.1-debian1-2.4%2Bdeb8u3?upstream=jasper",
                   "version": "1.900.1-debian1-2.4+deb8u3",
                 },
               },
@@ -5986,6 +6138,7 @@ Object {
                 "id": "lcms2/liblcms2-dev@2.6-3+deb8u1",
                 "info": Object {
                   "name": "lcms2/liblcms2-dev",
+                  "purl": "pkg:deb/liblcms2-dev@2.6-3%2Bdeb8u1?upstream=lcms2",
                   "version": "2.6-3+deb8u1",
                 },
               },
@@ -5993,6 +6146,7 @@ Object {
                 "id": "jquery/libjs-jquery@1.7.2+dfsg-3.2",
                 "info": Object {
                   "name": "jquery/libjs-jquery",
+                  "purl": "pkg:deb/libjs-jquery@1.7.2%2Bdfsg-3.2?upstream=jquery",
                   "version": "1.7.2+dfsg-3.2",
                 },
               },
@@ -6000,6 +6154,7 @@ Object {
                 "id": "libexif/libexif12@0.6.21-2",
                 "info": Object {
                   "name": "libexif/libexif12",
+                  "purl": "pkg:deb/libexif12@0.6.21-2?upstream=libexif",
                   "version": "0.6.21-2",
                 },
               },
@@ -6007,6 +6162,7 @@ Object {
                 "id": "libexif/libexif-dev@0.6.21-2",
                 "info": Object {
                   "name": "libexif/libexif-dev",
+                  "purl": "pkg:deb/libexif-dev@0.6.21-2?upstream=libexif",
                   "version": "0.6.21-2",
                 },
               },
@@ -6014,6 +6170,7 @@ Object {
                 "id": "liblqr/liblqr-1-0-dev@0.4.2-2",
                 "info": Object {
                   "name": "liblqr/liblqr-1-0-dev",
+                  "purl": "pkg:deb/liblqr-1-0-dev@0.4.2-2?upstream=liblqr",
                   "version": "0.4.2-2",
                 },
               },
@@ -6021,6 +6178,7 @@ Object {
                 "id": "cairo/libcairo-gobject2@1.14.0-2.1+deb8u2",
                 "info": Object {
                   "name": "cairo/libcairo-gobject2",
+                  "purl": "pkg:deb/libcairo-gobject2@1.14.0-2.1%2Bdeb8u2?upstream=cairo",
                   "version": "1.14.0-2.1+deb8u2",
                 },
               },
@@ -6028,6 +6186,7 @@ Object {
                 "id": "lzo2/liblzo2-2@2.08-1.2",
                 "info": Object {
                   "name": "lzo2/liblzo2-2",
+                  "purl": "pkg:deb/liblzo2-2@2.08-1.2?upstream=lzo2",
                   "version": "2.08-1.2",
                 },
               },
@@ -6035,6 +6194,7 @@ Object {
                 "id": "cairo/libcairo-script-interpreter2@1.14.0-2.1+deb8u2",
                 "info": Object {
                   "name": "cairo/libcairo-script-interpreter2",
+                  "purl": "pkg:deb/libcairo-script-interpreter2@1.14.0-2.1%2Bdeb8u2?upstream=cairo",
                   "version": "1.14.0-2.1+deb8u2",
                 },
               },
@@ -6042,6 +6202,7 @@ Object {
                 "id": "pkg-config@0.28-1",
                 "info": Object {
                   "name": "pkg-config",
+                  "purl": "pkg:deb/pkg-config@0.28-1",
                   "version": "0.28-1",
                 },
               },
@@ -6049,6 +6210,7 @@ Object {
                 "id": "fontconfig/libfontconfig1-dev@2.11.0-6.3+deb8u1",
                 "info": Object {
                   "name": "fontconfig/libfontconfig1-dev",
+                  "purl": "pkg:deb/libfontconfig1-dev@2.11.0-6.3%2Bdeb8u1?upstream=fontconfig",
                   "version": "2.11.0-6.3+deb8u1",
                 },
               },
@@ -6056,6 +6218,7 @@ Object {
                 "id": "libice/libice6@2:1.0.9-1+b1",
                 "info": Object {
                   "name": "libice/libice6",
+                  "purl": "pkg:deb/libice6@2:1.0.9-1%2Bb1?upstream=libice%402%3A1.0.9-1",
                   "version": "2:1.0.9-1+b1",
                 },
               },
@@ -6063,6 +6226,7 @@ Object {
                 "id": "libice/libice-dev@2:1.0.9-1+b1",
                 "info": Object {
                   "name": "libice/libice-dev",
+                  "purl": "pkg:deb/libice-dev@2:1.0.9-1%2Bb1?upstream=libice%402%3A1.0.9-1",
                   "version": "2:1.0.9-1+b1",
                 },
               },
@@ -6070,6 +6234,7 @@ Object {
                 "id": "lsb/lsb-base@4.1+Debian13+nmu1",
                 "info": Object {
                   "name": "lsb/lsb-base",
+                  "purl": "pkg:deb/lsb-base@4.1%2BDebian13%2Bnmu1?upstream=lsb",
                   "version": "4.1+Debian13+nmu1",
                 },
               },
@@ -6077,6 +6242,7 @@ Object {
                 "id": "xorg/x11-common@1:7.7+7",
                 "info": Object {
                   "name": "xorg/x11-common",
+                  "purl": "pkg:deb/x11-common@1:7.7%2B7?upstream=xorg",
                   "version": "1:7.7+7",
                 },
               },
@@ -6084,6 +6250,7 @@ Object {
                 "id": "libsm/libsm6@2:1.2.2-1+b1",
                 "info": Object {
                   "name": "libsm/libsm6",
+                  "purl": "pkg:deb/libsm6@2:1.2.2-1%2Bb1?upstream=libsm%402%3A1.2.2-1",
                   "version": "2:1.2.2-1+b1",
                 },
               },
@@ -6091,6 +6258,7 @@ Object {
                 "id": "libsm/libsm-dev@2:1.2.2-1+b1",
                 "info": Object {
                   "name": "libsm/libsm-dev",
+                  "purl": "pkg:deb/libsm-dev@2:1.2.2-1%2Bb1?upstream=libsm%402%3A1.2.2-1",
                   "version": "2:1.2.2-1+b1",
                 },
               },
@@ -6098,6 +6266,7 @@ Object {
                 "id": "libx11/libx11-dev@2:1.6.2-3+deb8u1",
                 "info": Object {
                   "name": "libx11/libx11-dev",
+                  "purl": "pkg:deb/libx11-dev@2:1.6.2-3%2Bdeb8u1?upstream=libx11",
                   "version": "2:1.6.2-3+deb8u1",
                 },
               },
@@ -6105,6 +6274,7 @@ Object {
                 "id": "libxcb/libxcb1-dev@1.10-3+b1",
                 "info": Object {
                   "name": "libxcb/libxcb1-dev",
+                  "purl": "pkg:deb/libxcb1-dev@1.10-3%2Bb1?upstream=libxcb%401.10-3",
                   "version": "1.10-3+b1",
                 },
               },
@@ -6112,6 +6282,7 @@ Object {
                 "id": "libxcb/libxcb-render0-dev@1.10-3+b1",
                 "info": Object {
                   "name": "libxcb/libxcb-render0-dev",
+                  "purl": "pkg:deb/libxcb-render0-dev@1.10-3%2Bb1?upstream=libxcb%401.10-3",
                   "version": "1.10-3+b1",
                 },
               },
@@ -6119,6 +6290,7 @@ Object {
                 "id": "libxcb/libxcb-shm0-dev@1.10-3+b1",
                 "info": Object {
                   "name": "libxcb/libxcb-shm0-dev",
+                  "purl": "pkg:deb/libxcb-shm0-dev@1.10-3%2Bb1?upstream=libxcb%401.10-3",
                   "version": "1.10-3+b1",
                 },
               },
@@ -6126,6 +6298,7 @@ Object {
                 "id": "x11proto-input/x11proto-input-dev@2.3.1-1",
                 "info": Object {
                   "name": "x11proto-input/x11proto-input-dev",
+                  "purl": "pkg:deb/x11proto-input-dev@2.3.1-1?upstream=x11proto-input",
                   "version": "2.3.1-1",
                 },
               },
@@ -6133,6 +6306,7 @@ Object {
                 "id": "x11proto-xext/x11proto-xext-dev@7.3.0-1",
                 "info": Object {
                   "name": "x11proto-xext/x11proto-xext-dev",
+                  "purl": "pkg:deb/x11proto-xext-dev@7.3.0-1?upstream=x11proto-xext",
                   "version": "7.3.0-1",
                 },
               },
@@ -6140,6 +6314,7 @@ Object {
                 "id": "libxext/libxext-dev@2:1.3.3-1",
                 "info": Object {
                   "name": "libxext/libxext-dev",
+                  "purl": "pkg:deb/libxext-dev@2:1.3.3-1?upstream=libxext",
                   "version": "2:1.3.3-1",
                 },
               },
@@ -6147,6 +6322,7 @@ Object {
                 "id": "x11proto-render/x11proto-render-dev@2:0.11.1-2",
                 "info": Object {
                   "name": "x11proto-render/x11proto-render-dev",
+                  "purl": "pkg:deb/x11proto-render-dev@2:0.11.1-2?upstream=x11proto-render",
                   "version": "2:0.11.1-2",
                 },
               },
@@ -6154,6 +6330,7 @@ Object {
                 "id": "libxrender/libxrender-dev@1:0.9.8-1+b1",
                 "info": Object {
                   "name": "libxrender/libxrender-dev",
+                  "purl": "pkg:deb/libxrender-dev@1:0.9.8-1%2Bb1?upstream=libxrender%401%3A0.9.8-1",
                   "version": "1:0.9.8-1+b1",
                 },
               },
@@ -6161,6 +6338,7 @@ Object {
                 "id": "pixman/libpixman-1-dev@0.32.6-3",
                 "info": Object {
                   "name": "pixman/libpixman-1-dev",
+                  "purl": "pkg:deb/libpixman-1-dev@0.32.6-3?upstream=pixman",
                   "version": "0.32.6-3",
                 },
               },
@@ -6168,6 +6346,7 @@ Object {
                 "id": "cairo/libcairo2-dev@1.14.0-2.1+deb8u2",
                 "info": Object {
                   "name": "cairo/libcairo2-dev",
+                  "purl": "pkg:deb/libcairo2-dev@1.14.0-2.1%2Bdeb8u2?upstream=cairo",
                   "version": "1.14.0-2.1+deb8u2",
                 },
               },
@@ -6175,6 +6354,7 @@ Object {
                 "id": "gdk-pixbuf/gir1.2-gdkpixbuf-2.0@2.31.1-2+deb8u7",
                 "info": Object {
                   "name": "gdk-pixbuf/gir1.2-gdkpixbuf-2.0",
+                  "purl": "pkg:deb/gir1.2-gdkpixbuf-2.0@2.31.1-2%2Bdeb8u7?upstream=gdk-pixbuf",
                   "version": "2.31.1-2+deb8u7",
                 },
               },
@@ -6182,6 +6362,7 @@ Object {
                 "id": "libpthread-stubs/libpthread-stubs0-dev@0.3-4",
                 "info": Object {
                   "name": "libpthread-stubs/libpthread-stubs0-dev",
+                  "purl": "pkg:deb/libpthread-stubs0-dev@0.3-4?upstream=libpthread-stubs",
                   "version": "0.3-4",
                 },
               },
@@ -6189,6 +6370,7 @@ Object {
                 "id": "x11proto-kb/x11proto-kb-dev@1.0.6-2",
                 "info": Object {
                   "name": "x11proto-kb/x11proto-kb-dev",
+                  "purl": "pkg:deb/x11proto-kb-dev@1.0.6-2?upstream=x11proto-kb",
                   "version": "1.0.6-2",
                 },
               },
@@ -6196,6 +6378,7 @@ Object {
                 "id": "xtrans/xtrans-dev@1.3.4-1",
                 "info": Object {
                   "name": "xtrans/xtrans-dev",
+                  "purl": "pkg:deb/xtrans-dev@1.3.4-1?upstream=xtrans",
                   "version": "1.3.4-1",
                 },
               },
@@ -6203,6 +6386,7 @@ Object {
                 "id": "shared-mime-info@1.3-1",
                 "info": Object {
                   "name": "shared-mime-info",
+                  "purl": "pkg:deb/shared-mime-info@1.3-1",
                   "version": "1.3-1",
                 },
               },
@@ -6210,6 +6394,7 @@ Object {
                 "id": "gdk-pixbuf/libgdk-pixbuf2.0-dev@2.31.1-2+deb8u7",
                 "info": Object {
                   "name": "gdk-pixbuf/libgdk-pixbuf2.0-dev",
+                  "purl": "pkg:deb/libgdk-pixbuf2.0-dev@2.31.1-2%2Bdeb8u7?upstream=gdk-pixbuf",
                   "version": "2.31.1-2+deb8u7",
                 },
               },
@@ -6217,6 +6402,7 @@ Object {
                 "id": "glib2.0/libglib2.0-data@2.42.1-1",
                 "info": Object {
                   "name": "glib2.0/libglib2.0-data",
+                  "purl": "pkg:deb/libglib2.0-data@2.42.1-1?upstream=glib2.0",
                   "version": "2.42.1-1",
                 },
               },
@@ -6224,6 +6410,7 @@ Object {
                 "id": "libelf/libelfg0@0.8.13-5",
                 "info": Object {
                   "name": "libelf/libelfg0",
+                  "purl": "pkg:deb/libelfg0@0.8.13-5?upstream=libelf",
                   "version": "0.8.13-5",
                 },
               },
@@ -6231,6 +6418,7 @@ Object {
                 "id": "glib2.0/libglib2.0-bin@2.42.1-1+b1",
                 "info": Object {
                   "name": "glib2.0/libglib2.0-bin",
+                  "purl": "pkg:deb/libglib2.0-bin@2.42.1-1%2Bb1?upstream=glib2.0%402.42.1-1",
                   "version": "2.42.1-1+b1",
                 },
               },
@@ -6238,6 +6426,7 @@ Object {
                 "id": "pcre3/libpcrecpp0@2:8.35-3.3+deb8u4",
                 "info": Object {
                   "name": "pcre3/libpcrecpp0",
+                  "purl": "pkg:deb/libpcrecpp0@2:8.35-3.3%2Bdeb8u4?upstream=pcre3",
                   "version": "2:8.35-3.3+deb8u4",
                 },
               },
@@ -6245,6 +6434,7 @@ Object {
                 "id": "pcre3/libpcre3-dev@2:8.35-3.3+deb8u4",
                 "info": Object {
                   "name": "pcre3/libpcre3-dev",
+                  "purl": "pkg:deb/libpcre3-dev@2:8.35-3.3%2Bdeb8u4?upstream=pcre3",
                   "version": "2:8.35-3.3+deb8u4",
                 },
               },
@@ -6252,6 +6442,7 @@ Object {
                 "id": "gobject-introspection/gir1.2-glib-2.0@1.42.0-2.2",
                 "info": Object {
                   "name": "gobject-introspection/gir1.2-glib-2.0",
+                  "purl": "pkg:deb/gir1.2-glib-2.0@1.42.0-2.2?upstream=gobject-introspection",
                   "version": "1.42.0-2.2",
                 },
               },
@@ -6259,6 +6450,7 @@ Object {
                 "id": "gobject-introspection/libgirepository-1.0-1@1.42.0-2.2",
                 "info": Object {
                   "name": "gobject-introspection/libgirepository-1.0-1",
+                  "purl": "pkg:deb/libgirepository-1.0-1@1.42.0-2.2?upstream=gobject-introspection",
                   "version": "1.42.0-2.2",
                 },
               },
@@ -6266,6 +6458,7 @@ Object {
                 "id": "gobject-introspection/gir1.2-freedesktop@1.42.0-2.2",
                 "info": Object {
                   "name": "gobject-introspection/gir1.2-freedesktop",
+                  "purl": "pkg:deb/gir1.2-freedesktop@1.42.0-2.2?upstream=gobject-introspection",
                   "version": "1.42.0-2.2",
                 },
               },
@@ -6273,6 +6466,7 @@ Object {
                 "id": "librsvg/gir1.2-rsvg-2.0@2.40.5-1+deb8u2",
                 "info": Object {
                   "name": "librsvg/gir1.2-rsvg-2.0",
+                  "purl": "pkg:deb/gir1.2-rsvg-2.0@2.40.5-1%2Bdeb8u2?upstream=librsvg",
                   "version": "2.40.5-1+deb8u2",
                 },
               },
@@ -6280,6 +6474,7 @@ Object {
                 "id": "librsvg/librsvg2-common@2.40.5-1+deb8u2",
                 "info": Object {
                   "name": "librsvg/librsvg2-common",
+                  "purl": "pkg:deb/librsvg2-common@2.40.5-1%2Bdeb8u2?upstream=librsvg",
                   "version": "2.40.5-1+deb8u2",
                 },
               },
@@ -6287,6 +6482,7 @@ Object {
                 "id": "librsvg/librsvg2-dev@2.40.5-1+deb8u2",
                 "info": Object {
                   "name": "librsvg/librsvg2-dev",
+                  "purl": "pkg:deb/librsvg2-dev@2.40.5-1%2Bdeb8u2?upstream=librsvg",
                   "version": "2.40.5-1+deb8u2",
                 },
               },
@@ -6294,6 +6490,7 @@ Object {
                 "id": "libwmf/libwmf-dev@0.2.8.4-10.3+deb8u2",
                 "info": Object {
                   "name": "libwmf/libwmf-dev",
+                  "purl": "pkg:deb/libwmf-dev@0.2.8.4-10.3%2Bdeb8u2?upstream=libwmf",
                   "version": "0.2.8.4-10.3+deb8u2",
                 },
               },
@@ -6301,6 +6498,7 @@ Object {
                 "id": "libxml2/libxml2-dev@2.9.1+dfsg1-5+deb8u6",
                 "info": Object {
                   "name": "libxml2/libxml2-dev",
+                  "purl": "pkg:deb/libxml2-dev@2.9.1%2Bdfsg1-5%2Bdeb8u6?upstream=libxml2",
                   "version": "2.9.1+dfsg1-5+deb8u6",
                 },
               },
@@ -6308,6 +6506,7 @@ Object {
                 "id": "libxt/libxt6@1:1.1.4-1+b1",
                 "info": Object {
                   "name": "libxt/libxt6",
+                  "purl": "pkg:deb/libxt6@1:1.1.4-1%2Bb1?upstream=libxt%401%3A1.1.4-1",
                   "version": "1:1.1.4-1+b1",
                 },
               },
@@ -6315,6 +6514,7 @@ Object {
                 "id": "libxt/libxt-dev@1:1.1.4-1+b1",
                 "info": Object {
                   "name": "libxt/libxt-dev",
+                  "purl": "pkg:deb/libxt-dev@1:1.1.4-1%2Bb1?upstream=libxt%401%3A1.1.4-1",
                   "version": "1:1.1.4-1+b1",
                 },
               },
@@ -6322,6 +6522,7 @@ Object {
                 "id": "ilmbase/libilmbase-dev@1.0.1-6.1",
                 "info": Object {
                   "name": "ilmbase/libilmbase-dev",
+                  "purl": "pkg:deb/libilmbase-dev@1.0.1-6.1?upstream=ilmbase",
                   "version": "1.0.1-6.1",
                 },
               },
@@ -6329,6 +6530,7 @@ Object {
                 "id": "openexr/libopenexr-dev@1.6.1-8",
                 "info": Object {
                   "name": "openexr/libopenexr-dev",
+                  "purl": "pkg:deb/libopenexr-dev@1.6.1-8?upstream=openexr",
                   "version": "1.6.1-8",
                 },
               },
@@ -6336,6 +6538,7 @@ Object {
                 "id": "jbigkit/libjbig-dev@2.1-3.1",
                 "info": Object {
                   "name": "jbigkit/libjbig-dev",
+                  "purl": "pkg:deb/libjbig-dev@2.1-3.1?upstream=jbigkit",
                   "version": "2.1-3.1",
                 },
               },
@@ -6343,6 +6546,7 @@ Object {
                 "id": "tiff/libtiffxx5@4.0.3-12.3+deb8u5",
                 "info": Object {
                   "name": "tiff/libtiffxx5",
+                  "purl": "pkg:deb/libtiffxx5@4.0.3-12.3%2Bdeb8u5?upstream=tiff",
                   "version": "4.0.3-12.3+deb8u5",
                 },
               },
@@ -6350,6 +6554,7 @@ Object {
                 "id": "xz-utils/liblzma-dev@5.1.1alpha+20120614-2+b3",
                 "info": Object {
                   "name": "xz-utils/liblzma-dev",
+                  "purl": "pkg:deb/liblzma-dev@5.1.1alpha%2B20120614-2%2Bb3?upstream=xz-utils%405.1.1alpha%2B20120614-2",
                   "version": "5.1.1alpha+20120614-2+b3",
                 },
               },
@@ -6357,6 +6562,7 @@ Object {
                 "id": "tiff/libtiff5-dev@4.0.3-12.3+deb8u5",
                 "info": Object {
                   "name": "tiff/libtiff5-dev",
+                  "purl": "pkg:deb/libtiff5-dev@4.0.3-12.3%2Bdeb8u5?upstream=tiff",
                   "version": "4.0.3-12.3+deb8u5",
                 },
               },
@@ -6364,6 +6570,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6.q16-dev@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6.q16-dev",
+                  "purl": "pkg:deb/libmagickcore-6.q16-dev@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6371,6 +6578,7 @@ Object {
                 "id": "imagemagick/libmagickcore-dev@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-dev",
+                  "purl": "pkg:deb/libmagickcore-dev@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6378,6 +6586,7 @@ Object {
                 "id": "imagemagick/libmagickwand-6-headers@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickwand-6-headers",
+                  "purl": "pkg:deb/libmagickwand-6-headers@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6385,6 +6594,7 @@ Object {
                 "id": "imagemagick/libmagickwand-6.q16-dev@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickwand-6.q16-dev",
+                  "purl": "pkg:deb/libmagickwand-6.q16-dev@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6392,6 +6602,7 @@ Object {
                 "id": "imagemagick/libmagickwand-dev@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickwand-dev",
+                  "purl": "pkg:deb/libmagickwand-dev@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6399,6 +6610,7 @@ Object {
                 "id": "adduser@3.113+nmu3",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.113%2Bnmu3",
                   "version": "3.113+nmu3",
                 },
               },
@@ -6406,6 +6618,7 @@ Object {
                 "id": "slang2/libslang2@2.3.0-2",
                 "info": Object {
                   "name": "slang2/libslang2",
+                  "purl": "pkg:deb/libslang2@2.3.0-2?upstream=slang2",
                   "version": "2.3.0-2",
                 },
               },
@@ -6413,6 +6626,7 @@ Object {
                 "id": "insserv@1.14.0-5",
                 "info": Object {
                   "name": "insserv",
+                  "purl": "pkg:deb/insserv@1.14.0-5",
                   "version": "1.14.0-5",
                 },
               },
@@ -6420,6 +6634,7 @@ Object {
                 "id": "startpar@0.59-3",
                 "info": Object {
                   "name": "startpar",
+                  "purl": "pkg:deb/startpar@0.59-3",
                   "version": "0.59-3",
                 },
               },
@@ -6427,6 +6642,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.88dsf-59",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.88dsf-59?upstream=sysvinit",
                   "version": "2.88dsf-59",
                 },
               },
@@ -6434,6 +6650,7 @@ Object {
                 "id": "sysvinit/sysv-rc@2.88dsf-59",
                 "info": Object {
                   "name": "sysvinit/sysv-rc",
+                  "purl": "pkg:deb/sysv-rc@2.88dsf-59?upstream=sysvinit",
                   "version": "2.88dsf-59",
                 },
               },
@@ -6441,6 +6658,7 @@ Object {
                 "id": "util-linux/libmount1@2.25.2-6",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.25.2-6?upstream=util-linux",
                   "version": "2.25.2-6",
                 },
               },
@@ -6448,6 +6666,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.25.2-6",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.25.2-6?upstream=util-linux",
                   "version": "2.25.2-6",
                 },
               },
@@ -6455,6 +6674,7 @@ Object {
                 "id": "util-linux/mount@2.25.2-6",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.25.2-6?upstream=util-linux",
                   "version": "2.25.2-6",
                 },
               },
@@ -6462,6 +6682,7 @@ Object {
                 "id": "sysvinit/initscripts@2.88dsf-59",
                 "info": Object {
                   "name": "sysvinit/initscripts",
+                  "purl": "pkg:deb/initscripts@2.88dsf-59?upstream=sysvinit",
                   "version": "2.88dsf-59",
                 },
               },
@@ -6469,6 +6690,7 @@ Object {
                 "id": "tzdata@2018d-0+deb8u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2018d-0%2Bdeb8u1",
                   "version": "2018d-0+deb8u1",
                 },
               },
@@ -6476,6 +6698,7 @@ Object {
                 "id": "lvm2/dmsetup@2:1.02.90-2.2+deb8u1",
                 "info": Object {
                   "name": "lvm2/dmsetup",
+                  "purl": "pkg:deb/dmsetup@2:1.02.90-2.2%2Bdeb8u1?upstream=lvm2%402.02.111-2.2%2Bdeb8u1",
                   "version": "2:1.02.90-2.2+deb8u1",
                 },
               },
@@ -6483,6 +6706,7 @@ Object {
                 "id": "systemd/libudev1@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@215-17%2Bdeb8u7?upstream=systemd",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6490,6 +6714,7 @@ Object {
                 "id": "lvm2/libdevmapper1.02.1@2:1.02.90-2.2+deb8u1",
                 "info": Object {
                   "name": "lvm2/libdevmapper1.02.1",
+                  "purl": "pkg:deb/libdevmapper1.02.1@2:1.02.90-2.2%2Bdeb8u1?upstream=lvm2%402.02.111-2.2%2Bdeb8u1",
                   "version": "2:1.02.90-2.2+deb8u1",
                 },
               },
@@ -6497,6 +6722,7 @@ Object {
                 "id": "kmod/libkmod2@18-3",
                 "info": Object {
                   "name": "kmod/libkmod2",
+                  "purl": "pkg:deb/libkmod2@18-3?upstream=kmod",
                   "version": "18-3",
                 },
               },
@@ -6504,6 +6730,7 @@ Object {
                 "id": "libcap2@1:2.24-8",
                 "info": Object {
                   "name": "libcap2",
+                  "purl": "pkg:deb/libcap2@1:2.24-8",
                   "version": "1:2.24-8",
                 },
               },
@@ -6511,6 +6738,7 @@ Object {
                 "id": "libcap2/libcap2-bin@1:2.24-8",
                 "info": Object {
                   "name": "libcap2/libcap2-bin",
+                  "purl": "pkg:deb/libcap2-bin@1:2.24-8?upstream=libcap2",
                   "version": "1:2.24-8",
                 },
               },
@@ -6518,6 +6746,7 @@ Object {
                 "id": "systemd/libsystemd0@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@215-17%2Bdeb8u7?upstream=systemd",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6525,6 +6754,7 @@ Object {
                 "id": "procps/libprocps3@2:3.3.9-9",
                 "info": Object {
                   "name": "procps/libprocps3",
+                  "purl": "pkg:deb/libprocps3@2:3.3.9-9?upstream=procps",
                   "version": "2:3.3.9-9",
                 },
               },
@@ -6532,6 +6762,7 @@ Object {
                 "id": "procps@2:3.3.9-9+deb8u1",
                 "info": Object {
                   "name": "procps",
+                  "purl": "pkg:deb/procps@2:3.3.9-9%2Bdeb8u1",
                   "version": "2:3.3.9-9+deb8u1",
                 },
               },
@@ -6539,6 +6770,7 @@ Object {
                 "id": "systemd/udev@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd/udev",
+                  "purl": "pkg:deb/udev@215-17%2Bdeb8u7?upstream=systemd",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6546,6 +6778,7 @@ Object {
                 "id": "systemd@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd",
+                  "purl": "pkg:deb/systemd@215-17%2Bdeb8u7",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6553,6 +6786,7 @@ Object {
                 "id": "systemd/systemd-sysv@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd/systemd-sysv",
+                  "purl": "pkg:deb/systemd-sysv@215-17%2Bdeb8u7?upstream=systemd",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6560,6 +6794,7 @@ Object {
                 "id": "init-system-helpers/init@1.22",
                 "info": Object {
                   "name": "init-system-helpers/init",
+                  "purl": "pkg:deb/init@1.22?upstream=init-system-helpers",
                   "version": "1.22",
                 },
               },
@@ -6567,6 +6802,7 @@ Object {
                 "id": "iproute2@3.16.0-2",
                 "info": Object {
                   "name": "iproute2",
+                  "purl": "pkg:deb/iproute2@3.16.0-2",
                   "version": "3.16.0-2",
                 },
               },
@@ -6574,6 +6810,7 @@ Object {
                 "id": "libtasn1-6@4.2-3+deb8u3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.2-3%2Bdeb8u3",
                   "version": "4.2-3+deb8u3",
                 },
               },
@@ -6581,6 +6818,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.20.7-1",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.20.7-1?upstream=p11-kit",
                   "version": "0.20.7-1",
                 },
               },
@@ -6588,6 +6826,7 @@ Object {
                 "id": "gnutls28/libgnutls-openssl27@3.3.8-6+deb8u7",
                 "info": Object {
                   "name": "gnutls28/libgnutls-openssl27",
+                  "purl": "pkg:deb/libgnutls-openssl27@3.3.8-6%2Bdeb8u7?upstream=gnutls28",
                   "version": "3.3.8-6+deb8u7",
                 },
               },
@@ -6595,6 +6834,7 @@ Object {
                 "id": "iputils/iputils-ping@3:20121221-5+b2",
                 "info": Object {
                   "name": "iputils/iputils-ping",
+                  "purl": "pkg:deb/iputils-ping@3:20121221-5%2Bb2?upstream=iputils%403%3A20121221-5",
                   "version": "3:20121221-5+b2",
                 },
               },
@@ -6602,6 +6842,7 @@ Object {
                 "id": "krb5/krb5-multidev@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/krb5-multidev",
+                  "purl": "pkg:deb/krb5-multidev@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -6609,6 +6850,7 @@ Object {
                 "id": "krb5/libkrb5-dev@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkrb5-dev",
+                  "purl": "pkg:deb/libkrb5-dev@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -6616,6 +6858,7 @@ Object {
                 "id": "libevent/libevent-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-2.0-5",
+                  "purl": "pkg:deb/libevent-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -6623,6 +6866,7 @@ Object {
                 "id": "libevent/libevent-core-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-core-2.0-5",
+                  "purl": "pkg:deb/libevent-core-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -6630,6 +6874,7 @@ Object {
                 "id": "libevent/libevent-extra-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-extra-2.0-5",
+                  "purl": "pkg:deb/libevent-extra-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -6637,6 +6882,7 @@ Object {
                 "id": "libevent/libevent-openssl-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-openssl-2.0-5",
+                  "purl": "pkg:deb/libevent-openssl-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -6644,6 +6890,7 @@ Object {
                 "id": "libevent/libevent-pthreads-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-pthreads-2.0-5",
+                  "purl": "pkg:deb/libevent-pthreads-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -6651,6 +6898,7 @@ Object {
                 "id": "libevent/libevent-dev@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-dev",
+                  "purl": "pkg:deb/libevent-dev@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -6658,6 +6906,7 @@ Object {
                 "id": "libffi/libffi-dev@3.1-2+deb8u1",
                 "info": Object {
                   "name": "libffi/libffi-dev",
+                  "purl": "pkg:deb/libffi-dev@3.1-2%2Bdeb8u1?upstream=libffi",
                   "version": "3.1-2+deb8u1",
                 },
               },
@@ -6665,6 +6914,7 @@ Object {
                 "id": "file/libmagic1@1:5.22+15-2+deb8u3",
                 "info": Object {
                   "name": "file/libmagic1",
+                  "purl": "pkg:deb/libmagic1@1:5.22%2B15-2%2Bdeb8u3?upstream=file",
                   "version": "1:5.22+15-2+deb8u3",
                 },
               },
@@ -6672,6 +6922,7 @@ Object {
                 "id": "gcc-4.9/cpp-4.9@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/cpp-4.9",
+                  "purl": "pkg:deb/cpp-4.9@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6679,6 +6930,7 @@ Object {
                 "id": "gcc-4.9/libasan1@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libasan1",
+                  "purl": "pkg:deb/libasan1@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6686,6 +6938,7 @@ Object {
                 "id": "gcc-4.9/libatomic1@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libatomic1",
+                  "purl": "pkg:deb/libatomic1@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6693,6 +6946,7 @@ Object {
                 "id": "gcc-4.9/libcilkrts5@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libcilkrts5",
+                  "purl": "pkg:deb/libcilkrts5@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6700,6 +6954,7 @@ Object {
                 "id": "gcc-4.9/libitm1@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libitm1",
+                  "purl": "pkg:deb/libitm1@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6707,6 +6962,7 @@ Object {
                 "id": "gcc-4.9/liblsan0@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/liblsan0",
+                  "purl": "pkg:deb/liblsan0@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6714,6 +6970,7 @@ Object {
                 "id": "gcc-4.9/libquadmath0@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libquadmath0",
+                  "purl": "pkg:deb/libquadmath0@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6721,6 +6978,7 @@ Object {
                 "id": "gcc-4.9/libtsan0@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libtsan0",
+                  "purl": "pkg:deb/libtsan0@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6728,6 +6986,7 @@ Object {
                 "id": "gcc-4.9/libubsan0@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libubsan0",
+                  "purl": "pkg:deb/libubsan0@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6735,6 +6994,7 @@ Object {
                 "id": "libtool@2.4.2-1.11",
                 "info": Object {
                   "name": "libtool",
+                  "purl": "pkg:deb/libtool@2.4.2-1.11",
                   "version": "2.4.2-1.11",
                 },
               },
@@ -6742,6 +7002,7 @@ Object {
                 "id": "libwebp/libwebp5@0.4.1-1.2+b2",
                 "info": Object {
                   "name": "libwebp/libwebp5",
+                  "purl": "pkg:deb/libwebp5@0.4.1-1.2%2Bb2?upstream=libwebp%400.4.1-1.2",
                   "version": "0.4.1-1.2+b2",
                 },
               },
@@ -6749,6 +7010,7 @@ Object {
                 "id": "libwebp/libwebpdemux1@0.4.1-1.2+b2",
                 "info": Object {
                   "name": "libwebp/libwebpdemux1",
+                  "purl": "pkg:deb/libwebpdemux1@0.4.1-1.2%2Bb2?upstream=libwebp%400.4.1-1.2",
                   "version": "0.4.1-1.2+b2",
                 },
               },
@@ -6756,6 +7018,7 @@ Object {
                 "id": "libwebp/libwebpmux1@0.4.1-1.2+b2",
                 "info": Object {
                   "name": "libwebp/libwebpmux1",
+                  "purl": "pkg:deb/libwebpmux1@0.4.1-1.2%2Bb2?upstream=libwebp%400.4.1-1.2",
                   "version": "0.4.1-1.2+b2",
                 },
               },
@@ -6763,6 +7026,7 @@ Object {
                 "id": "libwebp/libwebp-dev@0.4.1-1.2+b2",
                 "info": Object {
                   "name": "libwebp/libwebp-dev",
+                  "purl": "pkg:deb/libwebp-dev@0.4.1-1.2%2Bb2?upstream=libwebp%400.4.1-1.2",
                   "version": "0.4.1-1.2+b2",
                 },
               },
@@ -6770,6 +7034,7 @@ Object {
                 "id": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
                 "info": Object {
                   "name": "libxslt/libxslt1.1",
+                  "purl": "pkg:deb/libxslt1.1@1.1.28-2%2Bdeb8u3?upstream=libxslt",
                   "version": "1.1.28-2+deb8u3",
                 },
               },
@@ -6777,6 +7042,7 @@ Object {
                 "id": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
                 "info": Object {
                   "name": "libxslt/libxslt1-dev",
+                  "purl": "pkg:deb/libxslt1-dev@1.1.28-2%2Bdeb8u3?upstream=libxslt",
                   "version": "1.1.28-2+deb8u3",
                 },
               },
@@ -6784,6 +7050,7 @@ Object {
                 "id": "libyaml/libyaml-0-2@0.1.6-3",
                 "info": Object {
                   "name": "libyaml/libyaml-0-2",
+                  "purl": "pkg:deb/libyaml-0-2@0.1.6-3?upstream=libyaml",
                   "version": "0.1.6-3",
                 },
               },
@@ -6791,6 +7058,7 @@ Object {
                 "id": "libyaml/libyaml-dev@0.1.6-3",
                 "info": Object {
                   "name": "libyaml/libyaml-dev",
+                  "purl": "pkg:deb/libyaml-dev@0.1.6-3?upstream=libyaml",
                   "version": "0.1.6-3",
                 },
               },
@@ -6798,6 +7066,7 @@ Object {
                 "id": "explorercanvas/libjs-excanvas@0.r3-3",
                 "info": Object {
                   "name": "explorercanvas/libjs-excanvas",
+                  "purl": "pkg:deb/libjs-excanvas@0.r3-3?upstream=explorercanvas",
                   "version": "0.r3-3",
                 },
               },
@@ -6805,6 +7074,7 @@ Object {
                 "id": "mercurial/mercurial-common@3.1.2-2+deb8u4",
                 "info": Object {
                   "name": "mercurial/mercurial-common",
+                  "purl": "pkg:deb/mercurial-common@3.1.2-2%2Bdeb8u4?upstream=mercurial",
                   "version": "3.1.2-2+deb8u4",
                 },
               },
@@ -6812,6 +7082,7 @@ Object {
                 "id": "mercurial@3.1.2-2+deb8u4",
                 "info": Object {
                   "name": "mercurial",
+                  "purl": "pkg:deb/mercurial@3.1.2-2%2Bdeb8u4",
                   "version": "3.1.2-2+deb8u4",
                 },
               },
@@ -7337,6 +7608,7 @@ Object {
                 "id": "mysql-5.5/mysql-common@5.5.60-0+deb8u1",
                 "info": Object {
                   "name": "mysql-5.5/mysql-common",
+                  "purl": "pkg:deb/mysql-common@5.5.60-0%2Bdeb8u1?upstream=mysql-5.5",
                   "version": "5.5.60-0+deb8u1",
                 },
               },
@@ -7344,6 +7616,7 @@ Object {
                 "id": "mysql-5.5/libmysqlclient18@5.5.60-0+deb8u1",
                 "info": Object {
                   "name": "mysql-5.5/libmysqlclient18",
+                  "purl": "pkg:deb/libmysqlclient18@5.5.60-0%2Bdeb8u1?upstream=mysql-5.5",
                   "version": "5.5.60-0+deb8u1",
                 },
               },
@@ -7351,6 +7624,7 @@ Object {
                 "id": "mysql-5.5/libmysqlclient-dev@5.5.60-0+deb8u1",
                 "info": Object {
                   "name": "mysql-5.5/libmysqlclient-dev",
+                  "purl": "pkg:deb/libmysqlclient-dev@5.5.60-0%2Bdeb8u1?upstream=mysql-5.5",
                   "version": "5.5.60-0+deb8u1",
                 },
               },
@@ -7358,6 +7632,7 @@ Object {
                 "id": "ncurses/libtinfo-dev@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libtinfo-dev",
+                  "purl": "pkg:deb/libtinfo-dev@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7365,6 +7640,7 @@ Object {
                 "id": "ncurses/ncurses-bin@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7372,6 +7648,7 @@ Object {
                 "id": "ncurses/libncurses5-dev@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libncurses5-dev",
+                  "purl": "pkg:deb/libncurses5-dev@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7379,6 +7656,7 @@ Object {
                 "id": "ncurses/libncursesw5-dev@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libncursesw5-dev",
+                  "purl": "pkg:deb/libncursesw5-dev@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7386,6 +7664,7 @@ Object {
                 "id": "ncurses/ncurses-base@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7393,6 +7672,7 @@ Object {
                 "id": "netbase@5.3",
                 "info": Object {
                   "name": "netbase",
+                  "purl": "pkg:deb/netbase@5.3",
                   "version": "5.3",
                 },
               },
@@ -7400,6 +7680,7 @@ Object {
                 "id": "libbsd/libbsd0@0.7.0-2",
                 "info": Object {
                   "name": "libbsd/libbsd0",
+                  "purl": "pkg:deb/libbsd0@0.7.0-2?upstream=libbsd",
                   "version": "0.7.0-2",
                 },
               },
@@ -7407,6 +7688,7 @@ Object {
                 "id": "libedit/libedit2@3.1-20140620-2",
                 "info": Object {
                   "name": "libedit/libedit2",
+                  "purl": "pkg:deb/libedit2@3.1-20140620-2?upstream=libedit",
                   "version": "3.1-20140620-2",
                 },
               },
@@ -7414,6 +7696,7 @@ Object {
                 "id": "openssh/openssh-client@1:6.7p1-5+deb8u4",
                 "info": Object {
                   "name": "openssh/openssh-client",
+                  "purl": "pkg:deb/openssh-client@1:6.7p1-5%2Bdeb8u4?upstream=openssh",
                   "version": "1:6.7p1-5+deb8u4",
                 },
               },
@@ -7421,6 +7704,7 @@ Object {
                 "id": "openssl/libssl-dev@1.0.1t-1+deb8u8",
                 "info": Object {
                   "name": "openssl/libssl-dev",
+                  "purl": "pkg:deb/libssl-dev@1.0.1t-1%2Bdeb8u8?upstream=openssl",
                   "version": "1.0.1t-1+deb8u8",
                 },
               },
@@ -7428,6 +7712,7 @@ Object {
                 "id": "pam/libpam-runtime@1.1.8-3.1+deb8u2",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.1.8-3.1%2Bdeb8u2?upstream=pam",
                   "version": "1.1.8-3.1+deb8u2",
                 },
               },
@@ -7435,6 +7720,7 @@ Object {
                 "id": "e2fsprogs/comerr-dev@2.1-1.42.12-2+b1",
                 "info": Object {
                   "name": "e2fsprogs/comerr-dev",
+                  "purl": "pkg:deb/comerr-dev@2.1-1.42.12-2%2Bb1?upstream=e2fsprogs%401.42.12-2",
                   "version": "2.1-1.42.12-2+b1",
                 },
               },
@@ -7442,6 +7728,7 @@ Object {
                 "id": "krb5/libgssrpc4@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libgssrpc4",
+                  "purl": "pkg:deb/libgssrpc4@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7449,6 +7736,7 @@ Object {
                 "id": "krb5/libkadm5clnt-mit9@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkadm5clnt-mit9",
+                  "purl": "pkg:deb/libkadm5clnt-mit9@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7456,6 +7744,7 @@ Object {
                 "id": "krb5/libkdb5-7@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkdb5-7",
+                  "purl": "pkg:deb/libkdb5-7@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7463,6 +7752,7 @@ Object {
                 "id": "krb5/libkadm5srv-mit9@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkadm5srv-mit9",
+                  "purl": "pkg:deb/libkadm5srv-mit9@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7470,6 +7760,7 @@ Object {
                 "id": "cyrus-sasl2/libsasl2-modules-db@2.1.26.dfsg1-13+deb8u1",
                 "info": Object {
                   "name": "cyrus-sasl2/libsasl2-modules-db",
+                  "purl": "pkg:deb/libsasl2-modules-db@2.1.26.dfsg1-13%2Bdeb8u1?upstream=cyrus-sasl2",
                   "version": "2.1.26.dfsg1-13+deb8u1",
                 },
               },
@@ -7477,6 +7768,7 @@ Object {
                 "id": "cyrus-sasl2/libsasl2-2@2.1.26.dfsg1-13+deb8u1",
                 "info": Object {
                   "name": "cyrus-sasl2/libsasl2-2",
+                  "purl": "pkg:deb/libsasl2-2@2.1.26.dfsg1-13%2Bdeb8u1?upstream=cyrus-sasl2",
                   "version": "2.1.26.dfsg1-13+deb8u1",
                 },
               },
@@ -7484,6 +7776,7 @@ Object {
                 "id": "postgresql-9.4/libpq5@9.4.15-0+deb8u1",
                 "info": Object {
                   "name": "postgresql-9.4/libpq5",
+                  "purl": "pkg:deb/libpq5@9.4.15-0%2Bdeb8u1?upstream=postgresql-9.4",
                   "version": "9.4.15-0+deb8u1",
                 },
               },
@@ -7491,6 +7784,7 @@ Object {
                 "id": "postgresql-9.4/libpq-dev@9.4.15-0+deb8u1",
                 "info": Object {
                   "name": "postgresql-9.4/libpq-dev",
+                  "purl": "pkg:deb/libpq-dev@9.4.15-0%2Bdeb8u1?upstream=postgresql-9.4",
                   "version": "9.4.15-0+deb8u1",
                 },
               },
@@ -7498,6 +7792,7 @@ Object {
                 "id": "readline6/libreadline6-dev@6.3-8+b3",
                 "info": Object {
                   "name": "readline6/libreadline6-dev",
+                  "purl": "pkg:deb/libreadline6-dev@6.3-8%2Bb3?upstream=readline6%406.3-8",
                   "version": "6.3-8+b3",
                 },
               },
@@ -7505,6 +7800,7 @@ Object {
                 "id": "readline6/libreadline-dev@6.3-8+b3",
                 "info": Object {
                   "name": "readline6/libreadline-dev",
+                  "purl": "pkg:deb/libreadline-dev@6.3-8%2Bb3?upstream=readline6%406.3-8",
                   "version": "6.3-8+b3",
                 },
               },
@@ -7512,6 +7808,7 @@ Object {
                 "id": "sed@4.2.2-4+deb8u1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.2.2-4%2Bdeb8u1",
                   "version": "4.2.2-4+deb8u1",
                 },
               },
@@ -7519,6 +7816,7 @@ Object {
                 "id": "shadow/login@1:4.2-3+deb8u4",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.2-3%2Bdeb8u4?upstream=shadow",
                   "version": "1:4.2-3+deb8u4",
                 },
               },
@@ -7526,6 +7824,7 @@ Object {
                 "id": "sqlite3/libsqlite3-dev@3.8.7.1-1+deb8u2",
                 "info": Object {
                   "name": "sqlite3/libsqlite3-dev",
+                  "purl": "pkg:deb/libsqlite3-dev@3.8.7.1-1%2Bdeb8u2?upstream=sqlite3",
                   "version": "3.8.7.1-1+deb8u2",
                 },
               },
@@ -7533,6 +7832,7 @@ Object {
                 "id": "apr-util/libaprutil1@1.5.4-1",
                 "info": Object {
                   "name": "apr-util/libaprutil1",
+                  "purl": "pkg:deb/libaprutil1@1.5.4-1?upstream=apr-util",
                   "version": "1.5.4-1",
                 },
               },
@@ -7540,6 +7840,7 @@ Object {
                 "id": "apr/libapr1@1.5.1-3",
                 "info": Object {
                   "name": "apr/libapr1",
+                  "purl": "pkg:deb/libapr1@1.5.1-3?upstream=apr",
                   "version": "1.5.1-3",
                 },
               },
@@ -7547,6 +7848,7 @@ Object {
                 "id": "serf/libserf-1-1@1.3.8-1",
                 "info": Object {
                   "name": "serf/libserf-1-1",
+                  "purl": "pkg:deb/libserf-1-1@1.3.8-1?upstream=serf",
                   "version": "1.3.8-1",
                 },
               },
@@ -7554,6 +7856,7 @@ Object {
                 "id": "subversion/libsvn1@1.8.10-6+deb8u5",
                 "info": Object {
                   "name": "subversion/libsvn1",
+                  "purl": "pkg:deb/libsvn1@1.8.10-6%2Bdeb8u5?upstream=subversion",
                   "version": "1.8.10-6+deb8u5",
                 },
               },
@@ -7561,6 +7864,7 @@ Object {
                 "id": "subversion@1.8.10-6+deb8u5",
                 "info": Object {
                   "name": "subversion",
+                  "purl": "pkg:deb/subversion@1.8.10-6%2Bdeb8u5",
                   "version": "1.8.10-6+deb8u5",
                 },
               },
@@ -7568,6 +7872,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.25.2-6",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.25.2-6?upstream=util-linux%402.25.2-6",
                   "version": "1:2.25.2-6",
                 },
               },
@@ -7575,6 +7880,7 @@ Object {
                 "id": "icu/libicu52@52.1-8+deb8u7",
                 "info": Object {
                   "name": "icu/libicu52",
+                  "purl": "pkg:deb/libicu52@52.1-8%2Bdeb8u7?upstream=icu",
                   "version": "52.1-8+deb8u7",
                 },
               },
@@ -7582,6 +7888,7 @@ Object {
                 "id": "libpsl/libpsl0@0.5.1-1",
                 "info": Object {
                   "name": "libpsl/libpsl0",
+                  "purl": "pkg:deb/libpsl0@0.5.1-1?upstream=libpsl",
                   "version": "0.5.1-1",
                 },
               },
@@ -7589,6 +7896,7 @@ Object {
                 "id": "wget@1.16-1+deb8u5",
                 "info": Object {
                   "name": "wget",
+                  "purl": "pkg:deb/wget@1.16-1%2Bdeb8u5",
                   "version": "1.16-1+deb8u5",
                 },
               },

--- a/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
@@ -1154,6 +1154,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
+                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1161,6 +1162,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
+                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1168,6 +1170,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
+                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1175,6 +1178,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1182,6 +1186,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1189,6 +1194,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1196,6 +1202,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1203,6 +1210,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1210,6 +1218,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1217,6 +1226,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1224,6 +1234,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1231,6 +1242,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.118",
                   "version": "3.118",
                 },
               },
@@ -1238,6 +1250,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1245,6 +1258,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
+                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1252,6 +1266,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1259,6 +1274,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
                   "version": "1.8.4-5",
                 },
               },
@@ -1266,6 +1282,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@241-7~deb10u1?upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1273,6 +1290,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@241-7~deb10u1?upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1280,6 +1298,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2?upstream=apt",
                   "version": "1.8.2",
                 },
               },
@@ -1287,6 +1306,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
                   "version": "2019.1",
                 },
               },
@@ -1294,6 +1314,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1301,6 +1322,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1308,6 +1330,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
+                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1315,6 +1338,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
+                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1322,6 +1346,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
+                  "purl": "pkg:deb/libidn2-0@2.0.5-1?upstream=libidn2",
                   "version": "2.0.5-1",
                 },
               },
@@ -1329,6 +1354,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.13-3",
                   "version": "4.13-3",
                 },
               },
@@ -1336,6 +1362,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1343,6 +1370,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
+                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1350,6 +1378,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
+                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1357,6 +1386,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1364,6 +1394,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
+                  "purl": "pkg:deb/libgnutls30@3.6.7-4?upstream=gnutls28",
                   "version": "3.6.7-4",
                 },
               },
@@ -1371,6 +1402,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
+                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1378,6 +1410,7 @@ Object {
                 "id": "apt@1.8.2",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.8.2",
                   "version": "1.8.2",
                 },
               },
@@ -1385,6 +1418,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1392,6 +1426,7 @@ Object {
                 "id": "base-files@10.3+deb10u1",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u1",
                   "version": "10.3+deb10u1",
                 },
               },
@@ -1399,6 +1434,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1406,6 +1442,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.46",
                   "version": "3.5.46",
                 },
               },
@@ -1413,6 +1450,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.6.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -1420,6 +1458,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
+                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1427,6 +1466,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@5.0-4",
                   "version": "5.0-4",
                 },
               },
@@ -1434,6 +1474,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.30-3",
                   "version": "8.30-3",
                 },
               },
@@ -1441,6 +1482,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.10.2-5",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1448,6 +1490,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
                 },
               },
@@ -1455,6 +1498,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
+                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1462,6 +1506,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
+                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1469,6 +1514,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1476,6 +1522,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1483,6 +1530,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1490,6 +1538,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u1",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1497,6 +1546,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1504,6 +1554,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1511,6 +1562,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@3.3-1",
                   "version": "3.3-1",
                 },
               },
@@ -1518,6 +1570,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.9-3",
                   "version": "1.9-3",
                 },
               },
@@ -1525,6 +1578,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.21",
                   "version": "3.21",
                 },
               },
@@ -1532,6 +1586,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1644,6 +1699,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
+                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1651,6 +1707,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1658,6 +1715,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1665,6 +1723,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1672,6 +1731,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.7-1",
                   "version": "4.7-1",
                 },
               },
@@ -1679,6 +1739,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1686,6 +1747,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1693,6 +1755,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1700,6 +1763,7 @@ Object {
                 "id": "tzdata@2019b-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2019b-0%2Bdeb10u1",
                   "version": "2019b-0+deb10u1",
                 },
               },
@@ -1707,6 +1771,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1714,6 +1779,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1721,6 +1787,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1728,6 +1795,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1735,6 +1803,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
+                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1742,6 +1811,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
@@ -1154,6 +1154,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
+                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1161,6 +1162,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
+                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1168,6 +1170,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
+                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1175,6 +1178,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1182,6 +1186,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1189,6 +1194,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1196,6 +1202,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1203,6 +1210,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1210,6 +1218,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1217,6 +1226,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1224,6 +1234,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1231,6 +1242,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.118",
                   "version": "3.118",
                 },
               },
@@ -1238,6 +1250,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1245,6 +1258,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
+                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1252,6 +1266,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1259,6 +1274,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
                   "version": "1.8.4-5",
                 },
               },
@@ -1266,6 +1282,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@241-7~deb10u1?upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1273,6 +1290,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@241-7~deb10u1?upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1280,6 +1298,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2?upstream=apt",
                   "version": "1.8.2",
                 },
               },
@@ -1287,6 +1306,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
                   "version": "2019.1",
                 },
               },
@@ -1294,6 +1314,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1301,6 +1322,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1308,6 +1330,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
+                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1315,6 +1338,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
+                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1322,6 +1346,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
+                  "purl": "pkg:deb/libidn2-0@2.0.5-1?upstream=libidn2",
                   "version": "2.0.5-1",
                 },
               },
@@ -1329,6 +1354,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.13-3",
                   "version": "4.13-3",
                 },
               },
@@ -1336,6 +1362,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1343,6 +1370,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
+                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1350,6 +1378,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
+                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1357,6 +1386,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1364,6 +1394,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
+                  "purl": "pkg:deb/libgnutls30@3.6.7-4?upstream=gnutls28",
                   "version": "3.6.7-4",
                 },
               },
@@ -1371,6 +1402,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
+                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1378,6 +1410,7 @@ Object {
                 "id": "apt@1.8.2",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.8.2",
                   "version": "1.8.2",
                 },
               },
@@ -1385,6 +1418,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1392,6 +1426,7 @@ Object {
                 "id": "base-files@10.3+deb10u1",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u1",
                   "version": "10.3+deb10u1",
                 },
               },
@@ -1399,6 +1434,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1406,6 +1442,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.46",
                   "version": "3.5.46",
                 },
               },
@@ -1413,6 +1450,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.6.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -1420,6 +1458,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
+                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1427,6 +1466,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@5.0-4",
                   "version": "5.0-4",
                 },
               },
@@ -1434,6 +1474,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.30-3",
                   "version": "8.30-3",
                 },
               },
@@ -1441,6 +1482,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.10.2-5",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1448,6 +1490,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
                 },
               },
@@ -1455,6 +1498,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
+                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1462,6 +1506,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
+                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1469,6 +1514,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1476,6 +1522,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1483,6 +1530,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1490,6 +1538,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u1",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1497,6 +1546,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1504,6 +1554,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1511,6 +1562,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@3.3-1",
                   "version": "3.3-1",
                 },
               },
@@ -1518,6 +1570,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.9-3",
                   "version": "1.9-3",
                 },
               },
@@ -1525,6 +1578,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.21",
                   "version": "3.21",
                 },
               },
@@ -1532,6 +1586,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1644,6 +1699,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
+                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1651,6 +1707,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1658,6 +1715,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1665,6 +1723,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1672,6 +1731,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.7-1",
                   "version": "4.7-1",
                 },
               },
@@ -1679,6 +1739,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1686,6 +1747,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1693,6 +1755,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1700,6 +1763,7 @@ Object {
                 "id": "tzdata@2019b-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2019b-0%2Bdeb10u1",
                   "version": "2019b-0+deb10u1",
                 },
               },
@@ -1707,6 +1771,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1714,6 +1779,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1721,6 +1787,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1728,6 +1795,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1735,6 +1803,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
+                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1742,6 +1811,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
+++ b/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
@@ -1233,6 +1233,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
+                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1240,6 +1241,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
+                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1247,6 +1249,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
+                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1254,6 +1257,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1261,6 +1265,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1268,6 +1273,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1275,6 +1281,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1282,6 +1289,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1289,6 +1297,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1296,6 +1305,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1303,6 +1313,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1310,6 +1321,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.118",
                   "version": "3.118",
                 },
               },
@@ -1317,6 +1329,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1324,6 +1337,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
+                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1331,6 +1345,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1338,6 +1353,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
                   "version": "1.8.4-5",
                 },
               },
@@ -1345,6 +1361,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@241-7~deb10u1?upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1352,6 +1369,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@241-7~deb10u1?upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1359,6 +1377,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2?upstream=apt",
                   "version": "1.8.2",
                 },
               },
@@ -1366,6 +1385,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
                   "version": "2019.1",
                 },
               },
@@ -1373,6 +1393,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1380,6 +1401,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1387,6 +1409,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
+                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1394,6 +1417,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
+                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1401,6 +1425,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
+                  "purl": "pkg:deb/libidn2-0@2.0.5-1?upstream=libidn2",
                   "version": "2.0.5-1",
                 },
               },
@@ -1408,6 +1433,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.13-3",
                   "version": "4.13-3",
                 },
               },
@@ -1415,6 +1441,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1422,6 +1449,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
+                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1429,6 +1457,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
+                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1436,6 +1465,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1443,6 +1473,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
+                  "purl": "pkg:deb/libgnutls30@3.6.7-4?upstream=gnutls28",
                   "version": "3.6.7-4",
                 },
               },
@@ -1450,6 +1481,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
+                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1457,6 +1489,7 @@ Object {
                 "id": "apt@1.8.2",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.8.2",
                   "version": "1.8.2",
                 },
               },
@@ -1464,6 +1497,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1471,6 +1505,7 @@ Object {
                 "id": "base-files@10.3+deb10u1",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u1",
                   "version": "10.3+deb10u1",
                 },
               },
@@ -1478,6 +1513,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1485,6 +1521,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.46",
                   "version": "3.5.46",
                 },
               },
@@ -1492,6 +1529,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.6.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -1499,6 +1537,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
+                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1506,6 +1545,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@5.0-4",
                   "version": "5.0-4",
                 },
               },
@@ -1513,6 +1553,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.30-3",
                   "version": "8.30-3",
                 },
               },
@@ -1520,6 +1561,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.10.2-5",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1527,6 +1569,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
                 },
               },
@@ -1534,6 +1577,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
+                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1541,6 +1585,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
+                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1548,6 +1593,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1555,6 +1601,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1562,6 +1609,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1569,6 +1617,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u1",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1576,6 +1625,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1583,6 +1633,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1590,6 +1641,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@3.3-1",
                   "version": "3.3-1",
                 },
               },
@@ -1597,6 +1649,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.9-3",
                   "version": "1.9-3",
                 },
               },
@@ -1604,6 +1657,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.21",
                   "version": "3.21",
                 },
               },
@@ -1611,6 +1665,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1723,6 +1778,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
+                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1730,6 +1786,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1737,6 +1794,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1744,6 +1802,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1751,6 +1810,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.7-1",
                   "version": "4.7-1",
                 },
               },
@@ -1758,6 +1818,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1765,6 +1826,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1772,6 +1834,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1779,6 +1842,7 @@ Object {
                 "id": "tzdata@2019b-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2019b-0%2Bdeb10u1",
                   "version": "2019b-0+deb10u1",
                 },
               },
@@ -1786,6 +1850,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1793,6 +1858,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1800,6 +1866,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1807,6 +1874,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1814,6 +1882,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
+                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1821,6 +1890,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
@@ -1052,6 +1052,7 @@ Object {
                 "id": "adduser@3.115",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.115",
                   "version": "3.115",
                 },
               },
@@ -1059,6 +1060,7 @@ Object {
                 "id": "shadow/passwd@1:4.4-4.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.4-4.1?upstream=shadow",
                   "version": "1:4.4-4.1",
                 },
               },
@@ -1066,6 +1068,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.4.10",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.4.10?upstream=apt",
                   "version": "1.4.10",
                 },
               },
@@ -1073,6 +1076,7 @@ Object {
                 "id": "debian-archive-keyring@2017.5+deb9u1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2017.5%2Bdeb9u1",
                   "version": "2017.5+deb9u1",
                 },
               },
@@ -1080,6 +1084,7 @@ Object {
                 "id": "gcc-6/libstdc++6@6.3.0-18+deb9u1",
                 "info": Object {
                   "name": "gcc-6/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@6.3.0-18%2Bdeb9u1?upstream=gcc-6",
                   "version": "6.3.0-18+deb9u1",
                 },
               },
@@ -1087,6 +1092,7 @@ Object {
                 "id": "gnupg2/gpgv@2.1.18-8~deb9u4",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.1.18-8~deb9u4?upstream=gnupg2",
                   "version": "2.1.18-8~deb9u4",
                 },
               },
@@ -1094,6 +1100,7 @@ Object {
                 "id": "init-system-helpers@1.48",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.48",
                   "version": "1.48",
                 },
               },
@@ -1101,6 +1108,7 @@ Object {
                 "id": "apt@1.4.10",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.4.10",
                   "version": "1.4.10",
                 },
               },
@@ -1108,6 +1116,7 @@ Object {
                 "id": "lz4/liblz4-1@0.0~r131-2+b1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@0.0~r131-2%2Bb1?upstream=lz4%400.0~r131-2",
                   "version": "0.0~r131-2+b1",
                 },
               },
@@ -1115,6 +1124,7 @@ Object {
                 "id": "base-files@9.9+deb9u13",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@9.9%2Bdeb9u13",
                   "version": "9.9+deb9u13",
                 },
               },
@@ -1122,6 +1132,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.227",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.227?upstream=cdebconf",
                   "version": "0.227",
                 },
               },
@@ -1129,6 +1140,7 @@ Object {
                 "id": "base-passwd@3.5.43",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.43",
                   "version": "3.5.43",
                 },
               },
@@ -1136,6 +1148,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1143,6 +1156,7 @@ Object {
                 "id": "debianutils@4.8.1.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.1.1",
                   "version": "4.8.1.1",
                 },
               },
@@ -1150,6 +1164,7 @@ Object {
                 "id": "dash@0.5.8-2.4",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.8-2.4",
                   "version": "0.5.8-2.4",
                 },
               },
@@ -1157,6 +1172,7 @@ Object {
                 "id": "ncurses/libtinfo5@6.0+20161126-1+deb9u2",
                 "info": Object {
                   "name": "ncurses/libtinfo5",
+                  "purl": "pkg:deb/libtinfo5@6.0%2B20161126-1%2Bdeb9u2?upstream=ncurses",
                   "version": "6.0+20161126-1+deb9u2",
                 },
               },
@@ -1164,6 +1180,7 @@ Object {
                 "id": "bash@4.4-5",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@4.4-5",
                   "version": "4.4-5",
                 },
               },
@@ -1171,6 +1188,7 @@ Object {
                 "id": "coreutils@8.26-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.26-3",
                   "version": "8.26-3",
                 },
               },
@@ -1178,6 +1196,7 @@ Object {
                 "id": "sensible-utils@0.0.9+deb9u1",
                 "info": Object {
                   "name": "sensible-utils",
+                  "purl": "pkg:deb/sensible-utils@0.0.9%2Bdeb9u1",
                   "version": "0.0.9+deb9u1",
                 },
               },
@@ -1185,6 +1204,7 @@ Object {
                 "id": "diffutils@1:3.5-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.5-3",
                   "version": "1:3.5-3",
                 },
               },
@@ -1192,6 +1212,7 @@ Object {
                 "id": "e2fsprogs/e2fslibs@1.43.4-2+deb9u2",
                 "info": Object {
                   "name": "e2fsprogs/e2fslibs",
+                  "purl": "pkg:deb/e2fslibs@1.43.4-2%2Bdeb9u2?upstream=e2fsprogs",
                   "version": "1.43.4-2+deb9u2",
                 },
               },
@@ -1199,6 +1220,7 @@ Object {
                 "id": "e2fsprogs/libcomerr2@1.43.4-2+deb9u2",
                 "info": Object {
                   "name": "e2fsprogs/libcomerr2",
+                  "purl": "pkg:deb/libcomerr2@1.43.4-2%2Bdeb9u2?upstream=e2fsprogs",
                   "version": "1.43.4-2+deb9u2",
                 },
               },
@@ -1206,6 +1228,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.43.4-2+deb9u2",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.43.4-2%2Bdeb9u2?upstream=e2fsprogs",
                   "version": "1.43.4-2+deb9u2",
                 },
               },
@@ -1213,6 +1236,7 @@ Object {
                 "id": "ncurses/libncursesw5@6.0+20161126-1+deb9u2",
                 "info": Object {
                   "name": "ncurses/libncursesw5",
+                  "purl": "pkg:deb/libncursesw5@6.0%2B20161126-1%2Bdeb9u2?upstream=ncurses",
                   "version": "6.0+20161126-1+deb9u2",
                 },
               },
@@ -1220,6 +1244,7 @@ Object {
                 "id": "pam/libpam0g@1.1.8-3.6",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.1.8-3.6?upstream=pam",
                   "version": "1.1.8-3.6",
                 },
               },
@@ -1227,6 +1252,7 @@ Object {
                 "id": "systemd/libsystemd0@232-25+deb9u12",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@232-25%2Bdeb9u12?upstream=systemd",
                   "version": "232-25+deb9u12",
                 },
               },
@@ -1234,6 +1260,7 @@ Object {
                 "id": "systemd/libudev1@232-25+deb9u12",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@232-25%2Bdeb9u12?upstream=systemd",
                   "version": "232-25+deb9u12",
                 },
               },
@@ -1241,6 +1268,7 @@ Object {
                 "id": "util-linux/libblkid1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1248,6 +1276,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1255,6 +1284,7 @@ Object {
                 "id": "util-linux/libmount1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1262,6 +1292,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1269,6 +1300,7 @@ Object {
                 "id": "util-linux/libuuid1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1276,6 +1308,7 @@ Object {
                 "id": "util-linux@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.29.2-1%2Bdeb9u1",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1283,6 +1316,7 @@ Object {
                 "id": "e2fsprogs@1.43.4-2+deb9u2",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.43.4-2%2Bdeb9u2",
                   "version": "1.43.4-2+deb9u2",
                 },
               },
@@ -1290,6 +1324,7 @@ Object {
                 "id": "findutils@4.6.0+git+20161106-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20161106-2",
                   "version": "4.6.0+git+20161106-2",
                 },
               },
@@ -1297,6 +1332,7 @@ Object {
                 "id": "glibc/libc-bin@2.24-11+deb9u4",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.24-11%2Bdeb9u4?upstream=glibc",
                   "version": "2.24-11+deb9u4",
                 },
               },
@@ -1304,6 +1340,7 @@ Object {
                 "id": "libgcrypt20@1.7.6-2+deb9u3",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.7.6-2%2Bdeb9u3",
                   "version": "1.7.6-2+deb9u3",
                 },
               },
@@ -1311,6 +1348,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.26-2",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.26-2?upstream=libgpg-error",
                   "version": "1.26-2",
                 },
               },
@@ -1318,6 +1356,7 @@ Object {
                 "id": "grep@2.27-2",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@2.27-2",
                   "version": "2.27-2",
                 },
               },
@@ -1325,6 +1364,7 @@ Object {
                 "id": "gzip/gzip@1.6-5+b1",
                 "info": Object {
                   "name": "gzip/gzip",
+                  "purl": "pkg:deb/gzip@1.6-5%2Bb1?upstream=gzip%401.6-5",
                   "version": "1.6-5+b1",
                 },
               },
@@ -1332,6 +1372,7 @@ Object {
                 "id": "hostname/hostname@3.18+b1",
                 "info": Object {
                   "name": "hostname/hostname",
+                  "purl": "pkg:deb/hostname@3.18%2Bb1?upstream=hostname%403.18",
                   "version": "3.18+b1",
                 },
               },
@@ -1339,6 +1380,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28-12+deb9u1",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28-12%2Bdeb9u1?upstream=db5.3",
                   "version": "5.3.28-12+deb9u1",
                 },
               },
@@ -1346,6 +1388,7 @@ Object {
                 "id": "elfutils/libelf1@0.168-1",
                 "info": Object {
                   "name": "elfutils/libelf1",
+                  "purl": "pkg:deb/libelf1@0.168-1?upstream=elfutils",
                   "version": "0.168-1",
                 },
               },
@@ -1353,6 +1396,7 @@ Object {
                 "id": "libmnl/libmnl0@1.0.4-2",
                 "info": Object {
                   "name": "libmnl/libmnl0",
+                  "purl": "pkg:deb/libmnl0@1.0.4-2?upstream=libmnl",
                   "version": "1.0.4-2",
                 },
               },
@@ -1360,6 +1404,7 @@ Object {
                 "id": "iproute2@4.9.0-1+deb9u1",
                 "info": Object {
                   "name": "iproute2",
+                  "purl": "pkg:deb/iproute2@4.9.0-1%2Bdeb9u1",
                   "version": "4.9.0-1+deb9u1",
                 },
               },
@@ -1367,6 +1412,7 @@ Object {
                 "id": "libcap2@1:2.25-1",
                 "info": Object {
                   "name": "libcap2",
+                  "purl": "pkg:deb/libcap2@1:2.25-1",
                   "version": "1:2.25-1",
                 },
               },
@@ -1374,6 +1420,7 @@ Object {
                 "id": "libidn/libidn11@1.33-1+deb9u1",
                 "info": Object {
                   "name": "libidn/libidn11",
+                  "purl": "pkg:deb/libidn11@1.33-1%2Bdeb9u1?upstream=libidn",
                   "version": "1.33-1+deb9u1",
                 },
               },
@@ -1381,6 +1428,7 @@ Object {
                 "id": "nettle/libnettle6@3.3-1+b2",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.3-1%2Bb2?upstream=nettle%403.3-1",
                   "version": "3.3-1+b2",
                 },
               },
@@ -1388,6 +1436,7 @@ Object {
                 "id": "iputils/iputils-ping@3:20161105-1",
                 "info": Object {
                   "name": "iputils/iputils-ping",
+                  "purl": "pkg:deb/iputils-ping@3:20161105-1?upstream=iputils",
                   "version": "3:20161105-1",
                 },
               },
@@ -1395,6 +1444,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.6-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.6-2?upstream=libsemanage",
                   "version": "2.6-2",
                 },
               },
@@ -1402,6 +1452,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.6-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.6-2?upstream=libsemanage",
                   "version": "2.6-2",
                 },
               },
@@ -1409,6 +1460,7 @@ Object {
                 "id": "libsepol/libsepol1@2.6-2",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.6-2?upstream=libsepol",
                   "version": "2.6-2",
                 },
               },
@@ -1416,6 +1468,7 @@ Object {
                 "id": "lsb/lsb-base@9.20161125",
                 "info": Object {
                   "name": "lsb/lsb-base",
+                  "purl": "pkg:deb/lsb-base@9.20161125?upstream=lsb",
                   "version": "9.20161125",
                 },
               },
@@ -1556,6 +1609,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.0+20161126-1+deb9u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.0%2B20161126-1%2Bdeb9u2?upstream=ncurses",
                   "version": "6.0+20161126-1+deb9u2",
                 },
               },
@@ -1563,6 +1617,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.0+20161126-1+deb9u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.0%2B20161126-1%2Bdeb9u2?upstream=ncurses",
                   "version": "6.0+20161126-1+deb9u2",
                 },
               },
@@ -1570,6 +1625,7 @@ Object {
                 "id": "pam/libpam-modules@1.1.8-3.6",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.1.8-3.6?upstream=pam",
                   "version": "1.1.8-3.6",
                 },
               },
@@ -1577,6 +1633,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.1.8-3.6",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.1.8-3.6?upstream=pam",
                   "version": "1.1.8-3.6",
                 },
               },
@@ -1584,6 +1641,7 @@ Object {
                 "id": "pam/libpam-runtime@1.1.8-3.6",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.1.8-3.6?upstream=pam",
                   "version": "1.1.8-3.6",
                 },
               },
@@ -1591,6 +1649,7 @@ Object {
                 "id": "sed@4.4-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.4-1",
                   "version": "4.4-1",
                 },
               },
@@ -1598,6 +1657,7 @@ Object {
                 "id": "shadow/login@1:4.4-4.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.4-4.1?upstream=shadow",
                   "version": "1:4.4-4.1",
                 },
               },
@@ -1605,6 +1665,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.88dsf-59.9",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.88dsf-59.9?upstream=sysvinit",
                   "version": "2.88dsf-59.9",
                 },
               },
@@ -1612,6 +1673,7 @@ Object {
                 "id": "tzdata@2020a-0+deb9u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb9u1",
                   "version": "2020a-0+deb9u1",
                 },
               },
@@ -1619,6 +1681,7 @@ Object {
                 "id": "ustr/libustr-1.0-1@1.0.4-6",
                 "info": Object {
                   "name": "ustr/libustr-1.0-1",
+                  "purl": "pkg:deb/libustr-1.0-1@1.0.4-6?upstream=ustr",
                   "version": "1.0.4-6",
                 },
               },
@@ -1626,6 +1689,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.29.2-1%2Bdeb9u1?upstream=util-linux%402.29.2-1%2Bdeb9u1",
                   "version": "1:2.29.2-1+deb9u1",
                 },
               },
@@ -1633,6 +1697,7 @@ Object {
                 "id": "util-linux/mount@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.29.2-1%2Bdeb9u1?upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
@@ -102,6 +102,7 @@ Object {
                 "id": "base-files@10.3+deb10u5",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u5",
                   "version": "10.3+deb10u5",
                 },
               },
@@ -109,6 +110,7 @@ Object {
                 "id": "glibc/libc6@2.28-10",
                 "info": Object {
                   "name": "glibc/libc6",
+                  "purl": "pkg:deb/libc6@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -116,6 +118,7 @@ Object {
                 "id": "netbase@5.6",
                 "info": Object {
                   "name": "netbase",
+                  "purl": "pkg:deb/netbase@5.6",
                   "version": "5.6",
                 },
               },
@@ -123,6 +126,7 @@ Object {
                 "id": "openssl/libssl1.1@1.1.1d-0+deb10u3",
                 "info": Object {
                   "name": "openssl/libssl1.1",
+                  "purl": "pkg:deb/libssl1.1@1.1.1d-0%2Bdeb10u3?upstream=openssl",
                   "version": "1.1.1d-0+deb10u3",
                 },
               },
@@ -130,6 +134,7 @@ Object {
                 "id": "openssl@1.1.1d-0+deb10u3",
                 "info": Object {
                   "name": "openssl",
+                  "purl": "pkg:deb/openssl@1.1.1d-0%2Bdeb10u3",
                   "version": "1.1.1d-0+deb10u3",
                 },
               },
@@ -137,6 +142,7 @@ Object {
                 "id": "tzdata@2020a-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb10u1",
                   "version": "2020a-0+deb10u1",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
@@ -3030,7 +3030,7 @@ Object {
                 "id": "acl@2.2.53-1.el8",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:rpm/acl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/acl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -3038,7 +3038,7 @@ Object {
                 "id": "annobin@8.90-1.el8",
                 "info": Object {
                   "name": "annobin",
-                  "purl": "pkg:rpm/annobin@8.90-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/annobin@8.90-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.90-1.el8",
                 },
               },
@@ -3046,7 +3046,7 @@ Object {
                 "id": "audit-libs@3.0-0.17.20191104git1c2f876.el8",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@3.0-0.17.20191104git1c2f876.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/audit-libs@3.0-0.17.20191104git1c2f876.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0-0.17.20191104git1c2f876.el8",
                 },
               },
@@ -3054,7 +3054,7 @@ Object {
                 "id": "autoconf@2.69-27.el8",
                 "info": Object {
                   "name": "autoconf",
-                  "purl": "pkg:rpm/autoconf@2.69-27.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/autoconf@2.69-27.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.69-27.el8",
                 },
               },
@@ -3062,7 +3062,7 @@ Object {
                 "id": "automake@1.16.1-6.el8",
                 "info": Object {
                   "name": "automake",
-                  "purl": "pkg:rpm/automake@1.16.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/automake@1.16.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.16.1-6.el8",
                 },
               },
@@ -3070,7 +3070,7 @@ Object {
                 "id": "basesystem@11-5.el8",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/basesystem@11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "11-5.el8",
                 },
               },
@@ -3078,7 +3078,7 @@ Object {
                 "id": "bash@4.4.19-10.el8",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.4.19-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/bash@4.4.19-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.4.19-10.el8",
                 },
               },
@@ -3086,7 +3086,7 @@ Object {
                 "id": "binutils@2.30-73.el8",
                 "info": Object {
                   "name": "binutils",
-                  "purl": "pkg:rpm/binutils@2.30-73.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/binutils@2.30-73.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.30-73.el8",
                 },
               },
@@ -3094,7 +3094,7 @@ Object {
                 "id": "brotli@1.0.6-1.el8",
                 "info": Object {
                   "name": "brotli",
-                  "purl": "pkg:rpm/brotli@1.0.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/brotli@1.0.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.6-1.el8",
                 },
               },
@@ -3102,7 +3102,7 @@ Object {
                 "id": "bsdtar@3.3.2-8.el8_1",
                 "info": Object {
                   "name": "bsdtar",
-                  "purl": "pkg:rpm/bsdtar@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/bsdtar@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.3.2-8.el8_1",
                 },
               },
@@ -3110,7 +3110,7 @@ Object {
                 "id": "bzip2@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2",
-                  "purl": "pkg:rpm/bzip2@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/bzip2@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -3118,7 +3118,7 @@ Object {
                 "id": "bzip2-devel@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2-devel",
-                  "purl": "pkg:rpm/bzip2-devel@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/bzip2-devel@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -3126,7 +3126,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/bzip2-libs@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -3134,7 +3134,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-80.0.el8_1",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-80.0.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/ca-certificates@2019.2.32-80.0.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2019.2.32-80.0.el8_1",
                 },
               },
@@ -3142,7 +3142,7 @@ Object {
                 "id": "chkconfig@1.11-1.el8",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/chkconfig@1.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.11-1.el8",
                 },
               },
@@ -3150,7 +3150,7 @@ Object {
                 "id": "cmake@3.11.4-7.el8",
                 "info": Object {
                   "name": "cmake",
-                  "purl": "pkg:rpm/cmake@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/cmake@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11.4-7.el8",
                 },
               },
@@ -3158,7 +3158,7 @@ Object {
                 "id": "cmake-data@3.11.4-7.el8",
                 "info": Object {
                   "name": "cmake-data",
-                  "purl": "pkg:rpm/cmake-data@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/cmake-data@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11.4-7.el8",
                 },
               },
@@ -3166,7 +3166,7 @@ Object {
                 "id": "cmake-filesystem@3.11.4-7.el8",
                 "info": Object {
                   "name": "cmake-filesystem",
-                  "purl": "pkg:rpm/cmake-filesystem@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/cmake-filesystem@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11.4-7.el8",
                 },
               },
@@ -3174,7 +3174,7 @@ Object {
                 "id": "cmake-rpm-macros@3.11.4-7.el8",
                 "info": Object {
                   "name": "cmake-rpm-macros",
-                  "purl": "pkg:rpm/cmake-rpm-macros@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/cmake-rpm-macros@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11.4-7.el8",
                 },
               },
@@ -3182,7 +3182,7 @@ Object {
                 "id": "coreutils-single@8.30-7.el8_2.1",
                 "info": Object {
                   "name": "coreutils-single",
-                  "purl": "pkg:rpm/coreutils-single@8.30-7.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/coreutils-single@8.30-7.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.30-7.el8_2.1",
                 },
               },
@@ -3190,7 +3190,7 @@ Object {
                 "id": "cpp@8.3.1-5.el8",
                 "info": Object {
                   "name": "cpp",
-                  "purl": "pkg:rpm/cpp@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/cpp@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -3198,7 +3198,7 @@ Object {
                 "id": "cracklib@2.9.6-15.el8",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.6-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/cracklib@2.9.6-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.6-15.el8",
                 },
               },
@@ -3206,7 +3206,7 @@ Object {
                 "id": "crypto-policies@20191128-2.git23e1bf1.el8",
                 "info": Object {
                   "name": "crypto-policies",
-                  "purl": "pkg:rpm/crypto-policies@20191128-2.git23e1bf1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/crypto-policies@20191128-2.git23e1bf1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "20191128-2.git23e1bf1.el8",
                 },
               },
@@ -3214,7 +3214,7 @@ Object {
                 "id": "cryptsetup-libs@2.2.2-1.el8",
                 "info": Object {
                   "name": "cryptsetup-libs",
-                  "purl": "pkg:rpm/cryptsetup-libs@2.2.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/cryptsetup-libs@2.2.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.2-1.el8",
                 },
               },
@@ -3222,7 +3222,7 @@ Object {
                 "id": "curl@7.61.1-12.el8",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/curl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -3230,7 +3230,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.27-1.el8",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.27-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.27-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.1.27-1.el8",
                 },
               },
@@ -3238,7 +3238,7 @@ Object {
                 "id": "dbus@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus",
-                  "purl": "pkg:rpm/dbus@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dbus@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3246,7 +3246,7 @@ Object {
                 "id": "dbus-common@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus-common",
-                  "purl": "pkg:rpm/dbus-common@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dbus-common@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3254,7 +3254,7 @@ Object {
                 "id": "dbus-daemon@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus-daemon",
-                  "purl": "pkg:rpm/dbus-daemon@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dbus-daemon@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3262,7 +3262,7 @@ Object {
                 "id": "dbus-glib@0.110-2.el8",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.110-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dbus-glib@0.110-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.110-2.el8",
                 },
               },
@@ -3270,7 +3270,7 @@ Object {
                 "id": "dbus-libs@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dbus-libs@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3278,7 +3278,7 @@ Object {
                 "id": "dbus-tools@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus-tools",
-                  "purl": "pkg:rpm/dbus-tools@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dbus-tools@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3286,7 +3286,7 @@ Object {
                 "id": "dejavu-fonts-common@2.35-6.el8",
                 "info": Object {
                   "name": "dejavu-fonts-common",
-                  "purl": "pkg:rpm/dejavu-fonts-common@2.35-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dejavu-fonts-common@2.35-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.35-6.el8",
                 },
               },
@@ -3294,7 +3294,7 @@ Object {
                 "id": "dejavu-sans-fonts@2.35-6.el8",
                 "info": Object {
                   "name": "dejavu-sans-fonts",
-                  "purl": "pkg:rpm/dejavu-sans-fonts@2.35-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dejavu-sans-fonts@2.35-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.35-6.el8",
                 },
               },
@@ -3302,7 +3302,7 @@ Object {
                 "id": "device-mapper@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper",
-                  "purl": "pkg:rpm/device-mapper@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/device-mapper@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -3310,7 +3310,7 @@ Object {
                 "id": "device-mapper-libs@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper-libs",
-                  "purl": "pkg:rpm/device-mapper-libs@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/device-mapper-libs@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -3318,7 +3318,7 @@ Object {
                 "id": "dmidecode@1:3.2-5.el8",
                 "info": Object {
                   "name": "dmidecode",
-                  "purl": "pkg:rpm/dmidecode@1:3.2-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dmidecode@1:3.2-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:3.2-5.el8",
                 },
               },
@@ -3326,7 +3326,7 @@ Object {
                 "id": "dnf@4.2.17-6.el8",
                 "info": Object {
                   "name": "dnf",
-                  "purl": "pkg:rpm/dnf@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dnf@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.17-6.el8",
                 },
               },
@@ -3334,7 +3334,7 @@ Object {
                 "id": "dnf-data@4.2.17-6.el8",
                 "info": Object {
                   "name": "dnf-data",
-                  "purl": "pkg:rpm/dnf-data@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dnf-data@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.17-6.el8",
                 },
               },
@@ -3342,7 +3342,7 @@ Object {
                 "id": "dnf-plugin-subscription-manager@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "dnf-plugin-subscription-manager",
-                  "purl": "pkg:rpm/dnf-plugin-subscription-manager@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dnf-plugin-subscription-manager@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -3350,7 +3350,7 @@ Object {
                 "id": "dnf-plugins-core@4.0.12-3.el8",
                 "info": Object {
                   "name": "dnf-plugins-core",
-                  "purl": "pkg:rpm/dnf-plugins-core@4.0.12-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dnf-plugins-core@4.0.12-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.0.12-3.el8",
                 },
               },
@@ -3358,7 +3358,7 @@ Object {
                 "id": "dwz@0.12-9.el8",
                 "info": Object {
                   "name": "dwz",
-                  "purl": "pkg:rpm/dwz@0.12-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/dwz@0.12-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.12-9.el8",
                 },
               },
@@ -3366,7 +3366,7 @@ Object {
                 "id": "efi-srpm-macros@3-2.el8",
                 "info": Object {
                   "name": "efi-srpm-macros",
-                  "purl": "pkg:rpm/efi-srpm-macros@3-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/efi-srpm-macros@3-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3-2.el8",
                 },
               },
@@ -3374,7 +3374,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -3382,7 +3382,7 @@ Object {
                 "id": "elfutils-libelf@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/elfutils-libelf@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -3390,7 +3390,7 @@ Object {
                 "id": "elfutils-libs@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/elfutils-libs@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -3398,7 +3398,7 @@ Object {
                 "id": "emacs-filesystem@1:26.1-5.el8",
                 "info": Object {
                   "name": "emacs-filesystem",
-                  "purl": "pkg:rpm/emacs-filesystem@1:26.1-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/emacs-filesystem@1:26.1-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:26.1-5.el8",
                 },
               },
@@ -3406,7 +3406,7 @@ Object {
                 "id": "environment-modules@4.1.4-4.el8",
                 "info": Object {
                   "name": "environment-modules",
-                  "purl": "pkg:rpm/environment-modules@4.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/environment-modules@4.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.1.4-4.el8",
                 },
               },
@@ -3414,7 +3414,7 @@ Object {
                 "id": "expat@2.2.5-3.el8",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/expat@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.5-3.el8",
                 },
               },
@@ -3422,7 +3422,7 @@ Object {
                 "id": "expat-devel@2.2.5-3.el8",
                 "info": Object {
                   "name": "expat-devel",
-                  "purl": "pkg:rpm/expat-devel@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/expat-devel@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.5-3.el8",
                 },
               },
@@ -3430,7 +3430,7 @@ Object {
                 "id": "file@5.33-13.el8",
                 "info": Object {
                   "name": "file",
-                  "purl": "pkg:rpm/file@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/file@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.33-13.el8",
                 },
               },
@@ -3438,7 +3438,7 @@ Object {
                 "id": "file-libs@5.33-13.el8",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/file-libs@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.33-13.el8",
                 },
               },
@@ -3446,7 +3446,7 @@ Object {
                 "id": "filesystem@3.8-2.el8",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.8-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/filesystem@3.8-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.8-2.el8",
                 },
               },
@@ -3454,7 +3454,7 @@ Object {
                 "id": "findutils@1:4.6.0-20.el8",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.6.0-20.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/findutils@1:4.6.0-20.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:4.6.0-20.el8",
                 },
               },
@@ -3462,7 +3462,7 @@ Object {
                 "id": "fipscheck@1.5.0-4.el8",
                 "info": Object {
                   "name": "fipscheck",
-                  "purl": "pkg:rpm/fipscheck@1.5.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/fipscheck@1.5.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.0-4.el8",
                 },
               },
@@ -3470,7 +3470,7 @@ Object {
                 "id": "fipscheck-lib@1.5.0-4.el8",
                 "info": Object {
                   "name": "fipscheck-lib",
-                  "purl": "pkg:rpm/fipscheck-lib@1.5.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/fipscheck-lib@1.5.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.0-4.el8",
                 },
               },
@@ -3478,7 +3478,7 @@ Object {
                 "id": "fontconfig@2.13.1-3.el8",
                 "info": Object {
                   "name": "fontconfig",
-                  "purl": "pkg:rpm/fontconfig@2.13.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/fontconfig@2.13.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.13.1-3.el8",
                 },
               },
@@ -3486,7 +3486,7 @@ Object {
                 "id": "fontconfig-devel@2.13.1-3.el8",
                 "info": Object {
                   "name": "fontconfig-devel",
-                  "purl": "pkg:rpm/fontconfig-devel@2.13.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/fontconfig-devel@2.13.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.13.1-3.el8",
                 },
               },
@@ -3494,7 +3494,7 @@ Object {
                 "id": "fontpackages-filesystem@1.44-22.el8",
                 "info": Object {
                   "name": "fontpackages-filesystem",
-                  "purl": "pkg:rpm/fontpackages-filesystem@1.44-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/fontpackages-filesystem@1.44-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.44-22.el8",
                 },
               },
@@ -3502,7 +3502,7 @@ Object {
                 "id": "freetype@2.9.1-4.el8",
                 "info": Object {
                   "name": "freetype",
-                  "purl": "pkg:rpm/freetype@2.9.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/freetype@2.9.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.1-4.el8",
                 },
               },
@@ -3510,7 +3510,7 @@ Object {
                 "id": "freetype-devel@2.9.1-4.el8",
                 "info": Object {
                   "name": "freetype-devel",
-                  "purl": "pkg:rpm/freetype-devel@2.9.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/freetype-devel@2.9.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.1-4.el8",
                 },
               },
@@ -3518,7 +3518,7 @@ Object {
                 "id": "gawk@4.2.1-1.el8",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.2.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gawk@4.2.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.1-1.el8",
                 },
               },
@@ -3526,7 +3526,7 @@ Object {
                 "id": "gc@7.6.4-3.el8",
                 "info": Object {
                   "name": "gc",
-                  "purl": "pkg:rpm/gc@7.6.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gc@7.6.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.6.4-3.el8",
                 },
               },
@@ -3534,7 +3534,7 @@ Object {
                 "id": "gcc@8.3.1-5.el8",
                 "info": Object {
                   "name": "gcc",
-                  "purl": "pkg:rpm/gcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -3542,7 +3542,7 @@ Object {
                 "id": "gcc-c++@8.3.1-5.el8",
                 "info": Object {
                   "name": "gcc-c++",
-                  "purl": "pkg:rpm/gcc-c%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gcc-c%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -3550,7 +3550,7 @@ Object {
                 "id": "gcc-gdb-plugin@8.3.1-5.el8",
                 "info": Object {
                   "name": "gcc-gdb-plugin",
-                  "purl": "pkg:rpm/gcc-gdb-plugin@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gcc-gdb-plugin@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -3558,7 +3558,7 @@ Object {
                 "id": "gd@2.2.5-6.el8",
                 "info": Object {
                   "name": "gd",
-                  "purl": "pkg:rpm/gd@2.2.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gd@2.2.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.5-6.el8",
                 },
               },
@@ -3566,7 +3566,7 @@ Object {
                 "id": "gd-devel@2.2.5-6.el8",
                 "info": Object {
                   "name": "gd-devel",
-                  "purl": "pkg:rpm/gd-devel@2.2.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gd-devel@2.2.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.5-6.el8",
                 },
               },
@@ -3574,7 +3574,7 @@ Object {
                 "id": "gdb@8.2-11.el8",
                 "info": Object {
                   "name": "gdb",
-                  "purl": "pkg:rpm/gdb@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gdb@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.2-11.el8",
                 },
               },
@@ -3582,7 +3582,7 @@ Object {
                 "id": "gdb-gdbserver@8.2-11.el8",
                 "info": Object {
                   "name": "gdb-gdbserver",
-                  "purl": "pkg:rpm/gdb-gdbserver@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gdb-gdbserver@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.2-11.el8",
                 },
               },
@@ -3590,7 +3590,7 @@ Object {
                 "id": "gdb-headless@8.2-11.el8",
                 "info": Object {
                   "name": "gdb-headless",
-                  "purl": "pkg:rpm/gdb-headless@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gdb-headless@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.2-11.el8",
                 },
               },
@@ -3598,7 +3598,7 @@ Object {
                 "id": "gdbm@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gdbm@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -3606,7 +3606,7 @@ Object {
                 "id": "gdbm-libs@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm-libs",
-                  "purl": "pkg:rpm/gdbm-libs@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gdbm-libs@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -3614,7 +3614,7 @@ Object {
                 "id": "gettext@0.19.8.1-17.el8",
                 "info": Object {
                   "name": "gettext",
-                  "purl": "pkg:rpm/gettext@0.19.8.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gettext@0.19.8.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.19.8.1-17.el8",
                 },
               },
@@ -3622,7 +3622,7 @@ Object {
                 "id": "gettext-libs@0.19.8.1-17.el8",
                 "info": Object {
                   "name": "gettext-libs",
-                  "purl": "pkg:rpm/gettext-libs@0.19.8.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gettext-libs@0.19.8.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.19.8.1-17.el8",
                 },
               },
@@ -3630,7 +3630,7 @@ Object {
                 "id": "ghc-srpm-macros@1.4.2-7.el8",
                 "info": Object {
                   "name": "ghc-srpm-macros",
-                  "purl": "pkg:rpm/ghc-srpm-macros@1.4.2-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/ghc-srpm-macros@1.4.2-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-7.el8",
                 },
               },
@@ -3638,7 +3638,7 @@ Object {
                 "id": "git@2.18.4-2.el8_2",
                 "info": Object {
                   "name": "git",
-                  "purl": "pkg:rpm/git@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/git@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.18.4-2.el8_2",
                 },
               },
@@ -3646,7 +3646,7 @@ Object {
                 "id": "git-core@2.18.4-2.el8_2",
                 "info": Object {
                   "name": "git-core",
-                  "purl": "pkg:rpm/git-core@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/git-core@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.18.4-2.el8_2",
                 },
               },
@@ -3654,7 +3654,7 @@ Object {
                 "id": "git-core-doc@2.18.4-2.el8_2",
                 "info": Object {
                   "name": "git-core-doc",
-                  "purl": "pkg:rpm/git-core-doc@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/git-core-doc@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.18.4-2.el8_2",
                 },
               },
@@ -3662,7 +3662,7 @@ Object {
                 "id": "glib2@2.56.4-8.el8",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.4-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/glib2@2.56.4-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.56.4-8.el8",
                 },
               },
@@ -3670,7 +3670,7 @@ Object {
                 "id": "glibc@2.28-101.el8",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/glibc@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3678,7 +3678,7 @@ Object {
                 "id": "glibc-common@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/glibc-common@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3686,7 +3686,7 @@ Object {
                 "id": "glibc-devel@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-devel",
-                  "purl": "pkg:rpm/glibc-devel@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/glibc-devel@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3694,7 +3694,7 @@ Object {
                 "id": "glibc-headers@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-headers",
-                  "purl": "pkg:rpm/glibc-headers@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/glibc-headers@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3702,7 +3702,7 @@ Object {
                 "id": "glibc-langpack-en@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/glibc-langpack-en@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/glibc-langpack-en@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3710,7 +3710,7 @@ Object {
                 "id": "glibc-locale-source@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-locale-source",
-                  "purl": "pkg:rpm/glibc-locale-source@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/glibc-locale-source@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3718,7 +3718,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/glibc-minimal-langpack@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3726,7 +3726,7 @@ Object {
                 "id": "gmp@1:6.1.2-10.el8",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.1.2-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gmp@1:6.1.2-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:6.1.2-10.el8",
                 },
               },
@@ -3734,7 +3734,7 @@ Object {
                 "id": "gnupg2@2.2.9-1.el8",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gnupg2@2.2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.9-1.el8",
                 },
               },
@@ -3742,7 +3742,7 @@ Object {
                 "id": "gnutls@3.6.8-11.el8_2",
                 "info": Object {
                   "name": "gnutls",
-                  "purl": "pkg:rpm/gnutls@3.6.8-11.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gnutls@3.6.8-11.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.6.8-11.el8_2",
                 },
               },
@@ -3750,7 +3750,7 @@ Object {
                 "id": "go-srpm-macros@2-16.el8",
                 "info": Object {
                   "name": "go-srpm-macros",
-                  "purl": "pkg:rpm/go-srpm-macros@2-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/go-srpm-macros@2-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2-16.el8",
                 },
               },
@@ -3758,7 +3758,7 @@ Object {
                 "id": "gobject-introspection@1.56.1-1.el8",
                 "info": Object {
                   "name": "gobject-introspection",
-                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.56.1-1.el8",
                 },
               },
@@ -3766,7 +3766,7 @@ Object {
                 "id": "gpg-pubkey@fd431d51-4ae0493b",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@fd431d51-4ae0493b?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gpg-pubkey@fd431d51-4ae0493b?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "fd431d51-4ae0493b",
                 },
               },
@@ -3774,7 +3774,7 @@ Object {
                 "id": "gpgme@1.10.0-6.el8",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gpgme@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.10.0-6.el8",
                 },
               },
@@ -3782,7 +3782,7 @@ Object {
                 "id": "grep@3.1-6.el8",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@3.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/grep@3.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1-6.el8",
                 },
               },
@@ -3790,7 +3790,7 @@ Object {
                 "id": "groff-base@1.22.3-18.el8",
                 "info": Object {
                   "name": "groff-base",
-                  "purl": "pkg:rpm/groff-base@1.22.3-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/groff-base@1.22.3-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.22.3-18.el8",
                 },
               },
@@ -3798,7 +3798,7 @@ Object {
                 "id": "guile@5:2.0.14-7.el8",
                 "info": Object {
                   "name": "guile",
-                  "purl": "pkg:rpm/guile@5:2.0.14-7.el8?epoch=5&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/guile@5:2.0.14-7.el8?epoch=5&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5:2.0.14-7.el8",
                 },
               },
@@ -3806,7 +3806,7 @@ Object {
                 "id": "gzip@1.9-9.el8",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.9-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/gzip@1.9-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.9-9.el8",
                 },
               },
@@ -3814,7 +3814,7 @@ Object {
                 "id": "ima-evm-utils@1.1-5.el8",
                 "info": Object {
                   "name": "ima-evm-utils",
-                  "purl": "pkg:rpm/ima-evm-utils@1.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/ima-evm-utils@1.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1-5.el8",
                 },
               },
@@ -3822,7 +3822,7 @@ Object {
                 "id": "info@6.5-6.el8",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@6.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/info@6.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.5-6.el8",
                 },
               },
@@ -3830,7 +3830,7 @@ Object {
                 "id": "iptables-libs@1.8.4-10.el8",
                 "info": Object {
                   "name": "iptables-libs",
-                  "purl": "pkg:rpm/iptables-libs@1.8.4-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/iptables-libs@1.8.4-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.4-10.el8",
                 },
               },
@@ -3838,7 +3838,7 @@ Object {
                 "id": "isl@0.16.1-6.el8",
                 "info": Object {
                   "name": "isl",
-                  "purl": "pkg:rpm/isl@0.16.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/isl@0.16.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.16.1-6.el8",
                 },
               },
@@ -3846,7 +3846,7 @@ Object {
                 "id": "jbigkit-libs@2.1-14.el8",
                 "info": Object {
                   "name": "jbigkit-libs",
-                  "purl": "pkg:rpm/jbigkit-libs@2.1-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/jbigkit-libs@2.1-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.1-14.el8",
                 },
               },
@@ -3854,7 +3854,7 @@ Object {
                 "id": "json-c@0.13.1-0.2.el8",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.13.1-0.2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/json-c@0.13.1-0.2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.13.1-0.2.el8",
                 },
               },
@@ -3862,7 +3862,7 @@ Object {
                 "id": "json-glib@1.4.4-1.el8",
                 "info": Object {
                   "name": "json-glib",
-                  "purl": "pkg:rpm/json-glib@1.4.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/json-glib@1.4.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.4-1.el8",
                 },
               },
@@ -3870,7 +3870,7 @@ Object {
                 "id": "kernel-headers@4.18.0-193.6.3.el8_2",
                 "info": Object {
                   "name": "kernel-headers",
-                  "purl": "pkg:rpm/kernel-headers@4.18.0-193.6.3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/kernel-headers@4.18.0-193.6.3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.18.0-193.6.3.el8_2",
                 },
               },
@@ -3878,7 +3878,7 @@ Object {
                 "id": "keyutils-libs@1.5.10-6.el8",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/keyutils-libs@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.10-6.el8",
                 },
               },
@@ -3886,7 +3886,7 @@ Object {
                 "id": "keyutils-libs-devel@1.5.10-6.el8",
                 "info": Object {
                   "name": "keyutils-libs-devel",
-                  "purl": "pkg:rpm/keyutils-libs-devel@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/keyutils-libs-devel@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.10-6.el8",
                 },
               },
@@ -3894,7 +3894,7 @@ Object {
                 "id": "kmod-libs@25-16.el8",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/kmod-libs@25-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/kmod-libs@25-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "25-16.el8",
                 },
               },
@@ -3902,7 +3902,7 @@ Object {
                 "id": "krb5-devel@1.17-18.el8",
                 "info": Object {
                   "name": "krb5-devel",
-                  "purl": "pkg:rpm/krb5-devel@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/krb5-devel@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-18.el8",
                 },
               },
@@ -3910,7 +3910,7 @@ Object {
                 "id": "krb5-libs@1.17-18.el8",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/krb5-libs@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-18.el8",
                 },
               },
@@ -3918,7 +3918,7 @@ Object {
                 "id": "langpacks-en@1.0-12.el8",
                 "info": Object {
                   "name": "langpacks-en",
-                  "purl": "pkg:rpm/langpacks-en@1.0-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/langpacks-en@1.0-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0-12.el8",
                 },
               },
@@ -3926,7 +3926,7 @@ Object {
                 "id": "less@530-1.el8",
                 "info": Object {
                   "name": "less",
-                  "purl": "pkg:rpm/less@530-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/less@530-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "530-1.el8",
                 },
               },
@@ -3934,7 +3934,7 @@ Object {
                 "id": "libICE@1.0.9-15.el8",
                 "info": Object {
                   "name": "libICE",
-                  "purl": "pkg:rpm/libICE@1.0.9-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libICE@1.0.9-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.9-15.el8",
                 },
               },
@@ -3942,7 +3942,7 @@ Object {
                 "id": "libSM@1.2.3-1.el8",
                 "info": Object {
                   "name": "libSM",
-                  "purl": "pkg:rpm/libSM@1.2.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libSM@1.2.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.3-1.el8",
                 },
               },
@@ -3950,7 +3950,7 @@ Object {
                 "id": "libX11@1.6.8-3.el8",
                 "info": Object {
                   "name": "libX11",
-                  "purl": "pkg:rpm/libX11@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libX11@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.8-3.el8",
                 },
               },
@@ -3958,7 +3958,7 @@ Object {
                 "id": "libX11-common@1.6.8-3.el8",
                 "info": Object {
                   "name": "libX11-common",
-                  "purl": "pkg:rpm/libX11-common@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libX11-common@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.8-3.el8",
                 },
               },
@@ -3966,7 +3966,7 @@ Object {
                 "id": "libX11-devel@1.6.8-3.el8",
                 "info": Object {
                   "name": "libX11-devel",
-                  "purl": "pkg:rpm/libX11-devel@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libX11-devel@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.8-3.el8",
                 },
               },
@@ -3974,7 +3974,7 @@ Object {
                 "id": "libX11-xcb@1.6.8-3.el8",
                 "info": Object {
                   "name": "libX11-xcb",
-                  "purl": "pkg:rpm/libX11-xcb@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libX11-xcb@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.8-3.el8",
                 },
               },
@@ -3982,7 +3982,7 @@ Object {
                 "id": "libXau@1.0.8-13.el8",
                 "info": Object {
                   "name": "libXau",
-                  "purl": "pkg:rpm/libXau@1.0.8-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libXau@1.0.8-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.8-13.el8",
                 },
               },
@@ -3990,7 +3990,7 @@ Object {
                 "id": "libXau-devel@1.0.8-13.el8",
                 "info": Object {
                   "name": "libXau-devel",
-                  "purl": "pkg:rpm/libXau-devel@1.0.8-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libXau-devel@1.0.8-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.8-13.el8",
                 },
               },
@@ -3998,7 +3998,7 @@ Object {
                 "id": "libXext@1.3.3-9.el8",
                 "info": Object {
                   "name": "libXext",
-                  "purl": "pkg:rpm/libXext@1.3.3-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libXext@1.3.3-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.3.3-9.el8",
                 },
               },
@@ -4006,7 +4006,7 @@ Object {
                 "id": "libXpm@3.5.12-8.el8",
                 "info": Object {
                   "name": "libXpm",
-                  "purl": "pkg:rpm/libXpm@3.5.12-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libXpm@3.5.12-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.5.12-8.el8",
                 },
               },
@@ -4014,7 +4014,7 @@ Object {
                 "id": "libXpm-devel@3.5.12-8.el8",
                 "info": Object {
                   "name": "libXpm-devel",
-                  "purl": "pkg:rpm/libXpm-devel@3.5.12-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libXpm-devel@3.5.12-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.5.12-8.el8",
                 },
               },
@@ -4022,7 +4022,7 @@ Object {
                 "id": "libXt@1.1.5-12.el8",
                 "info": Object {
                   "name": "libXt",
-                  "purl": "pkg:rpm/libXt@1.1.5-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libXt@1.1.5-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.5-12.el8",
                 },
               },
@@ -4030,7 +4030,7 @@ Object {
                 "id": "libacl@2.2.53-1.el8",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libacl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -4038,7 +4038,7 @@ Object {
                 "id": "libarchive@3.3.2-8.el8_1",
                 "info": Object {
                   "name": "libarchive",
-                  "purl": "pkg:rpm/libarchive@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libarchive@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.3.2-8.el8_1",
                 },
               },
@@ -4046,7 +4046,7 @@ Object {
                 "id": "libassuan@2.5.1-3.el8",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.5.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libassuan@2.5.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.5.1-3.el8",
                 },
               },
@@ -4054,7 +4054,7 @@ Object {
                 "id": "libatomic_ops@7.6.2-3.el8",
                 "info": Object {
                   "name": "libatomic_ops",
-                  "purl": "pkg:rpm/libatomic_ops@7.6.2-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libatomic_ops@7.6.2-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.6.2-3.el8",
                 },
               },
@@ -4062,7 +4062,7 @@ Object {
                 "id": "libattr@2.4.48-3.el8",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.48-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libattr@2.4.48-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.4.48-3.el8",
                 },
               },
@@ -4070,7 +4070,7 @@ Object {
                 "id": "libbabeltrace@1.5.4-2.el8",
                 "info": Object {
                   "name": "libbabeltrace",
-                  "purl": "pkg:rpm/libbabeltrace@1.5.4-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libbabeltrace@1.5.4-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.4-2.el8",
                 },
               },
@@ -4078,7 +4078,7 @@ Object {
                 "id": "libblkid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libblkid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4086,7 +4086,7 @@ Object {
                 "id": "libcap@2.26-3.el8",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.26-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libcap@2.26-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.26-3.el8",
                 },
               },
@@ -4094,7 +4094,7 @@ Object {
                 "id": "libcap-ng@0.7.9-5.el8",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.7.9-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libcap-ng@0.7.9-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.7.9-5.el8",
                 },
               },
@@ -4102,7 +4102,7 @@ Object {
                 "id": "libcom_err@1.45.4-3.el8",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libcom_err@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.45.4-3.el8",
                 },
               },
@@ -4110,7 +4110,7 @@ Object {
                 "id": "libcom_err-devel@1.45.4-3.el8",
                 "info": Object {
                   "name": "libcom_err-devel",
-                  "purl": "pkg:rpm/libcom_err-devel@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libcom_err-devel@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.45.4-3.el8",
                 },
               },
@@ -4118,7 +4118,7 @@ Object {
                 "id": "libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "libcomps",
-                  "purl": "pkg:rpm/libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -4126,7 +4126,7 @@ Object {
                 "id": "libcroco@0.6.12-4.el8",
                 "info": Object {
                   "name": "libcroco",
-                  "purl": "pkg:rpm/libcroco@0.6.12-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libcroco@0.6.12-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.6.12-4.el8",
                 },
               },
@@ -4134,7 +4134,7 @@ Object {
                 "id": "libcurl@7.61.1-12.el8",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libcurl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -4142,7 +4142,7 @@ Object {
                 "id": "libcurl-devel@7.61.1-12.el8",
                 "info": Object {
                   "name": "libcurl-devel",
-                  "purl": "pkg:rpm/libcurl-devel@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libcurl-devel@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -4150,7 +4150,7 @@ Object {
                 "id": "libdb@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libdb@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -4158,7 +4158,7 @@ Object {
                 "id": "libdb-utils@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libdb-utils@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -4166,7 +4166,7 @@ Object {
                 "id": "libdnf@0.39.1-5.el8",
                 "info": Object {
                   "name": "libdnf",
-                  "purl": "pkg:rpm/libdnf@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libdnf@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.39.1-5.el8",
                 },
               },
@@ -4174,7 +4174,7 @@ Object {
                 "id": "libedit@3.1-23.20170329cvs.el8",
                 "info": Object {
                   "name": "libedit",
-                  "purl": "pkg:rpm/libedit@3.1-23.20170329cvs.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libedit@3.1-23.20170329cvs.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1-23.20170329cvs.el8",
                 },
               },
@@ -4182,7 +4182,7 @@ Object {
                 "id": "libfdisk@2.32.1-22.el8",
                 "info": Object {
                   "name": "libfdisk",
-                  "purl": "pkg:rpm/libfdisk@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libfdisk@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4190,7 +4190,7 @@ Object {
                 "id": "libffi@3.1-21.el8",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.1-21.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libffi@3.1-21.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1-21.el8",
                 },
               },
@@ -4198,7 +4198,7 @@ Object {
                 "id": "libgcc@8.3.1-5.el8",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libgcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -4206,7 +4206,7 @@ Object {
                 "id": "libgcrypt@1.8.3-4.el8",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libgcrypt@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.3-4.el8",
                 },
               },
@@ -4214,7 +4214,7 @@ Object {
                 "id": "libgcrypt-devel@1.8.3-4.el8",
                 "info": Object {
                   "name": "libgcrypt-devel",
-                  "purl": "pkg:rpm/libgcrypt-devel@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libgcrypt-devel@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.3-4.el8",
                 },
               },
@@ -4222,7 +4222,7 @@ Object {
                 "id": "libgomp@8.3.1-5.el8",
                 "info": Object {
                   "name": "libgomp",
-                  "purl": "pkg:rpm/libgomp@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libgomp@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -4230,7 +4230,7 @@ Object {
                 "id": "libgpg-error@1.31-1.el8",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libgpg-error@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.31-1.el8",
                 },
               },
@@ -4238,7 +4238,7 @@ Object {
                 "id": "libgpg-error-devel@1.31-1.el8",
                 "info": Object {
                   "name": "libgpg-error-devel",
-                  "purl": "pkg:rpm/libgpg-error-devel@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libgpg-error-devel@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.31-1.el8",
                 },
               },
@@ -4246,7 +4246,7 @@ Object {
                 "id": "libidn2@2.2.0-1.el8",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.2.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libidn2@2.2.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.0-1.el8",
                 },
               },
@@ -4254,7 +4254,7 @@ Object {
                 "id": "libipt@1.6.1-8.el8",
                 "info": Object {
                   "name": "libipt",
-                  "purl": "pkg:rpm/libipt@1.6.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libipt@1.6.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.1-8.el8",
                 },
               },
@@ -4262,7 +4262,7 @@ Object {
                 "id": "libjpeg-turbo@1.5.3-10.el8",
                 "info": Object {
                   "name": "libjpeg-turbo",
-                  "purl": "pkg:rpm/libjpeg-turbo@1.5.3-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libjpeg-turbo@1.5.3-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.3-10.el8",
                 },
               },
@@ -4270,7 +4270,7 @@ Object {
                 "id": "libjpeg-turbo-devel@1.5.3-10.el8",
                 "info": Object {
                   "name": "libjpeg-turbo-devel",
-                  "purl": "pkg:rpm/libjpeg-turbo-devel@1.5.3-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libjpeg-turbo-devel@1.5.3-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.3-10.el8",
                 },
               },
@@ -4278,7 +4278,7 @@ Object {
                 "id": "libkadm5@1.17-18.el8",
                 "info": Object {
                   "name": "libkadm5",
-                  "purl": "pkg:rpm/libkadm5@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libkadm5@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-18.el8",
                 },
               },
@@ -4286,7 +4286,7 @@ Object {
                 "id": "libksba@1.3.5-7.el8",
                 "info": Object {
                   "name": "libksba",
-                  "purl": "pkg:rpm/libksba@1.3.5-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libksba@1.3.5-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.3.5-7.el8",
                 },
               },
@@ -4294,7 +4294,7 @@ Object {
                 "id": "libmetalink@0.1.3-7.el8",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libmetalink@0.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.1.3-7.el8",
                 },
               },
@@ -4302,7 +4302,7 @@ Object {
                 "id": "libmodulemd1@1.8.16-0.2.8.2.1",
                 "info": Object {
                   "name": "libmodulemd1",
-                  "purl": "pkg:rpm/libmodulemd1@1.8.16-0.2.8.2.1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libmodulemd1@1.8.16-0.2.8.2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.16-0.2.8.2.1",
                 },
               },
@@ -4310,7 +4310,7 @@ Object {
                 "id": "libmount@2.32.1-22.el8",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libmount@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4318,7 +4318,7 @@ Object {
                 "id": "libmpc@1.0.2-9.el8",
                 "info": Object {
                   "name": "libmpc",
-                  "purl": "pkg:rpm/libmpc@1.0.2-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libmpc@1.0.2-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.2-9.el8",
                 },
               },
@@ -4326,7 +4326,7 @@ Object {
                 "id": "libnghttp2@1.33.0-3.el8_2.1",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.33.0-3.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libnghttp2@1.33.0-3.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.33.0-3.el8_2.1",
                 },
               },
@@ -4334,7 +4334,7 @@ Object {
                 "id": "libnl3@3.5.0-1.el8",
                 "info": Object {
                   "name": "libnl3",
-                  "purl": "pkg:rpm/libnl3@3.5.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libnl3@3.5.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.5.0-1.el8",
                 },
               },
@@ -4342,7 +4342,7 @@ Object {
                 "id": "libnsl2@1.2.0-2.20180605git4a062cf.el8",
                 "info": Object {
                   "name": "libnsl2",
-                  "purl": "pkg:rpm/libnsl2@1.2.0-2.20180605git4a062cf.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libnsl2@1.2.0-2.20180605git4a062cf.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.0-2.20180605git4a062cf.el8",
                 },
               },
@@ -4350,7 +4350,7 @@ Object {
                 "id": "libpcap@14:1.9.0-3.el8",
                 "info": Object {
                   "name": "libpcap",
-                  "purl": "pkg:rpm/libpcap@14:1.9.0-3.el8?epoch=14&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpcap@14:1.9.0-3.el8?epoch=14&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "14:1.9.0-3.el8",
                 },
               },
@@ -4358,7 +4358,7 @@ Object {
                 "id": "libpipeline@1.5.0-2.el8",
                 "info": Object {
                   "name": "libpipeline",
-                  "purl": "pkg:rpm/libpipeline@1.5.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpipeline@1.5.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.0-2.el8",
                 },
               },
@@ -4366,7 +4366,7 @@ Object {
                 "id": "libpkgconf@1.4.2-1.el8",
                 "info": Object {
                   "name": "libpkgconf",
-                  "purl": "pkg:rpm/libpkgconf@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpkgconf@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-1.el8",
                 },
               },
@@ -4374,7 +4374,7 @@ Object {
                 "id": "libpng@2:1.6.34-5.el8",
                 "info": Object {
                   "name": "libpng",
-                  "purl": "pkg:rpm/libpng@2:1.6.34-5.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpng@2:1.6.34-5.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:1.6.34-5.el8",
                 },
               },
@@ -4382,7 +4382,7 @@ Object {
                 "id": "libpng-devel@2:1.6.34-5.el8",
                 "info": Object {
                   "name": "libpng-devel",
-                  "purl": "pkg:rpm/libpng-devel@2:1.6.34-5.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpng-devel@2:1.6.34-5.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:1.6.34-5.el8",
                 },
               },
@@ -4390,7 +4390,7 @@ Object {
                 "id": "libpq@12.1-3.el8",
                 "info": Object {
                   "name": "libpq",
-                  "purl": "pkg:rpm/libpq@12.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpq@12.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "12.1-3.el8",
                 },
               },
@@ -4398,7 +4398,7 @@ Object {
                 "id": "libpq-devel@12.1-3.el8",
                 "info": Object {
                   "name": "libpq-devel",
-                  "purl": "pkg:rpm/libpq-devel@12.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpq-devel@12.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "12.1-3.el8",
                 },
               },
@@ -4406,7 +4406,7 @@ Object {
                 "id": "libpsl@0.20.2-5.el8",
                 "info": Object {
                   "name": "libpsl",
-                  "purl": "pkg:rpm/libpsl@0.20.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpsl@0.20.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.20.2-5.el8",
                 },
               },
@@ -4414,7 +4414,7 @@ Object {
                 "id": "libpwquality@1.4.0-9.el8",
                 "info": Object {
                   "name": "libpwquality",
-                  "purl": "pkg:rpm/libpwquality@1.4.0-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libpwquality@1.4.0-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.0-9.el8",
                 },
               },
@@ -4422,7 +4422,7 @@ Object {
                 "id": "librepo@1.11.0-2.el8",
                 "info": Object {
                   "name": "librepo",
-                  "purl": "pkg:rpm/librepo@1.11.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/librepo@1.11.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.11.0-2.el8",
                 },
               },
@@ -4430,7 +4430,7 @@ Object {
                 "id": "libreport-filesystem@2.9.5-10.el8",
                 "info": Object {
                   "name": "libreport-filesystem",
-                  "purl": "pkg:rpm/libreport-filesystem@2.9.5-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libreport-filesystem@2.9.5-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.5-10.el8",
                 },
               },
@@ -4438,7 +4438,7 @@ Object {
                 "id": "librhsm@0.0.3-3.el8",
                 "info": Object {
                   "name": "librhsm",
-                  "purl": "pkg:rpm/librhsm@0.0.3-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/librhsm@0.0.3-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.0.3-3.el8",
                 },
               },
@@ -4446,7 +4446,7 @@ Object {
                 "id": "libseccomp@2.4.1-1.el8",
                 "info": Object {
                   "name": "libseccomp",
-                  "purl": "pkg:rpm/libseccomp@2.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libseccomp@2.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.4.1-1.el8",
                 },
               },
@@ -4454,7 +4454,7 @@ Object {
                 "id": "libsecret@0.18.6-1.el8",
                 "info": Object {
                   "name": "libsecret",
-                  "purl": "pkg:rpm/libsecret@0.18.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libsecret@0.18.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.18.6-1.el8",
                 },
               },
@@ -4462,7 +4462,7 @@ Object {
                 "id": "libselinux@2.9-3.el8",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libselinux@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-3.el8",
                 },
               },
@@ -4470,7 +4470,7 @@ Object {
                 "id": "libselinux-devel@2.9-3.el8",
                 "info": Object {
                   "name": "libselinux-devel",
-                  "purl": "pkg:rpm/libselinux-devel@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libselinux-devel@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-3.el8",
                 },
               },
@@ -4478,7 +4478,7 @@ Object {
                 "id": "libsemanage@2.9-2.el8",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.9-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libsemanage@2.9-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-2.el8",
                 },
               },
@@ -4486,7 +4486,7 @@ Object {
                 "id": "libsepol@2.9-1.el8",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libsepol@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-1.el8",
                 },
               },
@@ -4494,7 +4494,7 @@ Object {
                 "id": "libsepol-devel@2.9-1.el8",
                 "info": Object {
                   "name": "libsepol-devel",
-                  "purl": "pkg:rpm/libsepol-devel@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libsepol-devel@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-1.el8",
                 },
               },
@@ -4502,7 +4502,7 @@ Object {
                 "id": "libsigsegv@2.11-5.el8",
                 "info": Object {
                   "name": "libsigsegv",
-                  "purl": "pkg:rpm/libsigsegv@2.11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libsigsegv@2.11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.11-5.el8",
                 },
               },
@@ -4510,7 +4510,7 @@ Object {
                 "id": "libsmartcols@2.32.1-22.el8",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libsmartcols@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4518,7 +4518,7 @@ Object {
                 "id": "libsolv@0.7.7-1.el8",
                 "info": Object {
                   "name": "libsolv",
-                  "purl": "pkg:rpm/libsolv@0.7.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libsolv@0.7.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.7.7-1.el8",
                 },
               },
@@ -4526,7 +4526,7 @@ Object {
                 "id": "libssh@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh",
-                  "purl": "pkg:rpm/libssh@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libssh@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -4534,7 +4534,7 @@ Object {
                 "id": "libssh-config@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh-config",
-                  "purl": "pkg:rpm/libssh-config@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libssh-config@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -4542,7 +4542,7 @@ Object {
                 "id": "libstdc++@8.3.1-5.el8",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libstdc%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -4550,7 +4550,7 @@ Object {
                 "id": "libstdc++-devel@8.3.1-5.el8",
                 "info": Object {
                   "name": "libstdc++-devel",
-                  "purl": "pkg:rpm/libstdc%2B%2B-devel@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libstdc%2B%2B-devel@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -4558,7 +4558,7 @@ Object {
                 "id": "libtasn1@4.13-3.el8",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.13-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libtasn1@4.13-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.13-3.el8",
                 },
               },
@@ -4566,7 +4566,7 @@ Object {
                 "id": "libtiff@4.0.9-17.el8",
                 "info": Object {
                   "name": "libtiff",
-                  "purl": "pkg:rpm/libtiff@4.0.9-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libtiff@4.0.9-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.0.9-17.el8",
                 },
               },
@@ -4574,7 +4574,7 @@ Object {
                 "id": "libtiff-devel@4.0.9-17.el8",
                 "info": Object {
                   "name": "libtiff-devel",
-                  "purl": "pkg:rpm/libtiff-devel@4.0.9-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libtiff-devel@4.0.9-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.0.9-17.el8",
                 },
               },
@@ -4582,7 +4582,7 @@ Object {
                 "id": "libtirpc@1.1.4-4.el8",
                 "info": Object {
                   "name": "libtirpc",
-                  "purl": "pkg:rpm/libtirpc@1.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libtirpc@1.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.4-4.el8",
                 },
               },
@@ -4590,7 +4590,7 @@ Object {
                 "id": "libtool-ltdl@2.4.6-25.el8",
                 "info": Object {
                   "name": "libtool-ltdl",
-                  "purl": "pkg:rpm/libtool-ltdl@2.4.6-25.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libtool-ltdl@2.4.6-25.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.4.6-25.el8",
                 },
               },
@@ -4598,7 +4598,7 @@ Object {
                 "id": "libunistring@0.9.9-3.el8",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libunistring@0.9.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.9.9-3.el8",
                 },
               },
@@ -4606,7 +4606,7 @@ Object {
                 "id": "libusbx@1.0.22-1.el8",
                 "info": Object {
                   "name": "libusbx",
-                  "purl": "pkg:rpm/libusbx@1.0.22-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libusbx@1.0.22-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.22-1.el8",
                 },
               },
@@ -4614,7 +4614,7 @@ Object {
                 "id": "libuser@0.62-23.el8",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.62-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libuser@0.62-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.62-23.el8",
                 },
               },
@@ -4622,7 +4622,7 @@ Object {
                 "id": "libutempter@1.1.6-14.el8",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.6-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libutempter@1.1.6-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.6-14.el8",
                 },
               },
@@ -4630,7 +4630,7 @@ Object {
                 "id": "libuuid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libuuid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4638,7 +4638,7 @@ Object {
                 "id": "libuuid-devel@2.32.1-22.el8",
                 "info": Object {
                   "name": "libuuid-devel",
-                  "purl": "pkg:rpm/libuuid-devel@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libuuid-devel@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4646,7 +4646,7 @@ Object {
                 "id": "libuv@1:1.23.1-1.el8",
                 "info": Object {
                   "name": "libuv",
-                  "purl": "pkg:rpm/libuv@1:1.23.1-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libuv@1:1.23.1-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.23.1-1.el8",
                 },
               },
@@ -4654,7 +4654,7 @@ Object {
                 "id": "libverto@0.3.0-5.el8",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libverto@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.3.0-5.el8",
                 },
               },
@@ -4662,7 +4662,7 @@ Object {
                 "id": "libverto-devel@0.3.0-5.el8",
                 "info": Object {
                   "name": "libverto-devel",
-                  "purl": "pkg:rpm/libverto-devel@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libverto-devel@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.3.0-5.el8",
                 },
               },
@@ -4670,7 +4670,7 @@ Object {
                 "id": "libwebp@1.0.0-1.el8",
                 "info": Object {
                   "name": "libwebp",
-                  "purl": "pkg:rpm/libwebp@1.0.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libwebp@1.0.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.0-1.el8",
                 },
               },
@@ -4678,7 +4678,7 @@ Object {
                 "id": "libwebp-devel@1.0.0-1.el8",
                 "info": Object {
                   "name": "libwebp-devel",
-                  "purl": "pkg:rpm/libwebp-devel@1.0.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libwebp-devel@1.0.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.0-1.el8",
                 },
               },
@@ -4686,7 +4686,7 @@ Object {
                 "id": "libxcb@1.13.1-1.el8",
                 "info": Object {
                   "name": "libxcb",
-                  "purl": "pkg:rpm/libxcb@1.13.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libxcb@1.13.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.13.1-1.el8",
                 },
               },
@@ -4694,7 +4694,7 @@ Object {
                 "id": "libxcb-devel@1.13.1-1.el8",
                 "info": Object {
                   "name": "libxcb-devel",
-                  "purl": "pkg:rpm/libxcb-devel@1.13.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libxcb-devel@1.13.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.13.1-1.el8",
                 },
               },
@@ -4702,7 +4702,7 @@ Object {
                 "id": "libxcrypt@4.1.1-4.el8",
                 "info": Object {
                   "name": "libxcrypt",
-                  "purl": "pkg:rpm/libxcrypt@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libxcrypt@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.1.1-4.el8",
                 },
               },
@@ -4710,7 +4710,7 @@ Object {
                 "id": "libxcrypt-devel@4.1.1-4.el8",
                 "info": Object {
                   "name": "libxcrypt-devel",
-                  "purl": "pkg:rpm/libxcrypt-devel@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libxcrypt-devel@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.1.1-4.el8",
                 },
               },
@@ -4718,7 +4718,7 @@ Object {
                 "id": "libxml2@2.9.7-7.el8",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -4726,7 +4726,7 @@ Object {
                 "id": "libxml2-devel@2.9.7-7.el8",
                 "info": Object {
                   "name": "libxml2-devel",
-                  "purl": "pkg:rpm/libxml2-devel@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libxml2-devel@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -4734,7 +4734,7 @@ Object {
                 "id": "libxslt@1.1.32-4.el8",
                 "info": Object {
                   "name": "libxslt",
-                  "purl": "pkg:rpm/libxslt@1.1.32-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libxslt@1.1.32-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.32-4.el8",
                 },
               },
@@ -4742,7 +4742,7 @@ Object {
                 "id": "libxslt-devel@1.1.32-4.el8",
                 "info": Object {
                   "name": "libxslt-devel",
-                  "purl": "pkg:rpm/libxslt-devel@1.1.32-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libxslt-devel@1.1.32-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.32-4.el8",
                 },
               },
@@ -4750,7 +4750,7 @@ Object {
                 "id": "libyaml@0.1.7-5.el8",
                 "info": Object {
                   "name": "libyaml",
-                  "purl": "pkg:rpm/libyaml@0.1.7-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libyaml@0.1.7-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.1.7-5.el8",
                 },
               },
@@ -4758,7 +4758,7 @@ Object {
                 "id": "libzstd@1.4.2-2.el8",
                 "info": Object {
                   "name": "libzstd",
-                  "purl": "pkg:rpm/libzstd@1.4.2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/libzstd@1.4.2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-2.el8",
                 },
               },
@@ -4766,7 +4766,7 @@ Object {
                 "id": "lsof@4.91-2.el8",
                 "info": Object {
                   "name": "lsof",
-                  "purl": "pkg:rpm/lsof@4.91-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/lsof@4.91-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.91-2.el8",
                 },
               },
@@ -4774,7 +4774,7 @@ Object {
                 "id": "lua-libs@5.3.4-11.el8",
                 "info": Object {
                   "name": "lua-libs",
-                  "purl": "pkg:rpm/lua-libs@5.3.4-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/lua-libs@5.3.4-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.3.4-11.el8",
                 },
               },
@@ -4782,7 +4782,7 @@ Object {
                 "id": "lz4-libs@1.8.1.2-4.el8",
                 "info": Object {
                   "name": "lz4-libs",
-                  "purl": "pkg:rpm/lz4-libs@1.8.1.2-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/lz4-libs@1.8.1.2-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.1.2-4.el8",
                 },
               },
@@ -4790,7 +4790,7 @@ Object {
                 "id": "m4@1.4.18-7.el8",
                 "info": Object {
                   "name": "m4",
-                  "purl": "pkg:rpm/m4@1.4.18-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/m4@1.4.18-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.18-7.el8",
                 },
               },
@@ -4798,7 +4798,7 @@ Object {
                 "id": "make@1:4.2.1-10.el8",
                 "info": Object {
                   "name": "make",
-                  "purl": "pkg:rpm/make@1:4.2.1-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/make@1:4.2.1-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:4.2.1-10.el8",
                 },
               },
@@ -4806,7 +4806,7 @@ Object {
                 "id": "man-db@2.7.6.1-17.el8",
                 "info": Object {
                   "name": "man-db",
-                  "purl": "pkg:rpm/man-db@2.7.6.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/man-db@2.7.6.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.7.6.1-17.el8",
                 },
               },
@@ -4814,7 +4814,7 @@ Object {
                 "id": "mariadb-connector-c@3.0.7-1.el8",
                 "info": Object {
                   "name": "mariadb-connector-c",
-                  "purl": "pkg:rpm/mariadb-connector-c@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/mariadb-connector-c@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0.7-1.el8",
                 },
               },
@@ -4822,7 +4822,7 @@ Object {
                 "id": "mariadb-connector-c-config@3.0.7-1.el8",
                 "info": Object {
                   "name": "mariadb-connector-c-config",
-                  "purl": "pkg:rpm/mariadb-connector-c-config@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/mariadb-connector-c-config@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0.7-1.el8",
                 },
               },
@@ -4830,7 +4830,7 @@ Object {
                 "id": "mariadb-connector-c-devel@3.0.7-1.el8",
                 "info": Object {
                   "name": "mariadb-connector-c-devel",
-                  "purl": "pkg:rpm/mariadb-connector-c-devel@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/mariadb-connector-c-devel@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0.7-1.el8",
                 },
               },
@@ -4838,7 +4838,7 @@ Object {
                 "id": "mpfr@3.1.6-1.el8",
                 "info": Object {
                   "name": "mpfr",
-                  "purl": "pkg:rpm/mpfr@3.1.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/mpfr@3.1.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1.6-1.el8",
                 },
               },
@@ -4846,7 +4846,7 @@ Object {
                 "id": "ncurses@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/ncurses@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -4854,7 +4854,7 @@ Object {
                 "id": "ncurses-base@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/ncurses-base@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -4862,7 +4862,7 @@ Object {
                 "id": "ncurses-libs@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/ncurses-libs@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -4870,7 +4870,7 @@ Object {
                 "id": "nettle@3.4.1-1.el8",
                 "info": Object {
                   "name": "nettle",
-                  "purl": "pkg:rpm/nettle@3.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/nettle@3.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.4.1-1.el8",
                 },
               },
@@ -4878,7 +4878,7 @@ Object {
                 "id": "nodejs@1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 "info": Object {
                   "name": "nodejs",
-                  "purl": "pkg:rpm/nodejs@1:10.21.0-3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs:10&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/nodejs@1:10.21.0-3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 },
               },
@@ -4886,7 +4886,7 @@ Object {
                 "id": "nodejs-full-i18n@1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 "info": Object {
                   "name": "nodejs-full-i18n",
-                  "purl": "pkg:rpm/nodejs-full-i18n@1:10.21.0-3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs:10&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/nodejs-full-i18n@1:10.21.0-3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 },
               },
@@ -4894,7 +4894,7 @@ Object {
                 "id": "nodejs-nodemon@1.18.3-1.module+el8+2632+6c5111ed",
                 "info": Object {
                   "name": "nodejs-nodemon",
-                  "purl": "pkg:rpm/nodejs-nodemon@1.18.3-1.module%2Bel8%2B2632%2B6c5111ed?module=nodejs:10&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/nodejs-nodemon@1.18.3-1.module%2Bel8%2B2632%2B6c5111ed?module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.18.3-1.module+el8+2632+6c5111ed",
                 },
               },
@@ -4902,7 +4902,7 @@ Object {
                 "id": "npm@1:6.14.4-1.10.21.0.3.module+el8.2.0+7071+d2377ea3",
                 "info": Object {
                   "name": "npm",
-                  "purl": "pkg:rpm/npm@1:6.14.4-1.10.21.0.3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs:10&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/npm@1:6.14.4-1.10.21.0.3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:6.14.4-1.10.21.0.3.module+el8.2.0+7071+d2377ea3",
                 },
               },
@@ -4910,7 +4910,7 @@ Object {
                 "id": "npth@1.5-4.el8",
                 "info": Object {
                   "name": "npth",
-                  "purl": "pkg:rpm/npth@1.5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/npth@1.5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5-4.el8",
                 },
               },
@@ -4918,7 +4918,7 @@ Object {
                 "id": "nss_wrapper@1.1.5-3.el8",
                 "info": Object {
                   "name": "nss_wrapper",
-                  "purl": "pkg:rpm/nss_wrapper@1.1.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/nss_wrapper@1.1.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.5-3.el8",
                 },
               },
@@ -4926,7 +4926,7 @@ Object {
                 "id": "ocaml-srpm-macros@5-4.el8",
                 "info": Object {
                   "name": "ocaml-srpm-macros",
-                  "purl": "pkg:rpm/ocaml-srpm-macros@5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/ocaml-srpm-macros@5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5-4.el8",
                 },
               },
@@ -4934,7 +4934,7 @@ Object {
                 "id": "openblas-srpm-macros@2-2.el8",
                 "info": Object {
                   "name": "openblas-srpm-macros",
-                  "purl": "pkg:rpm/openblas-srpm-macros@2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/openblas-srpm-macros@2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2-2.el8",
                 },
               },
@@ -4942,7 +4942,7 @@ Object {
                 "id": "openldap@2.4.46-11.el8",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.46-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/openldap@2.4.46-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.4.46-11.el8",
                 },
               },
@@ -4950,7 +4950,7 @@ Object {
                 "id": "openssh@8.0p1-4.el8_1",
                 "info": Object {
                   "name": "openssh",
-                  "purl": "pkg:rpm/openssh@8.0p1-4.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/openssh@8.0p1-4.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.0p1-4.el8_1",
                 },
               },
@@ -4958,7 +4958,7 @@ Object {
                 "id": "openssh-clients@8.0p1-4.el8_1",
                 "info": Object {
                   "name": "openssh-clients",
-                  "purl": "pkg:rpm/openssh-clients@8.0p1-4.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/openssh-clients@8.0p1-4.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.0p1-4.el8_1",
                 },
               },
@@ -4966,7 +4966,7 @@ Object {
                 "id": "openssl@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl",
-                  "purl": "pkg:rpm/openssl@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/openssl@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -4974,7 +4974,7 @@ Object {
                 "id": "openssl-devel@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl-devel",
-                  "purl": "pkg:rpm/openssl-devel@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/openssl-devel@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -4982,7 +4982,7 @@ Object {
                 "id": "openssl-libs@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/openssl-libs@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -4990,7 +4990,7 @@ Object {
                 "id": "p11-kit@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/p11-kit@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -4998,7 +4998,7 @@ Object {
                 "id": "p11-kit-trust@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/p11-kit-trust@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -5006,7 +5006,7 @@ Object {
                 "id": "pam@1.3.1-8.el8",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.3.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pam@1.3.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.3.1-8.el8",
                 },
               },
@@ -5014,7 +5014,7 @@ Object {
                 "id": "passwd@0.80-3.el8",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.80-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/passwd@0.80-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.80-3.el8",
                 },
               },
@@ -5022,7 +5022,7 @@ Object {
                 "id": "patch@2.7.6-11.el8",
                 "info": Object {
                   "name": "patch",
-                  "purl": "pkg:rpm/patch@2.7.6-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/patch@2.7.6-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.7.6-11.el8",
                 },
               },
@@ -5030,7 +5030,7 @@ Object {
                 "id": "pcre@8.42-4.el8",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.42-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pcre@8.42-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.42-4.el8",
                 },
               },
@@ -5038,7 +5038,7 @@ Object {
                 "id": "pcre2@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2",
-                  "purl": "pkg:rpm/pcre2@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pcre2@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -5046,7 +5046,7 @@ Object {
                 "id": "pcre2-devel@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2-devel",
-                  "purl": "pkg:rpm/pcre2-devel@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pcre2-devel@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -5054,7 +5054,7 @@ Object {
                 "id": "pcre2-utf16@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2-utf16",
-                  "purl": "pkg:rpm/pcre2-utf16@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pcre2-utf16@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -5062,7 +5062,7 @@ Object {
                 "id": "pcre2-utf32@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2-utf32",
-                  "purl": "pkg:rpm/pcre2-utf32@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pcre2-utf32@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -5070,7 +5070,7 @@ Object {
                 "id": "perl-Carp@1.42-396.el8",
                 "info": Object {
                   "name": "perl-Carp",
-                  "purl": "pkg:rpm/perl-Carp@1.42-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Carp@1.42-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.42-396.el8",
                 },
               },
@@ -5078,7 +5078,7 @@ Object {
                 "id": "perl-Data-Dumper@2.167-399.el8",
                 "info": Object {
                   "name": "perl-Data-Dumper",
-                  "purl": "pkg:rpm/perl-Data-Dumper@2.167-399.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Data-Dumper@2.167-399.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.167-399.el8",
                 },
               },
@@ -5086,7 +5086,7 @@ Object {
                 "id": "perl-Digest@1.17-395.el8",
                 "info": Object {
                   "name": "perl-Digest",
-                  "purl": "pkg:rpm/perl-Digest@1.17-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Digest@1.17-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-395.el8",
                 },
               },
@@ -5094,7 +5094,7 @@ Object {
                 "id": "perl-Digest-MD5@2.55-396.el8",
                 "info": Object {
                   "name": "perl-Digest-MD5",
-                  "purl": "pkg:rpm/perl-Digest-MD5@2.55-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Digest-MD5@2.55-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.55-396.el8",
                 },
               },
@@ -5102,7 +5102,7 @@ Object {
                 "id": "perl-Encode@4:2.97-3.el8",
                 "info": Object {
                   "name": "perl-Encode",
-                  "purl": "pkg:rpm/perl-Encode@4:2.97-3.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Encode@4:2.97-3.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:2.97-3.el8",
                 },
               },
@@ -5110,7 +5110,7 @@ Object {
                 "id": "perl-Errno@1.28-416.el8",
                 "info": Object {
                   "name": "perl-Errno",
-                  "purl": "pkg:rpm/perl-Errno@1.28-416.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Errno@1.28-416.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.28-416.el8",
                 },
               },
@@ -5118,7 +5118,7 @@ Object {
                 "id": "perl-Error@1:0.17025-2.el8",
                 "info": Object {
                   "name": "perl-Error",
-                  "purl": "pkg:rpm/perl-Error@1:0.17025-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Error@1:0.17025-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:0.17025-2.el8",
                 },
               },
@@ -5126,7 +5126,7 @@ Object {
                 "id": "perl-Exporter@5.72-396.el8",
                 "info": Object {
                   "name": "perl-Exporter",
-                  "purl": "pkg:rpm/perl-Exporter@5.72-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Exporter@5.72-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.72-396.el8",
                 },
               },
@@ -5134,7 +5134,7 @@ Object {
                 "id": "perl-File-Path@2.15-2.el8",
                 "info": Object {
                   "name": "perl-File-Path",
-                  "purl": "pkg:rpm/perl-File-Path@2.15-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-File-Path@2.15-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.15-2.el8",
                 },
               },
@@ -5142,7 +5142,7 @@ Object {
                 "id": "perl-File-Temp@0.230.600-1.el8",
                 "info": Object {
                   "name": "perl-File-Temp",
-                  "purl": "pkg:rpm/perl-File-Temp@0.230.600-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-File-Temp@0.230.600-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.230.600-1.el8",
                 },
               },
@@ -5150,7 +5150,7 @@ Object {
                 "id": "perl-Getopt-Long@1:2.50-4.el8",
                 "info": Object {
                   "name": "perl-Getopt-Long",
-                  "purl": "pkg:rpm/perl-Getopt-Long@1:2.50-4.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Getopt-Long@1:2.50-4.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:2.50-4.el8",
                 },
               },
@@ -5158,7 +5158,7 @@ Object {
                 "id": "perl-Git@2.18.4-2.el8_2",
                 "info": Object {
                   "name": "perl-Git",
-                  "purl": "pkg:rpm/perl-Git@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Git@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.18.4-2.el8_2",
                 },
               },
@@ -5166,7 +5166,7 @@ Object {
                 "id": "perl-HTTP-Tiny@0.074-1.el8",
                 "info": Object {
                   "name": "perl-HTTP-Tiny",
-                  "purl": "pkg:rpm/perl-HTTP-Tiny@0.074-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-HTTP-Tiny@0.074-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.074-1.el8",
                 },
               },
@@ -5174,7 +5174,7 @@ Object {
                 "id": "perl-IO@1.38-416.el8",
                 "info": Object {
                   "name": "perl-IO",
-                  "purl": "pkg:rpm/perl-IO@1.38-416.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-IO@1.38-416.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.38-416.el8",
                 },
               },
@@ -5182,7 +5182,7 @@ Object {
                 "id": "perl-IO-Socket-IP@0.39-5.el8",
                 "info": Object {
                   "name": "perl-IO-Socket-IP",
-                  "purl": "pkg:rpm/perl-IO-Socket-IP@0.39-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-IO-Socket-IP@0.39-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.39-5.el8",
                 },
               },
@@ -5190,7 +5190,7 @@ Object {
                 "id": "perl-IO-Socket-SSL@2.066-4.el8",
                 "info": Object {
                   "name": "perl-IO-Socket-SSL",
-                  "purl": "pkg:rpm/perl-IO-Socket-SSL@2.066-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-IO-Socket-SSL@2.066-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.066-4.el8",
                 },
               },
@@ -5198,7 +5198,7 @@ Object {
                 "id": "perl-MIME-Base64@3.15-396.el8",
                 "info": Object {
                   "name": "perl-MIME-Base64",
-                  "purl": "pkg:rpm/perl-MIME-Base64@3.15-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-MIME-Base64@3.15-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.15-396.el8",
                 },
               },
@@ -5206,7 +5206,7 @@ Object {
                 "id": "perl-Mozilla-CA@20160104-7.el8",
                 "info": Object {
                   "name": "perl-Mozilla-CA",
-                  "purl": "pkg:rpm/perl-Mozilla-CA@20160104-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Mozilla-CA@20160104-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "20160104-7.el8",
                 },
               },
@@ -5214,7 +5214,7 @@ Object {
                 "id": "perl-Net-SSLeay@1.88-1.el8",
                 "info": Object {
                   "name": "perl-Net-SSLeay",
-                  "purl": "pkg:rpm/perl-Net-SSLeay@1.88-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Net-SSLeay@1.88-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.88-1.el8",
                 },
               },
@@ -5222,7 +5222,7 @@ Object {
                 "id": "perl-PathTools@3.74-1.el8",
                 "info": Object {
                   "name": "perl-PathTools",
-                  "purl": "pkg:rpm/perl-PathTools@3.74-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-PathTools@3.74-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.74-1.el8",
                 },
               },
@@ -5230,7 +5230,7 @@ Object {
                 "id": "perl-Pod-Escapes@1:1.07-395.el8",
                 "info": Object {
                   "name": "perl-Pod-Escapes",
-                  "purl": "pkg:rpm/perl-Pod-Escapes@1:1.07-395.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Pod-Escapes@1:1.07-395.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.07-395.el8",
                 },
               },
@@ -5238,7 +5238,7 @@ Object {
                 "id": "perl-Pod-Perldoc@3.28-396.el8",
                 "info": Object {
                   "name": "perl-Pod-Perldoc",
-                  "purl": "pkg:rpm/perl-Pod-Perldoc@3.28-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Pod-Perldoc@3.28-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.28-396.el8",
                 },
               },
@@ -5246,7 +5246,7 @@ Object {
                 "id": "perl-Pod-Simple@1:3.35-395.el8",
                 "info": Object {
                   "name": "perl-Pod-Simple",
-                  "purl": "pkg:rpm/perl-Pod-Simple@1:3.35-395.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Pod-Simple@1:3.35-395.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:3.35-395.el8",
                 },
               },
@@ -5254,7 +5254,7 @@ Object {
                 "id": "perl-Pod-Usage@4:1.69-395.el8",
                 "info": Object {
                   "name": "perl-Pod-Usage",
-                  "purl": "pkg:rpm/perl-Pod-Usage@4:1.69-395.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Pod-Usage@4:1.69-395.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:1.69-395.el8",
                 },
               },
@@ -5262,7 +5262,7 @@ Object {
                 "id": "perl-Scalar-List-Utils@3:1.49-2.el8",
                 "info": Object {
                   "name": "perl-Scalar-List-Utils",
-                  "purl": "pkg:rpm/perl-Scalar-List-Utils@3:1.49-2.el8?epoch=3&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Scalar-List-Utils@3:1.49-2.el8?epoch=3&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3:1.49-2.el8",
                 },
               },
@@ -5270,7 +5270,7 @@ Object {
                 "id": "perl-Socket@4:2.027-3.el8",
                 "info": Object {
                   "name": "perl-Socket",
-                  "purl": "pkg:rpm/perl-Socket@4:2.027-3.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Socket@4:2.027-3.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:2.027-3.el8",
                 },
               },
@@ -5278,7 +5278,7 @@ Object {
                 "id": "perl-Storable@1:3.11-3.el8",
                 "info": Object {
                   "name": "perl-Storable",
-                  "purl": "pkg:rpm/perl-Storable@1:3.11-3.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Storable@1:3.11-3.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:3.11-3.el8",
                 },
               },
@@ -5286,7 +5286,7 @@ Object {
                 "id": "perl-Term-ANSIColor@4.06-396.el8",
                 "info": Object {
                   "name": "perl-Term-ANSIColor",
-                  "purl": "pkg:rpm/perl-Term-ANSIColor@4.06-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Term-ANSIColor@4.06-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.06-396.el8",
                 },
               },
@@ -5294,7 +5294,7 @@ Object {
                 "id": "perl-Term-Cap@1.17-395.el8",
                 "info": Object {
                   "name": "perl-Term-Cap",
-                  "purl": "pkg:rpm/perl-Term-Cap@1.17-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Term-Cap@1.17-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-395.el8",
                 },
               },
@@ -5302,7 +5302,7 @@ Object {
                 "id": "perl-TermReadKey@2.37-7.el8",
                 "info": Object {
                   "name": "perl-TermReadKey",
-                  "purl": "pkg:rpm/perl-TermReadKey@2.37-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-TermReadKey@2.37-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.37-7.el8",
                 },
               },
@@ -5310,7 +5310,7 @@ Object {
                 "id": "perl-Text-ParseWords@3.30-395.el8",
                 "info": Object {
                   "name": "perl-Text-ParseWords",
-                  "purl": "pkg:rpm/perl-Text-ParseWords@3.30-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Text-ParseWords@3.30-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.30-395.el8",
                 },
               },
@@ -5318,7 +5318,7 @@ Object {
                 "id": "perl-Text-Tabs+Wrap@2013.0523-395.el8",
                 "info": Object {
                   "name": "perl-Text-Tabs+Wrap",
-                  "purl": "pkg:rpm/perl-Text-Tabs%2BWrap@2013.0523-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Text-Tabs%2BWrap@2013.0523-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2013.0523-395.el8",
                 },
               },
@@ -5326,7 +5326,7 @@ Object {
                 "id": "perl-Thread-Queue@3.13-1.el8",
                 "info": Object {
                   "name": "perl-Thread-Queue",
-                  "purl": "pkg:rpm/perl-Thread-Queue@3.13-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Thread-Queue@3.13-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.13-1.el8",
                 },
               },
@@ -5334,7 +5334,7 @@ Object {
                 "id": "perl-Time-Local@1:1.280-1.el8",
                 "info": Object {
                   "name": "perl-Time-Local",
-                  "purl": "pkg:rpm/perl-Time-Local@1:1.280-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Time-Local@1:1.280-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.280-1.el8",
                 },
               },
@@ -5342,7 +5342,7 @@ Object {
                 "id": "perl-URI@1.73-3.el8",
                 "info": Object {
                   "name": "perl-URI",
-                  "purl": "pkg:rpm/perl-URI@1.73-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-URI@1.73-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.73-3.el8",
                 },
               },
@@ -5350,7 +5350,7 @@ Object {
                 "id": "perl-Unicode-Normalize@1.25-396.el8",
                 "info": Object {
                   "name": "perl-Unicode-Normalize",
-                  "purl": "pkg:rpm/perl-Unicode-Normalize@1.25-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-Unicode-Normalize@1.25-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.25-396.el8",
                 },
               },
@@ -5358,7 +5358,7 @@ Object {
                 "id": "perl-constant@1.33-396.el8",
                 "info": Object {
                   "name": "perl-constant",
-                  "purl": "pkg:rpm/perl-constant@1.33-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-constant@1.33-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.33-396.el8",
                 },
               },
@@ -5366,7 +5366,7 @@ Object {
                 "id": "perl-interpreter@4:5.26.3-416.el8",
                 "info": Object {
                   "name": "perl-interpreter",
-                  "purl": "pkg:rpm/perl-interpreter@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-interpreter@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:5.26.3-416.el8",
                 },
               },
@@ -5374,7 +5374,7 @@ Object {
                 "id": "perl-libnet@3.11-3.el8",
                 "info": Object {
                   "name": "perl-libnet",
-                  "purl": "pkg:rpm/perl-libnet@3.11-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-libnet@3.11-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11-3.el8",
                 },
               },
@@ -5382,7 +5382,7 @@ Object {
                 "id": "perl-libs@4:5.26.3-416.el8",
                 "info": Object {
                   "name": "perl-libs",
-                  "purl": "pkg:rpm/perl-libs@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-libs@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:5.26.3-416.el8",
                 },
               },
@@ -5390,7 +5390,7 @@ Object {
                 "id": "perl-macros@4:5.26.3-416.el8",
                 "info": Object {
                   "name": "perl-macros",
-                  "purl": "pkg:rpm/perl-macros@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-macros@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:5.26.3-416.el8",
                 },
               },
@@ -5398,7 +5398,7 @@ Object {
                 "id": "perl-parent@1:0.237-1.el8",
                 "info": Object {
                   "name": "perl-parent",
-                  "purl": "pkg:rpm/perl-parent@1:0.237-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-parent@1:0.237-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:0.237-1.el8",
                 },
               },
@@ -5406,7 +5406,7 @@ Object {
                 "id": "perl-podlators@4.11-1.el8",
                 "info": Object {
                   "name": "perl-podlators",
-                  "purl": "pkg:rpm/perl-podlators@4.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-podlators@4.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.11-1.el8",
                 },
               },
@@ -5414,7 +5414,7 @@ Object {
                 "id": "perl-srpm-macros@1-25.el8",
                 "info": Object {
                   "name": "perl-srpm-macros",
-                  "purl": "pkg:rpm/perl-srpm-macros@1-25.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-srpm-macros@1-25.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1-25.el8",
                 },
               },
@@ -5422,7 +5422,7 @@ Object {
                 "id": "perl-threads@1:2.21-2.el8",
                 "info": Object {
                   "name": "perl-threads",
-                  "purl": "pkg:rpm/perl-threads@1:2.21-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-threads@1:2.21-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:2.21-2.el8",
                 },
               },
@@ -5430,7 +5430,7 @@ Object {
                 "id": "perl-threads-shared@1.58-2.el8",
                 "info": Object {
                   "name": "perl-threads-shared",
-                  "purl": "pkg:rpm/perl-threads-shared@1.58-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/perl-threads-shared@1.58-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.58-2.el8",
                 },
               },
@@ -5438,7 +5438,7 @@ Object {
                 "id": "pkgconf@1.4.2-1.el8",
                 "info": Object {
                   "name": "pkgconf",
-                  "purl": "pkg:rpm/pkgconf@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pkgconf@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-1.el8",
                 },
               },
@@ -5446,7 +5446,7 @@ Object {
                 "id": "pkgconf-m4@1.4.2-1.el8",
                 "info": Object {
                   "name": "pkgconf-m4",
-                  "purl": "pkg:rpm/pkgconf-m4@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pkgconf-m4@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-1.el8",
                 },
               },
@@ -5454,7 +5454,7 @@ Object {
                 "id": "pkgconf-pkg-config@1.4.2-1.el8",
                 "info": Object {
                   "name": "pkgconf-pkg-config",
-                  "purl": "pkg:rpm/pkgconf-pkg-config@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/pkgconf-pkg-config@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-1.el8",
                 },
               },
@@ -5462,7 +5462,7 @@ Object {
                 "id": "platform-python@3.6.8-23.el8",
                 "info": Object {
                   "name": "platform-python",
-                  "purl": "pkg:rpm/platform-python@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/platform-python@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.6.8-23.el8",
                 },
               },
@@ -5470,7 +5470,7 @@ Object {
                 "id": "platform-python-setuptools@39.2.0-5.el8",
                 "info": Object {
                   "name": "platform-python-setuptools",
-                  "purl": "pkg:rpm/platform-python-setuptools@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/platform-python-setuptools@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -5478,7 +5478,7 @@ Object {
                 "id": "popt@1.16-14.el8",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.16-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/popt@1.16-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.16-14.el8",
                 },
               },
@@ -5486,7 +5486,7 @@ Object {
                 "id": "procps-ng@3.3.15-1.el8",
                 "info": Object {
                   "name": "procps-ng",
-                  "purl": "pkg:rpm/procps-ng@3.3.15-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/procps-ng@3.3.15-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.3.15-1.el8",
                 },
               },
@@ -5494,7 +5494,7 @@ Object {
                 "id": "publicsuffix-list-dafsa@20180723-1.el8",
                 "info": Object {
                   "name": "publicsuffix-list-dafsa",
-                  "purl": "pkg:rpm/publicsuffix-list-dafsa@20180723-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/publicsuffix-list-dafsa@20180723-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "20180723-1.el8",
                 },
               },
@@ -5502,7 +5502,7 @@ Object {
                 "id": "python-srpm-macros@3-38.el8",
                 "info": Object {
                   "name": "python-srpm-macros",
-                  "purl": "pkg:rpm/python-srpm-macros@3-38.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python-srpm-macros@3-38.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3-38.el8",
                 },
               },
@@ -5510,7 +5510,7 @@ Object {
                 "id": "python3-dateutil@1:2.6.1-6.el8",
                 "info": Object {
                   "name": "python3-dateutil",
-                  "purl": "pkg:rpm/python3-dateutil@1:2.6.1-6.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-dateutil@1:2.6.1-6.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:2.6.1-6.el8",
                 },
               },
@@ -5518,7 +5518,7 @@ Object {
                 "id": "python3-dbus@1.2.4-15.el8",
                 "info": Object {
                   "name": "python3-dbus",
-                  "purl": "pkg:rpm/python3-dbus@1.2.4-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-dbus@1.2.4-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.4-15.el8",
                 },
               },
@@ -5526,7 +5526,7 @@ Object {
                 "id": "python3-decorator@4.2.1-2.el8",
                 "info": Object {
                   "name": "python3-decorator",
-                  "purl": "pkg:rpm/python3-decorator@4.2.1-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-decorator@4.2.1-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.1-2.el8",
                 },
               },
@@ -5534,7 +5534,7 @@ Object {
                 "id": "python3-dmidecode@3.12.2-15.el8",
                 "info": Object {
                   "name": "python3-dmidecode",
-                  "purl": "pkg:rpm/python3-dmidecode@3.12.2-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-dmidecode@3.12.2-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.12.2-15.el8",
                 },
               },
@@ -5542,7 +5542,7 @@ Object {
                 "id": "python3-dnf@4.2.17-6.el8",
                 "info": Object {
                   "name": "python3-dnf",
-                  "purl": "pkg:rpm/python3-dnf@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-dnf@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.17-6.el8",
                 },
               },
@@ -5550,7 +5550,7 @@ Object {
                 "id": "python3-dnf-plugins-core@4.0.12-3.el8",
                 "info": Object {
                   "name": "python3-dnf-plugins-core",
-                  "purl": "pkg:rpm/python3-dnf-plugins-core@4.0.12-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-dnf-plugins-core@4.0.12-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.0.12-3.el8",
                 },
               },
@@ -5558,7 +5558,7 @@ Object {
                 "id": "python3-ethtool@0.14-3.el8",
                 "info": Object {
                   "name": "python3-ethtool",
-                  "purl": "pkg:rpm/python3-ethtool@0.14-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-ethtool@0.14-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.14-3.el8",
                 },
               },
@@ -5566,7 +5566,7 @@ Object {
                 "id": "python3-gobject-base@3.28.3-1.el8",
                 "info": Object {
                   "name": "python3-gobject-base",
-                  "purl": "pkg:rpm/python3-gobject-base@3.28.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-gobject-base@3.28.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.28.3-1.el8",
                 },
               },
@@ -5574,7 +5574,7 @@ Object {
                 "id": "python3-gpg@1.10.0-6.el8",
                 "info": Object {
                   "name": "python3-gpg",
-                  "purl": "pkg:rpm/python3-gpg@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-gpg@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.10.0-6.el8",
                 },
               },
@@ -5582,7 +5582,7 @@ Object {
                 "id": "python3-hawkey@0.39.1-5.el8",
                 "info": Object {
                   "name": "python3-hawkey",
-                  "purl": "pkg:rpm/python3-hawkey@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-hawkey@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.39.1-5.el8",
                 },
               },
@@ -5590,7 +5590,7 @@ Object {
                 "id": "python3-iniparse@0.4-31.el8",
                 "info": Object {
                   "name": "python3-iniparse",
-                  "purl": "pkg:rpm/python3-iniparse@0.4-31.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-iniparse@0.4-31.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.4-31.el8",
                 },
               },
@@ -5598,7 +5598,7 @@ Object {
                 "id": "python3-inotify@0.9.6-13.el8",
                 "info": Object {
                   "name": "python3-inotify",
-                  "purl": "pkg:rpm/python3-inotify@0.9.6-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-inotify@0.9.6-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.9.6-13.el8",
                 },
               },
@@ -5606,7 +5606,7 @@ Object {
                 "id": "python3-libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "python3-libcomps",
-                  "purl": "pkg:rpm/python3-libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -5614,7 +5614,7 @@ Object {
                 "id": "python3-libdnf@0.39.1-5.el8",
                 "info": Object {
                   "name": "python3-libdnf",
-                  "purl": "pkg:rpm/python3-libdnf@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-libdnf@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.39.1-5.el8",
                 },
               },
@@ -5622,7 +5622,7 @@ Object {
                 "id": "python3-librepo@1.11.0-2.el8",
                 "info": Object {
                   "name": "python3-librepo",
-                  "purl": "pkg:rpm/python3-librepo@1.11.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-librepo@1.11.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.11.0-2.el8",
                 },
               },
@@ -5630,7 +5630,7 @@ Object {
                 "id": "python3-libs@3.6.8-23.el8",
                 "info": Object {
                   "name": "python3-libs",
-                  "purl": "pkg:rpm/python3-libs@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-libs@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.6.8-23.el8",
                 },
               },
@@ -5638,7 +5638,7 @@ Object {
                 "id": "python3-libxml2@2.9.7-7.el8",
                 "info": Object {
                   "name": "python3-libxml2",
-                  "purl": "pkg:rpm/python3-libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -5646,7 +5646,7 @@ Object {
                 "id": "python3-pip-wheel@9.0.3-16.el8",
                 "info": Object {
                   "name": "python3-pip-wheel",
-                  "purl": "pkg:rpm/python3-pip-wheel@9.0.3-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-pip-wheel@9.0.3-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "9.0.3-16.el8",
                 },
               },
@@ -5654,7 +5654,7 @@ Object {
                 "id": "python3-rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "python3-rpm",
-                  "purl": "pkg:rpm/python3-rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -5662,7 +5662,7 @@ Object {
                 "id": "python3-rpm-macros@3-38.el8",
                 "info": Object {
                   "name": "python3-rpm-macros",
-                  "purl": "pkg:rpm/python3-rpm-macros@3-38.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-rpm-macros@3-38.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3-38.el8",
                 },
               },
@@ -5670,7 +5670,7 @@ Object {
                 "id": "python3-setuptools-wheel@39.2.0-5.el8",
                 "info": Object {
                   "name": "python3-setuptools-wheel",
-                  "purl": "pkg:rpm/python3-setuptools-wheel@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-setuptools-wheel@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -5678,7 +5678,7 @@ Object {
                 "id": "python3-six@1.11.0-8.el8",
                 "info": Object {
                   "name": "python3-six",
-                  "purl": "pkg:rpm/python3-six@1.11.0-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-six@1.11.0-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.11.0-8.el8",
                 },
               },
@@ -5686,7 +5686,7 @@ Object {
                 "id": "python3-subscription-manager-rhsm@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "python3-subscription-manager-rhsm",
-                  "purl": "pkg:rpm/python3-subscription-manager-rhsm@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-subscription-manager-rhsm@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -5694,7 +5694,7 @@ Object {
                 "id": "python3-syspurpose@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "python3-syspurpose",
-                  "purl": "pkg:rpm/python3-syspurpose@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/python3-syspurpose@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -5702,7 +5702,7 @@ Object {
                 "id": "qt5-srpm-macros@5.12.5-3.el8",
                 "info": Object {
                   "name": "qt5-srpm-macros",
-                  "purl": "pkg:rpm/qt5-srpm-macros@5.12.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/qt5-srpm-macros@5.12.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.12.5-3.el8",
                 },
               },
@@ -5710,7 +5710,7 @@ Object {
                 "id": "readline@7.0-10.el8",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@7.0-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/readline@7.0-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.0-10.el8",
                 },
               },
@@ -5718,7 +5718,7 @@ Object {
                 "id": "redhat-release@8.2-1.0.el8",
                 "info": Object {
                   "name": "redhat-release",
-                  "purl": "pkg:rpm/redhat-release@8.2-1.0.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/redhat-release@8.2-1.0.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.2-1.0.el8",
                 },
               },
@@ -5726,7 +5726,7 @@ Object {
                 "id": "redhat-rpm-config@122-1.el8",
                 "info": Object {
                   "name": "redhat-rpm-config",
-                  "purl": "pkg:rpm/redhat-rpm-config@122-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/redhat-rpm-config@122-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "122-1.el8",
                 },
               },
@@ -5734,7 +5734,7 @@ Object {
                 "id": "rootfiles@8.1-22.el8",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rootfiles@8.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.1-22.el8",
                 },
               },
@@ -5742,7 +5742,7 @@ Object {
                 "id": "rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -5750,7 +5750,7 @@ Object {
                 "id": "rpm-build-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rpm-build-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -5758,7 +5758,7 @@ Object {
                 "id": "rpm-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rpm-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -5766,7 +5766,7 @@ Object {
                 "id": "rsync@3.1.3-7.el8",
                 "info": Object {
                   "name": "rsync",
-                  "purl": "pkg:rpm/rsync@3.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rsync@3.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1.3-7.el8",
                 },
               },
@@ -5774,7 +5774,7 @@ Object {
                 "id": "rust-srpm-macros@5-2.el8",
                 "info": Object {
                   "name": "rust-srpm-macros",
-                  "purl": "pkg:rpm/rust-srpm-macros@5-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rust-srpm-macros@5-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5-2.el8",
                 },
               },
@@ -5782,7 +5782,7 @@ Object {
                 "id": "scl-utils@1:2.0.2-12.el8",
                 "info": Object {
                   "name": "scl-utils",
-                  "purl": "pkg:rpm/scl-utils@1:2.0.2-12.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/scl-utils@1:2.0.2-12.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:2.0.2-12.el8",
                 },
               },
@@ -5790,7 +5790,7 @@ Object {
                 "id": "sed@4.5-1.el8",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.5-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/sed@4.5-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.5-1.el8",
                 },
               },
@@ -5798,7 +5798,7 @@ Object {
                 "id": "setup@2.12.2-5.el8",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.12.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/setup@2.12.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.12.2-5.el8",
                 },
               },
@@ -5806,7 +5806,7 @@ Object {
                 "id": "shadow-utils@2:4.6-8.el8",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.6-8.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/shadow-utils@2:4.6-8.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:4.6-8.el8",
                 },
               },
@@ -5814,7 +5814,7 @@ Object {
                 "id": "sqlite@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/sqlite@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -5822,7 +5822,7 @@ Object {
                 "id": "sqlite-devel@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite-devel",
-                  "purl": "pkg:rpm/sqlite-devel@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/sqlite-devel@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -5830,7 +5830,7 @@ Object {
                 "id": "sqlite-libs@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite-libs",
-                  "purl": "pkg:rpm/sqlite-libs@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/sqlite-libs@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -5838,7 +5838,7 @@ Object {
                 "id": "subscription-manager@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "subscription-manager",
-                  "purl": "pkg:rpm/subscription-manager@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/subscription-manager@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -5846,7 +5846,7 @@ Object {
                 "id": "subscription-manager-rhsm-certificates@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "subscription-manager-rhsm-certificates",
-                  "purl": "pkg:rpm/subscription-manager-rhsm-certificates@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/subscription-manager-rhsm-certificates@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -5854,7 +5854,7 @@ Object {
                 "id": "systemd@239-30.el8_2",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/systemd@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/systemd@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "239-30.el8_2",
                 },
               },
@@ -5862,7 +5862,7 @@ Object {
                 "id": "systemd-libs@239-30.el8_2",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/systemd-libs@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "239-30.el8_2",
                 },
               },
@@ -5870,7 +5870,7 @@ Object {
                 "id": "systemd-pam@239-30.el8_2",
                 "info": Object {
                   "name": "systemd-pam",
-                  "purl": "pkg:rpm/systemd-pam@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/systemd-pam@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "239-30.el8_2",
                 },
               },
@@ -5878,7 +5878,7 @@ Object {
                 "id": "tar@2:1.30-4.el8",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.30-4.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/tar@2:1.30-4.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:1.30-4.el8",
                 },
               },
@@ -5886,7 +5886,7 @@ Object {
                 "id": "tcl@1:8.6.8-2.el8",
                 "info": Object {
                   "name": "tcl",
-                  "purl": "pkg:rpm/tcl@1:8.6.8-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/tcl@1:8.6.8-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:8.6.8-2.el8",
                 },
               },
@@ -5894,7 +5894,7 @@ Object {
                 "id": "tzdata@2020a-1.el8",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2020a-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/tzdata@2020a-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2020a-1.el8",
                 },
               },
@@ -5902,7 +5902,7 @@ Object {
                 "id": "unzip@6.0-43.el8",
                 "info": Object {
                   "name": "unzip",
-                  "purl": "pkg:rpm/unzip@6.0-43.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/unzip@6.0-43.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.0-43.el8",
                 },
               },
@@ -5910,7 +5910,7 @@ Object {
                 "id": "usermode@1.113-1.el8",
                 "info": Object {
                   "name": "usermode",
-                  "purl": "pkg:rpm/usermode@1.113-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/usermode@1.113-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.113-1.el8",
                 },
               },
@@ -5918,7 +5918,7 @@ Object {
                 "id": "util-linux@2.32.1-22.el8",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/util-linux@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -5926,7 +5926,7 @@ Object {
                 "id": "vim-minimal@2:8.0.1763-13.el8",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.0.1763-13.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/vim-minimal@2:8.0.1763-13.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:8.0.1763-13.el8",
                 },
               },
@@ -5934,7 +5934,7 @@ Object {
                 "id": "virt-what@1.18-6.el8",
                 "info": Object {
                   "name": "virt-what",
-                  "purl": "pkg:rpm/virt-what@1.18-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/virt-what@1.18-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.18-6.el8",
                 },
               },
@@ -5942,7 +5942,7 @@ Object {
                 "id": "wget@1.19.5-8.el8_1.1",
                 "info": Object {
                   "name": "wget",
-                  "purl": "pkg:rpm/wget@1.19.5-8.el8_1.1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/wget@1.19.5-8.el8_1.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.19.5-8.el8_1.1",
                 },
               },
@@ -5950,7 +5950,7 @@ Object {
                 "id": "which@2.21-12.el8",
                 "info": Object {
                   "name": "which",
-                  "purl": "pkg:rpm/which@2.21-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/which@2.21-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.21-12.el8",
                 },
               },
@@ -5958,7 +5958,7 @@ Object {
                 "id": "xorg-x11-proto-devel@2018.4-1.el8",
                 "info": Object {
                   "name": "xorg-x11-proto-devel",
-                  "purl": "pkg:rpm/xorg-x11-proto-devel@2018.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/xorg-x11-proto-devel@2018.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2018.4-1.el8",
                 },
               },
@@ -5966,7 +5966,7 @@ Object {
                 "id": "xz@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz",
-                  "purl": "pkg:rpm/xz@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/xz@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -5974,7 +5974,7 @@ Object {
                 "id": "xz-devel@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz-devel",
-                  "purl": "pkg:rpm/xz-devel@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/xz-devel@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -5982,7 +5982,7 @@ Object {
                 "id": "xz-libs@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/xz-libs@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -5990,7 +5990,7 @@ Object {
                 "id": "yum@4.2.17-6.el8",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/yum@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.17-6.el8",
                 },
               },
@@ -5998,7 +5998,7 @@ Object {
                 "id": "zip@3.0-23.el8",
                 "info": Object {
                   "name": "zip",
-                  "purl": "pkg:rpm/zip@3.0-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/zip@3.0-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0-23.el8",
                 },
               },
@@ -6006,7 +6006,7 @@ Object {
                 "id": "zlib@1.2.11-13.el8",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.11-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/zlib@1.2.11-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.11-13.el8",
                 },
               },
@@ -6014,7 +6014,7 @@ Object {
                 "id": "zlib-devel@1.2.11-13.el8",
                 "info": Object {
                   "name": "zlib-devel",
-                  "purl": "pkg:rpm/zlib-devel@1.2.11-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-beta-rpms,rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-htb-rpms,rhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/zlib-devel@1.2.11-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.11-13.el8",
                 },
               },
@@ -7586,7 +7586,7 @@ Object {
                 "id": "acl@2.2.53-1.el8",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:rpm/acl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/acl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -7594,7 +7594,7 @@ Object {
                 "id": "audit-libs@3.0-0.17.20191104git1c2f876.el8",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@3.0-0.17.20191104git1c2f876.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/audit-libs@3.0-0.17.20191104git1c2f876.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.0-0.17.20191104git1c2f876.el8",
                 },
               },
@@ -7602,7 +7602,7 @@ Object {
                 "id": "basesystem@11-5.el8",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/basesystem@11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "11-5.el8",
                 },
               },
@@ -7610,7 +7610,7 @@ Object {
                 "id": "bash@4.4.19-10.el8",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.4.19-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/bash@4.4.19-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.4.19-10.el8",
                 },
               },
@@ -7618,7 +7618,7 @@ Object {
                 "id": "brotli@1.0.6-1.el8",
                 "info": Object {
                   "name": "brotli",
-                  "purl": "pkg:rpm/brotli@1.0.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/brotli@1.0.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.0.6-1.el8",
                 },
               },
@@ -7626,7 +7626,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/bzip2-libs@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -7634,7 +7634,7 @@ Object {
                 "id": "ca-certificates@2020.2.41-80.0.el8_2",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2020.2.41-80.0.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/ca-certificates@2020.2.41-80.0.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2020.2.41-80.0.el8_2",
                 },
               },
@@ -7642,7 +7642,7 @@ Object {
                 "id": "chkconfig@1.11-1.el8",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/chkconfig@1.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.11-1.el8",
                 },
               },
@@ -7650,7 +7650,7 @@ Object {
                 "id": "coreutils-single@8.30-7.el8_2.1",
                 "info": Object {
                   "name": "coreutils-single",
-                  "purl": "pkg:rpm/coreutils-single@8.30-7.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/coreutils-single@8.30-7.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.30-7.el8_2.1",
                 },
               },
@@ -7658,7 +7658,7 @@ Object {
                 "id": "cracklib@2.9.6-15.el8",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.6-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/cracklib@2.9.6-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9.6-15.el8",
                 },
               },
@@ -7666,7 +7666,7 @@ Object {
                 "id": "crypto-policies@20191128-2.git23e1bf1.el8",
                 "info": Object {
                   "name": "crypto-policies",
-                  "purl": "pkg:rpm/crypto-policies@20191128-2.git23e1bf1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/crypto-policies@20191128-2.git23e1bf1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "20191128-2.git23e1bf1.el8",
                 },
               },
@@ -7674,7 +7674,7 @@ Object {
                 "id": "cryptsetup-libs@2.2.2-1.el8",
                 "info": Object {
                   "name": "cryptsetup-libs",
-                  "purl": "pkg:rpm/cryptsetup-libs@2.2.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/cryptsetup-libs@2.2.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.2-1.el8",
                 },
               },
@@ -7682,7 +7682,7 @@ Object {
                 "id": "curl@7.61.1-12.el8",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/curl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -7690,7 +7690,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.27-1.el8",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.27-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.27-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.1.27-1.el8",
                 },
               },
@@ -7698,7 +7698,7 @@ Object {
                 "id": "dbus@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus",
-                  "purl": "pkg:rpm/dbus@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dbus@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7706,7 +7706,7 @@ Object {
                 "id": "dbus-common@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus-common",
-                  "purl": "pkg:rpm/dbus-common@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dbus-common@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7714,7 +7714,7 @@ Object {
                 "id": "dbus-daemon@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus-daemon",
-                  "purl": "pkg:rpm/dbus-daemon@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dbus-daemon@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7722,7 +7722,7 @@ Object {
                 "id": "dbus-glib@0.110-2.el8",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.110-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dbus-glib@0.110-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.110-2.el8",
                 },
               },
@@ -7730,7 +7730,7 @@ Object {
                 "id": "dbus-libs@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dbus-libs@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7738,7 +7738,7 @@ Object {
                 "id": "dbus-tools@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus-tools",
-                  "purl": "pkg:rpm/dbus-tools@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dbus-tools@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7746,7 +7746,7 @@ Object {
                 "id": "device-mapper@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper",
-                  "purl": "pkg:rpm/device-mapper@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/device-mapper@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -7754,7 +7754,7 @@ Object {
                 "id": "device-mapper-libs@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper-libs",
-                  "purl": "pkg:rpm/device-mapper-libs@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/device-mapper-libs@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -7762,7 +7762,7 @@ Object {
                 "id": "dmidecode@1:3.2-5.el8",
                 "info": Object {
                   "name": "dmidecode",
-                  "purl": "pkg:rpm/dmidecode@1:3.2-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dmidecode@1:3.2-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:3.2-5.el8",
                 },
               },
@@ -7770,7 +7770,7 @@ Object {
                 "id": "dnf@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "dnf",
-                  "purl": "pkg:rpm/dnf@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dnf@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -7778,7 +7778,7 @@ Object {
                 "id": "dnf-data@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "dnf-data",
-                  "purl": "pkg:rpm/dnf-data@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dnf-data@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -7786,7 +7786,7 @@ Object {
                 "id": "dnf-plugin-subscription-manager@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "dnf-plugin-subscription-manager",
-                  "purl": "pkg:rpm/dnf-plugin-subscription-manager@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/dnf-plugin-subscription-manager@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -7794,7 +7794,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -7802,7 +7802,7 @@ Object {
                 "id": "elfutils-libelf@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/elfutils-libelf@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -7810,7 +7810,7 @@ Object {
                 "id": "elfutils-libs@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/elfutils-libs@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -7818,7 +7818,7 @@ Object {
                 "id": "expat@2.2.5-3.el8",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/expat@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.5-3.el8",
                 },
               },
@@ -7826,7 +7826,7 @@ Object {
                 "id": "file-libs@5.33-13.el8",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/file-libs@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.33-13.el8",
                 },
               },
@@ -7834,7 +7834,7 @@ Object {
                 "id": "filesystem@3.8-2.el8",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.8-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/filesystem@3.8-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.8-2.el8",
                 },
               },
@@ -7842,7 +7842,7 @@ Object {
                 "id": "findutils@1:4.6.0-20.el8",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.6.0-20.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/findutils@1:4.6.0-20.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:4.6.0-20.el8",
                 },
               },
@@ -7850,7 +7850,7 @@ Object {
                 "id": "gawk@4.2.1-1.el8",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.2.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gawk@4.2.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.1-1.el8",
                 },
               },
@@ -7858,7 +7858,7 @@ Object {
                 "id": "gdb-gdbserver@8.2-11.el8",
                 "info": Object {
                   "name": "gdb-gdbserver",
-                  "purl": "pkg:rpm/gdb-gdbserver@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gdb-gdbserver@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.2-11.el8",
                 },
               },
@@ -7866,7 +7866,7 @@ Object {
                 "id": "gdbm@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gdbm@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -7874,7 +7874,7 @@ Object {
                 "id": "gdbm-libs@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm-libs",
-                  "purl": "pkg:rpm/gdbm-libs@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gdbm-libs@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -7882,7 +7882,7 @@ Object {
                 "id": "glib2@2.56.4-8.el8",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.4-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/glib2@2.56.4-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.56.4-8.el8",
                 },
               },
@@ -7890,7 +7890,7 @@ Object {
                 "id": "glibc@2.28-101.el8",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/glibc@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -7898,7 +7898,7 @@ Object {
                 "id": "glibc-common@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/glibc-common@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -7906,7 +7906,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/glibc-minimal-langpack@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -7914,7 +7914,7 @@ Object {
                 "id": "gmp@1:6.1.2-10.el8",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.1.2-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gmp@1:6.1.2-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:6.1.2-10.el8",
                 },
               },
@@ -7922,7 +7922,7 @@ Object {
                 "id": "gnupg2@2.2.9-1.el8",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gnupg2@2.2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.9-1.el8",
                 },
               },
@@ -7930,7 +7930,7 @@ Object {
                 "id": "gnutls@3.6.8-11.el8_2",
                 "info": Object {
                   "name": "gnutls",
-                  "purl": "pkg:rpm/gnutls@3.6.8-11.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gnutls@3.6.8-11.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.6.8-11.el8_2",
                 },
               },
@@ -7938,7 +7938,7 @@ Object {
                 "id": "gobject-introspection@1.56.1-1.el8",
                 "info": Object {
                   "name": "gobject-introspection",
-                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.56.1-1.el8",
                 },
               },
@@ -7946,7 +7946,7 @@ Object {
                 "id": "gpg-pubkey@fd431d51-4ae0493b",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@fd431d51-4ae0493b?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gpg-pubkey@fd431d51-4ae0493b?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "fd431d51-4ae0493b",
                 },
               },
@@ -7954,7 +7954,7 @@ Object {
                 "id": "gpgme@1.10.0-6.el8",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gpgme@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.10.0-6.el8",
                 },
               },
@@ -7962,7 +7962,7 @@ Object {
                 "id": "grep@3.1-6.el8",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@3.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/grep@3.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.1-6.el8",
                 },
               },
@@ -7970,7 +7970,7 @@ Object {
                 "id": "gzip@1.9-9.el8",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.9-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/gzip@1.9-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.9-9.el8",
                 },
               },
@@ -7978,7 +7978,7 @@ Object {
                 "id": "ima-evm-utils@1.1-5.el8",
                 "info": Object {
                   "name": "ima-evm-utils",
-                  "purl": "pkg:rpm/ima-evm-utils@1.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/ima-evm-utils@1.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.1-5.el8",
                 },
               },
@@ -7986,7 +7986,7 @@ Object {
                 "id": "info@6.5-6.el8",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@6.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/info@6.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "6.5-6.el8",
                 },
               },
@@ -7994,7 +7994,7 @@ Object {
                 "id": "iptables-libs@1.8.4-10.el8_2.1",
                 "info": Object {
                   "name": "iptables-libs",
-                  "purl": "pkg:rpm/iptables-libs@1.8.4-10.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/iptables-libs@1.8.4-10.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.8.4-10.el8_2.1",
                 },
               },
@@ -8002,7 +8002,7 @@ Object {
                 "id": "json-c@0.13.1-0.2.el8",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.13.1-0.2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/json-c@0.13.1-0.2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.13.1-0.2.el8",
                 },
               },
@@ -8010,7 +8010,7 @@ Object {
                 "id": "json-glib@1.4.4-1.el8",
                 "info": Object {
                   "name": "json-glib",
-                  "purl": "pkg:rpm/json-glib@1.4.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/json-glib@1.4.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.4.4-1.el8",
                 },
               },
@@ -8018,7 +8018,7 @@ Object {
                 "id": "keyutils-libs@1.5.10-6.el8",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/keyutils-libs@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.5.10-6.el8",
                 },
               },
@@ -8026,7 +8026,7 @@ Object {
                 "id": "kmod-libs@25-16.el8",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/kmod-libs@25-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/kmod-libs@25-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "25-16.el8",
                 },
               },
@@ -8034,7 +8034,7 @@ Object {
                 "id": "krb5-libs@1.17-18.el8",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/krb5-libs@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.17-18.el8",
                 },
               },
@@ -8042,7 +8042,7 @@ Object {
                 "id": "langpacks-en@1.0-12.el8",
                 "info": Object {
                   "name": "langpacks-en",
-                  "purl": "pkg:rpm/langpacks-en@1.0-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/langpacks-en@1.0-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.0-12.el8",
                 },
               },
@@ -8050,7 +8050,7 @@ Object {
                 "id": "libacl@2.2.53-1.el8",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libacl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -8058,7 +8058,7 @@ Object {
                 "id": "libarchive@3.3.2-8.el8_1",
                 "info": Object {
                   "name": "libarchive",
-                  "purl": "pkg:rpm/libarchive@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libarchive@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.3.2-8.el8_1",
                 },
               },
@@ -8066,7 +8066,7 @@ Object {
                 "id": "libassuan@2.5.1-3.el8",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.5.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libassuan@2.5.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.5.1-3.el8",
                 },
               },
@@ -8074,7 +8074,7 @@ Object {
                 "id": "libattr@2.4.48-3.el8",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.48-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libattr@2.4.48-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.4.48-3.el8",
                 },
               },
@@ -8082,7 +8082,7 @@ Object {
                 "id": "libblkid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libblkid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8090,7 +8090,7 @@ Object {
                 "id": "libcap@2.26-3.el8",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.26-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libcap@2.26-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.26-3.el8",
                 },
               },
@@ -8098,7 +8098,7 @@ Object {
                 "id": "libcap-ng@0.7.9-5.el8",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.7.9-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libcap-ng@0.7.9-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.7.9-5.el8",
                 },
               },
@@ -8106,7 +8106,7 @@ Object {
                 "id": "libcom_err@1.45.4-3.el8",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libcom_err@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.45.4-3.el8",
                 },
               },
@@ -8114,7 +8114,7 @@ Object {
                 "id": "libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "libcomps",
-                  "purl": "pkg:rpm/libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -8122,7 +8122,7 @@ Object {
                 "id": "libcurl@7.61.1-12.el8",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libcurl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -8130,7 +8130,7 @@ Object {
                 "id": "libdb@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libdb@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -8138,7 +8138,7 @@ Object {
                 "id": "libdb-utils@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libdb-utils@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -8146,7 +8146,7 @@ Object {
                 "id": "libdnf@0.39.1-6.el8_2",
                 "info": Object {
                   "name": "libdnf",
-                  "purl": "pkg:rpm/libdnf@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libdnf@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.39.1-6.el8_2",
                 },
               },
@@ -8154,7 +8154,7 @@ Object {
                 "id": "libfdisk@2.32.1-22.el8",
                 "info": Object {
                   "name": "libfdisk",
-                  "purl": "pkg:rpm/libfdisk@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libfdisk@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8162,7 +8162,7 @@ Object {
                 "id": "libffi@3.1-21.el8",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.1-21.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libffi@3.1-21.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.1-21.el8",
                 },
               },
@@ -8170,7 +8170,7 @@ Object {
                 "id": "libgcc@8.3.1-5.el8",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libgcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -8178,7 +8178,7 @@ Object {
                 "id": "libgcrypt@1.8.3-4.el8",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libgcrypt@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.8.3-4.el8",
                 },
               },
@@ -8186,7 +8186,7 @@ Object {
                 "id": "libgpg-error@1.31-1.el8",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libgpg-error@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.31-1.el8",
                 },
               },
@@ -8194,7 +8194,7 @@ Object {
                 "id": "libidn2@2.2.0-1.el8",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.2.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libidn2@2.2.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.0-1.el8",
                 },
               },
@@ -8202,7 +8202,7 @@ Object {
                 "id": "libksba@1.3.5-7.el8",
                 "info": Object {
                   "name": "libksba",
-                  "purl": "pkg:rpm/libksba@1.3.5-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libksba@1.3.5-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.3.5-7.el8",
                 },
               },
@@ -8210,7 +8210,7 @@ Object {
                 "id": "libmetalink@0.1.3-7.el8",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libmetalink@0.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.1.3-7.el8",
                 },
               },
@@ -8218,7 +8218,7 @@ Object {
                 "id": "libmodulemd1@1.8.16-0.2.8.2.1",
                 "info": Object {
                   "name": "libmodulemd1",
-                  "purl": "pkg:rpm/libmodulemd1@1.8.16-0.2.8.2.1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libmodulemd1@1.8.16-0.2.8.2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.8.16-0.2.8.2.1",
                 },
               },
@@ -8226,7 +8226,7 @@ Object {
                 "id": "libmount@2.32.1-22.el8",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libmount@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8234,7 +8234,7 @@ Object {
                 "id": "libnghttp2@1.33.0-3.el8_2.1",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.33.0-3.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libnghttp2@1.33.0-3.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.33.0-3.el8_2.1",
                 },
               },
@@ -8242,7 +8242,7 @@ Object {
                 "id": "libnl3@3.5.0-1.el8",
                 "info": Object {
                   "name": "libnl3",
-                  "purl": "pkg:rpm/libnl3@3.5.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libnl3@3.5.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.5.0-1.el8",
                 },
               },
@@ -8250,7 +8250,7 @@ Object {
                 "id": "libnsl2@1.2.0-2.20180605git4a062cf.el8",
                 "info": Object {
                   "name": "libnsl2",
-                  "purl": "pkg:rpm/libnsl2@1.2.0-2.20180605git4a062cf.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libnsl2@1.2.0-2.20180605git4a062cf.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.2.0-2.20180605git4a062cf.el8",
                 },
               },
@@ -8258,7 +8258,7 @@ Object {
                 "id": "libpcap@14:1.9.0-3.el8",
                 "info": Object {
                   "name": "libpcap",
-                  "purl": "pkg:rpm/libpcap@14:1.9.0-3.el8?epoch=14&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libpcap@14:1.9.0-3.el8?epoch=14&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "14:1.9.0-3.el8",
                 },
               },
@@ -8266,7 +8266,7 @@ Object {
                 "id": "libpsl@0.20.2-5.el8",
                 "info": Object {
                   "name": "libpsl",
-                  "purl": "pkg:rpm/libpsl@0.20.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libpsl@0.20.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.20.2-5.el8",
                 },
               },
@@ -8274,7 +8274,7 @@ Object {
                 "id": "libpwquality@1.4.0-9.el8",
                 "info": Object {
                   "name": "libpwquality",
-                  "purl": "pkg:rpm/libpwquality@1.4.0-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libpwquality@1.4.0-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.4.0-9.el8",
                 },
               },
@@ -8282,7 +8282,7 @@ Object {
                 "id": "librepo@1.11.0-3.el8_2",
                 "info": Object {
                   "name": "librepo",
-                  "purl": "pkg:rpm/librepo@1.11.0-3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/librepo@1.11.0-3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.11.0-3.el8_2",
                 },
               },
@@ -8290,7 +8290,7 @@ Object {
                 "id": "libreport-filesystem@2.9.5-10.el8",
                 "info": Object {
                   "name": "libreport-filesystem",
-                  "purl": "pkg:rpm/libreport-filesystem@2.9.5-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libreport-filesystem@2.9.5-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9.5-10.el8",
                 },
               },
@@ -8298,7 +8298,7 @@ Object {
                 "id": "librhsm@0.0.3-3.el8",
                 "info": Object {
                   "name": "librhsm",
-                  "purl": "pkg:rpm/librhsm@0.0.3-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/librhsm@0.0.3-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.0.3-3.el8",
                 },
               },
@@ -8306,7 +8306,7 @@ Object {
                 "id": "libseccomp@2.4.1-1.el8",
                 "info": Object {
                   "name": "libseccomp",
-                  "purl": "pkg:rpm/libseccomp@2.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libseccomp@2.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.4.1-1.el8",
                 },
               },
@@ -8314,7 +8314,7 @@ Object {
                 "id": "libselinux@2.9-3.el8",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libselinux@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9-3.el8",
                 },
               },
@@ -8322,7 +8322,7 @@ Object {
                 "id": "libsemanage@2.9-2.el8",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.9-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libsemanage@2.9-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9-2.el8",
                 },
               },
@@ -8330,7 +8330,7 @@ Object {
                 "id": "libsepol@2.9-1.el8",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libsepol@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9-1.el8",
                 },
               },
@@ -8338,7 +8338,7 @@ Object {
                 "id": "libsigsegv@2.11-5.el8",
                 "info": Object {
                   "name": "libsigsegv",
-                  "purl": "pkg:rpm/libsigsegv@2.11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libsigsegv@2.11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.11-5.el8",
                 },
               },
@@ -8346,7 +8346,7 @@ Object {
                 "id": "libsmartcols@2.32.1-22.el8",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libsmartcols@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8354,7 +8354,7 @@ Object {
                 "id": "libsolv@0.7.7-1.el8",
                 "info": Object {
                   "name": "libsolv",
-                  "purl": "pkg:rpm/libsolv@0.7.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libsolv@0.7.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.7.7-1.el8",
                 },
               },
@@ -8362,7 +8362,7 @@ Object {
                 "id": "libssh@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh",
-                  "purl": "pkg:rpm/libssh@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libssh@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -8370,7 +8370,7 @@ Object {
                 "id": "libssh-config@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh-config",
-                  "purl": "pkg:rpm/libssh-config@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libssh-config@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -8378,7 +8378,7 @@ Object {
                 "id": "libstdc++@8.3.1-5.el8",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libstdc%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -8386,7 +8386,7 @@ Object {
                 "id": "libtasn1@4.13-3.el8",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.13-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libtasn1@4.13-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.13-3.el8",
                 },
               },
@@ -8394,7 +8394,7 @@ Object {
                 "id": "libtirpc@1.1.4-4.el8",
                 "info": Object {
                   "name": "libtirpc",
-                  "purl": "pkg:rpm/libtirpc@1.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libtirpc@1.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.1.4-4.el8",
                 },
               },
@@ -8402,7 +8402,7 @@ Object {
                 "id": "libunistring@0.9.9-3.el8",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libunistring@0.9.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.9.9-3.el8",
                 },
               },
@@ -8410,7 +8410,7 @@ Object {
                 "id": "libusbx@1.0.22-1.el8",
                 "info": Object {
                   "name": "libusbx",
-                  "purl": "pkg:rpm/libusbx@1.0.22-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libusbx@1.0.22-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.0.22-1.el8",
                 },
               },
@@ -8418,7 +8418,7 @@ Object {
                 "id": "libuser@0.62-23.el8",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.62-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libuser@0.62-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.62-23.el8",
                 },
               },
@@ -8426,7 +8426,7 @@ Object {
                 "id": "libutempter@1.1.6-14.el8",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.6-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libutempter@1.1.6-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.1.6-14.el8",
                 },
               },
@@ -8434,7 +8434,7 @@ Object {
                 "id": "libuuid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libuuid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8442,7 +8442,7 @@ Object {
                 "id": "libverto@0.3.0-5.el8",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libverto@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.3.0-5.el8",
                 },
               },
@@ -8450,7 +8450,7 @@ Object {
                 "id": "libxcrypt@4.1.1-4.el8",
                 "info": Object {
                   "name": "libxcrypt",
-                  "purl": "pkg:rpm/libxcrypt@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libxcrypt@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.1.1-4.el8",
                 },
               },
@@ -8458,7 +8458,7 @@ Object {
                 "id": "libxml2@2.9.7-7.el8",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -8466,7 +8466,7 @@ Object {
                 "id": "libyaml@0.1.7-5.el8",
                 "info": Object {
                   "name": "libyaml",
-                  "purl": "pkg:rpm/libyaml@0.1.7-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libyaml@0.1.7-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.1.7-5.el8",
                 },
               },
@@ -8474,7 +8474,7 @@ Object {
                 "id": "libzstd@1.4.2-2.el8",
                 "info": Object {
                   "name": "libzstd",
-                  "purl": "pkg:rpm/libzstd@1.4.2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/libzstd@1.4.2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.4.2-2.el8",
                 },
               },
@@ -8482,7 +8482,7 @@ Object {
                 "id": "lua-libs@5.3.4-11.el8",
                 "info": Object {
                   "name": "lua-libs",
-                  "purl": "pkg:rpm/lua-libs@5.3.4-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/lua-libs@5.3.4-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.3.4-11.el8",
                 },
               },
@@ -8490,7 +8490,7 @@ Object {
                 "id": "lz4-libs@1.8.1.2-4.el8",
                 "info": Object {
                   "name": "lz4-libs",
-                  "purl": "pkg:rpm/lz4-libs@1.8.1.2-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/lz4-libs@1.8.1.2-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.8.1.2-4.el8",
                 },
               },
@@ -8498,7 +8498,7 @@ Object {
                 "id": "mpfr@3.1.6-1.el8",
                 "info": Object {
                   "name": "mpfr",
-                  "purl": "pkg:rpm/mpfr@3.1.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/mpfr@3.1.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.1.6-1.el8",
                 },
               },
@@ -8506,7 +8506,7 @@ Object {
                 "id": "ncurses-base@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/ncurses-base@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -8514,7 +8514,7 @@ Object {
                 "id": "ncurses-libs@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/ncurses-libs@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -8522,7 +8522,7 @@ Object {
                 "id": "nettle@3.4.1-1.el8",
                 "info": Object {
                   "name": "nettle",
-                  "purl": "pkg:rpm/nettle@3.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/nettle@3.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.4.1-1.el8",
                 },
               },
@@ -8530,7 +8530,7 @@ Object {
                 "id": "npth@1.5-4.el8",
                 "info": Object {
                   "name": "npth",
-                  "purl": "pkg:rpm/npth@1.5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/npth@1.5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.5-4.el8",
                 },
               },
@@ -8538,7 +8538,7 @@ Object {
                 "id": "openldap@2.4.46-11.el8",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.46-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/openldap@2.4.46-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.4.46-11.el8",
                 },
               },
@@ -8546,7 +8546,7 @@ Object {
                 "id": "openssl-libs@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/openssl-libs@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -8554,7 +8554,7 @@ Object {
                 "id": "p11-kit@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/p11-kit@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -8562,7 +8562,7 @@ Object {
                 "id": "p11-kit-trust@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/p11-kit-trust@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -8570,7 +8570,7 @@ Object {
                 "id": "pam@1.3.1-8.el8",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.3.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/pam@1.3.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.3.1-8.el8",
                 },
               },
@@ -8578,7 +8578,7 @@ Object {
                 "id": "passwd@0.80-3.el8",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.80-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/passwd@0.80-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.80-3.el8",
                 },
               },
@@ -8586,7 +8586,7 @@ Object {
                 "id": "pcre@8.42-4.el8",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.42-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/pcre@8.42-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.42-4.el8",
                 },
               },
@@ -8594,7 +8594,7 @@ Object {
                 "id": "pcre2@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2",
-                  "purl": "pkg:rpm/pcre2@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/pcre2@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -8602,7 +8602,7 @@ Object {
                 "id": "platform-python@3.6.8-23.el8",
                 "info": Object {
                   "name": "platform-python",
-                  "purl": "pkg:rpm/platform-python@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/platform-python@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.6.8-23.el8",
                 },
               },
@@ -8610,7 +8610,7 @@ Object {
                 "id": "platform-python-setuptools@39.2.0-5.el8",
                 "info": Object {
                   "name": "platform-python-setuptools",
-                  "purl": "pkg:rpm/platform-python-setuptools@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/platform-python-setuptools@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -8618,7 +8618,7 @@ Object {
                 "id": "popt@1.16-14.el8",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.16-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/popt@1.16-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.16-14.el8",
                 },
               },
@@ -8626,7 +8626,7 @@ Object {
                 "id": "publicsuffix-list-dafsa@20180723-1.el8",
                 "info": Object {
                   "name": "publicsuffix-list-dafsa",
-                  "purl": "pkg:rpm/publicsuffix-list-dafsa@20180723-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/publicsuffix-list-dafsa@20180723-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "20180723-1.el8",
                 },
               },
@@ -8634,7 +8634,7 @@ Object {
                 "id": "python3-dateutil@1:2.6.1-6.el8",
                 "info": Object {
                   "name": "python3-dateutil",
-                  "purl": "pkg:rpm/python3-dateutil@1:2.6.1-6.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-dateutil@1:2.6.1-6.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:2.6.1-6.el8",
                 },
               },
@@ -8642,7 +8642,7 @@ Object {
                 "id": "python3-dbus@1.2.4-15.el8",
                 "info": Object {
                   "name": "python3-dbus",
-                  "purl": "pkg:rpm/python3-dbus@1.2.4-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-dbus@1.2.4-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.2.4-15.el8",
                 },
               },
@@ -8650,7 +8650,7 @@ Object {
                 "id": "python3-decorator@4.2.1-2.el8",
                 "info": Object {
                   "name": "python3-decorator",
-                  "purl": "pkg:rpm/python3-decorator@4.2.1-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-decorator@4.2.1-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.1-2.el8",
                 },
               },
@@ -8658,7 +8658,7 @@ Object {
                 "id": "python3-dmidecode@3.12.2-15.el8",
                 "info": Object {
                   "name": "python3-dmidecode",
-                  "purl": "pkg:rpm/python3-dmidecode@3.12.2-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-dmidecode@3.12.2-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.12.2-15.el8",
                 },
               },
@@ -8666,7 +8666,7 @@ Object {
                 "id": "python3-dnf@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "python3-dnf",
-                  "purl": "pkg:rpm/python3-dnf@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-dnf@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -8674,7 +8674,7 @@ Object {
                 "id": "python3-dnf-plugins-core@4.0.12-4.el8_2",
                 "info": Object {
                   "name": "python3-dnf-plugins-core",
-                  "purl": "pkg:rpm/python3-dnf-plugins-core@4.0.12-4.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-dnf-plugins-core@4.0.12-4.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.0.12-4.el8_2",
                 },
               },
@@ -8682,7 +8682,7 @@ Object {
                 "id": "python3-ethtool@0.14-3.el8",
                 "info": Object {
                   "name": "python3-ethtool",
-                  "purl": "pkg:rpm/python3-ethtool@0.14-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-ethtool@0.14-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.14-3.el8",
                 },
               },
@@ -8690,7 +8690,7 @@ Object {
                 "id": "python3-gobject-base@3.28.3-1.el8",
                 "info": Object {
                   "name": "python3-gobject-base",
-                  "purl": "pkg:rpm/python3-gobject-base@3.28.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-gobject-base@3.28.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.28.3-1.el8",
                 },
               },
@@ -8698,7 +8698,7 @@ Object {
                 "id": "python3-gpg@1.10.0-6.el8",
                 "info": Object {
                   "name": "python3-gpg",
-                  "purl": "pkg:rpm/python3-gpg@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-gpg@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.10.0-6.el8",
                 },
               },
@@ -8706,7 +8706,7 @@ Object {
                 "id": "python3-hawkey@0.39.1-6.el8_2",
                 "info": Object {
                   "name": "python3-hawkey",
-                  "purl": "pkg:rpm/python3-hawkey@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-hawkey@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.39.1-6.el8_2",
                 },
               },
@@ -8714,7 +8714,7 @@ Object {
                 "id": "python3-iniparse@0.4-31.el8",
                 "info": Object {
                   "name": "python3-iniparse",
-                  "purl": "pkg:rpm/python3-iniparse@0.4-31.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-iniparse@0.4-31.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.4-31.el8",
                 },
               },
@@ -8722,7 +8722,7 @@ Object {
                 "id": "python3-inotify@0.9.6-13.el8",
                 "info": Object {
                   "name": "python3-inotify",
-                  "purl": "pkg:rpm/python3-inotify@0.9.6-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-inotify@0.9.6-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.9.6-13.el8",
                 },
               },
@@ -8730,7 +8730,7 @@ Object {
                 "id": "python3-libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "python3-libcomps",
-                  "purl": "pkg:rpm/python3-libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -8738,7 +8738,7 @@ Object {
                 "id": "python3-libdnf@0.39.1-6.el8_2",
                 "info": Object {
                   "name": "python3-libdnf",
-                  "purl": "pkg:rpm/python3-libdnf@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-libdnf@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.39.1-6.el8_2",
                 },
               },
@@ -8746,7 +8746,7 @@ Object {
                 "id": "python3-librepo@1.11.0-3.el8_2",
                 "info": Object {
                   "name": "python3-librepo",
-                  "purl": "pkg:rpm/python3-librepo@1.11.0-3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-librepo@1.11.0-3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.11.0-3.el8_2",
                 },
               },
@@ -8754,7 +8754,7 @@ Object {
                 "id": "python3-libs@3.6.8-23.el8",
                 "info": Object {
                   "name": "python3-libs",
-                  "purl": "pkg:rpm/python3-libs@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-libs@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.6.8-23.el8",
                 },
               },
@@ -8762,7 +8762,7 @@ Object {
                 "id": "python3-libxml2@2.9.7-7.el8",
                 "info": Object {
                   "name": "python3-libxml2",
-                  "purl": "pkg:rpm/python3-libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -8770,7 +8770,7 @@ Object {
                 "id": "python3-pip-wheel@9.0.3-16.el8",
                 "info": Object {
                   "name": "python3-pip-wheel",
-                  "purl": "pkg:rpm/python3-pip-wheel@9.0.3-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-pip-wheel@9.0.3-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "9.0.3-16.el8",
                 },
               },
@@ -8778,7 +8778,7 @@ Object {
                 "id": "python3-rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "python3-rpm",
-                  "purl": "pkg:rpm/python3-rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -8786,7 +8786,7 @@ Object {
                 "id": "python3-setuptools-wheel@39.2.0-5.el8",
                 "info": Object {
                   "name": "python3-setuptools-wheel",
-                  "purl": "pkg:rpm/python3-setuptools-wheel@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-setuptools-wheel@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -8794,7 +8794,7 @@ Object {
                 "id": "python3-six@1.11.0-8.el8",
                 "info": Object {
                   "name": "python3-six",
-                  "purl": "pkg:rpm/python3-six@1.11.0-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-six@1.11.0-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.11.0-8.el8",
                 },
               },
@@ -8802,7 +8802,7 @@ Object {
                 "id": "python3-subscription-manager-rhsm@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "python3-subscription-manager-rhsm",
-                  "purl": "pkg:rpm/python3-subscription-manager-rhsm@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-subscription-manager-rhsm@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -8810,7 +8810,7 @@ Object {
                 "id": "python3-syspurpose@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "python3-syspurpose",
-                  "purl": "pkg:rpm/python3-syspurpose@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/python3-syspurpose@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -8818,7 +8818,7 @@ Object {
                 "id": "readline@7.0-10.el8",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@7.0-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/readline@7.0-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "7.0-10.el8",
                 },
               },
@@ -8826,7 +8826,7 @@ Object {
                 "id": "redhat-release@8.2-1.0.el8",
                 "info": Object {
                   "name": "redhat-release",
-                  "purl": "pkg:rpm/redhat-release@8.2-1.0.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/redhat-release@8.2-1.0.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.2-1.0.el8",
                 },
               },
@@ -8834,7 +8834,7 @@ Object {
                 "id": "rootfiles@8.1-22.el8",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rootfiles@8.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.1-22.el8",
                 },
               },
@@ -8842,7 +8842,7 @@ Object {
                 "id": "rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -8850,7 +8850,7 @@ Object {
                 "id": "rpm-build-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rpm-build-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -8858,7 +8858,7 @@ Object {
                 "id": "rpm-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rpm-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -8866,7 +8866,7 @@ Object {
                 "id": "sed@4.5-1.el8",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.5-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/sed@4.5-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.5-1.el8",
                 },
               },
@@ -8874,7 +8874,7 @@ Object {
                 "id": "setup@2.12.2-5.el8",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.12.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/setup@2.12.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.12.2-5.el8",
                 },
               },
@@ -8882,7 +8882,7 @@ Object {
                 "id": "shadow-utils@2:4.6-8.el8",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.6-8.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/shadow-utils@2:4.6-8.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2:4.6-8.el8",
                 },
               },
@@ -8890,7 +8890,7 @@ Object {
                 "id": "sqlite-libs@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite-libs",
-                  "purl": "pkg:rpm/sqlite-libs@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/sqlite-libs@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -8898,7 +8898,7 @@ Object {
                 "id": "subscription-manager@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "subscription-manager",
-                  "purl": "pkg:rpm/subscription-manager@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/subscription-manager@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -8906,7 +8906,7 @@ Object {
                 "id": "subscription-manager-rhsm-certificates@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "subscription-manager-rhsm-certificates",
-                  "purl": "pkg:rpm/subscription-manager-rhsm-certificates@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/subscription-manager-rhsm-certificates@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -8914,7 +8914,7 @@ Object {
                 "id": "systemd@239-31.el8_2.2",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/systemd@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/systemd@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "239-31.el8_2.2",
                 },
               },
@@ -8922,7 +8922,7 @@ Object {
                 "id": "systemd-libs@239-31.el8_2.2",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/systemd-libs@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "239-31.el8_2.2",
                 },
               },
@@ -8930,7 +8930,7 @@ Object {
                 "id": "systemd-pam@239-31.el8_2.2",
                 "info": Object {
                   "name": "systemd-pam",
-                  "purl": "pkg:rpm/systemd-pam@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/systemd-pam@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "239-31.el8_2.2",
                 },
               },
@@ -8938,7 +8938,7 @@ Object {
                 "id": "tar@2:1.30-4.el8",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.30-4.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/tar@2:1.30-4.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2:1.30-4.el8",
                 },
               },
@@ -8946,7 +8946,7 @@ Object {
                 "id": "tzdata@2020a-1.el8",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2020a-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/tzdata@2020a-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2020a-1.el8",
                 },
               },
@@ -8954,7 +8954,7 @@ Object {
                 "id": "usermode@1.113-1.el8",
                 "info": Object {
                   "name": "usermode",
-                  "purl": "pkg:rpm/usermode@1.113-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/usermode@1.113-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.113-1.el8",
                 },
               },
@@ -8962,7 +8962,7 @@ Object {
                 "id": "util-linux@2.32.1-22.el8",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/util-linux@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8970,7 +8970,7 @@ Object {
                 "id": "vim-minimal@2:8.0.1763-13.el8",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.0.1763-13.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/vim-minimal@2:8.0.1763-13.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2:8.0.1763-13.el8",
                 },
               },
@@ -8978,7 +8978,7 @@ Object {
                 "id": "virt-what@1.18-6.el8",
                 "info": Object {
                   "name": "virt-what",
-                  "purl": "pkg:rpm/virt-what@1.18-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/virt-what@1.18-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.18-6.el8",
                 },
               },
@@ -8986,7 +8986,7 @@ Object {
                 "id": "which@2.21-12.el8",
                 "info": Object {
                   "name": "which",
-                  "purl": "pkg:rpm/which@2.21-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/which@2.21-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.21-12.el8",
                 },
               },
@@ -8994,7 +8994,7 @@ Object {
                 "id": "xz-libs@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/xz-libs@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -9002,7 +9002,7 @@ Object {
                 "id": "yum@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/yum@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -9010,7 +9010,7 @@ Object {
                 "id": "zlib@1.2.11-16.el8_2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.11-16.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/zlib@1.2.11-16.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.2.11-16.el8_2",
                 },
               },

--- a/test/system/package-managers/__snapshots__/deb.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/deb.spec.ts.snap
@@ -1154,6 +1154,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
+                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1161,6 +1162,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
+                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1168,6 +1170,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
+                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1175,6 +1178,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1182,6 +1186,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1189,6 +1194,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1196,6 +1202,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1203,6 +1210,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1210,6 +1218,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1217,6 +1226,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1224,6 +1234,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1231,6 +1242,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.118",
                   "version": "3.118",
                 },
               },
@@ -1238,6 +1250,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1245,6 +1258,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
+                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1252,6 +1266,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1259,6 +1274,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
                   "version": "1.8.4-5",
                 },
               },
@@ -1266,6 +1282,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@241-7~deb10u4?upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1273,6 +1290,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@241-7~deb10u4?upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1280,6 +1298,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2.1",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2.1?upstream=apt",
                   "version": "1.8.2.1",
                 },
               },
@@ -1287,6 +1306,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
                   "version": "2019.1",
                 },
               },
@@ -1294,6 +1314,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1301,6 +1322,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1308,6 +1330,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
+                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1315,6 +1338,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
+                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1322,6 +1346,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
+                  "purl": "pkg:deb/libidn2-0@2.0.5-1%2Bdeb10u1?upstream=libidn2",
                   "version": "2.0.5-1+deb10u1",
                 },
               },
@@ -1329,6 +1354,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.13-3",
                   "version": "4.13-3",
                 },
               },
@@ -1336,6 +1362,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1343,6 +1370,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
+                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1350,6 +1378,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
+                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1357,6 +1386,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1364,6 +1394,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
+                  "purl": "pkg:deb/libgnutls30@3.6.7-4%2Bdeb10u5?upstream=gnutls28",
                   "version": "3.6.7-4+deb10u5",
                 },
               },
@@ -1371,6 +1402,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
+                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1378,6 +1410,7 @@ Object {
                 "id": "apt@1.8.2.1",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.8.2.1",
                   "version": "1.8.2.1",
                 },
               },
@@ -1385,6 +1418,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1392,6 +1426,7 @@ Object {
                 "id": "base-files@10.3+deb10u5",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u5",
                   "version": "10.3+deb10u5",
                 },
               },
@@ -1399,6 +1434,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1406,6 +1442,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.46",
                   "version": "3.5.46",
                 },
               },
@@ -1413,6 +1450,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.6.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -1420,6 +1458,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
+                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1427,6 +1466,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@5.0-4",
                   "version": "5.0-4",
                 },
               },
@@ -1434,6 +1474,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.30-3",
                   "version": "8.30-3",
                 },
               },
@@ -1441,6 +1482,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.10.2-5",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1448,6 +1490,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
                 },
               },
@@ -1455,6 +1498,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
+                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1462,6 +1506,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
+                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1469,6 +1514,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1476,6 +1522,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1483,6 +1530,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1490,6 +1538,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u3",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1497,6 +1546,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1504,6 +1554,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1511,6 +1562,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@3.3-1",
                   "version": "3.3-1",
                 },
               },
@@ -1518,6 +1570,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.9-3",
                   "version": "1.9-3",
                 },
               },
@@ -1525,6 +1578,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.21",
                   "version": "3.21",
                 },
               },
@@ -1532,6 +1586,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1644,6 +1699,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
+                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1651,6 +1707,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1658,6 +1715,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1665,6 +1723,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1672,6 +1731,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.7-1",
                   "version": "4.7-1",
                 },
               },
@@ -1679,6 +1739,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1686,6 +1747,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1693,6 +1755,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1700,6 +1763,7 @@ Object {
                 "id": "tzdata@2020a-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb10u1",
                   "version": "2020a-0+deb10u1",
                 },
               },
@@ -1707,6 +1771,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1714,6 +1779,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1721,6 +1787,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1728,6 +1795,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1735,6 +1803,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
+                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1742,6 +1811,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/platforms/__snapshots__/amd.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/amd.spec.ts.snap
@@ -1170,6 +1170,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
+                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1177,6 +1178,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
+                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1184,6 +1186,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
+                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1191,6 +1194,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1198,6 +1202,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1205,6 +1210,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1212,6 +1218,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1219,6 +1226,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1226,6 +1234,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1233,6 +1242,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1240,6 +1250,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1247,6 +1258,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.118",
                   "version": "3.118",
                 },
               },
@@ -1254,6 +1266,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1261,6 +1274,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
+                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1268,6 +1282,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1275,6 +1290,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
                   "version": "1.8.4-5",
                 },
               },
@@ -1282,6 +1298,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@241-7~deb10u4?upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1289,6 +1306,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@241-7~deb10u4?upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1296,6 +1314,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2.1",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2.1?upstream=apt",
                   "version": "1.8.2.1",
                 },
               },
@@ -1303,6 +1322,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
                   "version": "2019.1",
                 },
               },
@@ -1310,6 +1330,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1317,6 +1338,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1324,6 +1346,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
+                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1331,6 +1354,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
+                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1338,6 +1362,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
+                  "purl": "pkg:deb/libidn2-0@2.0.5-1%2Bdeb10u1?upstream=libidn2",
                   "version": "2.0.5-1+deb10u1",
                 },
               },
@@ -1345,6 +1370,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.13-3",
                   "version": "4.13-3",
                 },
               },
@@ -1352,6 +1378,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1359,6 +1386,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
+                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1366,6 +1394,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
+                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1373,6 +1402,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1380,6 +1410,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
+                  "purl": "pkg:deb/libgnutls30@3.6.7-4%2Bdeb10u5?upstream=gnutls28",
                   "version": "3.6.7-4+deb10u5",
                 },
               },
@@ -1387,6 +1418,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
+                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1394,6 +1426,7 @@ Object {
                 "id": "apt@1.8.2.1",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.8.2.1",
                   "version": "1.8.2.1",
                 },
               },
@@ -1401,6 +1434,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1408,6 +1442,7 @@ Object {
                 "id": "base-files@10.3+deb10u6",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u6",
                   "version": "10.3+deb10u6",
                 },
               },
@@ -1415,6 +1450,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1422,6 +1458,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.46",
                   "version": "3.5.46",
                 },
               },
@@ -1429,6 +1466,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.6.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -1436,6 +1474,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
+                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1443,6 +1482,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@5.0-4",
                   "version": "5.0-4",
                 },
               },
@@ -1450,6 +1490,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.30-3",
                   "version": "8.30-3",
                 },
               },
@@ -1457,6 +1498,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.10.2-5",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1464,6 +1506,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
                 },
               },
@@ -1471,6 +1514,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
+                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1478,6 +1522,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
+                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1485,6 +1530,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1492,6 +1538,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1499,6 +1546,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1506,6 +1554,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u3",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1513,6 +1562,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1520,6 +1570,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1527,6 +1578,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@3.3-1",
                   "version": "3.3-1",
                 },
               },
@@ -1534,6 +1586,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.9-3",
                   "version": "1.9-3",
                 },
               },
@@ -1541,6 +1594,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.21",
                   "version": "3.21",
                 },
               },
@@ -1548,6 +1602,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1555,6 +1610,7 @@ Object {
                 "id": "lsb/lsb-base@10.2019051400",
                 "info": Object {
                   "name": "lsb/lsb-base",
+                  "purl": "pkg:deb/lsb-base@10.2019051400?upstream=lsb",
                   "version": "10.2019051400",
                 },
               },
@@ -1667,6 +1723,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
+                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1674,6 +1731,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1681,6 +1739,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1688,6 +1747,7 @@ Object {
                 "id": "openssl/libssl1.1@1.1.1d-0+deb10u3",
                 "info": Object {
                   "name": "openssl/libssl1.1",
+                  "purl": "pkg:deb/libssl1.1@1.1.1d-0%2Bdeb10u3?upstream=openssl",
                   "version": "1.1.1d-0+deb10u3",
                 },
               },
@@ -1695,6 +1755,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1702,6 +1763,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.7-1",
                   "version": "4.7-1",
                 },
               },
@@ -1709,6 +1771,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1716,6 +1779,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1723,6 +1787,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1730,6 +1795,7 @@ Object {
                 "id": "tzdata@2020a-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb10u1",
                   "version": "2020a-0+deb10u1",
                 },
               },
@@ -1737,6 +1803,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1744,6 +1811,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1751,6 +1819,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1758,6 +1827,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1765,6 +1835,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
+                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1772,6 +1843,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3054,6 +3126,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
+                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -3061,6 +3134,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
+                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -3068,6 +3142,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
+                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -3075,6 +3150,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -3082,6 +3158,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -3089,6 +3166,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -3096,6 +3174,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -3103,6 +3182,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -3110,6 +3190,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -3117,6 +3198,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -3124,6 +3206,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -3131,6 +3214,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.118",
                   "version": "3.118",
                 },
               },
@@ -3138,6 +3222,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -3145,6 +3230,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
+                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -3152,6 +3238,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -3159,6 +3246,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
                   "version": "1.8.4-5",
                 },
               },
@@ -3166,6 +3254,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@241-7~deb10u4?upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -3173,6 +3262,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@241-7~deb10u4?upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -3180,6 +3270,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2.1",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2.1?upstream=apt",
                   "version": "1.8.2.1",
                 },
               },
@@ -3187,6 +3278,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
                   "version": "2019.1",
                 },
               },
@@ -3194,6 +3286,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -3201,6 +3294,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -3208,6 +3302,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
+                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -3215,6 +3310,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
+                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -3222,6 +3318,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
+                  "purl": "pkg:deb/libidn2-0@2.0.5-1%2Bdeb10u1?upstream=libidn2",
                   "version": "2.0.5-1+deb10u1",
                 },
               },
@@ -3229,6 +3326,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.13-3",
                   "version": "4.13-3",
                 },
               },
@@ -3236,6 +3334,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -3243,6 +3342,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
+                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -3250,6 +3350,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
+                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -3257,6 +3358,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -3264,6 +3366,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
+                  "purl": "pkg:deb/libgnutls30@3.6.7-4%2Bdeb10u5?upstream=gnutls28",
                   "version": "3.6.7-4+deb10u5",
                 },
               },
@@ -3271,6 +3374,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
+                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -3278,6 +3382,7 @@ Object {
                 "id": "apt@1.8.2.1",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.8.2.1",
                   "version": "1.8.2.1",
                 },
               },
@@ -3285,6 +3390,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -3292,6 +3398,7 @@ Object {
                 "id": "base-files@10.3+deb10u6",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u6",
                   "version": "10.3+deb10u6",
                 },
               },
@@ -3299,6 +3406,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -3306,6 +3414,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.46",
                   "version": "3.5.46",
                 },
               },
@@ -3313,6 +3422,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.6.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -3320,6 +3430,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
+                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -3327,6 +3438,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@5.0-4",
                   "version": "5.0-4",
                 },
               },
@@ -3334,6 +3446,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.30-3",
                   "version": "8.30-3",
                 },
               },
@@ -3341,6 +3454,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.10.2-5",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -3348,6 +3462,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
                 },
               },
@@ -3355,6 +3470,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
+                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -3362,6 +3478,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
+                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -3369,6 +3486,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -3376,6 +3494,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3383,6 +3502,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3390,6 +3510,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u3",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -3397,6 +3518,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -3404,6 +3526,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -3411,6 +3534,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@3.3-1",
                   "version": "3.3-1",
                 },
               },
@@ -3418,6 +3542,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.9-3",
                   "version": "1.9-3",
                 },
               },
@@ -3425,6 +3550,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.21",
                   "version": "3.21",
                 },
               },
@@ -3432,6 +3558,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -3439,6 +3566,7 @@ Object {
                 "id": "lsb/lsb-base@10.2019051400",
                 "info": Object {
                   "name": "lsb/lsb-base",
+                  "purl": "pkg:deb/lsb-base@10.2019051400?upstream=lsb",
                   "version": "10.2019051400",
                 },
               },
@@ -3551,6 +3679,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
+                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -3558,6 +3687,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -3565,6 +3695,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -3572,6 +3703,7 @@ Object {
                 "id": "openssl/libssl1.1@1.1.1d-0+deb10u3",
                 "info": Object {
                   "name": "openssl/libssl1.1",
+                  "purl": "pkg:deb/libssl1.1@1.1.1d-0%2Bdeb10u3?upstream=openssl",
                   "version": "1.1.1d-0+deb10u3",
                 },
               },
@@ -3579,6 +3711,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -3586,6 +3719,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.7-1",
                   "version": "4.7-1",
                 },
               },
@@ -3593,6 +3727,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -3600,6 +3735,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3607,6 +3743,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -3614,6 +3751,7 @@ Object {
                 "id": "tzdata@2020a-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb10u1",
                   "version": "2020a-0+deb10u1",
                 },
               },
@@ -3621,6 +3759,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -3628,6 +3767,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3635,6 +3775,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3642,6 +3783,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3649,6 +3791,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
+                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3656,6 +3799,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/red-hat-repositories/__snapshots__/red-hat-repositories.spec.ts.snap
+++ b/test/system/red-hat-repositories/__snapshots__/red-hat-repositories.spec.ts.snap
@@ -1154,6 +1154,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
+                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1161,6 +1162,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
+                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1168,6 +1170,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
+                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1175,6 +1178,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
+                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1182,6 +1186,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
+                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1189,6 +1194,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
+                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1196,6 +1202,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
+                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1203,6 +1210,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
+                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1210,6 +1218,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
+                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1217,6 +1226,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
+                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1224,6 +1234,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
+                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1231,6 +1242,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
+                  "purl": "pkg:deb/adduser@3.118",
                   "version": "3.118",
                 },
               },
@@ -1238,6 +1250,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
+                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1245,6 +1258,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
+                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1252,6 +1266,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
+                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1259,6 +1274,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
+                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
                   "version": "1.8.4-5",
                 },
               },
@@ -1266,6 +1282,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libsystemd0",
+                  "purl": "pkg:deb/libsystemd0@241-7~deb10u1?upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1273,6 +1290,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libudev1",
+                  "purl": "pkg:deb/libudev1@241-7~deb10u1?upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1280,6 +1298,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
+                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2?upstream=apt",
                   "version": "1.8.2",
                 },
               },
@@ -1287,6 +1306,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
+                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
                   "version": "2019.1",
                 },
               },
@@ -1294,6 +1314,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
+                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1301,6 +1322,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
+                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1308,6 +1330,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
+                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1315,6 +1338,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
+                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1322,6 +1346,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
+                  "purl": "pkg:deb/libidn2-0@2.0.5-1?upstream=libidn2",
                   "version": "2.0.5-1",
                 },
               },
@@ -1329,6 +1354,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
+                  "purl": "pkg:deb/libtasn1-6@4.13-3",
                   "version": "4.13-3",
                 },
               },
@@ -1336,6 +1362,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
+                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1343,6 +1370,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
+                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1350,6 +1378,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
+                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1357,6 +1386,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
+                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1364,6 +1394,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
+                  "purl": "pkg:deb/libgnutls30@3.6.7-4?upstream=gnutls28",
                   "version": "3.6.7-4",
                 },
               },
@@ -1371,6 +1402,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
+                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1378,6 +1410,7 @@ Object {
                 "id": "apt@1.8.2",
                 "info": Object {
                   "name": "apt",
+                  "purl": "pkg:deb/apt@1.8.2",
                   "version": "1.8.2",
                 },
               },
@@ -1385,6 +1418,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
+                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1392,6 +1426,7 @@ Object {
                 "id": "base-files@10.3+deb10u1",
                 "info": Object {
                   "name": "base-files",
+                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u1",
                   "version": "10.3+deb10u1",
                 },
               },
@@ -1399,6 +1434,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
+                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1406,6 +1442,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
+                  "purl": "pkg:deb/base-passwd@3.5.46",
                   "version": "3.5.46",
                 },
               },
@@ -1413,6 +1450,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
+                  "purl": "pkg:deb/debianutils@4.8.6.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -1420,6 +1458,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
+                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1427,6 +1466,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
+                  "purl": "pkg:deb/bash@5.0-4",
                   "version": "5.0-4",
                 },
               },
@@ -1434,6 +1474,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
+                  "purl": "pkg:deb/coreutils@8.30-3",
                   "version": "8.30-3",
                 },
               },
@@ -1441,6 +1482,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
+                  "purl": "pkg:deb/dash@0.5.10.2-5",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1448,6 +1490,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
+                  "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
                 },
               },
@@ -1455,6 +1498,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
+                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1462,6 +1506,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
+                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1469,6 +1514,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
+                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1476,6 +1522,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
+                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1483,6 +1530,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
+                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1490,6 +1538,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs",
+                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u1",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1497,6 +1546,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
+                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1504,6 +1554,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
+                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1511,6 +1562,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
+                  "purl": "pkg:deb/grep@3.3-1",
                   "version": "3.3-1",
                 },
               },
@@ -1518,6 +1570,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
+                  "purl": "pkg:deb/gzip@1.9-3",
                   "version": "1.9-3",
                 },
               },
@@ -1525,6 +1578,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
+                  "purl": "pkg:deb/hostname@3.21",
                   "version": "3.21",
                 },
               },
@@ -1532,6 +1586,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
+                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1644,6 +1699,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
+                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1651,6 +1707,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
+                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1658,6 +1715,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
+                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1665,6 +1723,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
+                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1672,6 +1731,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
+                  "purl": "pkg:deb/sed@4.7-1",
                   "version": "4.7-1",
                 },
               },
@@ -1679,6 +1739,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
+                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1686,6 +1747,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
+                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1693,6 +1755,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
+                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1700,6 +1763,7 @@ Object {
                 "id": "tzdata@2019b-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
+                  "purl": "pkg:deb/tzdata@2019b-0%2Bdeb10u1",
                   "version": "2019b-0+deb10u1",
                 },
               },
@@ -1707,6 +1771,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
+                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1714,6 +1779,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
+                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1721,6 +1787,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
+                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1728,6 +1795,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
+                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1735,6 +1803,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
+                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1742,6 +1811,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
+                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

The source version of a package may not be the same as the package version, which is why we should track them whenever they differ. This change ensures we populate an "upstream" qualifier (similarly to how Syft does this) with the source name and version. "upstream" is a non-standard qualifier, but matches Syft for consistency.

Tracking the source version is important because Snyk's vuln intel on Debian is based on the source version not the binary version. Some packages like postgres-client have differing binary and source versions, which results in reporting false positives once the wrong vulnerable version range is matched.
