### PR TITLE
fix: removes meta-common-packages generation for Linux package managers

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -221,6 +221,7 @@ export interface PluginOptions {
 export interface DepTreeDep {
   name: string;
   version: string;
+  sourceVersion?: string;
   dependencies: {
     [depName: string]: DepTreeDep;
   };

--- a/test/lib/dependency-tree/index.spec.ts
+++ b/test/lib/dependency-tree/index.spec.ts
@@ -1,0 +1,78 @@
+import { AnalyzedPackageWithVersion } from "../../../lib/analyzer/types";
+import { buildTree } from "../../../lib/dependency-tree";
+
+const targetImage = "snyk/deptree-test@1.0.0";
+const targetOS = {
+  name: "snykos",
+  version: "1",
+  prettyName: "SnykOS GNU/Linux 1",
+};
+const freqDep = {
+  Name: `libsut`,
+  Version: "1.0",
+  Provides: [],
+  Deps: {},
+  AutoInstalled: true,
+  Purl: `pkg:snyk/libsut@1.0`,
+};
+
+function buildFreqDepsList(count: number) {
+  const depsInfoList: AnalyzedPackageWithVersion[] = [];
+
+  for (let i = 0, l = count; i < l; i = i + 1) {
+    depsInfoList.push({
+      Name: `libtest-${i + 1}`,
+      Version: "1.0",
+      Provides: [],
+      Deps: { libsut: true },
+      AutoInstalled: true,
+      Purl: `pkg:snyk/libtest-${i + 1}@1.0`,
+    });
+  }
+
+  depsInfoList.push(freqDep);
+
+  return depsInfoList;
+}
+
+function obj2array(obj) {
+  const arr: any[] = [];
+  for (const dep in obj) {
+    if (obj.hasOwnProperty(dep)) {
+      arr.push(obj[dep]);
+    }
+  }
+
+  return arr;
+}
+
+describe("dependency-tree", () => {
+  describe("buildTree", () => {
+    describe("Linux Package Managers", () => {
+      it("should attach frequent deps to parent when threshold is exceeded", () => {
+        const fixture = buildFreqDepsList(100);
+        const tree = buildTree(targetImage, "deb", fixture, targetOS);
+        const res = obj2array(tree.dependencies);
+        expect(
+          res.filter((dep) => freqDep.Name in dep.dependencies),
+        ).toHaveLength(0);
+      });
+      it("should attach frequent deps to root when threshold is not met", () => {
+        const fixture = buildFreqDepsList(50);
+        const tree = buildTree(targetImage, "deb", fixture, targetOS);
+        const res = obj2array(tree.dependencies);
+        expect(
+          res.filter((dep) => freqDep.Name in dep.dependencies),
+        ).not.toHaveLength(0);
+      });
+    });
+
+    describe("Non-Linux Package Managers", () => {
+      it("should attach frequent deps to meta-common-packages for non-linux pkg managers when threshold is met", () => {
+        const fixture = buildFreqDepsList(100);
+        const tree = buildTree(targetImage, "snyk", fixture, targetOS);
+        expect(tree.dependencies["meta-common-packages"]).toBeTruthy();
+      });
+    });
+  });
+});

--- a/test/system/app-os/__snapshots__/globs.spec.ts.snap
+++ b/test/system/app-os/__snapshots__/globs.spec.ts.snap
@@ -12,6 +12,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
                       "nodeId": "adduser@3.118|1",
                     },
                     Object {
@@ -19,6 +22,9 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.8.2.1|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
                     },
                     Object {
                       "nodeId": "audit/libaudit-common@1:2.8.4-3",
@@ -36,6 +42,9 @@ Object {
                       "nodeId": "bash@5.0-4",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.249",
                     },
                     Object {
@@ -45,6 +54,9 @@ Object {
                       "nodeId": "dash@0.5.10.2-5",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2019.1",
                     },
                     Object {
@@ -52,6 +64,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.44.5-1+deb10u3",
@@ -69,10 +84,19 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20190209-2",
                     },
                     Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
                       "nodeId": "gcc-8/libstdc++6@8.3.0-6",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
                     },
                     Object {
                       "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
@@ -117,6 +141,9 @@ Object {
                       "nodeId": "libseccomp/libseccomp2@2.3.3-4",
                     },
                     Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
                       "nodeId": "libsemanage/libsemanage-common@2.8-2",
                     },
                     Object {
@@ -136,9 +163,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2|1",
@@ -171,6 +195,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.3.1-5|1",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                    },
+                    Object {
                       "nodeId": "sed@4.7-1",
                     },
                     Object {
@@ -187,6 +217,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
                     },
                     Object {
                       "nodeId": "tzdata@2020d-0+deb10u1",
@@ -218,9 +251,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.33.1-0.1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|debian@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
                 },
                 Object {
                   "deps": Array [],
@@ -615,6 +659,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "mawk/mawk@1.3.3-17+b3",
                   "pkgId": "mawk/mawk@1.3.3-17+b3",
                 },
@@ -673,6 +722,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.30-3",
                   "pkgId": "coreutils@8.30-3",
                 },
@@ -687,8 +741,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils@1:3.7-3",
                   "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
                 },
                 Object {
                   "deps": Array [],
@@ -761,8 +825,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.28-10",
                   "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
                 },
                 Object {
                   "deps": Array [],
@@ -854,121 +933,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.53-4",
-                  "pkgId": "acl/libacl1@2.2.53-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.48-4",
-                  "pkgId": "attr/libattr1@1:2.4.48-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.71",
-                  "pkgId": "debconf@1.5.71",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.19.7",
-                  "pkgId": "dpkg@1.19.7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.28-10",
-                  "pkgId": "glibc/libc6@2.28-10",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "libselinux/libselinux1@2.8-1+b1",
                   "pkgId": "libselinux/libselinux1@2.8-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-12",
-                  "pkgId": "pcre3/libpcre3@2:8.39-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
-                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.30+dfsg-6",
-                  "pkgId": "tar@1.30+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.53-4",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.48-4",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.71",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.19.7",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.28-10",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-12",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
-                    },
-                    Object {
-                      "nodeId": "tar@1.30+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
                 },
                 Object {
                   "deps": Array [],
@@ -1011,6 +977,16 @@ Object {
                   "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.3.1-5|2",
                   "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
                 },
                 Object {
                   "deps": Array [],
@@ -1098,6 +1074,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.93-8",
                   "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1193,6 +1174,16 @@ Object {
                   "nodeId": "util-linux/mount@2.33.1-0.1",
                   "pkgId": "util-linux/mount@2.33.1-0.1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -1210,6 +1201,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|debian",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
                 },
               },
               Object {
@@ -1477,6 +1475,13 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
@@ -1533,6 +1538,13 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
@@ -1549,11 +1561,25 @@ Object {
                 },
               },
               Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
                 },
               },
               Object {
@@ -1613,10 +1639,31 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
                   "version": "2.28-10",
                 },
               },
@@ -1709,108 +1756,10 @@ Object {
                 },
               },
               Object {
-                "id": "acl/libacl1@2.2.53-4",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.53-4",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.48-4",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.48-4",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-9.2~deb10u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.71",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.71",
-                },
-              },
-              Object {
-                "id": "dpkg@1.19.7",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.19.7",
-                },
-              },
-              Object {
-                "id": "gcc-8/gcc-8-base@8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/gcc-8-base",
-                  "version": "8.3.0-6",
-                },
-              },
-              Object {
-                "id": "gcc-8/libgcc1@1:8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/libgcc1",
-                  "version": "1:8.3.0-6",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.28-10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.28-10",
-                },
-              },
-              Object {
                 "id": "libselinux/libselinux1@2.8-1+b1",
                 "info": Object {
                   "name": "libselinux/libselinux1",
                   "version": "2.8-1+b1",
-                },
-              },
-              Object {
-                "id": "pcre3/libpcre3@2:8.39-12",
-                "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-12",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.28.1-6+deb10u1",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.28.1-6+deb10u1",
-                },
-              },
-              Object {
-                "id": "tar@1.30+dfsg-6",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.30+dfsg-6",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.4-1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.4-1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.11.dfsg-1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
                 },
               },
               Object {
@@ -1846,6 +1795,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6+deb10u1",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6+deb10u1",
+                },
+              },
+              Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
@@ -1875,6 +1838,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
                 },
               },
               Object {
@@ -1931,6 +1901,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
                 },
               },
             ],

--- a/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
@@ -438,10 +438,22 @@ Object {
                       "nodeId": "acl@2.2.52-2",
                     },
                     Object {
+                      "nodeId": "acl/libacl1@2.2.52-2",
+                    },
+                    Object {
                       "nodeId": "apt@1.0.9.8.4",
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg4.12@1.0.9.8.4",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.47-2",
+                    },
+                    Object {
+                      "nodeId": "audit/libaudit-common@1:2.4-1",
+                    },
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.4-1+b1",
                     },
                     Object {
                       "nodeId": "autoconf@2.69-8|1",
@@ -459,6 +471,9 @@ Object {
                       "nodeId": "bzip2/bzip2@1.0.6-7+b3",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-7+b3",
+                    },
+                    Object {
                       "nodeId": "bzip2/libbz2-dev@1.0.6-7+b3",
                     },
                     Object {
@@ -468,7 +483,13 @@ Object {
                       "nodeId": "ca-certificates@20141019+deb8u3",
                     },
                     Object {
+                      "nodeId": "cairo/libcairo2@1.14.0-2.1+deb8u2",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.192",
+                    },
+                    Object {
+                      "nodeId": "coreutils@8.23-4",
                     },
                     Object {
                       "nodeId": "cryptsetup/libcryptsetup4@2:1.6.6-5|1",
@@ -486,13 +507,25 @@ Object {
                       "nodeId": "db-defaults/libdb-dev@5.3.0+b1",
                     },
                     Object {
+                      "nodeId": "db5.3/libdb5.3@5.3.28-9+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "debconf@1.5.56+deb8u1",
+                    },
+                    Object {
                       "nodeId": "debconf/debconf-i18n@1.5.56+deb8u1",
                     },
                     Object {
                       "nodeId": "debian-archive-keyring@2017.5~deb8u1|2",
                     },
                     Object {
+                      "nodeId": "debianutils/debianutils@4.4+b1",
+                    },
+                    Object {
                       "nodeId": "diffutils/diffutils@1:3.3-1+b1",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.17.27",
                     },
                     Object {
                       "nodeId": "dpkg/dpkg-dev@1.17.27",
@@ -504,7 +537,13 @@ Object {
                       "nodeId": "e2fsprogs/e2fsprogs@1.42.12-2+b1",
                     },
                     Object {
+                      "nodeId": "e2fsprogs/libcomerr2@1.42.12-2+b1",
+                    },
+                    Object {
                       "nodeId": "e2fsprogs/libss2@1.42.12-2+b1",
+                    },
+                    Object {
+                      "nodeId": "expat/libexpat1@2.1.0-6+deb8u4",
                     },
                     Object {
                       "nodeId": "file@1:5.22+15-2+deb8u3|1",
@@ -513,7 +552,31 @@ Object {
                       "nodeId": "findutils/findutils@4.4.2-9+b1",
                     },
                     Object {
+                      "nodeId": "fontconfig@2.11.0-6.3+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "fontconfig/fontconfig-config@2.11.0-6.3+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "fontconfig/libfontconfig1@2.11.0-6.3+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "fonts-dejavu/fonts-dejavu-core@2.34-1",
+                    },
+                    Object {
+                      "nodeId": "freetype/libfreetype6@2.5.2-3+deb8u2",
+                    },
+                    Object {
                       "nodeId": "gcc-4.8/gcc-4.8-base@4.8.4-1",
+                    },
+                    Object {
+                      "nodeId": "gcc-4.9/gcc-4.9-base@4.9.2-10+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "gcc-4.9/libgcc1@1:4.9.2-10+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "gcc-4.9/libstdc++6@4.9.2-10+deb8u1",
                     },
                     Object {
                       "nodeId": "gcc-defaults/g++@4:4.9.2-2",
@@ -531,10 +594,28 @@ Object {
                       "nodeId": "git@1:2.1.4-2.1+deb8u6",
                     },
                     Object {
+                      "nodeId": "glib2.0/libglib2.0-0@2.42.1-1+b1",
+                    },
+                    Object {
                       "nodeId": "glib2.0/libglib2.0-dev@2.42.1-1+b1|1",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.19-18+deb8u10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc-dev-bin@2.19-18+deb8u10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.19-18+deb8u10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6-dev@2.19-18+deb8u10",
+                    },
+                    Object {
+                      "nodeId": "glibc/multiarch-support@2.19-18+deb8u10",
+                    },
+                    Object {
+                      "nodeId": "gmp/libgmp10@2:6.0.0+dfsg-6",
                     },
                     Object {
                       "nodeId": "gnupg@1.4.18-7+deb8u4|2",
@@ -573,13 +654,28 @@ Object {
                       "nodeId": "iputils/iputils-ping@3:20121221-5+b2",
                     },
                     Object {
+                      "nodeId": "jbigkit/libjbig0@2.1-3.1",
+                    },
+                    Object {
+                      "nodeId": "keyutils/libkeyutils1@1.5.9-5+b1",
+                    },
+                    Object {
                       "nodeId": "kmod/libkmod2@18-3",
+                    },
+                    Object {
+                      "nodeId": "krb5/libk5crypto3@1.12.1+dfsg-19+deb8u4",
                     },
                     Object {
                       "nodeId": "krb5/libkrb5-dev@1.12.1+dfsg-19+deb8u4",
                     },
                     Object {
+                      "nodeId": "krb5/libkrb5support0@1.12.1+dfsg-19+deb8u4",
+                    },
+                    Object {
                       "nodeId": "libcap2/libcap2-bin@1:2.24-8|2",
+                    },
+                    Object {
+                      "nodeId": "libdatrie/libdatrie1@0.2.8-1",
                     },
                     Object {
                       "nodeId": "libevent/libevent-dev@2.0.21-stable-2+deb8u1",
@@ -588,13 +684,34 @@ Object {
                       "nodeId": "libffi/libffi-dev@3.1-2+deb8u1",
                     },
                     Object {
+                      "nodeId": "libffi/libffi6@3.1-2+deb8u1",
+                    },
+                    Object {
                       "nodeId": "libjpeg-turbo/libjpeg-dev@1:1.3.1-12|2",
+                    },
+                    Object {
+                      "nodeId": "libjpeg-turbo/libjpeg62-turbo@1:1.3.1-12",
                     },
                     Object {
                       "nodeId": "liblocale-gettext-perl/liblocale-gettext-perl@1.05-8+b1",
                     },
                     Object {
+                      "nodeId": "libpng/libpng12-0@1.2.50-2+deb8u3",
+                    },
+                    Object {
                       "nodeId": "libpng/libpng12-dev@1.2.50-2+deb8u3",
+                    },
+                    Object {
+                      "nodeId": "libselinux/libselinux1@2.3-2",
+                    },
+                    Object {
+                      "nodeId": "libsemanage/libsemanage-common@2.3-1",
+                    },
+                    Object {
+                      "nodeId": "libsemanage/libsemanage1@2.3-1+b1",
+                    },
+                    Object {
+                      "nodeId": "libsepol/libsepol1@2.3-2",
                     },
                     Object {
                       "nodeId": "libtext-charwidth-perl/libtext-charwidth-perl@0.04-7+b3",
@@ -606,6 +723,12 @@ Object {
                       "nodeId": "libtext-wrapi18n-perl@0.06-7|2",
                     },
                     Object {
+                      "nodeId": "libthai/libthai-data@0.1.21-1",
+                    },
+                    Object {
+                      "nodeId": "libthai/libthai0@0.1.21-1",
+                    },
+                    Object {
                       "nodeId": "libtool@2.4.2-1.11",
                     },
                     Object {
@@ -615,13 +738,49 @@ Object {
                       "nodeId": "libwebp/libwebp-dev@0.4.1-1.2+b2",
                     },
                     Object {
+                      "nodeId": "libx11/libx11-6@2:1.6.2-3+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "libx11/libx11-data@2:1.6.2-3+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "libxau/libxau-dev@1:1.0.8-1",
+                    },
+                    Object {
+                      "nodeId": "libxau/libxau6@1:1.0.8-1",
+                    },
+                    Object {
+                      "nodeId": "libxcb/libxcb-render0@1.10-3+b1",
+                    },
+                    Object {
+                      "nodeId": "libxcb/libxcb-shm0@1.10-3+b1",
+                    },
+                    Object {
+                      "nodeId": "libxcb/libxcb1@1.10-3+b1",
+                    },
+                    Object {
+                      "nodeId": "libxdmcp/libxdmcp-dev@1:1.1.1-1+b1",
+                    },
+                    Object {
+                      "nodeId": "libxdmcp/libxdmcp6@1:1.1.1-1+b1",
+                    },
+                    Object {
+                      "nodeId": "libxext/libxext6@2:1.3.3-1",
+                    },
+                    Object {
                       "nodeId": "libxml2/libxml2-dev@2.9.1+dfsg1-5+deb8u6|2",
+                    },
+                    Object {
+                      "nodeId": "libxrender/libxrender1@1:0.9.8-1+b1",
                     },
                     Object {
                       "nodeId": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
                     },
                     Object {
                       "nodeId": "libyaml/libyaml-dev@0.1.6-3",
+                    },
+                    Object {
+                      "nodeId": "linux/linux-libc-dev@3.16.56-1+deb8u1",
                     },
                     Object {
                       "nodeId": "lvm2/dmsetup@2:1.02.90-2.2+deb8u1|2",
@@ -636,9 +795,6 @@ Object {
                       "nodeId": "mercurial@3.1.2-2+deb8u4",
                     },
                     Object {
-                      "nodeId": "meta-common-packages@meta",
-                    },
-                    Object {
                       "nodeId": "mysql-5.5/libmysqlclient-dev@5.5.60-0+deb8u1",
                     },
                     Object {
@@ -646,6 +802,9 @@ Object {
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw5-dev@5.9+20140913-1+deb8u2",
+                    },
+                    Object {
+                      "nodeId": "ncurses/libtinfo5@5.9+20140913-1+deb8u2",
                     },
                     Object {
                       "nodeId": "ncurses/ncurses-base@5.9+20140913-1+deb8u2",
@@ -660,10 +819,31 @@ Object {
                       "nodeId": "openssl/libssl-dev@1.0.1t-1+deb8u8|1",
                     },
                     Object {
+                      "nodeId": "pam/libpam-modules@1.1.8-3.1+deb8u2+b1",
+                    },
+                    Object {
+                      "nodeId": "pam/libpam-modules-bin@1.1.8-3.1+deb8u2+b1",
+                    },
+                    Object {
                       "nodeId": "pam/libpam-runtime@1.1.8-3.1+deb8u2",
                     },
                     Object {
+                      "nodeId": "pam/libpam0g@1.1.8-3.1+deb8u2+b1",
+                    },
+                    Object {
+                      "nodeId": "pango1.0/libpango-1.0-0@1.36.8-3",
+                    },
+                    Object {
                       "nodeId": "patch@2.7.5-1",
+                    },
+                    Object {
+                      "nodeId": "pcre3/libpcre3@2:8.35-3.3+deb8u4",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.20.2-3+deb8u10",
+                    },
+                    Object {
+                      "nodeId": "pixman/libpixman-1-0@0.32.6-3",
                     },
                     Object {
                       "nodeId": "postgresql-9.4/libpq-dev@9.4.15-0+deb8u1",
@@ -681,7 +861,13 @@ Object {
                       "nodeId": "sed@4.2.2-4+deb8u1",
                     },
                     Object {
+                      "nodeId": "sensible-utils@0.0.9+deb8u1",
+                    },
+                    Object {
                       "nodeId": "shadow/login@1:4.2-3+deb8u4",
+                    },
+                    Object {
+                      "nodeId": "shadow/passwd@1:4.2-3+deb8u4",
                     },
                     Object {
                       "nodeId": "slang2/libslang2@2.3.0-2",
@@ -720,7 +906,19 @@ Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.88dsf-59|1",
                     },
                     Object {
+                      "nodeId": "tar@1.27.1-2+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "tiff/libtiff5@4.0.3-12.3+deb8u5",
+                    },
+                    Object {
                       "nodeId": "tzdata@2018d-0+deb8u1",
+                    },
+                    Object {
+                      "nodeId": "ucf@3.0030",
+                    },
+                    Object {
+                      "nodeId": "ustr/libustr-1.0-1@1.0.4-3+b2",
                     },
                     Object {
                       "nodeId": "util-linux@2.25.2-6|1",
@@ -738,16 +936,34 @@ Object {
                       "nodeId": "util-linux/libsmartcols1@2.25.2-6",
                     },
                     Object {
+                      "nodeId": "util-linux/libuuid1@2.25.2-6",
+                    },
+                    Object {
                       "nodeId": "util-linux/mount@2.25.2-6|2",
                     },
                     Object {
                       "nodeId": "wget@1.16-1+deb8u5",
                     },
                     Object {
+                      "nodeId": "x11proto-core/x11proto-core-dev@7.0.26-1",
+                    },
+                    Object {
+                      "nodeId": "xorg-sgml-doctools@1:1.11-1",
+                    },
+                    Object {
                       "nodeId": "xz-utils/liblzma-dev@5.1.1alpha+20120614-2+b3",
                     },
                     Object {
+                      "nodeId": "xz-utils/liblzma5@5.1.1alpha+20120614-2+b3",
+                    },
+                    Object {
                       "nodeId": "xz-utils/xz-utils@5.1.1alpha+20120614-2+b3",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.8.dfsg-2+b1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g-dev@1:1.2.8.dfsg-2+b1",
                     },
                   ],
                   "nodeId": "root-node",
@@ -757,6 +973,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "acl@2.2.52-2",
                   "pkgId": "acl@2.2.52-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.52-2",
+                  "pkgId": "acl/libacl1@2.2.52-2",
                 },
                 Object {
                   "deps": Array [],
@@ -811,6 +1032,21 @@ Object {
                   ],
                   "nodeId": "apt@1.0.9.8.4",
                   "pkgId": "apt@1.0.9.8.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.47-2",
+                  "pkgId": "attr/libattr1@1:2.4.47-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "audit/libaudit-common@1:2.4-1",
+                  "pkgId": "audit/libaudit-common@1:2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "audit/libaudit1@1:2.4-1+b1",
+                  "pkgId": "audit/libaudit1@1:2.4-1+b1",
                 },
                 Object {
                   "deps": Array [],
@@ -944,6 +1180,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "bzip2/bzip2@1.0.6-7+b3",
                   "pkgId": "bzip2/bzip2@1.0.6-7+b3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-7+b3",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-7+b3",
                 },
                 Object {
                   "deps": Array [],
@@ -1145,6 +1386,16 @@ Object {
                   ],
                   "nodeId": "ca-certificates@20141019+deb8u3",
                   "pkgId": "ca-certificates@20141019+deb8u3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "cairo/libcairo2@1.14.0-2.1+deb8u2",
+                  "pkgId": "cairo/libcairo2@1.14.0-2.1+deb8u2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "coreutils@8.23-4",
+                  "pkgId": "coreutils@8.23-4",
                 },
                 Object {
                   "deps": Array [],
@@ -1368,6 +1619,16 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "db5.3/libdb5.3@5.3.28-9+deb8u1",
+                  "pkgId": "db5.3/libdb5.3@5.3.28-9+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "debconf@1.5.56+deb8u1",
+                  "pkgId": "debconf@1.5.56+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "liblocale-gettext-perl/liblocale-gettext-perl@1.05-8+b1",
                   "pkgId": "liblocale-gettext-perl/liblocale-gettext-perl@1.05-8+b1",
                 },
@@ -1420,8 +1681,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debianutils/debianutils@4.4+b1",
+                  "pkgId": "debianutils/debianutils@4.4+b1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils/diffutils@1:3.3-1+b1",
                   "pkgId": "diffutils/diffutils@1:3.3-1+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.17.27",
+                  "pkgId": "dpkg@1.17.27",
                 },
                 Object {
                   "deps": Array [],
@@ -1566,6 +1837,16 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "e2fsprogs/libcomerr2@1.42.12-2+b1",
+                  "pkgId": "e2fsprogs/libcomerr2@1.42.12-2+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "expat/libexpat1@2.1.0-6+deb8u4",
+                  "pkgId": "expat/libexpat1@2.1.0-6+deb8u4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "file@1:5.22+15-2+deb8u3|1",
                   "pkgId": "file@1:5.22+15-2+deb8u3",
                 },
@@ -1585,8 +1866,53 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "info": Object {
+                    "labels": Object {
+                      "dockerLayerId": "UlVOIGFwdC1nZXQgaW5zdGFsbCAteSBpbWFnZW1hZ2ljaw==",
+                    },
+                  },
+                  "nodeId": "fontconfig@2.11.0-6.3+deb8u1",
+                  "pkgId": "fontconfig@2.11.0-6.3+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fontconfig/fontconfig-config@2.11.0-6.3+deb8u1",
+                  "pkgId": "fontconfig/fontconfig-config@2.11.0-6.3+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fontconfig/libfontconfig1@2.11.0-6.3+deb8u1",
+                  "pkgId": "fontconfig/libfontconfig1@2.11.0-6.3+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fonts-dejavu/fonts-dejavu-core@2.34-1",
+                  "pkgId": "fonts-dejavu/fonts-dejavu-core@2.34-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "freetype/libfreetype6@2.5.2-3+deb8u2",
+                  "pkgId": "freetype/libfreetype6@2.5.2-3+deb8u2",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "gcc-4.8/gcc-4.8-base@4.8.4-1",
                   "pkgId": "gcc-4.8/gcc-4.8-base@4.8.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-4.9/gcc-4.9-base@4.9.2-10+deb8u1",
+                  "pkgId": "gcc-4.9/gcc-4.9-base@4.9.2-10+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-4.9/libgcc1@1:4.9.2-10+deb8u1",
+                  "pkgId": "gcc-4.9/libgcc1@1:4.9.2-10+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-4.9/libstdc++6@4.9.2-10+deb8u1",
+                  "pkgId": "gcc-4.9/libstdc++6@4.9.2-10+deb8u1",
                 },
                 Object {
                   "deps": Array [],
@@ -1887,6 +2213,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "glib2.0/libglib2.0-0@2.42.1-1+b1",
+                  "pkgId": "glib2.0/libglib2.0-0@2.42.1-1+b1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glib2.0/libglib2.0-dev@2.42.1-1+b1|1",
                   "pkgId": "glib2.0/libglib2.0-dev@2.42.1-1+b1",
                 },
@@ -1909,6 +2240,31 @@ Object {
                   "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.19-18+deb8u10",
                   "pkgId": "glibc/libc-bin@2.19-18+deb8u10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc-dev-bin@2.19-18+deb8u10",
+                  "pkgId": "glibc/libc-dev-bin@2.19-18+deb8u10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.19-18+deb8u10",
+                  "pkgId": "glibc/libc6@2.19-18+deb8u10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6-dev@2.19-18+deb8u10",
+                  "pkgId": "glibc/libc6-dev@2.19-18+deb8u10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/multiarch-support@2.19-18+deb8u10",
+                  "pkgId": "glibc/multiarch-support@2.19-18+deb8u10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gmp/libgmp10@2:6.0.0+dfsg-6",
+                  "pkgId": "gmp/libgmp10@2:6.0.0+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -3589,6 +3945,21 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "jbigkit/libjbig0@2.1-3.1",
+                  "pkgId": "jbigkit/libjbig0@2.1-3.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "keyutils/libkeyutils1@1.5.9-5+b1",
+                  "pkgId": "keyutils/libkeyutils1@1.5.9-5+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "krb5/libk5crypto3@1.12.1+dfsg-19+deb8u4",
+                  "pkgId": "krb5/libk5crypto3@1.12.1+dfsg-19+deb8u4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "krb5/krb5-multidev@1.12.1+dfsg-19+deb8u4|1",
                   "pkgId": "krb5/krb5-multidev@1.12.1+dfsg-19+deb8u4",
                 },
@@ -3624,6 +3995,16 @@ Object {
                   ],
                   "nodeId": "krb5/libkrb5-dev@1.12.1+dfsg-19+deb8u4",
                   "pkgId": "krb5/libkrb5-dev@1.12.1+dfsg-19+deb8u4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "krb5/libkrb5support0@1.12.1+dfsg-19+deb8u4",
+                  "pkgId": "krb5/libkrb5support0@1.12.1+dfsg-19+deb8u4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libdatrie/libdatrie1@0.2.8-1",
+                  "pkgId": "libdatrie/libdatrie1@0.2.8-1",
                 },
                 Object {
                   "deps": Array [],
@@ -3690,6 +4071,51 @@ Object {
                   "deps": Array [],
                   "nodeId": "libffi/libffi-dev@3.1-2+deb8u1",
                   "pkgId": "libffi/libffi-dev@3.1-2+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libffi/libffi6@3.1-2+deb8u1",
+                  "pkgId": "libffi/libffi6@3.1-2+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libjpeg-turbo/libjpeg62-turbo@1:1.3.1-12",
+                  "pkgId": "libjpeg-turbo/libjpeg62-turbo@1:1.3.1-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libpng/libpng12-0@1.2.50-2+deb8u3",
+                  "pkgId": "libpng/libpng12-0@1.2.50-2+deb8u3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libselinux/libselinux1@2.3-2",
+                  "pkgId": "libselinux/libselinux1@2.3-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libsemanage/libsemanage-common@2.3-1",
+                  "pkgId": "libsemanage/libsemanage-common@2.3-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libsemanage/libsemanage1@2.3-1+b1",
+                  "pkgId": "libsemanage/libsemanage1@2.3-1+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libsepol/libsepol1@2.3-2",
+                  "pkgId": "libsepol/libsepol1@2.3-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libthai/libthai-data@0.1.21-1",
+                  "pkgId": "libthai/libthai-data@0.1.21-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libthai/libthai0@0.1.21-1",
+                  "pkgId": "libthai/libthai0@0.1.21-1",
                 },
                 Object {
                   "deps": Array [],
@@ -3821,283 +4247,6 @@ Object {
                   "pkgId": "libwebp/libwebp-dev@0.4.1-1.2+b2",
                 },
                 Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "libgcrypt20@1.6.3-2+deb8u4|2",
-                    },
-                    Object {
-                      "nodeId": "libxml2@2.9.1+dfsg1-5+deb8u6",
-                    },
-                  ],
-                  "nodeId": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
-                  "pkgId": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "libxml2/libxml2-dev@2.9.1+dfsg1-5+deb8u6|2",
-                    },
-                    Object {
-                      "nodeId": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
-                    },
-                  ],
-                  "nodeId": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
-                  "pkgId": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libyaml/libyaml-0-2@0.1.6-3",
-                  "pkgId": "libyaml/libyaml-0-2@0.1.6-3",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "libyaml/libyaml-0-2@0.1.6-3",
-                    },
-                  ],
-                  "nodeId": "libyaml/libyaml-dev@0.1.6-3",
-                  "pkgId": "libyaml/libyaml-dev@0.1.6-3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "explorercanvas/libjs-excanvas@0.r3-3",
-                  "pkgId": "explorercanvas/libjs-excanvas@0.r3-3",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "explorercanvas/libjs-excanvas@0.r3-3",
-                    },
-                    Object {
-                      "nodeId": "python-defaults/python@2.7.9-1|2",
-                    },
-                  ],
-                  "nodeId": "mercurial/mercurial-common@3.1.2-2+deb8u4",
-                  "pkgId": "mercurial/mercurial-common@3.1.2-2+deb8u4",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "mercurial/mercurial-common@3.1.2-2+deb8u4",
-                    },
-                    Object {
-                      "nodeId": "python-defaults/python@2.7.9-1|2",
-                    },
-                  ],
-                  "nodeId": "mercurial@3.1.2-2+deb8u4",
-                  "pkgId": "mercurial@3.1.2-2+deb8u4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.52-2",
-                  "pkgId": "acl/libacl1@2.2.52-2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.47-2",
-                  "pkgId": "attr/libattr1@1:2.4.47-2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "audit/libaudit-common@1:2.4-1",
-                  "pkgId": "audit/libaudit-common@1:2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "audit/libaudit1@1:2.4-1+b1",
-                  "pkgId": "audit/libaudit1@1:2.4-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-7+b3",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-7+b3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "cairo/libcairo2@1.14.0-2.1+deb8u2",
-                  "pkgId": "cairo/libcairo2@1.14.0-2.1+deb8u2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "coreutils@8.23-4",
-                  "pkgId": "coreutils@8.23-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "db5.3/libdb5.3@5.3.28-9+deb8u1",
-                  "pkgId": "db5.3/libdb5.3@5.3.28-9+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.56+deb8u1",
-                  "pkgId": "debconf@1.5.56+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debianutils/debianutils@4.4+b1",
-                  "pkgId": "debianutils/debianutils@4.4+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.17.27",
-                  "pkgId": "dpkg@1.17.27",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "e2fsprogs/libcomerr2@1.42.12-2+b1",
-                  "pkgId": "e2fsprogs/libcomerr2@1.42.12-2+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "expat/libexpat1@2.1.0-6+deb8u4",
-                  "pkgId": "expat/libexpat1@2.1.0-6+deb8u4",
-                },
-                Object {
-                  "deps": Array [],
-                  "info": Object {
-                    "labels": Object {
-                      "dockerLayerId": "UlVOIGFwdC1nZXQgaW5zdGFsbCAteSBpbWFnZW1hZ2ljaw==",
-                    },
-                  },
-                  "nodeId": "fontconfig@2.11.0-6.3+deb8u1",
-                  "pkgId": "fontconfig@2.11.0-6.3+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "fontconfig/fontconfig-config@2.11.0-6.3+deb8u1",
-                  "pkgId": "fontconfig/fontconfig-config@2.11.0-6.3+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "fontconfig/libfontconfig1@2.11.0-6.3+deb8u1",
-                  "pkgId": "fontconfig/libfontconfig1@2.11.0-6.3+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "fonts-dejavu/fonts-dejavu-core@2.34-1",
-                  "pkgId": "fonts-dejavu/fonts-dejavu-core@2.34-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "freetype/libfreetype6@2.5.2-3+deb8u2",
-                  "pkgId": "freetype/libfreetype6@2.5.2-3+deb8u2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-4.9/gcc-4.9-base@4.9.2-10+deb8u1",
-                  "pkgId": "gcc-4.9/gcc-4.9-base@4.9.2-10+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-4.9/libgcc1@1:4.9.2-10+deb8u1",
-                  "pkgId": "gcc-4.9/libgcc1@1:4.9.2-10+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-4.9/libstdc++6@4.9.2-10+deb8u1",
-                  "pkgId": "gcc-4.9/libstdc++6@4.9.2-10+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glib2.0/libglib2.0-0@2.42.1-1+b1",
-                  "pkgId": "glib2.0/libglib2.0-0@2.42.1-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc-dev-bin@2.19-18+deb8u10",
-                  "pkgId": "glibc/libc-dev-bin@2.19-18+deb8u10",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.19-18+deb8u10",
-                  "pkgId": "glibc/libc6@2.19-18+deb8u10",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6-dev@2.19-18+deb8u10",
-                  "pkgId": "glibc/libc6-dev@2.19-18+deb8u10",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/multiarch-support@2.19-18+deb8u10",
-                  "pkgId": "glibc/multiarch-support@2.19-18+deb8u10",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gmp/libgmp10@2:6.0.0+dfsg-6",
-                  "pkgId": "gmp/libgmp10@2:6.0.0+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "jbigkit/libjbig0@2.1-3.1",
-                  "pkgId": "jbigkit/libjbig0@2.1-3.1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "keyutils/libkeyutils1@1.5.9-5+b1",
-                  "pkgId": "keyutils/libkeyutils1@1.5.9-5+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "krb5/libk5crypto3@1.12.1+dfsg-19+deb8u4",
-                  "pkgId": "krb5/libk5crypto3@1.12.1+dfsg-19+deb8u4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "krb5/libkrb5support0@1.12.1+dfsg-19+deb8u4",
-                  "pkgId": "krb5/libkrb5support0@1.12.1+dfsg-19+deb8u4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libdatrie/libdatrie1@0.2.8-1",
-                  "pkgId": "libdatrie/libdatrie1@0.2.8-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libffi/libffi6@3.1-2+deb8u1",
-                  "pkgId": "libffi/libffi6@3.1-2+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libjpeg-turbo/libjpeg62-turbo@1:1.3.1-12",
-                  "pkgId": "libjpeg-turbo/libjpeg62-turbo@1:1.3.1-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libpng/libpng12-0@1.2.50-2+deb8u3",
-                  "pkgId": "libpng/libpng12-0@1.2.50-2+deb8u3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libselinux/libselinux1@2.3-2",
-                  "pkgId": "libselinux/libselinux1@2.3-2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libsemanage/libsemanage-common@2.3-1",
-                  "pkgId": "libsemanage/libsemanage-common@2.3-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libsemanage/libsemanage1@2.3-1+b1",
-                  "pkgId": "libsemanage/libsemanage1@2.3-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libsepol/libsepol1@2.3-2",
-                  "pkgId": "libsepol/libsepol1@2.3-2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libthai/libthai-data@0.1.21-1",
-                  "pkgId": "libthai/libthai-data@0.1.21-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libthai/libthai0@0.1.21-1",
-                  "pkgId": "libthai/libthai0@0.1.21-1",
-                },
-                Object {
                   "deps": Array [],
                   "nodeId": "libx11/libx11-6@2:1.6.2-3+deb8u1",
                   "pkgId": "libx11/libx11-6@2:1.6.2-3+deb8u1",
@@ -4153,334 +4302,76 @@ Object {
                   "pkgId": "libxrender/libxrender1@1:0.9.8-1+b1",
                 },
                 Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libgcrypt20@1.6.3-2+deb8u4|2",
+                    },
+                    Object {
+                      "nodeId": "libxml2@2.9.1+dfsg1-5+deb8u6",
+                    },
+                  ],
+                  "nodeId": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
+                  "pkgId": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libxml2/libxml2-dev@2.9.1+dfsg1-5+deb8u6|2",
+                    },
+                    Object {
+                      "nodeId": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
+                    },
+                  ],
+                  "nodeId": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
+                  "pkgId": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libyaml/libyaml-0-2@0.1.6-3",
+                  "pkgId": "libyaml/libyaml-0-2@0.1.6-3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "libyaml/libyaml-0-2@0.1.6-3",
+                    },
+                  ],
+                  "nodeId": "libyaml/libyaml-dev@0.1.6-3",
+                  "pkgId": "libyaml/libyaml-dev@0.1.6-3",
+                },
+                Object {
                   "deps": Array [],
                   "nodeId": "linux/linux-libc-dev@3.16.56-1+deb8u1",
                   "pkgId": "linux/linux-libc-dev@3.16.56-1+deb8u1",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "ncurses/libtinfo5@5.9+20140913-1+deb8u2",
-                  "pkgId": "ncurses/libtinfo5@5.9+20140913-1+deb8u2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pam/libpam-modules@1.1.8-3.1+deb8u2+b1",
-                  "pkgId": "pam/libpam-modules@1.1.8-3.1+deb8u2+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pam/libpam-modules-bin@1.1.8-3.1+deb8u2+b1",
-                  "pkgId": "pam/libpam-modules-bin@1.1.8-3.1+deb8u2+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pam/libpam0g@1.1.8-3.1+deb8u2+b1",
-                  "pkgId": "pam/libpam0g@1.1.8-3.1+deb8u2+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pango1.0/libpango-1.0-0@1.36.8-3",
-                  "pkgId": "pango1.0/libpango-1.0-0@1.36.8-3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.35-3.3+deb8u4",
-                  "pkgId": "pcre3/libpcre3@2:8.35-3.3+deb8u4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.20.2-3+deb8u10",
-                  "pkgId": "perl/perl-base@5.20.2-3+deb8u10",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pixman/libpixman-1-0@0.32.6-3",
-                  "pkgId": "pixman/libpixman-1-0@0.32.6-3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "sensible-utils@0.0.9+deb8u1",
-                  "pkgId": "sensible-utils@0.0.9+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "shadow/passwd@1:4.2-3+deb8u4",
-                  "pkgId": "shadow/passwd@1:4.2-3+deb8u4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.27.1-2+deb8u1",
-                  "pkgId": "tar@1.27.1-2+deb8u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tiff/libtiff5@4.0.3-12.3+deb8u5",
-                  "pkgId": "tiff/libtiff5@4.0.3-12.3+deb8u5",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "ucf@3.0030",
-                  "pkgId": "ucf@3.0030",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "ustr/libustr-1.0-1@1.0.4-3+b2",
-                  "pkgId": "ustr/libustr-1.0-1@1.0.4-3+b2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "util-linux/libuuid1@2.25.2-6",
-                  "pkgId": "util-linux/libuuid1@2.25.2-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "x11proto-core/x11proto-core-dev@7.0.26-1",
-                  "pkgId": "x11proto-core/x11proto-core-dev@7.0.26-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xorg-sgml-doctools@1:1.11-1",
-                  "pkgId": "xorg-sgml-doctools@1:1.11-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.1.1alpha+20120614-2+b3",
-                  "pkgId": "xz-utils/liblzma5@5.1.1alpha+20120614-2+b3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.8.dfsg-2+b1",
-                  "pkgId": "zlib/zlib1g@1:1.2.8.dfsg-2+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g-dev@1:1.2.8.dfsg-2+b1",
-                  "pkgId": "zlib/zlib1g-dev@1:1.2.8.dfsg-2+b1",
+                  "nodeId": "explorercanvas/libjs-excanvas@0.r3-3",
+                  "pkgId": "explorercanvas/libjs-excanvas@0.r3-3",
                 },
                 Object {
                   "deps": Array [
                     Object {
-                      "nodeId": "acl/libacl1@2.2.52-2",
+                      "nodeId": "explorercanvas/libjs-excanvas@0.r3-3",
                     },
                     Object {
-                      "nodeId": "attr/libattr1@1:2.4.47-2",
-                    },
-                    Object {
-                      "nodeId": "audit/libaudit-common@1:2.4-1",
-                    },
-                    Object {
-                      "nodeId": "audit/libaudit1@1:2.4-1+b1",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-7+b3",
-                    },
-                    Object {
-                      "nodeId": "cairo/libcairo2@1.14.0-2.1+deb8u2",
-                    },
-                    Object {
-                      "nodeId": "coreutils@8.23-4",
-                    },
-                    Object {
-                      "nodeId": "db5.3/libdb5.3@5.3.28-9+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.56+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "debianutils/debianutils@4.4+b1",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.17.27",
-                    },
-                    Object {
-                      "nodeId": "e2fsprogs/libcomerr2@1.42.12-2+b1",
-                    },
-                    Object {
-                      "nodeId": "expat/libexpat1@2.1.0-6+deb8u4",
-                    },
-                    Object {
-                      "nodeId": "fontconfig@2.11.0-6.3+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "fontconfig/fontconfig-config@2.11.0-6.3+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "fontconfig/libfontconfig1@2.11.0-6.3+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "fonts-dejavu/fonts-dejavu-core@2.34-1",
-                    },
-                    Object {
-                      "nodeId": "freetype/libfreetype6@2.5.2-3+deb8u2",
-                    },
-                    Object {
-                      "nodeId": "gcc-4.9/gcc-4.9-base@4.9.2-10+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "gcc-4.9/libgcc1@1:4.9.2-10+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "gcc-4.9/libstdc++6@4.9.2-10+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "glib2.0/libglib2.0-0@2.42.1-1+b1",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc-dev-bin@2.19-18+deb8u10",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.19-18+deb8u10",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6-dev@2.19-18+deb8u10",
-                    },
-                    Object {
-                      "nodeId": "glibc/multiarch-support@2.19-18+deb8u10",
-                    },
-                    Object {
-                      "nodeId": "gmp/libgmp10@2:6.0.0+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "jbigkit/libjbig0@2.1-3.1",
-                    },
-                    Object {
-                      "nodeId": "keyutils/libkeyutils1@1.5.9-5+b1",
-                    },
-                    Object {
-                      "nodeId": "krb5/libk5crypto3@1.12.1+dfsg-19+deb8u4",
-                    },
-                    Object {
-                      "nodeId": "krb5/libkrb5support0@1.12.1+dfsg-19+deb8u4",
-                    },
-                    Object {
-                      "nodeId": "libdatrie/libdatrie1@0.2.8-1",
-                    },
-                    Object {
-                      "nodeId": "libffi/libffi6@3.1-2+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "libjpeg-turbo/libjpeg62-turbo@1:1.3.1-12",
-                    },
-                    Object {
-                      "nodeId": "libpng/libpng12-0@1.2.50-2+deb8u3",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.3-2",
-                    },
-                    Object {
-                      "nodeId": "libsemanage/libsemanage-common@2.3-1",
-                    },
-                    Object {
-                      "nodeId": "libsemanage/libsemanage1@2.3-1+b1",
-                    },
-                    Object {
-                      "nodeId": "libsepol/libsepol1@2.3-2",
-                    },
-                    Object {
-                      "nodeId": "libthai/libthai-data@0.1.21-1",
-                    },
-                    Object {
-                      "nodeId": "libthai/libthai0@0.1.21-1",
-                    },
-                    Object {
-                      "nodeId": "libx11/libx11-6@2:1.6.2-3+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "libx11/libx11-data@2:1.6.2-3+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "libxau/libxau-dev@1:1.0.8-1",
-                    },
-                    Object {
-                      "nodeId": "libxau/libxau6@1:1.0.8-1",
-                    },
-                    Object {
-                      "nodeId": "libxcb/libxcb-render0@1.10-3+b1",
-                    },
-                    Object {
-                      "nodeId": "libxcb/libxcb-shm0@1.10-3+b1",
-                    },
-                    Object {
-                      "nodeId": "libxcb/libxcb1@1.10-3+b1",
-                    },
-                    Object {
-                      "nodeId": "libxdmcp/libxdmcp-dev@1:1.1.1-1+b1",
-                    },
-                    Object {
-                      "nodeId": "libxdmcp/libxdmcp6@1:1.1.1-1+b1",
-                    },
-                    Object {
-                      "nodeId": "libxext/libxext6@2:1.3.3-1",
-                    },
-                    Object {
-                      "nodeId": "libxrender/libxrender1@1:0.9.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "linux/linux-libc-dev@3.16.56-1+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "ncurses/libtinfo5@5.9+20140913-1+deb8u2",
-                    },
-                    Object {
-                      "nodeId": "pam/libpam-modules@1.1.8-3.1+deb8u2+b1",
-                    },
-                    Object {
-                      "nodeId": "pam/libpam-modules-bin@1.1.8-3.1+deb8u2+b1",
-                    },
-                    Object {
-                      "nodeId": "pam/libpam0g@1.1.8-3.1+deb8u2+b1",
-                    },
-                    Object {
-                      "nodeId": "pango1.0/libpango-1.0-0@1.36.8-3",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.35-3.3+deb8u4",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.20.2-3+deb8u10",
-                    },
-                    Object {
-                      "nodeId": "pixman/libpixman-1-0@0.32.6-3",
-                    },
-                    Object {
-                      "nodeId": "sensible-utils@0.0.9+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "shadow/passwd@1:4.2-3+deb8u4",
-                    },
-                    Object {
-                      "nodeId": "tar@1.27.1-2+deb8u1",
-                    },
-                    Object {
-                      "nodeId": "tiff/libtiff5@4.0.3-12.3+deb8u5",
-                    },
-                    Object {
-                      "nodeId": "ucf@3.0030",
-                    },
-                    Object {
-                      "nodeId": "ustr/libustr-1.0-1@1.0.4-3+b2",
-                    },
-                    Object {
-                      "nodeId": "util-linux/libuuid1@2.25.2-6",
-                    },
-                    Object {
-                      "nodeId": "x11proto-core/x11proto-core-dev@7.0.26-1",
-                    },
-                    Object {
-                      "nodeId": "xorg-sgml-doctools@1:1.11-1",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.1.1alpha+20120614-2+b3",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.8.dfsg-2+b1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g-dev@1:1.2.8.dfsg-2+b1",
+                      "nodeId": "python-defaults/python@2.7.9-1|2",
                     },
                   ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
+                  "nodeId": "mercurial/mercurial-common@3.1.2-2+deb8u4",
+                  "pkgId": "mercurial/mercurial-common@3.1.2-2+deb8u4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mercurial/mercurial-common@3.1.2-2+deb8u4",
+                    },
+                    Object {
+                      "nodeId": "python-defaults/python@2.7.9-1|2",
+                    },
+                  ],
+                  "nodeId": "mercurial@3.1.2-2+deb8u4",
+                  "pkgId": "mercurial@3.1.2-2+deb8u4",
                 },
                 Object {
                   "deps": Array [],
@@ -4547,6 +4438,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "ncurses/libtinfo5@5.9+20140913-1+deb8u2",
+                  "pkgId": "ncurses/libtinfo5@5.9+20140913-1+deb8u2",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "ncurses/ncurses-base@5.9+20140913-1+deb8u2",
                   "pkgId": "ncurses/ncurses-base@5.9+20140913-1+deb8u2",
                 },
@@ -4607,8 +4503,43 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "pam/libpam-modules@1.1.8-3.1+deb8u2+b1",
+                  "pkgId": "pam/libpam-modules@1.1.8-3.1+deb8u2+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pam/libpam-modules-bin@1.1.8-3.1+deb8u2+b1",
+                  "pkgId": "pam/libpam-modules-bin@1.1.8-3.1+deb8u2+b1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.1.8-3.1+deb8u2",
                   "pkgId": "pam/libpam-runtime@1.1.8-3.1+deb8u2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pam/libpam0g@1.1.8-3.1+deb8u2+b1",
+                  "pkgId": "pam/libpam0g@1.1.8-3.1+deb8u2+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pango1.0/libpango-1.0-0@1.36.8-3",
+                  "pkgId": "pango1.0/libpango-1.0-0@1.36.8-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.35-3.3+deb8u4",
+                  "pkgId": "pcre3/libpcre3@2:8.35-3.3+deb8u4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.20.2-3+deb8u10",
+                  "pkgId": "perl/perl-base@5.20.2-3+deb8u10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pixman/libpixman-1-0@0.32.6-3",
+                  "pkgId": "pixman/libpixman-1-0@0.32.6-3",
                 },
                 Object {
                   "deps": Array [],
@@ -4756,6 +4687,11 @@ Object {
                   "pkgId": "sed@4.2.2-4+deb8u1",
                 },
                 Object {
+                  "deps": Array [],
+                  "nodeId": "sensible-utils@0.0.9+deb8u1",
+                  "pkgId": "sensible-utils@0.0.9+deb8u1",
+                },
+                Object {
                   "deps": Array [
                     Object {
                       "nodeId": "pam/libpam-runtime@1.1.8-3.1+deb8u2",
@@ -4763,6 +4699,11 @@ Object {
                   ],
                   "nodeId": "shadow/login@1:4.2-3+deb8u4",
                   "pkgId": "shadow/login@1:4.2-3+deb8u4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "shadow/passwd@1:4.2-3+deb8u4",
+                  "pkgId": "shadow/passwd@1:4.2-3+deb8u4",
                 },
                 Object {
                   "deps": Array [
@@ -4859,6 +4800,26 @@ Object {
                   "pkgId": "subversion@1.8.10-6+deb8u5",
                 },
                 Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.27.1-2+deb8u1",
+                  "pkgId": "tar@1.27.1-2+deb8u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tiff/libtiff5@4.0.3-12.3+deb8u5",
+                  "pkgId": "tiff/libtiff5@4.0.3-12.3+deb8u5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ucf@3.0030",
+                  "pkgId": "ucf@3.0030",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ustr/libustr-1.0-1@1.0.4-3+b2",
+                  "pkgId": "ustr/libustr-1.0-1@1.0.4-3+b2",
+                },
+                Object {
                   "deps": Array [
                     Object {
                       "nodeId": "systemd/libsystemd0@215-17+deb8u7|2",
@@ -4866,6 +4827,11 @@ Object {
                   ],
                   "nodeId": "util-linux/bsdutils@1:2.25.2-6",
                   "pkgId": "util-linux/bsdutils@1:2.25.2-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-linux/libuuid1@2.25.2-6",
+                  "pkgId": "util-linux/libuuid1@2.25.2-6",
                 },
                 Object {
                   "deps": Array [],
@@ -4899,6 +4865,31 @@ Object {
                   "nodeId": "wget@1.16-1+deb8u5",
                   "pkgId": "wget@1.16-1+deb8u5",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "x11proto-core/x11proto-core-dev@7.0.26-1",
+                  "pkgId": "x11proto-core/x11proto-core-dev@7.0.26-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xorg-sgml-doctools@1:1.11-1",
+                  "pkgId": "xorg-sgml-doctools@1:1.11-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.1.1alpha+20120614-2+b3",
+                  "pkgId": "xz-utils/liblzma5@5.1.1alpha+20120614-2+b3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.8.dfsg-2+b1",
+                  "pkgId": "zlib/zlib1g@1:1.2.8.dfsg-2+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g-dev@1:1.2.8.dfsg-2+b1",
+                  "pkgId": "zlib/zlib1g-dev@1:1.2.8.dfsg-2+b1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -4923,6 +4914,13 @@ Object {
                 "info": Object {
                   "name": "acl",
                   "purl": "pkg:deb/acl@2.2.52-2",
+                  "version": "2.2.52-2",
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.52-2",
+                "info": Object {
+                  "name": "acl/libacl1",
                   "version": "2.2.52-2",
                 },
               },
@@ -4956,6 +4954,27 @@ Object {
                   "name": "apt",
                   "purl": "pkg:deb/apt@1.0.9.8.4",
                   "version": "1.0.9.8.4",
+                },
+              },
+              Object {
+                "id": "attr/libattr1@1:2.4.47-2",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.47-2",
+                },
+              },
+              Object {
+                "id": "audit/libaudit-common@1:2.4-1",
+                "info": Object {
+                  "name": "audit/libaudit-common",
+                  "version": "1:2.4-1",
+                },
+              },
+              Object {
+                "id": "audit/libaudit1@1:2.4-1+b1",
+                "info": Object {
+                  "name": "audit/libaudit1",
+                  "version": "1:2.4-1+b1",
                 },
               },
               Object {
@@ -5075,6 +5094,13 @@ Object {
                 "info": Object {
                   "name": "bzip2/bzip2",
                   "purl": "pkg:deb/bzip2@1.0.6-7%2Bb3?upstream=bzip2%401.0.6-7",
+                  "version": "1.0.6-7+b3",
+                },
+              },
+              Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-7+b3",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
                   "version": "1.0.6-7+b3",
                 },
               },
@@ -5239,6 +5265,20 @@ Object {
                 },
               },
               Object {
+                "id": "cairo/libcairo2@1.14.0-2.1+deb8u2",
+                "info": Object {
+                  "name": "cairo/libcairo2",
+                  "version": "1.14.0-2.1+deb8u2",
+                },
+              },
+              Object {
+                "id": "coreutils@8.23-4",
+                "info": Object {
+                  "name": "coreutils",
+                  "version": "8.23-4",
+                },
+              },
+              Object {
                 "id": "cryptsetup/libcryptsetup4@2:1.6.6-5",
                 "info": Object {
                   "name": "cryptsetup/libcryptsetup4",
@@ -5375,6 +5415,20 @@ Object {
                 },
               },
               Object {
+                "id": "db5.3/libdb5.3@5.3.28-9+deb8u1",
+                "info": Object {
+                  "name": "db5.3/libdb5.3",
+                  "version": "5.3.28-9+deb8u1",
+                },
+              },
+              Object {
+                "id": "debconf@1.5.56+deb8u1",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.56+deb8u1",
+                },
+              },
+              Object {
                 "id": "liblocale-gettext-perl/liblocale-gettext-perl@1.05-8+b1",
                 "info": Object {
                   "name": "liblocale-gettext-perl/liblocale-gettext-perl",
@@ -5423,11 +5477,25 @@ Object {
                 },
               },
               Object {
+                "id": "debianutils/debianutils@4.4+b1",
+                "info": Object {
+                  "name": "debianutils/debianutils",
+                  "version": "4.4+b1",
+                },
+              },
+              Object {
                 "id": "diffutils/diffutils@1:3.3-1+b1",
                 "info": Object {
                   "name": "diffutils/diffutils",
                   "purl": "pkg:deb/diffutils@1:3.3-1%2Bb1?upstream=diffutils%401%3A3.3-1",
                   "version": "1:3.3-1+b1",
+                },
+              },
+              Object {
+                "id": "dpkg@1.17.27",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.17.27",
                 },
               },
               Object {
@@ -5535,6 +5603,20 @@ Object {
                 },
               },
               Object {
+                "id": "e2fsprogs/libcomerr2@1.42.12-2+b1",
+                "info": Object {
+                  "name": "e2fsprogs/libcomerr2",
+                  "version": "1.42.12-2+b1",
+                },
+              },
+              Object {
+                "id": "expat/libexpat1@2.1.0-6+deb8u4",
+                "info": Object {
+                  "name": "expat/libexpat1",
+                  "version": "2.1.0-6+deb8u4",
+                },
+              },
+              Object {
                 "id": "file@1:5.22+15-2+deb8u3",
                 "info": Object {
                   "name": "file",
@@ -5551,11 +5633,67 @@ Object {
                 },
               },
               Object {
+                "id": "fontconfig@2.11.0-6.3+deb8u1",
+                "info": Object {
+                  "name": "fontconfig",
+                  "version": "2.11.0-6.3+deb8u1",
+                },
+              },
+              Object {
+                "id": "fontconfig/fontconfig-config@2.11.0-6.3+deb8u1",
+                "info": Object {
+                  "name": "fontconfig/fontconfig-config",
+                  "version": "2.11.0-6.3+deb8u1",
+                },
+              },
+              Object {
+                "id": "fontconfig/libfontconfig1@2.11.0-6.3+deb8u1",
+                "info": Object {
+                  "name": "fontconfig/libfontconfig1",
+                  "version": "2.11.0-6.3+deb8u1",
+                },
+              },
+              Object {
+                "id": "fonts-dejavu/fonts-dejavu-core@2.34-1",
+                "info": Object {
+                  "name": "fonts-dejavu/fonts-dejavu-core",
+                  "version": "2.34-1",
+                },
+              },
+              Object {
+                "id": "freetype/libfreetype6@2.5.2-3+deb8u2",
+                "info": Object {
+                  "name": "freetype/libfreetype6",
+                  "version": "2.5.2-3+deb8u2",
+                },
+              },
+              Object {
                 "id": "gcc-4.8/gcc-4.8-base@4.8.4-1",
                 "info": Object {
                   "name": "gcc-4.8/gcc-4.8-base",
                   "purl": "pkg:deb/gcc-4.8-base@4.8.4-1?upstream=gcc-4.8",
                   "version": "4.8.4-1",
+                },
+              },
+              Object {
+                "id": "gcc-4.9/gcc-4.9-base@4.9.2-10+deb8u1",
+                "info": Object {
+                  "name": "gcc-4.9/gcc-4.9-base",
+                  "version": "4.9.2-10+deb8u1",
+                },
+              },
+              Object {
+                "id": "gcc-4.9/libgcc1@1:4.9.2-10+deb8u1",
+                "info": Object {
+                  "name": "gcc-4.9/libgcc1",
+                  "version": "1:4.9.2-10+deb8u1",
+                },
+              },
+              Object {
+                "id": "gcc-4.9/libstdc++6@4.9.2-10+deb8u1",
+                "info": Object {
+                  "name": "gcc-4.9/libstdc++6",
+                  "version": "4.9.2-10+deb8u1",
                 },
               },
               Object {
@@ -5711,6 +5849,13 @@ Object {
                 },
               },
               Object {
+                "id": "glib2.0/libglib2.0-0@2.42.1-1+b1",
+                "info": Object {
+                  "name": "glib2.0/libglib2.0-0",
+                  "version": "2.42.1-1+b1",
+                },
+              },
+              Object {
                 "id": "glib2.0/libglib2.0-dev@2.42.1-1+b1",
                 "info": Object {
                   "name": "glib2.0/libglib2.0-dev",
@@ -5724,6 +5869,41 @@ Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.19-18%2Bdeb8u10?upstream=glibc",
                   "version": "2.19-18+deb8u10",
+                },
+              },
+              Object {
+                "id": "glibc/libc-dev-bin@2.19-18+deb8u10",
+                "info": Object {
+                  "name": "glibc/libc-dev-bin",
+                  "version": "2.19-18+deb8u10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.19-18+deb8u10",
+                "info": Object {
+                  "name": "glibc/libc6",
+                  "version": "2.19-18+deb8u10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6-dev@2.19-18+deb8u10",
+                "info": Object {
+                  "name": "glibc/libc6-dev",
+                  "version": "2.19-18+deb8u10",
+                },
+              },
+              Object {
+                "id": "glibc/multiarch-support@2.19-18+deb8u10",
+                "info": Object {
+                  "name": "glibc/multiarch-support",
+                  "version": "2.19-18+deb8u10",
+                },
+              },
+              Object {
+                "id": "gmp/libgmp10@2:6.0.0+dfsg-6",
+                "info": Object {
+                  "name": "gmp/libgmp10",
+                  "version": "2:6.0.0+dfsg-6",
                 },
               },
               Object {
@@ -6839,6 +7019,27 @@ Object {
                 },
               },
               Object {
+                "id": "jbigkit/libjbig0@2.1-3.1",
+                "info": Object {
+                  "name": "jbigkit/libjbig0",
+                  "version": "2.1-3.1",
+                },
+              },
+              Object {
+                "id": "keyutils/libkeyutils1@1.5.9-5+b1",
+                "info": Object {
+                  "name": "keyutils/libkeyutils1",
+                  "version": "1.5.9-5+b1",
+                },
+              },
+              Object {
+                "id": "krb5/libk5crypto3@1.12.1+dfsg-19+deb8u4",
+                "info": Object {
+                  "name": "krb5/libk5crypto3",
+                  "version": "1.12.1+dfsg-19+deb8u4",
+                },
+              },
+              Object {
                 "id": "krb5/krb5-multidev@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/krb5-multidev",
@@ -6852,6 +7053,20 @@ Object {
                   "name": "krb5/libkrb5-dev",
                   "purl": "pkg:deb/libkrb5-dev@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
+                },
+              },
+              Object {
+                "id": "krb5/libkrb5support0@1.12.1+dfsg-19+deb8u4",
+                "info": Object {
+                  "name": "krb5/libkrb5support0",
+                  "version": "1.12.1+dfsg-19+deb8u4",
+                },
+              },
+              Object {
+                "id": "libdatrie/libdatrie1@0.2.8-1",
+                "info": Object {
+                  "name": "libdatrie/libdatrie1",
+                  "version": "0.2.8-1",
                 },
               },
               Object {
@@ -6908,6 +7123,69 @@ Object {
                   "name": "libffi/libffi-dev",
                   "purl": "pkg:deb/libffi-dev@3.1-2%2Bdeb8u1?upstream=libffi",
                   "version": "3.1-2+deb8u1",
+                },
+              },
+              Object {
+                "id": "libffi/libffi6@3.1-2+deb8u1",
+                "info": Object {
+                  "name": "libffi/libffi6",
+                  "version": "3.1-2+deb8u1",
+                },
+              },
+              Object {
+                "id": "libjpeg-turbo/libjpeg62-turbo@1:1.3.1-12",
+                "info": Object {
+                  "name": "libjpeg-turbo/libjpeg62-turbo",
+                  "version": "1:1.3.1-12",
+                },
+              },
+              Object {
+                "id": "libpng/libpng12-0@1.2.50-2+deb8u3",
+                "info": Object {
+                  "name": "libpng/libpng12-0",
+                  "version": "1.2.50-2+deb8u3",
+                },
+              },
+              Object {
+                "id": "libselinux/libselinux1@2.3-2",
+                "info": Object {
+                  "name": "libselinux/libselinux1",
+                  "version": "2.3-2",
+                },
+              },
+              Object {
+                "id": "libsemanage/libsemanage-common@2.3-1",
+                "info": Object {
+                  "name": "libsemanage/libsemanage-common",
+                  "version": "2.3-1",
+                },
+              },
+              Object {
+                "id": "libsemanage/libsemanage1@2.3-1+b1",
+                "info": Object {
+                  "name": "libsemanage/libsemanage1",
+                  "version": "2.3-1+b1",
+                },
+              },
+              Object {
+                "id": "libsepol/libsepol1@2.3-2",
+                "info": Object {
+                  "name": "libsepol/libsepol1",
+                  "version": "2.3-2",
+                },
+              },
+              Object {
+                "id": "libthai/libthai-data@0.1.21-1",
+                "info": Object {
+                  "name": "libthai/libthai-data",
+                  "version": "0.1.21-1",
+                },
+              },
+              Object {
+                "id": "libthai/libthai0@0.1.21-1",
+                "info": Object {
+                  "name": "libthai/libthai0",
+                  "version": "0.1.21-1",
                 },
               },
               Object {
@@ -7031,349 +7309,6 @@ Object {
                 },
               },
               Object {
-                "id": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
-                "info": Object {
-                  "name": "libxslt/libxslt1.1",
-                  "purl": "pkg:deb/libxslt1.1@1.1.28-2%2Bdeb8u3?upstream=libxslt",
-                  "version": "1.1.28-2+deb8u3",
-                },
-              },
-              Object {
-                "id": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
-                "info": Object {
-                  "name": "libxslt/libxslt1-dev",
-                  "purl": "pkg:deb/libxslt1-dev@1.1.28-2%2Bdeb8u3?upstream=libxslt",
-                  "version": "1.1.28-2+deb8u3",
-                },
-              },
-              Object {
-                "id": "libyaml/libyaml-0-2@0.1.6-3",
-                "info": Object {
-                  "name": "libyaml/libyaml-0-2",
-                  "purl": "pkg:deb/libyaml-0-2@0.1.6-3?upstream=libyaml",
-                  "version": "0.1.6-3",
-                },
-              },
-              Object {
-                "id": "libyaml/libyaml-dev@0.1.6-3",
-                "info": Object {
-                  "name": "libyaml/libyaml-dev",
-                  "purl": "pkg:deb/libyaml-dev@0.1.6-3?upstream=libyaml",
-                  "version": "0.1.6-3",
-                },
-              },
-              Object {
-                "id": "explorercanvas/libjs-excanvas@0.r3-3",
-                "info": Object {
-                  "name": "explorercanvas/libjs-excanvas",
-                  "purl": "pkg:deb/libjs-excanvas@0.r3-3?upstream=explorercanvas",
-                  "version": "0.r3-3",
-                },
-              },
-              Object {
-                "id": "mercurial/mercurial-common@3.1.2-2+deb8u4",
-                "info": Object {
-                  "name": "mercurial/mercurial-common",
-                  "purl": "pkg:deb/mercurial-common@3.1.2-2%2Bdeb8u4?upstream=mercurial",
-                  "version": "3.1.2-2+deb8u4",
-                },
-              },
-              Object {
-                "id": "mercurial@3.1.2-2+deb8u4",
-                "info": Object {
-                  "name": "mercurial",
-                  "purl": "pkg:deb/mercurial@3.1.2-2%2Bdeb8u4",
-                  "version": "3.1.2-2+deb8u4",
-                },
-              },
-              Object {
-                "id": "acl/libacl1@2.2.52-2",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.52-2",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.47-2",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.47-2",
-                },
-              },
-              Object {
-                "id": "audit/libaudit-common@1:2.4-1",
-                "info": Object {
-                  "name": "audit/libaudit-common",
-                  "version": "1:2.4-1",
-                },
-              },
-              Object {
-                "id": "audit/libaudit1@1:2.4-1+b1",
-                "info": Object {
-                  "name": "audit/libaudit1",
-                  "version": "1:2.4-1+b1",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-7+b3",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-7+b3",
-                },
-              },
-              Object {
-                "id": "cairo/libcairo2@1.14.0-2.1+deb8u2",
-                "info": Object {
-                  "name": "cairo/libcairo2",
-                  "version": "1.14.0-2.1+deb8u2",
-                },
-              },
-              Object {
-                "id": "coreutils@8.23-4",
-                "info": Object {
-                  "name": "coreutils",
-                  "version": "8.23-4",
-                },
-              },
-              Object {
-                "id": "db5.3/libdb5.3@5.3.28-9+deb8u1",
-                "info": Object {
-                  "name": "db5.3/libdb5.3",
-                  "version": "5.3.28-9+deb8u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.56+deb8u1",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.56+deb8u1",
-                },
-              },
-              Object {
-                "id": "debianutils/debianutils@4.4+b1",
-                "info": Object {
-                  "name": "debianutils/debianutils",
-                  "version": "4.4+b1",
-                },
-              },
-              Object {
-                "id": "dpkg@1.17.27",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.17.27",
-                },
-              },
-              Object {
-                "id": "e2fsprogs/libcomerr2@1.42.12-2+b1",
-                "info": Object {
-                  "name": "e2fsprogs/libcomerr2",
-                  "version": "1.42.12-2+b1",
-                },
-              },
-              Object {
-                "id": "expat/libexpat1@2.1.0-6+deb8u4",
-                "info": Object {
-                  "name": "expat/libexpat1",
-                  "version": "2.1.0-6+deb8u4",
-                },
-              },
-              Object {
-                "id": "fontconfig@2.11.0-6.3+deb8u1",
-                "info": Object {
-                  "name": "fontconfig",
-                  "version": "2.11.0-6.3+deb8u1",
-                },
-              },
-              Object {
-                "id": "fontconfig/fontconfig-config@2.11.0-6.3+deb8u1",
-                "info": Object {
-                  "name": "fontconfig/fontconfig-config",
-                  "version": "2.11.0-6.3+deb8u1",
-                },
-              },
-              Object {
-                "id": "fontconfig/libfontconfig1@2.11.0-6.3+deb8u1",
-                "info": Object {
-                  "name": "fontconfig/libfontconfig1",
-                  "version": "2.11.0-6.3+deb8u1",
-                },
-              },
-              Object {
-                "id": "fonts-dejavu/fonts-dejavu-core@2.34-1",
-                "info": Object {
-                  "name": "fonts-dejavu/fonts-dejavu-core",
-                  "version": "2.34-1",
-                },
-              },
-              Object {
-                "id": "freetype/libfreetype6@2.5.2-3+deb8u2",
-                "info": Object {
-                  "name": "freetype/libfreetype6",
-                  "version": "2.5.2-3+deb8u2",
-                },
-              },
-              Object {
-                "id": "gcc-4.9/gcc-4.9-base@4.9.2-10+deb8u1",
-                "info": Object {
-                  "name": "gcc-4.9/gcc-4.9-base",
-                  "version": "4.9.2-10+deb8u1",
-                },
-              },
-              Object {
-                "id": "gcc-4.9/libgcc1@1:4.9.2-10+deb8u1",
-                "info": Object {
-                  "name": "gcc-4.9/libgcc1",
-                  "version": "1:4.9.2-10+deb8u1",
-                },
-              },
-              Object {
-                "id": "gcc-4.9/libstdc++6@4.9.2-10+deb8u1",
-                "info": Object {
-                  "name": "gcc-4.9/libstdc++6",
-                  "version": "4.9.2-10+deb8u1",
-                },
-              },
-              Object {
-                "id": "glib2.0/libglib2.0-0@2.42.1-1+b1",
-                "info": Object {
-                  "name": "glib2.0/libglib2.0-0",
-                  "version": "2.42.1-1+b1",
-                },
-              },
-              Object {
-                "id": "glibc/libc-dev-bin@2.19-18+deb8u10",
-                "info": Object {
-                  "name": "glibc/libc-dev-bin",
-                  "version": "2.19-18+deb8u10",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.19-18+deb8u10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.19-18+deb8u10",
-                },
-              },
-              Object {
-                "id": "glibc/libc6-dev@2.19-18+deb8u10",
-                "info": Object {
-                  "name": "glibc/libc6-dev",
-                  "version": "2.19-18+deb8u10",
-                },
-              },
-              Object {
-                "id": "glibc/multiarch-support@2.19-18+deb8u10",
-                "info": Object {
-                  "name": "glibc/multiarch-support",
-                  "version": "2.19-18+deb8u10",
-                },
-              },
-              Object {
-                "id": "gmp/libgmp10@2:6.0.0+dfsg-6",
-                "info": Object {
-                  "name": "gmp/libgmp10",
-                  "version": "2:6.0.0+dfsg-6",
-                },
-              },
-              Object {
-                "id": "jbigkit/libjbig0@2.1-3.1",
-                "info": Object {
-                  "name": "jbigkit/libjbig0",
-                  "version": "2.1-3.1",
-                },
-              },
-              Object {
-                "id": "keyutils/libkeyutils1@1.5.9-5+b1",
-                "info": Object {
-                  "name": "keyutils/libkeyutils1",
-                  "version": "1.5.9-5+b1",
-                },
-              },
-              Object {
-                "id": "krb5/libk5crypto3@1.12.1+dfsg-19+deb8u4",
-                "info": Object {
-                  "name": "krb5/libk5crypto3",
-                  "version": "1.12.1+dfsg-19+deb8u4",
-                },
-              },
-              Object {
-                "id": "krb5/libkrb5support0@1.12.1+dfsg-19+deb8u4",
-                "info": Object {
-                  "name": "krb5/libkrb5support0",
-                  "version": "1.12.1+dfsg-19+deb8u4",
-                },
-              },
-              Object {
-                "id": "libdatrie/libdatrie1@0.2.8-1",
-                "info": Object {
-                  "name": "libdatrie/libdatrie1",
-                  "version": "0.2.8-1",
-                },
-              },
-              Object {
-                "id": "libffi/libffi6@3.1-2+deb8u1",
-                "info": Object {
-                  "name": "libffi/libffi6",
-                  "version": "3.1-2+deb8u1",
-                },
-              },
-              Object {
-                "id": "libjpeg-turbo/libjpeg62-turbo@1:1.3.1-12",
-                "info": Object {
-                  "name": "libjpeg-turbo/libjpeg62-turbo",
-                  "version": "1:1.3.1-12",
-                },
-              },
-              Object {
-                "id": "libpng/libpng12-0@1.2.50-2+deb8u3",
-                "info": Object {
-                  "name": "libpng/libpng12-0",
-                  "version": "1.2.50-2+deb8u3",
-                },
-              },
-              Object {
-                "id": "libselinux/libselinux1@2.3-2",
-                "info": Object {
-                  "name": "libselinux/libselinux1",
-                  "version": "2.3-2",
-                },
-              },
-              Object {
-                "id": "libsemanage/libsemanage-common@2.3-1",
-                "info": Object {
-                  "name": "libsemanage/libsemanage-common",
-                  "version": "2.3-1",
-                },
-              },
-              Object {
-                "id": "libsemanage/libsemanage1@2.3-1+b1",
-                "info": Object {
-                  "name": "libsemanage/libsemanage1",
-                  "version": "2.3-1+b1",
-                },
-              },
-              Object {
-                "id": "libsepol/libsepol1@2.3-2",
-                "info": Object {
-                  "name": "libsepol/libsepol1",
-                  "version": "2.3-2",
-                },
-              },
-              Object {
-                "id": "libthai/libthai-data@0.1.21-1",
-                "info": Object {
-                  "name": "libthai/libthai-data",
-                  "version": "0.1.21-1",
-                },
-              },
-              Object {
-                "id": "libthai/libthai0@0.1.21-1",
-                "info": Object {
-                  "name": "libthai/libthai0",
-                  "version": "0.1.21-1",
-                },
-              },
-              Object {
                 "id": "libx11/libx11-6@2:1.6.2-3+deb8u1",
                 "info": Object {
                   "name": "libx11/libx11-6",
@@ -7451,6 +7386,38 @@ Object {
                 },
               },
               Object {
+                "id": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
+                "info": Object {
+                  "name": "libxslt/libxslt1.1",
+                  "purl": "pkg:deb/libxslt1.1@1.1.28-2%2Bdeb8u3?upstream=libxslt",
+                  "version": "1.1.28-2+deb8u3",
+                },
+              },
+              Object {
+                "id": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
+                "info": Object {
+                  "name": "libxslt/libxslt1-dev",
+                  "purl": "pkg:deb/libxslt1-dev@1.1.28-2%2Bdeb8u3?upstream=libxslt",
+                  "version": "1.1.28-2+deb8u3",
+                },
+              },
+              Object {
+                "id": "libyaml/libyaml-0-2@0.1.6-3",
+                "info": Object {
+                  "name": "libyaml/libyaml-0-2",
+                  "purl": "pkg:deb/libyaml-0-2@0.1.6-3?upstream=libyaml",
+                  "version": "0.1.6-3",
+                },
+              },
+              Object {
+                "id": "libyaml/libyaml-dev@0.1.6-3",
+                "info": Object {
+                  "name": "libyaml/libyaml-dev",
+                  "purl": "pkg:deb/libyaml-dev@0.1.6-3?upstream=libyaml",
+                  "version": "0.1.6-3",
+                },
+              },
+              Object {
                 "id": "linux/linux-libc-dev@3.16.56-1+deb8u1",
                 "info": Object {
                   "name": "linux/linux-libc-dev",
@@ -7458,150 +7425,27 @@ Object {
                 },
               },
               Object {
-                "id": "ncurses/libtinfo5@5.9+20140913-1+deb8u2",
+                "id": "explorercanvas/libjs-excanvas@0.r3-3",
                 "info": Object {
-                  "name": "ncurses/libtinfo5",
-                  "version": "5.9+20140913-1+deb8u2",
+                  "name": "explorercanvas/libjs-excanvas",
+                  "purl": "pkg:deb/libjs-excanvas@0.r3-3?upstream=explorercanvas",
+                  "version": "0.r3-3",
                 },
               },
               Object {
-                "id": "pam/libpam-modules@1.1.8-3.1+deb8u2+b1",
+                "id": "mercurial/mercurial-common@3.1.2-2+deb8u4",
                 "info": Object {
-                  "name": "pam/libpam-modules",
-                  "version": "1.1.8-3.1+deb8u2+b1",
+                  "name": "mercurial/mercurial-common",
+                  "purl": "pkg:deb/mercurial-common@3.1.2-2%2Bdeb8u4?upstream=mercurial",
+                  "version": "3.1.2-2+deb8u4",
                 },
               },
               Object {
-                "id": "pam/libpam-modules-bin@1.1.8-3.1+deb8u2+b1",
+                "id": "mercurial@3.1.2-2+deb8u4",
                 "info": Object {
-                  "name": "pam/libpam-modules-bin",
-                  "version": "1.1.8-3.1+deb8u2+b1",
-                },
-              },
-              Object {
-                "id": "pam/libpam0g@1.1.8-3.1+deb8u2+b1",
-                "info": Object {
-                  "name": "pam/libpam0g",
-                  "version": "1.1.8-3.1+deb8u2+b1",
-                },
-              },
-              Object {
-                "id": "pango1.0/libpango-1.0-0@1.36.8-3",
-                "info": Object {
-                  "name": "pango1.0/libpango-1.0-0",
-                  "version": "1.36.8-3",
-                },
-              },
-              Object {
-                "id": "pcre3/libpcre3@2:8.35-3.3+deb8u4",
-                "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.35-3.3+deb8u4",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.20.2-3+deb8u10",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.20.2-3+deb8u10",
-                },
-              },
-              Object {
-                "id": "pixman/libpixman-1-0@0.32.6-3",
-                "info": Object {
-                  "name": "pixman/libpixman-1-0",
-                  "version": "0.32.6-3",
-                },
-              },
-              Object {
-                "id": "sensible-utils@0.0.9+deb8u1",
-                "info": Object {
-                  "name": "sensible-utils",
-                  "version": "0.0.9+deb8u1",
-                },
-              },
-              Object {
-                "id": "shadow/passwd@1:4.2-3+deb8u4",
-                "info": Object {
-                  "name": "shadow/passwd",
-                  "version": "1:4.2-3+deb8u4",
-                },
-              },
-              Object {
-                "id": "tar@1.27.1-2+deb8u1",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.27.1-2+deb8u1",
-                },
-              },
-              Object {
-                "id": "tiff/libtiff5@4.0.3-12.3+deb8u5",
-                "info": Object {
-                  "name": "tiff/libtiff5",
-                  "version": "4.0.3-12.3+deb8u5",
-                },
-              },
-              Object {
-                "id": "ucf@3.0030",
-                "info": Object {
-                  "name": "ucf",
-                  "version": "3.0030",
-                },
-              },
-              Object {
-                "id": "ustr/libustr-1.0-1@1.0.4-3+b2",
-                "info": Object {
-                  "name": "ustr/libustr-1.0-1",
-                  "version": "1.0.4-3+b2",
-                },
-              },
-              Object {
-                "id": "util-linux/libuuid1@2.25.2-6",
-                "info": Object {
-                  "name": "util-linux/libuuid1",
-                  "version": "2.25.2-6",
-                },
-              },
-              Object {
-                "id": "x11proto-core/x11proto-core-dev@7.0.26-1",
-                "info": Object {
-                  "name": "x11proto-core/x11proto-core-dev",
-                  "version": "7.0.26-1",
-                },
-              },
-              Object {
-                "id": "xorg-sgml-doctools@1:1.11-1",
-                "info": Object {
-                  "name": "xorg-sgml-doctools",
-                  "version": "1:1.11-1",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.1.1alpha+20120614-2+b3",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.1.1alpha+20120614-2+b3",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.8.dfsg-2+b1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.8.dfsg-2+b1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g-dev@1:1.2.8.dfsg-2+b1",
-                "info": Object {
-                  "name": "zlib/zlib1g-dev",
-                  "version": "1:1.2.8.dfsg-2+b1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
+                  "name": "mercurial",
+                  "purl": "pkg:deb/mercurial@3.1.2-2%2Bdeb8u4",
+                  "version": "3.1.2-2+deb8u4",
                 },
               },
               Object {
@@ -7661,6 +7505,13 @@ Object {
                 },
               },
               Object {
+                "id": "ncurses/libtinfo5@5.9+20140913-1+deb8u2",
+                "info": Object {
+                  "name": "ncurses/libtinfo5",
+                  "version": "5.9+20140913-1+deb8u2",
+                },
+              },
+              Object {
                 "id": "ncurses/ncurses-base@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
@@ -7709,11 +7560,60 @@ Object {
                 },
               },
               Object {
+                "id": "pam/libpam-modules@1.1.8-3.1+deb8u2+b1",
+                "info": Object {
+                  "name": "pam/libpam-modules",
+                  "version": "1.1.8-3.1+deb8u2+b1",
+                },
+              },
+              Object {
+                "id": "pam/libpam-modules-bin@1.1.8-3.1+deb8u2+b1",
+                "info": Object {
+                  "name": "pam/libpam-modules-bin",
+                  "version": "1.1.8-3.1+deb8u2+b1",
+                },
+              },
+              Object {
                 "id": "pam/libpam-runtime@1.1.8-3.1+deb8u2",
                 "info": Object {
                   "name": "pam/libpam-runtime",
                   "purl": "pkg:deb/libpam-runtime@1.1.8-3.1%2Bdeb8u2?upstream=pam",
                   "version": "1.1.8-3.1+deb8u2",
+                },
+              },
+              Object {
+                "id": "pam/libpam0g@1.1.8-3.1+deb8u2+b1",
+                "info": Object {
+                  "name": "pam/libpam0g",
+                  "version": "1.1.8-3.1+deb8u2+b1",
+                },
+              },
+              Object {
+                "id": "pango1.0/libpango-1.0-0@1.36.8-3",
+                "info": Object {
+                  "name": "pango1.0/libpango-1.0-0",
+                  "version": "1.36.8-3",
+                },
+              },
+              Object {
+                "id": "pcre3/libpcre3@2:8.35-3.3+deb8u4",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.35-3.3+deb8u4",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.20.2-3+deb8u10",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.20.2-3+deb8u10",
+                },
+              },
+              Object {
+                "id": "pixman/libpixman-1-0@0.32.6-3",
+                "info": Object {
+                  "name": "pixman/libpixman-1-0",
+                  "version": "0.32.6-3",
                 },
               },
               Object {
@@ -7813,10 +7713,24 @@ Object {
                 },
               },
               Object {
+                "id": "sensible-utils@0.0.9+deb8u1",
+                "info": Object {
+                  "name": "sensible-utils",
+                  "version": "0.0.9+deb8u1",
+                },
+              },
+              Object {
                 "id": "shadow/login@1:4.2-3+deb8u4",
                 "info": Object {
                   "name": "shadow/login",
                   "purl": "pkg:deb/login@1:4.2-3%2Bdeb8u4?upstream=shadow",
+                  "version": "1:4.2-3+deb8u4",
+                },
+              },
+              Object {
+                "id": "shadow/passwd@1:4.2-3+deb8u4",
+                "info": Object {
+                  "name": "shadow/passwd",
                   "version": "1:4.2-3+deb8u4",
                 },
               },
@@ -7869,11 +7783,46 @@ Object {
                 },
               },
               Object {
+                "id": "tar@1.27.1-2+deb8u1",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.27.1-2+deb8u1",
+                },
+              },
+              Object {
+                "id": "tiff/libtiff5@4.0.3-12.3+deb8u5",
+                "info": Object {
+                  "name": "tiff/libtiff5",
+                  "version": "4.0.3-12.3+deb8u5",
+                },
+              },
+              Object {
+                "id": "ucf@3.0030",
+                "info": Object {
+                  "name": "ucf",
+                  "version": "3.0030",
+                },
+              },
+              Object {
+                "id": "ustr/libustr-1.0-1@1.0.4-3+b2",
+                "info": Object {
+                  "name": "ustr/libustr-1.0-1",
+                  "version": "1.0.4-3+b2",
+                },
+              },
+              Object {
                 "id": "util-linux/bsdutils@1:2.25.2-6",
                 "info": Object {
                   "name": "util-linux/bsdutils",
                   "purl": "pkg:deb/bsdutils@1:2.25.2-6?upstream=util-linux%402.25.2-6",
                   "version": "1:2.25.2-6",
+                },
+              },
+              Object {
+                "id": "util-linux/libuuid1@2.25.2-6",
+                "info": Object {
+                  "name": "util-linux/libuuid1",
+                  "version": "2.25.2-6",
                 },
               },
               Object {
@@ -7898,6 +7847,41 @@ Object {
                   "name": "wget",
                   "purl": "pkg:deb/wget@1.16-1%2Bdeb8u5",
                   "version": "1.16-1+deb8u5",
+                },
+              },
+              Object {
+                "id": "x11proto-core/x11proto-core-dev@7.0.26-1",
+                "info": Object {
+                  "name": "x11proto-core/x11proto-core-dev",
+                  "version": "7.0.26-1",
+                },
+              },
+              Object {
+                "id": "xorg-sgml-doctools@1:1.11-1",
+                "info": Object {
+                  "name": "xorg-sgml-doctools",
+                  "version": "1:1.11-1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.1.1alpha+20120614-2+b3",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.1.1alpha+20120614-2+b3",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.8.dfsg-2+b1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.8.dfsg-2+b1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g-dev@1:1.2.8.dfsg-2+b1",
+                "info": Object {
+                  "name": "zlib/zlib1g-dev",
+                  "version": "1:1.2.8.dfsg-2+b1",
                 },
               },
             ],

--- a/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
@@ -12,6 +12,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
                       "nodeId": "adduser@3.118|1",
                     },
                     Object {
@@ -19,6 +22,9 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.8.2|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
                     },
                     Object {
                       "nodeId": "audit/libaudit-common@1:2.8.4-3",
@@ -36,6 +42,9 @@ Object {
                       "nodeId": "bash@5.0-4",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.249",
                     },
                     Object {
@@ -48,6 +57,9 @@ Object {
                       "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2019.1",
                     },
                     Object {
@@ -55,6 +67,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.44.5-1+deb10u1",
@@ -72,10 +87,19 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20190209-2",
                     },
                     Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
                       "nodeId": "gcc-8/libstdc++6@8.3.0-6",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
                     },
                     Object {
                       "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
@@ -117,6 +141,9 @@ Object {
                       "nodeId": "libseccomp/libseccomp2@2.3.3-4",
                     },
                     Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
                       "nodeId": "libsemanage/libsemanage-common@2.8-2",
                     },
                     Object {
@@ -139,9 +166,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u1|1",
@@ -177,6 +201,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.3.1-5|1",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6",
+                    },
+                    Object {
                       "nodeId": "sed@4.7-1",
                     },
                     Object {
@@ -193,6 +223,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
                     },
                     Object {
                       "nodeId": "tzdata@2019b-0+deb10u1",
@@ -224,9 +257,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.33.1-0.1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|nginx-compressed-layers.tar@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
                 },
                 Object {
                   "deps": Array [],
@@ -621,6 +665,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "mawk/mawk@1.3.3-17+b3",
                   "pkgId": "mawk/mawk@1.3.3-17+b3",
                 },
@@ -679,6 +728,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.30-3",
                   "pkgId": "coreutils@8.30-3",
                 },
@@ -693,8 +747,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils@1:3.7-3",
                   "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
                 },
                 Object {
                   "deps": Array [],
@@ -767,8 +831,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.28-10",
                   "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
                 },
                 Object {
                   "deps": Array [],
@@ -792,121 +871,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.53-4",
-                  "pkgId": "acl/libacl1@2.2.53-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.48-4",
-                  "pkgId": "attr/libattr1@1:2.4.48-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.71",
-                  "pkgId": "debconf@1.5.71",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.19.7",
-                  "pkgId": "dpkg@1.19.7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.28-10",
-                  "pkgId": "glibc/libc6@2.28-10",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "libselinux/libselinux1@2.8-1+b1",
                   "pkgId": "libselinux/libselinux1@2.8-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-12",
-                  "pkgId": "pcre3/libpcre3@2:8.39-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.28.1-6",
-                  "pkgId": "perl/perl-base@5.28.1-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.30+dfsg-6",
-                  "pkgId": "tar@1.30+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.53-4",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.48-4",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.71",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.19.7",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.28-10",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-12",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.28.1-6",
-                    },
-                    Object {
-                      "nodeId": "tar@1.30+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
                 },
                 Object {
                   "deps": Array [],
@@ -949,6 +915,16 @@ Object {
                   "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.3.1-5|2",
                   "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6",
+                  "pkgId": "perl/perl-base@5.28.1-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1036,6 +1012,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.93-8",
                   "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1131,6 +1112,16 @@ Object {
                   "nodeId": "util-linux/mount@2.33.1-0.1",
                   "pkgId": "util-linux/mount@2.33.1-0.1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -1148,6 +1139,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|nginx-compressed-layers.tar",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
                 },
               },
               Object {
@@ -1415,6 +1413,13 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
@@ -1471,6 +1476,13 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
@@ -1487,11 +1499,25 @@ Object {
                 },
               },
               Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
                 },
               },
               Object {
@@ -1551,10 +1577,31 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
                   "version": "2.28-10",
                 },
               },
