### PR TITLE
test: fix test flake by using rmdirSync

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -32,13 +32,11 @@ function cleanupCallback(imageFolderPath: string, imageName: string) {
     if (fs.existsSync(fullImagePath)) {
       fs.unlinkSync(fullImagePath);
     }
-    fs.rmdir(imageFolderPath, (err) => {
-      if (err !== null) {
-        debug(
-          `Can't remove folder ${imageFolderPath}, got error ${err.message}`,
-        );
-      }
-    });
+    try {
+      fs.rmdirSync(imageFolderPath);
+    } catch (err) {
+      debug(`Can't remove folder ${imageFolderPath}, got error ${err.message}`);
+    }
   };
 }
 


### PR DESCRIPTION
The test asserts that cleanup has worked and the directory has been removed. However, because `rmdir` is asynchronous (internally, it's not a Promise), sometimes the directory was still there when our assertions ran.

Using `rmdirSync` should fix these issues and make us wait for the directory to be deleted.
The impact to runtime should be negligible, due to the fact that we delete the image-archive *before* the `rmdir` call with an `unlinkSync` already.
