### PR TITLE
chore: add openapi spec fact types

### DIFF
--- a/components/common.yaml
+++ b/components/common.yaml
@@ -17,8 +17,10 @@ schemas:
     type: string
     enum:
       - autoDetectedUserInstructions
+      - binaries
       - depGraph
       - dockerfileAnalysis
+      - dockerLayers
       - imageCreationTime
       - imageId
       - imageLabels
@@ -27,12 +29,14 @@ schemas:
       - imageNames
       - imageOsReleasePrettyName
       - imageSizeBytes
+      - hashes
       - jarFingerprints
       - keyBinariesHashes
       - loadedPackages
       - redHatRepositories
       - rootFs
       - testedFiles
+      - workloadMetadata
   Identity:
     type: object
     description: Identity defines "what" you found.

--- a/components/common.yaml
+++ b/components/common.yaml
@@ -16,23 +16,23 @@ schemas:
   FactType:
     type: string
     enum:
-      - depGraph
-      - keyBinariesHashes
-      - imageLayers
-      - dockerfileAnalysis
-      - rootFs
-      - imageId
-      - imageOsReleasePrettyName
-      - imageManifestFiles
-      - testedFiles
-      - jarFingerprints
       - autoDetectedUserInstructions
-      - imageLabels
-      - imageSizeBytes
-      - loadedPackages
+      - depGraph
+      - dockerfileAnalysis
       - imageCreationTime
+      - imageId
+      - imageLabels
+      - imageLayers
+      - imageManifestFiles
       - imageNames
+      - imageOsReleasePrettyName
+      - imageSizeBytes
+      - jarFingerprints
+      - keyBinariesHashes
+      - loadedPackages
       - redHatRepositories
+      - rootFs
+      - testedFiles
   Identity:
     type: object
     description: Identity defines "what" you found.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -50,27 +50,27 @@ export interface ImageNameInfo {
 }
 
 export type FactType =
+  | "autoDetectedUserInstructions"
   | "depGraph"
-  // Hashes of executables not installed by a package manager (e.g. if they were copied straight onto the image).
-  | "keyBinariesHashes"
+  | "dockerfileAnalysis"
+  | "imageCreationTime"
+  | "imageId"
+  | "imageLabels"
   // Collects the file names of the individual .tar layers found in the scanned image.
   | "imageLayers"
-  | "dockerfileAnalysis"
-  | "rootFs"
-  | "imageId"
-  | "imageOsReleasePrettyName"
   // Package manager manifests (e.g. requirements.txt, Gemfile.lock) collected as part of an application scan.
   | "imageManifestFiles"
-  // Used for application dependencies scanning; shows which files were used in the analysis of the dependencies.
-  | "testedFiles"
+  | "imageNames"
+  | "imageOsReleasePrettyName"
+  | "imageSizeBytes"
   // Hashes of extracted *.jar binaries, hashed with sha1 algorithm
   | "jarFingerprints"
-  | "autoDetectedUserInstructions"
-  | "imageLabels"
-  | "imageSizeBytes"
+  // Hashes of executables not installed by a package manager (e.g. if they were copied straight onto the image).
+  | "keyBinariesHashes"
   | "loadedPackages"
-  | "imageCreationTime"
-  | "imageNames";
+  | "rootFs"
+  // Used for application dependencies scanning; shows which files were used in the analysis of the dependencies.
+  | "testedFiles";
 
 export interface PluginResponse {
   /** The first result is guaranteed to be the OS dependencies scan result. */


### PR DESCRIPTION
#### What does this PR do?

- chore: alphabetically sort fact types
- chore: document openapi missing fact types