@@ -1591,108 +1638,10 @@ Object {
                 },
               },
               Object {
-                "id": "acl/libacl1@2.2.53-4",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.53-4",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.48-4",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.48-4",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-9.2~deb10u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.71",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.71",
-                },
-              },
-              Object {
-                "id": "dpkg@1.19.7",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.19.7",
-                },
-              },
-              Object {
-                "id": "gcc-8/gcc-8-base@8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/gcc-8-base",
-                  "version": "8.3.0-6",
-                },
-              },
-              Object {
-                "id": "gcc-8/libgcc1@1:8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/libgcc1",
-                  "version": "1:8.3.0-6",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.28-10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.28-10",
-                },
-              },
-              Object {
                 "id": "libselinux/libselinux1@2.8-1+b1",
                 "info": Object {
                   "name": "libselinux/libselinux1",
                   "version": "2.8-1+b1",
-                },
-              },
-              Object {
-                "id": "pcre3/libpcre3@2:8.39-12",
-                "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-12",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.28.1-6",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.28.1-6",
-                },
-              },
-              Object {
-                "id": "tar@1.30+dfsg-6",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.30+dfsg-6",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.4-1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.4-1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.11.dfsg-1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
                 },
               },
               Object {
@@ -1728,6 +1677,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6",
+                },
+              },
+              Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
@@ -1757,6 +1720,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
                 },
               },
               Object {
@@ -1813,6 +1783,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
                 },
               },
             ],

