### PR TITLE
feat: passing manifest and index digest to archive scanning

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { getImageArchive } from "./analyzer/image-inspector";
 import { readDockerfileAndAnalyse } from "./dockerfile";
 import { DockerFileAnalysis } from "./dockerfile/types";
+import { ImageName } from "./extractor/image";
 import { fullImageSavePath } from "./image-save-path";
 import { getArchivePath, getImageType } from "./image-type";
 import { isNumber, isTrue } from "./option-utils";
@@ -114,6 +115,17 @@ async function localArchiveAnalysis(
     // The target image becomes the base of the path, e.g. "archive.tar" for "/var/tmp/archive.tar"
     path.basename(archivePath);
 
+  let imageName: ImageName | undefined;
+  if (
+    (options.digests?.manifest || options.digests?.index) &&
+    options.imageNameAndTag
+  ) {
+    imageName = new ImageName(options.imageNameAndTag, {
+      manifest: options.digests?.manifest,
+      index: options.digests?.index,
+    });
+  }
+
   return await staticModule.analyzeStatically(
     imageIdentifier,
     dockerfileAnalysis,
@@ -121,6 +133,7 @@ async function localArchiveAnalysis(
     archivePath,
     globToFind,
     options,
+    imageName,
   );
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -158,6 +158,14 @@ export interface PluginOptions {
   imageNameAndDigest: string;
 
   /**
+   * WARNING! This is NOT used by the Snyk CLI!
+   *
+   * It is used by Docker Registry Agent to preserve the image digests if we can extract this
+   * information from pulling the image with Snyk Docker Pull.
+   */
+  digests: { manifest?: string; index?: string };
+
+  /**
    * Provide patterns on which to match for detecting package manager manifest files.
    * Used for the APP+OS deps feature, not by the CLI.
    */

--- a/test/system/plugin-option.spec.ts
+++ b/test/system/plugin-option.spec.ts
@@ -1,0 +1,62 @@
+import * as plugin from "../../lib";
+import { ImageName } from "../../lib/extractor/image";
+import { getFixture } from "../util";
+
+it("provides imageName fact with digests and imageNameAndTag scan options", async () => {
+  const fixturePath = getFixture([
+    "/docker-archives",
+    "skopeo-copy/busybox.tar",
+  ]);
+  const imagePath = `docker-archive:${fixturePath}`;
+
+  const pluginResultWithDockerSave = await plugin.scan({
+    path: imagePath,
+    imageNameAndTag: "busybox:stable",
+    digests: {
+      manifest:
+        "sha256:9604d5d228cf1ba638a767b0d879b600cf288c5aecd68c8b35e30911aadf0dab",
+      index:
+        "sha256:bde251f3026301ad8f8d55f59bc09efefb9307148d3c82e4c89322e182718362",
+    },
+  });
+
+  const imageName: ImageName =
+    pluginResultWithDockerSave.scanResults[0].facts.find(
+      (fact) => fact.type === "imageNames",
+    )!.data;
+  expect(imageName.names).toHaveLength(3);
+  expect(imageName.names).toEqual(
+    expect.arrayContaining([
+      "busybox:stable",
+      "busybox@sha256:9604d5d228cf1ba638a767b0d879b600cf288c5aecd68c8b35e30911aadf0dab",
+      "busybox@sha256:bde251f3026301ad8f8d55f59bc09efefb9307148d3c82e4c89322e182718362",
+    ]),
+  );
+});
+
+it("provides imageName fact with imageNameAndDigest and imageNameAndTag scan options", async () => {
+  const fixturePath = getFixture([
+    "/docker-archives",
+    "skopeo-copy/busybox.tar",
+  ]);
+  const imagePath = `docker-archive:${fixturePath}`;
+
+  const pluginResultWithDockerSave = await plugin.scan({
+    path: imagePath,
+    imageNameAndTag: "busybox:stable",
+    imageNameAndDigest:
+      "busybox@sha256:a29baa1d6820ccfc12f25dd9b4de24b998cab06826df2704fc8182e437147a5b",
+  });
+
+  const imageName: ImageName =
+    pluginResultWithDockerSave.scanResults[0].facts.find(
+      (fact) => fact.type === "imageNames",
+    )!.data;
+  expect(imageName.names).toHaveLength(2);
+  expect(imageName.names).toEqual(
+    expect.arrayContaining([
+      "busybox:stable",
+      "busybox@sha256:a29baa1d6820ccfc12f25dd9b4de24b998cab06826df2704fc8182e437147a5b",
+    ]),
+  );
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Passing digests scan option to docker and oci archive scanning to enrich imageName fact type.

#### Where should the reviewer start?
* lib/scan.ts
* lib/types.ts


#### How should this be manually tested?
scan an OCI/docker archive by providing both `imageNameAndTag` and `digests` scan options.


#### Any background context you want to provide?
This implementation would enable Docker Registry Agent to pass both manifest and index digest information to enrich imageName fact type in order for Container Image Service to consume this data.