--- a/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
@@ -12,6 +12,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
                       "nodeId": "adduser@3.118|1",
                     },
                     Object {
@@ -19,6 +22,9 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.8.2|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
                     },
                     Object {
                       "nodeId": "audit/libaudit-common@1:2.8.4-3",
@@ -36,6 +42,9 @@ Object {
                       "nodeId": "bash@5.0-4",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.249",
                     },
                     Object {
@@ -48,6 +57,9 @@ Object {
                       "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2019.1",
                     },
                     Object {
@@ -55,6 +67,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.44.5-1+deb10u1",
@@ -72,10 +87,19 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20190209-2",
                     },
                     Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
                       "nodeId": "gcc-8/libstdc++6@8.3.0-6",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
                     },
                     Object {
                       "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
@@ -117,6 +141,9 @@ Object {
                       "nodeId": "libseccomp/libseccomp2@2.3.3-4",
                     },
                     Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
                       "nodeId": "libsemanage/libsemanage-common@2.8-2",
                     },
                     Object {
@@ -139,9 +166,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u1|1",
@@ -177,6 +201,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.3.1-5|1",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6",
+                    },
+                    Object {
                       "nodeId": "sed@4.7-1",
                     },
                     Object {
@@ -193,6 +223,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
                     },
                     Object {
                       "nodeId": "tzdata@2019b-0+deb10u1",
@@ -224,9 +257,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.33.1-0.1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|nginx.tar@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
                 },
                 Object {
                   "deps": Array [],
@@ -621,6 +665,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "mawk/mawk@1.3.3-17+b3",
                   "pkgId": "mawk/mawk@1.3.3-17+b3",
                 },
@@ -679,6 +728,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.30-3",
                   "pkgId": "coreutils@8.30-3",
                 },
@@ -693,8 +747,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils@1:3.7-3",
                   "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
                 },
                 Object {
                   "deps": Array [],
@@ -767,8 +831,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.28-10",
                   "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
                 },
                 Object {
                   "deps": Array [],
@@ -792,121 +871,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.53-4",
-                  "pkgId": "acl/libacl1@2.2.53-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.48-4",
-                  "pkgId": "attr/libattr1@1:2.4.48-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.71",
-                  "pkgId": "debconf@1.5.71",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.19.7",
-                  "pkgId": "dpkg@1.19.7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.28-10",
-                  "pkgId": "glibc/libc6@2.28-10",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "libselinux/libselinux1@2.8-1+b1",
                   "pkgId": "libselinux/libselinux1@2.8-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-12",
-                  "pkgId": "pcre3/libpcre3@2:8.39-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.28.1-6",
-                  "pkgId": "perl/perl-base@5.28.1-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.30+dfsg-6",
-                  "pkgId": "tar@1.30+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.53-4",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.48-4",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.71",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.19.7",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.28-10",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-12",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.28.1-6",
-                    },
-                    Object {
-                      "nodeId": "tar@1.30+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
                 },
                 Object {
                   "deps": Array [],
@@ -949,6 +915,16 @@ Object {
                   "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.3.1-5|2",
                   "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6",
+                  "pkgId": "perl/perl-base@5.28.1-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1036,6 +1012,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.93-8",
                   "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1131,6 +1112,16 @@ Object {
                   "nodeId": "util-linux/mount@2.33.1-0.1",
                   "pkgId": "util-linux/mount@2.33.1-0.1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -1148,6 +1139,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|nginx.tar",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
                 },
               },
               Object {
@@ -1415,6 +1413,13 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
@@ -1471,6 +1476,13 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
@@ -1487,11 +1499,25 @@ Object {
                 },
               },
               Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
                 },
               },
               Object {
@@ -1551,10 +1577,31 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
                   "version": "2.28-10",
                 },
               },
@@ -1591,108 +1638,10 @@ Object {
                 },
               },
               Object {
-                "id": "acl/libacl1@2.2.53-4",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.53-4",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.48-4",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.48-4",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-9.2~deb10u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.71",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.71",
-                },
-              },
-              Object {
-                "id": "dpkg@1.19.7",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.19.7",
-                },
-              },
-              Object {
-                "id": "gcc-8/gcc-8-base@8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/gcc-8-base",
-                  "version": "8.3.0-6",
-                },
-              },
-              Object {
-                "id": "gcc-8/libgcc1@1:8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/libgcc1",
-                  "version": "1:8.3.0-6",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.28-10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.28-10",
-                },
-              },
-              Object {
                 "id": "libselinux/libselinux1@2.8-1+b1",
                 "info": Object {
                   "name": "libselinux/libselinux1",
                   "version": "2.8-1+b1",
-                },
-              },
-              Object {
-                "id": "pcre3/libpcre3@2:8.39-12",
-                "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-12",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.28.1-6",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.28.1-6",
-                },
-              },
-              Object {
-                "id": "tar@1.30+dfsg-6",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.30+dfsg-6",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.4-1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.4-1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.11.dfsg-1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
                 },
               },
               Object {
@@ -1728,6 +1677,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6",
+                },
+              },
+              Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
@@ -1757,6 +1720,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
                 },
               },
               Object {
@@ -1813,6 +1783,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
                 },
               },
             ],

--- a/test/system/index.spec.ts
+++ b/test/system/index.spec.ts
@@ -95,7 +95,7 @@ describe("system tests", () => {
     );
     expect(depGraph.pkgManager.repositories).toEqual([{ alias: "debian:8" }]);
 
-    expect(depGraph.getPkgs()).toHaveLength(383);
+    expect(depGraph.getPkgs()).toHaveLength(382);
   });
 
   test("inspect nginx:1.13.10", async () => {
@@ -140,7 +140,7 @@ describe("system tests", () => {
     expect(depGraph.rootPkg.version).toEqual(imgTag);
     expect(depGraph.pkgManager.repositories).toEqual([{ alias: "debian:9" }]);
 
-    expect(depGraph.getPkgs()).toHaveLength(110);
+    expect(depGraph.getPkgs()).toHaveLength(109);
 
     expect(Object.keys(dockerfileAnalysis.dockerfileLayers)).toHaveLength(1);
 

--- a/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
+++ b/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
@@ -91,6 +91,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
                       "nodeId": "adduser@3.118|1",
                     },
                     Object {
@@ -98,6 +101,9 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.8.2|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
                     },
                     Object {
                       "nodeId": "audit/libaudit-common@1:2.8.4-3",
@@ -115,6 +121,9 @@ Object {
                       "nodeId": "bash@5.0-4",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.249",
                     },
                     Object {
@@ -127,6 +136,9 @@ Object {
                       "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2019.1",
                     },
                     Object {
@@ -134,6 +146,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.44.5-1+deb10u1",
@@ -151,10 +166,19 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20190209-2",
                     },
                     Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
                       "nodeId": "gcc-8/libstdc++6@8.3.0-6",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
                     },
                     Object {
                       "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
@@ -196,6 +220,9 @@ Object {
                       "nodeId": "libseccomp/libseccomp2@2.3.3-4",
                     },
                     Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
                       "nodeId": "libsemanage/libsemanage-common@2.8-2",
                     },
                     Object {
@@ -218,9 +245,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u1|1",
@@ -256,6 +280,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.3.1-5|1",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6",
+                    },
+                    Object {
                       "nodeId": "sed@4.7-1",
                     },
                     Object {
@@ -272,6 +302,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
                     },
                     Object {
                       "nodeId": "tzdata@2019b-0+deb10u1",
@@ -303,9 +336,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.33.1-0.1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|nodes-fake-multi.tar@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
                 },
                 Object {
                   "deps": Array [],
@@ -700,6 +744,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "mawk/mawk@1.3.3-17+b3",
                   "pkgId": "mawk/mawk@1.3.3-17+b3",
                 },
@@ -758,6 +807,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.30-3",
                   "pkgId": "coreutils@8.30-3",
                 },
@@ -772,8 +826,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils@1:3.7-3",
                   "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
                 },
                 Object {
                   "deps": Array [],
@@ -846,8 +910,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.28-10",
                   "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
                 },
                 Object {
                   "deps": Array [],
@@ -871,121 +950,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.53-4",
-                  "pkgId": "acl/libacl1@2.2.53-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.48-4",
-                  "pkgId": "attr/libattr1@1:2.4.48-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.71",
-                  "pkgId": "debconf@1.5.71",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.19.7",
-                  "pkgId": "dpkg@1.19.7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.28-10",
-                  "pkgId": "glibc/libc6@2.28-10",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "libselinux/libselinux1@2.8-1+b1",
                   "pkgId": "libselinux/libselinux1@2.8-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-12",
-                  "pkgId": "pcre3/libpcre3@2:8.39-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.28.1-6",
-                  "pkgId": "perl/perl-base@5.28.1-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.30+dfsg-6",
-                  "pkgId": "tar@1.30+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.53-4",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.48-4",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.71",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.19.7",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.28-10",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-12",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.28.1-6",
-                    },
-                    Object {
-                      "nodeId": "tar@1.30+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
                 },
                 Object {
                   "deps": Array [],
@@ -1028,6 +994,16 @@ Object {
                   "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.3.1-5|2",
                   "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6",
+                  "pkgId": "perl/perl-base@5.28.1-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1115,6 +1091,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.93-8",
                   "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1210,6 +1191,16 @@ Object {
                   "nodeId": "util-linux/mount@2.33.1-0.1",
                   "pkgId": "util-linux/mount@2.33.1-0.1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -1227,6 +1218,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|nodes-fake-multi.tar",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
                 },
               },
               Object {
@@ -1494,6 +1492,13 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
@@ -1550,6 +1555,13 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
@@ -1566,11 +1578,25 @@ Object {
                 },
               },
               Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
                 },
               },
               Object {
@@ -1630,10 +1656,31 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
                   "version": "2.28-10",
                 },
               },
@@ -1670,108 +1717,10 @@ Object {
                 },
               },
               Object {
-                "id": "acl/libacl1@2.2.53-4",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.53-4",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.48-4",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.48-4",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-9.2~deb10u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.71",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.71",
-                },
-              },
-              Object {
-                "id": "dpkg@1.19.7",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.19.7",
-                },
-              },
-              Object {
-                "id": "gcc-8/gcc-8-base@8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/gcc-8-base",
-                  "version": "8.3.0-6",
-                },
-              },
-              Object {
-                "id": "gcc-8/libgcc1@1:8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/libgcc1",
-                  "version": "1:8.3.0-6",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.28-10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.28-10",
-                },
-              },
-              Object {
                 "id": "libselinux/libselinux1@2.8-1+b1",
                 "info": Object {
                   "name": "libselinux/libselinux1",
                   "version": "2.8-1+b1",
-                },
-              },
-              Object {
-                "id": "pcre3/libpcre3@2:8.39-12",
-                "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-12",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.28.1-6",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.28.1-6",
-                },
-              },
-              Object {
-                "id": "tar@1.30+dfsg-6",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.30+dfsg-6",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.4-1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.4-1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.11.dfsg-1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
                 },
               },
               Object {
@@ -1807,6 +1756,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6",
+                },
+              },
+              Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
@@ -1836,6 +1799,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
                 },
               },
               Object {
@@ -1892,6 +1862,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
                 },
               },
             ],

--- a/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
@@ -12,6 +12,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.52-3+b1",
+                    },
+                    Object {
                       "nodeId": "adduser@3.115|1",
                     },
                     Object {
@@ -19,6 +22,15 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.4.10|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.47-2+b2",
+                    },
+                    Object {
+                      "nodeId": "audit/libaudit-common@1:2.6.7-2",
+                    },
+                    Object {
+                      "nodeId": "audit/libaudit1@1:2.6.7-2",
                     },
                     Object {
                       "nodeId": "base-files@9.9+deb9u13|1",
@@ -30,6 +42,9 @@ Object {
                       "nodeId": "bash@4.4-5",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-8.1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.227",
                     },
                     Object {
@@ -39,6 +54,9 @@ Object {
                       "nodeId": "dash@0.5.8-2.4|2",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.61",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2017.5+deb9u1|2",
                     },
                     Object {
@@ -46,6 +64,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.5-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.18.25",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.43.4-2+deb9u2",
@@ -63,10 +84,22 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20161106-2",
                     },
                     Object {
+                      "nodeId": "gcc-6/gcc-6-base@6.3.0-18+deb9u1",
+                    },
+                    Object {
+                      "nodeId": "gcc-6/libgcc1@1:6.3.0-18+deb9u1",
+                    },
+                    Object {
                       "nodeId": "gcc-6/libstdc++6@6.3.0-18+deb9u1",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.24-11+deb9u4",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.24-11+deb9u4",
+                    },
+                    Object {
+                      "nodeId": "glibc/multiarch-support@2.24-11+deb9u4",
                     },
                     Object {
                       "nodeId": "gnupg2/gpgv@2.1.18-8~deb9u4|2",
@@ -90,10 +123,16 @@ Object {
                       "nodeId": "iputils/iputils-ping@3:20161105-1",
                     },
                     Object {
+                      "nodeId": "libcap-ng/libcap-ng0@0.7.7-3+b1",
+                    },
+                    Object {
                       "nodeId": "libgcrypt20@1.7.6-2+deb9u3|2",
                     },
                     Object {
                       "nodeId": "libgpg-error/libgpg-error0@1.26-2",
+                    },
+                    Object {
+                      "nodeId": "libselinux/libselinux1@2.6-3+b3",
                     },
                     Object {
                       "nodeId": "libsemanage/libsemanage-common@2.6-2",
@@ -112,9 +151,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw5@6.0+20161126-1+deb9u2|2",
@@ -141,6 +177,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.1.8-3.6",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-3",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.24.1-3+deb9u7",
+                    },
+                    Object {
                       "nodeId": "sed@4.4-1",
                     },
                     Object {
@@ -160,6 +202,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.88dsf-59.9",
+                    },
+                    Object {
+                      "nodeId": "tar@1.29b-1.1",
                     },
                     Object {
                       "nodeId": "tzdata@2020a-0+deb9u1",
@@ -191,9 +236,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.29.2-1+deb9u1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.2-1.2+b1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.8.dfsg-5",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|debian@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.52-3+b1",
+                  "pkgId": "acl/libacl1@2.2.52-3+b1",
                 },
                 Object {
                   "deps": Array [],
@@ -318,6 +374,21 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.47-2+b2",
+                  "pkgId": "attr/libattr1@1:2.4.47-2+b2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "audit/libaudit-common@1:2.6.7-2",
+                  "pkgId": "audit/libaudit-common@1:2.6.7-2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "audit/libaudit1@1:2.6.7-2",
+                  "pkgId": "audit/libaudit1@1:2.6.7-2",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "base-files@9.9+deb9u13|1",
                   "pkgId": "base-files@9.9+deb9u13",
                 },
@@ -402,8 +473,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-8.1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-8.1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.26-3",
                   "pkgId": "coreutils@8.26-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "debconf@1.5.61",
+                  "pkgId": "debconf@1.5.61",
                 },
                 Object {
                   "deps": Array [],
@@ -414,6 +495,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "diffutils@1:3.5-3",
                   "pkgId": "diffutils@1:3.5-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.18.25",
+                  "pkgId": "dpkg@1.18.25",
                 },
                 Object {
                   "deps": Array [],
@@ -616,8 +702,28 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-6/gcc-6-base@6.3.0-18+deb9u1",
+                  "pkgId": "gcc-6/gcc-6-base@6.3.0-18+deb9u1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-6/libgcc1@1:6.3.0-18+deb9u1",
+                  "pkgId": "gcc-6/libgcc1@1:6.3.0-18+deb9u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.24-11+deb9u4",
                   "pkgId": "glibc/libc-bin@2.24-11+deb9u4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.24-11+deb9u4",
+                  "pkgId": "glibc/libc6@2.24-11+deb9u4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/multiarch-support@2.24-11+deb9u4",
+                  "pkgId": "glibc/multiarch-support@2.24-11+deb9u4",
                 },
                 Object {
                   "deps": Array [],
@@ -715,6 +821,16 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "libcap-ng/libcap-ng0@0.7.7-3+b1",
+                  "pkgId": "libcap-ng/libcap-ng0@0.7.7-3+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libselinux/libselinux1@2.6-3+b3",
+                  "pkgId": "libselinux/libselinux1@2.6-3+b3",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "libsemanage/libsemanage-common@2.6-2",
                   "pkgId": "libsemanage/libsemanage-common@2.6-2",
                 },
@@ -747,156 +863,6 @@ Object {
                   "deps": Array [],
                   "nodeId": "lsb/lsb-base@9.20161125",
                   "pkgId": "lsb/lsb-base@9.20161125",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.52-3+b1",
-                  "pkgId": "acl/libacl1@2.2.52-3+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.47-2+b2",
-                  "pkgId": "attr/libattr1@1:2.4.47-2+b2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "audit/libaudit-common@1:2.6.7-2",
-                  "pkgId": "audit/libaudit-common@1:2.6.7-2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "audit/libaudit1@1:2.6.7-2",
-                  "pkgId": "audit/libaudit1@1:2.6.7-2",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-8.1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-8.1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.61",
-                  "pkgId": "debconf@1.5.61",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.18.25",
-                  "pkgId": "dpkg@1.18.25",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-6/gcc-6-base@6.3.0-18+deb9u1",
-                  "pkgId": "gcc-6/gcc-6-base@6.3.0-18+deb9u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-6/libgcc1@1:6.3.0-18+deb9u1",
-                  "pkgId": "gcc-6/libgcc1@1:6.3.0-18+deb9u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.24-11+deb9u4",
-                  "pkgId": "glibc/libc6@2.24-11+deb9u4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/multiarch-support@2.24-11+deb9u4",
-                  "pkgId": "glibc/multiarch-support@2.24-11+deb9u4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libcap-ng/libcap-ng0@0.7.7-3+b1",
-                  "pkgId": "libcap-ng/libcap-ng0@0.7.7-3+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "libselinux/libselinux1@2.6-3+b3",
-                  "pkgId": "libselinux/libselinux1@2.6-3+b3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-3",
-                  "pkgId": "pcre3/libpcre3@2:8.39-3",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.24.1-3+deb9u7",
-                  "pkgId": "perl/perl-base@5.24.1-3+deb9u7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.29b-1.1",
-                  "pkgId": "tar@1.29b-1.1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.2-1.2+b1",
-                  "pkgId": "xz-utils/liblzma5@5.2.2-1.2+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.8.dfsg-5",
-                  "pkgId": "zlib/zlib1g@1:1.2.8.dfsg-5",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.52-3+b1",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.47-2+b2",
-                    },
-                    Object {
-                      "nodeId": "audit/libaudit-common@1:2.6.7-2",
-                    },
-                    Object {
-                      "nodeId": "audit/libaudit1@1:2.6.7-2",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-8.1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.61",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.18.25",
-                    },
-                    Object {
-                      "nodeId": "gcc-6/gcc-6-base@6.3.0-18+deb9u1",
-                    },
-                    Object {
-                      "nodeId": "gcc-6/libgcc1@1:6.3.0-18+deb9u1",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.24-11+deb9u4",
-                    },
-                    Object {
-                      "nodeId": "glibc/multiarch-support@2.24-11+deb9u4",
-                    },
-                    Object {
-                      "nodeId": "libcap-ng/libcap-ng0@0.7.7-3+b1",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.6-3+b3",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-3",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.24.1-3+deb9u7",
-                    },
-                    Object {
-                      "nodeId": "tar@1.29b-1.1",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.2-1.2+b1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.8.dfsg-5",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
                 },
                 Object {
                   "deps": Array [],
@@ -962,6 +928,16 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-3",
+                  "pkgId": "pcre3/libpcre3@2:8.39-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.24.1-3+deb9u7",
+                  "pkgId": "perl/perl-base@5.24.1-3+deb9u7",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "sed@4.4-1",
                   "pkgId": "sed@4.4-1",
                 },
@@ -991,6 +967,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.88dsf-59.9",
                   "pkgId": "sysvinit/sysvinit-utils@2.88dsf-59.9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.29b-1.1",
+                  "pkgId": "tar@1.29b-1.1",
                 },
                 Object {
                   "deps": Array [],
@@ -1029,6 +1010,16 @@ Object {
                   "nodeId": "util-linux/mount@2.29.2-1+deb9u1",
                   "pkgId": "util-linux/mount@2.29.2-1+deb9u1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.2-1.2+b1",
+                  "pkgId": "xz-utils/liblzma5@5.2.2-1.2+b1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.8.dfsg-5",
+                  "pkgId": "zlib/zlib1g@1:1.2.8.dfsg-5",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -1046,6 +1037,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|debian",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.52-3+b1",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.52-3+b1",
                 },
               },
               Object {
@@ -1121,6 +1119,27 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.47-2+b2",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.47-2+b2",
+                },
+              },
+              Object {
+                "id": "audit/libaudit-common@1:2.6.7-2",
+                "info": Object {
+                  "name": "audit/libaudit-common",
+                  "version": "1:2.6.7-2",
+                },
+              },
+              Object {
+                "id": "audit/libaudit1@1:2.6.7-2",
+                "info": Object {
+                  "name": "audit/libaudit1",
+                  "version": "1:2.6.7-2",
+                },
+              },
+              Object {
                 "id": "base-files@9.9+deb9u13",
                 "info": Object {
                   "name": "base-files",
@@ -1185,11 +1204,25 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-8.1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-8.1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.26-3",
                 "info": Object {
                   "name": "coreutils",
                   "purl": "pkg:deb/coreutils@8.26-3",
                   "version": "8.26-3",
+                },
+              },
+              Object {
+                "id": "debconf@1.5.61",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.61",
                 },
               },
               Object {
@@ -1206,6 +1239,13 @@ Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.5-3",
                   "version": "1:3.5-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.18.25",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.18.25",
                 },
               },
               Object {
@@ -1329,10 +1369,38 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-6/gcc-6-base@6.3.0-18+deb9u1",
+                "info": Object {
+                  "name": "gcc-6/gcc-6-base",
+                  "version": "6.3.0-18+deb9u1",
+                },
+              },
+              Object {
+                "id": "gcc-6/libgcc1@1:6.3.0-18+deb9u1",
+                "info": Object {
+                  "name": "gcc-6/libgcc1",
+                  "version": "1:6.3.0-18+deb9u1",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.24-11+deb9u4",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.24-11%2Bdeb9u4?upstream=glibc",
+                  "version": "2.24-11+deb9u4",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.24-11+deb9u4",
+                "info": Object {
+                  "name": "glibc/libc6",
+                  "version": "2.24-11+deb9u4",
+                },
+              },
+              Object {
+                "id": "glibc/multiarch-support@2.24-11+deb9u4",
+                "info": Object {
+                  "name": "glibc/multiarch-support",
                   "version": "2.24-11+deb9u4",
                 },
               },
@@ -1441,6 +1509,20 @@ Object {
                 },
               },
               Object {
+                "id": "libcap-ng/libcap-ng0@0.7.7-3+b1",
+                "info": Object {
+                  "name": "libcap-ng/libcap-ng0",
+                  "version": "0.7.7-3+b1",
+                },
+              },
+              Object {
+                "id": "libselinux/libselinux1@2.6-3+b3",
+                "info": Object {
+                  "name": "libselinux/libselinux1",
+                  "version": "2.6-3+b3",
+                },
+              },
+              Object {
                 "id": "libsemanage/libsemanage-common@2.6-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
@@ -1470,139 +1552,6 @@ Object {
                   "name": "lsb/lsb-base",
                   "purl": "pkg:deb/lsb-base@9.20161125?upstream=lsb",
                   "version": "9.20161125",
-                },
-              },
-              Object {
-                "id": "acl/libacl1@2.2.52-3+b1",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.52-3+b1",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.47-2+b2",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.47-2+b2",
-                },
-              },
-              Object {
-                "id": "audit/libaudit-common@1:2.6.7-2",
-                "info": Object {
-                  "name": "audit/libaudit-common",
-                  "version": "1:2.6.7-2",
-                },
-              },
-              Object {
-                "id": "audit/libaudit1@1:2.6.7-2",
-                "info": Object {
-                  "name": "audit/libaudit1",
-                  "version": "1:2.6.7-2",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-8.1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-8.1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.61",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.61",
-                },
-              },
-              Object {
-                "id": "dpkg@1.18.25",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.18.25",
-                },
-              },
-              Object {
-                "id": "gcc-6/gcc-6-base@6.3.0-18+deb9u1",
-                "info": Object {
-                  "name": "gcc-6/gcc-6-base",
-                  "version": "6.3.0-18+deb9u1",
-                },
-              },
-              Object {
-                "id": "gcc-6/libgcc1@1:6.3.0-18+deb9u1",
-                "info": Object {
-                  "name": "gcc-6/libgcc1",
-                  "version": "1:6.3.0-18+deb9u1",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.24-11+deb9u4",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.24-11+deb9u4",
-                },
-              },
-              Object {
-                "id": "glibc/multiarch-support@2.24-11+deb9u4",
-                "info": Object {
-                  "name": "glibc/multiarch-support",
-                  "version": "2.24-11+deb9u4",
-                },
-              },
-              Object {
-                "id": "libcap-ng/libcap-ng0@0.7.7-3+b1",
-                "info": Object {
-                  "name": "libcap-ng/libcap-ng0",
-                  "version": "0.7.7-3+b1",
-                },
-              },
-              Object {
-                "id": "libselinux/libselinux1@2.6-3+b3",
-                "info": Object {
-                  "name": "libselinux/libselinux1",
-                  "version": "2.6-3+b3",
-                },
-              },
-              Object {
-                "id": "pcre3/libpcre3@2:8.39-3",
-                "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-3",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.24.1-3+deb9u7",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.24.1-3+deb9u7",
-                },
-              },
-              Object {
-                "id": "tar@1.29b-1.1",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.29b-1.1",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.2-1.2+b1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.2-1.2+b1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.8.dfsg-5",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.8.dfsg-5",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
                 },
               },
               Object {
@@ -1646,6 +1595,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-3",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-3",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.24.1-3+deb9u7",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.24.1-3+deb9u7",
+                },
+              },
+              Object {
                 "id": "sed@4.4-1",
                 "info": Object {
                   "name": "sed",
@@ -1667,6 +1630,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.88dsf-59.9?upstream=sysvinit",
                   "version": "2.88dsf-59.9",
+                },
+              },
+              Object {
+                "id": "tar@1.29b-1.1",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.29b-1.1",
                 },
               },
               Object {
@@ -1699,6 +1669,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.29.2-1%2Bdeb9u1?upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.2-1.2+b1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.2-1.2+b1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.8.dfsg-5",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.8.dfsg-5",
                 },
               },
             ],

--- a/test/system/package-managers/__snapshots__/deb.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/deb.spec.ts.snap
@@ -12,6 +12,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
                       "nodeId": "adduser@3.118|1",
                     },
                     Object {
@@ -19,6 +22,9 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.8.2.1|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
                     },
                     Object {
                       "nodeId": "audit/libaudit-common@1:2.8.4-3",
@@ -36,6 +42,9 @@ Object {
                       "nodeId": "bash@5.0-4",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.249",
                     },
                     Object {
@@ -48,6 +57,9 @@ Object {
                       "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2019.1",
                     },
                     Object {
@@ -55,6 +67,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.44.5-1+deb10u3",
@@ -72,10 +87,19 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20190209-2",
                     },
                     Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
                       "nodeId": "gcc-8/libstdc++6@8.3.0-6",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
                     },
                     Object {
                       "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
@@ -117,6 +141,9 @@ Object {
                       "nodeId": "libseccomp/libseccomp2@2.3.3-4",
                     },
                     Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
                       "nodeId": "libsemanage/libsemanage-common@2.8-2",
                     },
                     Object {
@@ -139,9 +166,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2|1",
@@ -177,6 +201,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.3.1-5|1",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                    },
+                    Object {
                       "nodeId": "sed@4.7-1",
                     },
                     Object {
@@ -193,6 +223,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
                     },
                     Object {
                       "nodeId": "tzdata@2020a-0+deb10u1",
@@ -224,9 +257,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.33.1-0.1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|debian@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
                 },
                 Object {
                   "deps": Array [],
@@ -621,6 +665,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "mawk/mawk@1.3.3-17+b3",
                   "pkgId": "mawk/mawk@1.3.3-17+b3",
                 },
@@ -679,6 +728,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.30-3",
                   "pkgId": "coreutils@8.30-3",
                 },
@@ -693,8 +747,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils@1:3.7-3",
                   "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
                 },
                 Object {
                   "deps": Array [],
@@ -767,8 +831,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.28-10",
                   "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
                 },
                 Object {
                   "deps": Array [],
@@ -792,121 +871,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.53-4",
-                  "pkgId": "acl/libacl1@2.2.53-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.48-4",
-                  "pkgId": "attr/libattr1@1:2.4.48-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.71",
-                  "pkgId": "debconf@1.5.71",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.19.7",
-                  "pkgId": "dpkg@1.19.7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.28-10",
-                  "pkgId": "glibc/libc6@2.28-10",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "libselinux/libselinux1@2.8-1+b1",
                   "pkgId": "libselinux/libselinux1@2.8-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-12",
-                  "pkgId": "pcre3/libpcre3@2:8.39-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
-                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.30+dfsg-6",
-                  "pkgId": "tar@1.30+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.53-4",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.48-4",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.71",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.19.7",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.28-10",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-12",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
-                    },
-                    Object {
-                      "nodeId": "tar@1.30+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
                 },
                 Object {
                   "deps": Array [],
@@ -949,6 +915,16 @@ Object {
                   "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.3.1-5|2",
                   "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
                 },
                 Object {
                   "deps": Array [],
@@ -1036,6 +1012,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.93-8",
                   "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1131,6 +1112,16 @@ Object {
                   "nodeId": "util-linux/mount@2.33.1-0.1",
                   "pkgId": "util-linux/mount@2.33.1-0.1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -1148,6 +1139,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|debian",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
                 },
               },
               Object {
@@ -1415,6 +1413,13 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
@@ -1471,6 +1476,13 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
@@ -1487,11 +1499,25 @@ Object {
                 },
               },
               Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
                 },
               },
               Object {
@@ -1551,10 +1577,31 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
                   "version": "2.28-10",
                 },
               },
@@ -1591,108 +1638,10 @@ Object {
                 },
               },
               Object {
-                "id": "acl/libacl1@2.2.53-4",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.53-4",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.48-4",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.48-4",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-9.2~deb10u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.71",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.71",
-                },
-              },
-              Object {
-                "id": "dpkg@1.19.7",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.19.7",
-                },
-              },
-              Object {
-                "id": "gcc-8/gcc-8-base@8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/gcc-8-base",
-                  "version": "8.3.0-6",
-                },
-              },
-              Object {
-                "id": "gcc-8/libgcc1@1:8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/libgcc1",
-                  "version": "1:8.3.0-6",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.28-10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.28-10",
-                },
-              },
-              Object {
                 "id": "libselinux/libselinux1@2.8-1+b1",
                 "info": Object {
                   "name": "libselinux/libselinux1",
                   "version": "2.8-1+b1",
-                },
-              },
-              Object {
-                "id": "pcre3/libpcre3@2:8.39-12",
-                "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-12",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.28.1-6+deb10u1",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.28.1-6+deb10u1",
-                },
-              },
-              Object {
-                "id": "tar@1.30+dfsg-6",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.30+dfsg-6",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.4-1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.4-1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.11.dfsg-1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
                 },
               },
               Object {
@@ -1728,6 +1677,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6+deb10u1",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6+deb10u1",
+                },
+              },
+              Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
@@ -1757,6 +1720,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
                 },
               },
               Object {
@@ -1813,6 +1783,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
                 },
               },
             ],

--- a/test/system/platforms/__snapshots__/amd.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/amd.spec.ts.snap
@@ -12,6 +12,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
                       "nodeId": "adduser@3.118|1",
                     },
                     Object {
@@ -19,6 +22,9 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.8.2.1|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
                     },
                     Object {
                       "nodeId": "audit/libaudit-common@1:2.8.4-3",
@@ -36,6 +42,9 @@ Object {
                       "nodeId": "bash@5.0-4",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.249",
                     },
                     Object {
@@ -48,6 +57,9 @@ Object {
                       "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2019.1",
                     },
                     Object {
@@ -55,6 +67,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.44.5-1+deb10u3",
@@ -72,10 +87,19 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20190209-2",
                     },
                     Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
                       "nodeId": "gcc-8/libstdc++6@8.3.0-6",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
                     },
                     Object {
                       "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
@@ -117,6 +141,9 @@ Object {
                       "nodeId": "libseccomp/libseccomp2@2.3.3-4",
                     },
                     Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
                       "nodeId": "libsemanage/libsemanage-common@2.8-2",
                     },
                     Object {
@@ -142,9 +169,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2|1",
@@ -183,6 +207,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.3.1-5|1",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                    },
+                    Object {
                       "nodeId": "sed@4.7-1",
                     },
                     Object {
@@ -199,6 +229,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
                     },
                     Object {
                       "nodeId": "tzdata@2020a-0+deb10u1",
@@ -230,9 +263,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.33.1-0.1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|redis@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
                 },
                 Object {
                   "deps": Array [],
@@ -627,6 +671,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "mawk/mawk@1.3.3-17+b3",
                   "pkgId": "mawk/mawk@1.3.3-17+b3",
                 },
@@ -685,6 +734,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.30-3",
                   "pkgId": "coreutils@8.30-3",
                 },
@@ -699,8 +753,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils@1:3.7-3",
                   "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
                 },
                 Object {
                   "deps": Array [],
@@ -773,8 +837,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.28-10",
                   "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
                 },
                 Object {
                   "deps": Array [],
@@ -798,126 +877,13 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "lsb/lsb-base@10.2019051400",
-                  "pkgId": "lsb/lsb-base@10.2019051400",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.53-4",
-                  "pkgId": "acl/libacl1@2.2.53-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.48-4",
-                  "pkgId": "attr/libattr1@1:2.4.48-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.71",
-                  "pkgId": "debconf@1.5.71",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.19.7",
-                  "pkgId": "dpkg@1.19.7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.28-10",
-                  "pkgId": "glibc/libc6@2.28-10",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "libselinux/libselinux1@2.8-1+b1",
                   "pkgId": "libselinux/libselinux1@2.8-1+b1",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-12",
-                  "pkgId": "pcre3/libpcre3@2:8.39-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
-                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.30+dfsg-6",
-                  "pkgId": "tar@1.30+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.53-4",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.48-4",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.71",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.19.7",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.28-10",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-12",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
-                    },
-                    Object {
-                      "nodeId": "tar@1.30+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
+                  "nodeId": "lsb/lsb-base@10.2019051400",
+                  "pkgId": "lsb/lsb-base@10.2019051400",
                 },
                 Object {
                   "deps": Array [],
@@ -965,6 +931,16 @@ Object {
                   "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.3.1-5|2",
                   "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
                 },
                 Object {
                   "deps": Array [],
@@ -1052,6 +1028,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.93-8",
                   "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1147,6 +1128,16 @@ Object {
                   "nodeId": "util-linux/mount@2.33.1-0.1",
                   "pkgId": "util-linux/mount@2.33.1-0.1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -1164,6 +1155,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|redis",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
                 },
               },
               Object {
@@ -1431,6 +1429,13 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
@@ -1487,6 +1492,13 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
@@ -1503,11 +1515,25 @@ Object {
                 },
               },
               Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
                 },
               },
               Object {
@@ -1567,10 +1593,31 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
                   "version": "2.28-10",
                 },
               },
@@ -1607,70 +1654,6 @@ Object {
                 },
               },
               Object {
-                "id": "lsb/lsb-base@10.2019051400",
-                "info": Object {
-                  "name": "lsb/lsb-base",
-                  "purl": "pkg:deb/lsb-base@10.2019051400?upstream=lsb",
-                  "version": "10.2019051400",
-                },
-              },
-              Object {
-                "id": "acl/libacl1@2.2.53-4",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.53-4",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.48-4",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.48-4",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-9.2~deb10u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.71",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.71",
-                },
-              },
-              Object {
-                "id": "dpkg@1.19.7",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.19.7",
-                },
-              },
-              Object {
-                "id": "gcc-8/gcc-8-base@8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/gcc-8-base",
-                  "version": "8.3.0-6",
-                },
-              },
-              Object {
-                "id": "gcc-8/libgcc1@1:8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/libgcc1",
-                  "version": "1:8.3.0-6",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.28-10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.28-10",
-                },
-              },
-              Object {
                 "id": "libselinux/libselinux1@2.8-1+b1",
                 "info": Object {
                   "name": "libselinux/libselinux1",
@@ -1678,45 +1661,11 @@ Object {
                 },
               },
               Object {
-                "id": "pcre3/libpcre3@2:8.39-12",
+                "id": "lsb/lsb-base@10.2019051400",
                 "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-12",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.28.1-6+deb10u1",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.28.1-6+deb10u1",
-                },
-              },
-              Object {
-                "id": "tar@1.30+dfsg-6",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.30+dfsg-6",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.4-1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.4-1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.11.dfsg-1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
+                  "name": "lsb/lsb-base",
+                  "purl": "pkg:deb/lsb-base@10.2019051400?upstream=lsb",
+                  "version": "10.2019051400",
                 },
               },
               Object {
@@ -1760,6 +1709,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6+deb10u1",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6+deb10u1",
+                },
+              },
+              Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
@@ -1789,6 +1752,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
                 },
               },
               Object {
@@ -1845,6 +1815,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
                 },
               },
             ],
@@ -1968,6 +1952,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
                       "nodeId": "adduser@3.118|1",
                     },
                     Object {
@@ -1975,6 +1962,9 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.8.2.1|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
                     },
                     Object {
                       "nodeId": "audit/libaudit-common@1:2.8.4-3",
@@ -1992,6 +1982,9 @@ Object {
                       "nodeId": "bash@5.0-4",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.249",
                     },
                     Object {
@@ -2004,6 +1997,9 @@ Object {
                       "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2019.1",
                     },
                     Object {
@@ -2011,6 +2007,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.44.5-1+deb10u3",
@@ -2028,10 +2027,19 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20190209-2",
                     },
                     Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
                       "nodeId": "gcc-8/libstdc++6@8.3.0-6",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
                     },
                     Object {
                       "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
@@ -2073,6 +2081,9 @@ Object {
                       "nodeId": "libseccomp/libseccomp2@2.3.3-4",
                     },
                     Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
                       "nodeId": "libsemanage/libsemanage-common@2.8-2",
                     },
                     Object {
@@ -2098,9 +2109,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u2|1",
@@ -2139,6 +2147,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.3.1-5|1",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                    },
+                    Object {
                       "nodeId": "sed@4.7-1",
                     },
                     Object {
@@ -2155,6 +2169,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
                     },
                     Object {
                       "nodeId": "tzdata@2020a-0+deb10u1",
@@ -2186,9 +2203,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.33.1-0.1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|redis@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
                 },
                 Object {
                   "deps": Array [],
@@ -2583,6 +2611,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "mawk/mawk@1.3.3-17+b3",
                   "pkgId": "mawk/mawk@1.3.3-17+b3",
                 },
@@ -2641,6 +2674,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.30-3",
                   "pkgId": "coreutils@8.30-3",
                 },
@@ -2655,8 +2693,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils@1:3.7-3",
                   "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
                 },
                 Object {
                   "deps": Array [],
@@ -2729,8 +2777,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.28-10",
                   "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
                 },
                 Object {
                   "deps": Array [],
@@ -2754,126 +2817,13 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "lsb/lsb-base@10.2019051400",
-                  "pkgId": "lsb/lsb-base@10.2019051400",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.53-4",
-                  "pkgId": "acl/libacl1@2.2.53-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.48-4",
-                  "pkgId": "attr/libattr1@1:2.4.48-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.71",
-                  "pkgId": "debconf@1.5.71",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.19.7",
-                  "pkgId": "dpkg@1.19.7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.28-10",
-                  "pkgId": "glibc/libc6@2.28-10",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "libselinux/libselinux1@2.8-1+b1",
                   "pkgId": "libselinux/libselinux1@2.8-1+b1",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-12",
-                  "pkgId": "pcre3/libpcre3@2:8.39-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
-                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.30+dfsg-6",
-                  "pkgId": "tar@1.30+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.53-4",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.48-4",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.71",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.19.7",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.28-10",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-12",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
-                    },
-                    Object {
-                      "nodeId": "tar@1.30+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
+                  "nodeId": "lsb/lsb-base@10.2019051400",
+                  "pkgId": "lsb/lsb-base@10.2019051400",
                 },
                 Object {
                   "deps": Array [],
@@ -2921,6 +2871,16 @@ Object {
                   "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.3.1-5|2",
                   "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6+deb10u1",
+                  "pkgId": "perl/perl-base@5.28.1-6+deb10u1",
                 },
                 Object {
                   "deps": Array [],
@@ -3008,6 +2968,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.93-8",
                   "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -3103,6 +3068,16 @@ Object {
                   "nodeId": "util-linux/mount@2.33.1-0.1",
                   "pkgId": "util-linux/mount@2.33.1-0.1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -3120,6 +3095,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|redis",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
                 },
               },
               Object {
@@ -3387,6 +3369,13 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
@@ -3443,6 +3432,13 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
@@ -3459,11 +3455,25 @@ Object {
                 },
               },
               Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
                 },
               },
               Object {
@@ -3523,10 +3533,31 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
                   "version": "2.28-10",
                 },
               },
@@ -3563,70 +3594,6 @@ Object {
                 },
               },
               Object {
-                "id": "lsb/lsb-base@10.2019051400",
-                "info": Object {
-                  "name": "lsb/lsb-base",
-                  "purl": "pkg:deb/lsb-base@10.2019051400?upstream=lsb",
-                  "version": "10.2019051400",
-                },
-              },
-              Object {
-                "id": "acl/libacl1@2.2.53-4",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.53-4",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.48-4",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.48-4",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-9.2~deb10u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.71",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.71",
-                },
-              },
-              Object {
-                "id": "dpkg@1.19.7",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.19.7",
-                },
-              },
-              Object {
-                "id": "gcc-8/gcc-8-base@8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/gcc-8-base",
-                  "version": "8.3.0-6",
-                },
-              },
-              Object {
-                "id": "gcc-8/libgcc1@1:8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/libgcc1",
-                  "version": "1:8.3.0-6",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.28-10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.28-10",
-                },
-              },
-              Object {
                 "id": "libselinux/libselinux1@2.8-1+b1",
                 "info": Object {
                   "name": "libselinux/libselinux1",
@@ -3634,45 +3601,11 @@ Object {
                 },
               },
               Object {
-                "id": "pcre3/libpcre3@2:8.39-12",
+                "id": "lsb/lsb-base@10.2019051400",
                 "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-12",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.28.1-6+deb10u1",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.28.1-6+deb10u1",
-                },
-              },
-              Object {
-                "id": "tar@1.30+dfsg-6",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.30+dfsg-6",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.4-1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.4-1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.11.dfsg-1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
+                  "name": "lsb/lsb-base",
+                  "purl": "pkg:deb/lsb-base@10.2019051400?upstream=lsb",
+                  "version": "10.2019051400",
                 },
               },
               Object {
@@ -3716,6 +3649,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6+deb10u1",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6+deb10u1",
+                },
+              },
+              Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
@@ -3745,6 +3692,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
                 },
               },
               Object {
@@ -3801,6 +3755,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
                 },
               },
             ],

--- a/test/system/platforms/__snapshots__/arm.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/arm.spec.ts.snap
@@ -87,7 +87,7 @@ Object {
                       "nodeId": "libxslt/libxslt@1.1.34-r0|1",
                     },
                     Object {
-                      "nodeId": "meta-common-packages@meta",
+                      "nodeId": "musl/musl@1.1.24-r9",
                     },
                     Object {
                       "nodeId": "musl/musl-utils@1.1.24-r8|2",
@@ -504,15 +504,6 @@ Object {
                   "pkgId": "musl/musl@1.1.24-r9",
                 },
                 Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "musl/musl@1.1.24-r9",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
-                },
-                Object {
                   "deps": Array [],
                   "nodeId": "pax-utils/scanelf@1.2.6-r0",
                   "pkgId": "pax-utils/scanelf@1.2.6-r0",
@@ -872,13 +863,6 @@ Object {
                 "info": Object {
                   "name": "musl/musl",
                   "version": "1.1.24-r9",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
                 },
               },
               Object {

--- a/test/system/red-hat-repositories/__snapshots__/red-hat-repositories.spec.ts.snap
+++ b/test/system/red-hat-repositories/__snapshots__/red-hat-repositories.spec.ts.snap
@@ -12,6 +12,9 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "acl/libacl1@2.2.53-4",
+                    },
+                    Object {
                       "nodeId": "adduser@3.118|1",
                     },
                     Object {
@@ -19,6 +22,9 @@ Object {
                     },
                     Object {
                       "nodeId": "apt/libapt-pkg5.0@1.8.2|2",
+                    },
+                    Object {
+                      "nodeId": "attr/libattr1@1:2.4.48-4",
                     },
                     Object {
                       "nodeId": "audit/libaudit-common@1:2.8.4-3",
@@ -36,6 +42,9 @@ Object {
                       "nodeId": "bash@5.0-4",
                     },
                     Object {
+                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                    },
+                    Object {
                       "nodeId": "cdebconf/libdebconfclient0@0.249",
                     },
                     Object {
@@ -48,6 +57,9 @@ Object {
                       "nodeId": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                     },
                     Object {
+                      "nodeId": "debconf@1.5.71",
+                    },
+                    Object {
                       "nodeId": "debian-archive-keyring@2019.1",
                     },
                     Object {
@@ -55,6 +67,9 @@ Object {
                     },
                     Object {
                       "nodeId": "diffutils@1:3.7-3",
+                    },
+                    Object {
+                      "nodeId": "dpkg@1.19.7",
                     },
                     Object {
                       "nodeId": "e2fsprogs@1.44.5-1+deb10u1",
@@ -72,10 +87,19 @@ Object {
                       "nodeId": "findutils@4.6.0+git+20190209-2",
                     },
                     Object {
+                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                    },
+                    Object {
+                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                    },
+                    Object {
                       "nodeId": "gcc-8/libstdc++6@8.3.0-6",
                     },
                     Object {
                       "nodeId": "glibc/libc-bin@2.28-10",
+                    },
+                    Object {
+                      "nodeId": "glibc/libc6@2.28-10",
                     },
                     Object {
                       "nodeId": "gmp/libgmp10@2:6.1.2+dfsg-4",
@@ -117,6 +141,9 @@ Object {
                       "nodeId": "libseccomp/libseccomp2@2.3.3-4",
                     },
                     Object {
+                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
+                    },
+                    Object {
                       "nodeId": "libsemanage/libsemanage-common@2.8-2",
                     },
                     Object {
@@ -139,9 +166,6 @@ Object {
                     },
                     Object {
                       "nodeId": "mawk/mawk@1.3.3-17+b3",
-                    },
-                    Object {
-                      "nodeId": "meta-common-packages@meta",
                     },
                     Object {
                       "nodeId": "ncurses/libncursesw6@6.1+20181013-2+deb10u1|1",
@@ -177,6 +201,12 @@ Object {
                       "nodeId": "pam/libpam0g@1.3.1-5|1",
                     },
                     Object {
+                      "nodeId": "pcre3/libpcre3@2:8.39-12",
+                    },
+                    Object {
+                      "nodeId": "perl/perl-base@5.28.1-6",
+                    },
+                    Object {
                       "nodeId": "sed@4.7-1",
                     },
                     Object {
@@ -193,6 +223,9 @@ Object {
                     },
                     Object {
                       "nodeId": "sysvinit/sysvinit-utils@2.93-8",
+                    },
+                    Object {
+                      "nodeId": "tar@1.30+dfsg-6",
                     },
                     Object {
                       "nodeId": "tzdata@2019b-0+deb10u1",
@@ -224,9 +257,20 @@ Object {
                     Object {
                       "nodeId": "util-linux/mount@2.33.1-0.1",
                     },
+                    Object {
+                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                    },
+                    Object {
+                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "docker-image|nginx-with-buildinfo.tar@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "acl/libacl1@2.2.53-4",
+                  "pkgId": "acl/libacl1@2.2.53-4",
                 },
                 Object {
                   "deps": Array [],
@@ -621,6 +665,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "attr/libattr1@1:2.4.48-4",
+                  "pkgId": "attr/libattr1@1:2.4.48-4",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "mawk/mawk@1.3.3-17+b3",
                   "pkgId": "mawk/mawk@1.3.3-17+b3",
                 },
@@ -679,6 +728,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "coreutils@8.30-3",
                   "pkgId": "coreutils@8.30-3",
                 },
@@ -693,8 +747,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "debconf@1.5.71",
+                  "pkgId": "debconf@1.5.71",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "diffutils@1:3.7-3",
                   "pkgId": "diffutils@1:3.7-3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dpkg@1.19.7",
+                  "pkgId": "dpkg@1.19.7",
                 },
                 Object {
                   "deps": Array [],
@@ -767,8 +831,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
+                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
+                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "glibc/libc-bin@2.28-10",
                   "pkgId": "glibc/libc-bin@2.28-10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc/libc6@2.28-10",
+                  "pkgId": "glibc/libc6@2.28-10",
                 },
                 Object {
                   "deps": Array [],
@@ -792,121 +871,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "acl/libacl1@2.2.53-4",
-                  "pkgId": "acl/libacl1@2.2.53-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "attr/libattr1@1:2.4.48-4",
-                  "pkgId": "attr/libattr1@1:2.4.48-4",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                  "pkgId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "debconf@1.5.71",
-                  "pkgId": "debconf@1.5.71",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "dpkg@1.19.7",
-                  "pkgId": "dpkg@1.19.7",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                  "pkgId": "gcc-8/gcc-8-base@8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                  "pkgId": "gcc-8/libgcc1@1:8.3.0-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "glibc/libc6@2.28-10",
-                  "pkgId": "glibc/libc6@2.28-10",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "libselinux/libselinux1@2.8-1+b1",
                   "pkgId": "libselinux/libselinux1@2.8-1+b1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "pcre3/libpcre3@2:8.39-12",
-                  "pkgId": "pcre3/libpcre3@2:8.39-12",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "perl/perl-base@5.28.1-6",
-                  "pkgId": "perl/perl-base@5.28.1-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "tar@1.30+dfsg-6",
-                  "pkgId": "tar@1.30+dfsg-6",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                },
-                Object {
-                  "deps": Array [
-                    Object {
-                      "nodeId": "acl/libacl1@2.2.53-4",
-                    },
-                    Object {
-                      "nodeId": "attr/libattr1@1:2.4.48-4",
-                    },
-                    Object {
-                      "nodeId": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                    },
-                    Object {
-                      "nodeId": "debconf@1.5.71",
-                    },
-                    Object {
-                      "nodeId": "dpkg@1.19.7",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/gcc-8-base@8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "gcc-8/libgcc1@1:8.3.0-6",
-                    },
-                    Object {
-                      "nodeId": "glibc/libc6@2.28-10",
-                    },
-                    Object {
-                      "nodeId": "libselinux/libselinux1@2.8-1+b1",
-                    },
-                    Object {
-                      "nodeId": "pcre3/libpcre3@2:8.39-12",
-                    },
-                    Object {
-                      "nodeId": "perl/perl-base@5.28.1-6",
-                    },
-                    Object {
-                      "nodeId": "tar@1.30+dfsg-6",
-                    },
-                    Object {
-                      "nodeId": "xz-utils/liblzma5@5.2.4-1",
-                    },
-                    Object {
-                      "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                    },
-                  ],
-                  "nodeId": "meta-common-packages@meta",
-                  "pkgId": "meta-common-packages@meta",
                 },
                 Object {
                   "deps": Array [],
@@ -949,6 +915,16 @@ Object {
                   "deps": Array [],
                   "nodeId": "pam/libpam-runtime@1.3.1-5|2",
                   "pkgId": "pam/libpam-runtime@1.3.1-5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre3/libpcre3@2:8.39-12",
+                  "pkgId": "pcre3/libpcre3@2:8.39-12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "perl/perl-base@5.28.1-6",
+                  "pkgId": "perl/perl-base@5.28.1-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1036,6 +1012,11 @@ Object {
                   ],
                   "nodeId": "sysvinit/sysvinit-utils@2.93-8",
                   "pkgId": "sysvinit/sysvinit-utils@2.93-8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tar@1.30+dfsg-6",
+                  "pkgId": "tar@1.30+dfsg-6",
                 },
                 Object {
                   "deps": Array [],
@@ -1131,6 +1112,16 @@ Object {
                   "nodeId": "util-linux/mount@2.33.1-0.1",
                   "pkgId": "util-linux/mount@2.33.1-0.1",
                 },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xz-utils/liblzma5@5.2.4-1",
+                  "pkgId": "xz-utils/liblzma5@5.2.4-1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                  "pkgId": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                },
               ],
               "rootNodeId": "root-node",
             },
@@ -1148,6 +1139,13 @@ Object {
                 "info": Object {
                   "name": "docker-image|nginx-with-buildinfo.tar",
                   "version": undefined,
+                },
+              },
+              Object {
+                "id": "acl/libacl1@2.2.53-4",
+                "info": Object {
+                  "name": "acl/libacl1",
+                  "version": "2.2.53-4",
                 },
               },
               Object {
@@ -1415,6 +1413,13 @@ Object {
                 },
               },
               Object {
+                "id": "attr/libattr1@1:2.4.48-4",
+                "info": Object {
+                  "name": "attr/libattr1",
+                  "version": "1:2.4.48-4",
+                },
+              },
+              Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
@@ -1471,6 +1476,13 @@ Object {
                 },
               },
               Object {
+                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
+                "info": Object {
+                  "name": "bzip2/libbz2-1.0",
+                  "version": "1.0.6-9.2~deb10u1",
+                },
+              },
+              Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
@@ -1487,11 +1499,25 @@ Object {
                 },
               },
               Object {
+                "id": "debconf@1.5.71",
+                "info": Object {
+                  "name": "debconf",
+                  "version": "1.5.71",
+                },
+              },
+              Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
                   "purl": "pkg:deb/diffutils@1:3.7-3",
                   "version": "1:3.7-3",
+                },
+              },
+              Object {
+                "id": "dpkg@1.19.7",
+                "info": Object {
+                  "name": "dpkg",
+                  "version": "1.19.7",
                 },
               },
               Object {
@@ -1551,10 +1577,31 @@ Object {
                 },
               },
               Object {
+                "id": "gcc-8/gcc-8-base@8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/gcc-8-base",
+                  "version": "8.3.0-6",
+                },
+              },
+              Object {
+                "id": "gcc-8/libgcc1@1:8.3.0-6",
+                "info": Object {
+                  "name": "gcc-8/libgcc1",
+                  "version": "1:8.3.0-6",
+                },
+              },
+              Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
                   "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "version": "2.28-10",
+                },
+              },
+              Object {
+                "id": "glibc/libc6@2.28-10",
+                "info": Object {
+                  "name": "glibc/libc6",
                   "version": "2.28-10",
                 },
               },
@@ -1591,108 +1638,10 @@ Object {
                 },
               },
               Object {
-                "id": "acl/libacl1@2.2.53-4",
-                "info": Object {
-                  "name": "acl/libacl1",
-                  "version": "2.2.53-4",
-                },
-              },
-              Object {
-                "id": "attr/libattr1@1:2.4.48-4",
-                "info": Object {
-                  "name": "attr/libattr1",
-                  "version": "1:2.4.48-4",
-                },
-              },
-              Object {
-                "id": "bzip2/libbz2-1.0@1.0.6-9.2~deb10u1",
-                "info": Object {
-                  "name": "bzip2/libbz2-1.0",
-                  "version": "1.0.6-9.2~deb10u1",
-                },
-              },
-              Object {
-                "id": "debconf@1.5.71",
-                "info": Object {
-                  "name": "debconf",
-                  "version": "1.5.71",
-                },
-              },
-              Object {
-                "id": "dpkg@1.19.7",
-                "info": Object {
-                  "name": "dpkg",
-                  "version": "1.19.7",
-                },
-              },
-              Object {
-                "id": "gcc-8/gcc-8-base@8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/gcc-8-base",
-                  "version": "8.3.0-6",
-                },
-              },
-              Object {
-                "id": "gcc-8/libgcc1@1:8.3.0-6",
-                "info": Object {
-                  "name": "gcc-8/libgcc1",
-                  "version": "1:8.3.0-6",
-                },
-              },
-              Object {
-                "id": "glibc/libc6@2.28-10",
-                "info": Object {
-                  "name": "glibc/libc6",
-                  "version": "2.28-10",
-                },
-              },
-              Object {
                 "id": "libselinux/libselinux1@2.8-1+b1",
                 "info": Object {
                   "name": "libselinux/libselinux1",
                   "version": "2.8-1+b1",
-                },
-              },
-              Object {
-                "id": "pcre3/libpcre3@2:8.39-12",
-                "info": Object {
-                  "name": "pcre3/libpcre3",
-                  "version": "2:8.39-12",
-                },
-              },
-              Object {
-                "id": "perl/perl-base@5.28.1-6",
-                "info": Object {
-                  "name": "perl/perl-base",
-                  "version": "5.28.1-6",
-                },
-              },
-              Object {
-                "id": "tar@1.30+dfsg-6",
-                "info": Object {
-                  "name": "tar",
-                  "version": "1.30+dfsg-6",
-                },
-              },
-              Object {
-                "id": "xz-utils/liblzma5@5.2.4-1",
-                "info": Object {
-                  "name": "xz-utils/liblzma5",
-                  "version": "5.2.4-1",
-                },
-              },
-              Object {
-                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
-                "info": Object {
-                  "name": "zlib/zlib1g",
-                  "version": "1:1.2.11.dfsg-1",
-                },
-              },
-              Object {
-                "id": "meta-common-packages@meta",
-                "info": Object {
-                  "name": "meta-common-packages",
-                  "version": "meta",
                 },
               },
               Object {
@@ -1728,6 +1677,20 @@ Object {
                 },
               },
               Object {
+                "id": "pcre3/libpcre3@2:8.39-12",
+                "info": Object {
+                  "name": "pcre3/libpcre3",
+                  "version": "2:8.39-12",
+                },
+              },
+              Object {
+                "id": "perl/perl-base@5.28.1-6",
+                "info": Object {
+                  "name": "perl/perl-base",
+                  "version": "5.28.1-6",
+                },
+              },
+              Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
@@ -1757,6 +1720,13 @@ Object {
                   "name": "sysvinit/sysvinit-utils",
                   "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
                   "version": "2.93-8",
+                },
+              },
+              Object {
+                "id": "tar@1.30+dfsg-6",
+                "info": Object {
+                  "name": "tar",
+                  "version": "1.30+dfsg-6",
                 },
               },
               Object {
@@ -1813,6 +1783,20 @@ Object {
                   "name": "util-linux/mount",
                   "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
                   "version": "2.33.1-0.1",
+                },
+              },
+              Object {
+                "id": "xz-utils/liblzma5@5.2.4-1",
+                "info": Object {
+                  "name": "xz-utils/liblzma5",
+                  "version": "5.2.4-1",
+                },
+              },
+              Object {
+                "id": "zlib/zlib1g@1:1.2.11.dfsg-1",
+                "info": Object {
+                  "name": "zlib/zlib1g",
+                  "version": "1:1.2.11.dfsg-1",
                 },
               },
             ],


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Frequently found dependencies can cause many upgrade paths to be generated which creates a bad UX when issue grouping is applied in the UI. Grouping these packages under a "fake" package, `meta-common-packages` solved this but broke the upgradable logic for Linux package managers, which need direct dependencies to be upgradable.

This commit attaches frequently found dependencies directly to the tree root for Linux package managers so the upgrade path shows the package as a direct dependency and becomes upgradable.

> Updated test snapshots to take account of `meta-common-packages` package no longer being present in scan results.


#### What are the relevant tickets?
[SUP-1367](https://snyksec.atlassian.net/browse/SUP-1637)

#### Screenshots
<img width="1429" alt="Screenshot 2023-07-21 at 17 52 03" src="https://github.com/snyk/snyk-docker-plugin/assets/92033541/bb42c5f0-a750-495e-afb5-ed7657918856">




[SUP-1367]: https://snyksec.atlassian.net/browse/SUP-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