### PR TITLE
fix: nodejs binary wrongfully identified as dpkg

### DIFF
--- a/lib/inputs/distroless/static.ts
+++ b/lib/inputs/distroless/static.ts
@@ -16,6 +16,12 @@ export function getAptFiles(extractedLayers: ExtractedLayers): string[] {
     if (!("dpkg" in extractedLayers[fileName])) {
       continue;
     }
+    // when the nodejs distroless image is build, the metadata is added to status.d
+    // this causes us to wronfgully identify nodejs as deb package
+    // https://github.com/GoogleContainerTools/distroless/blob/main/private/remote/node_archive.bzl#L29
+    if (fileName === "/var/lib/dpkg/status.d/nodejs") {
+      continue;
+    }
     files.push(extractedLayers[fileName].dpkg.toString("utf8"));
   }
 

--- a/test/system/static.test.ts
+++ b/test/system/static.test.ts
@@ -182,6 +182,33 @@ test("static analysis for distroless base-debian9", async (t) => {
   );
 });
 
+test("static analysis for distroless node image", async (t) => {
+  // 70b8c7f2d41a844d310c23e0695388c916a364ed was "latest" at the time of writing
+  const imageNameAndTag =
+    "gcr.io/distroless/nodejs20-debian11@sha256:ca5777fb7a45d6d19d9992a5517a2ad24ddd9844f0225e45b7151ede5ffc5de0";
+
+  const pluginResult = await plugin.scan({
+    path: imageNameAndTag,
+  });
+
+  const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
+    (fact) => fact.type === "depGraph",
+  )!.data;
+
+  const depGraphDepPkgs = depGraph.getDepPkgs();
+  t.ok(
+    depGraphDepPkgs.find((pkg) => pkg.name === "nodejs") === undefined,
+    "nodejs excluded from depGraph",
+  );
+  const binaryHashes = pluginResult.scanResults[0].facts.find(
+    (fact) => fact.type === "keyBinariesHashes",
+  );
+  t.ok(
+    binaryHashes?.data[0] ===
+      "570d27c6967c93217483c0a523b51ccf40f7bfb3af7140634e4cad0fdfea6ca1",
+  );
+});
+
 test("manifest files are detected", async (t) => {
   const imageNameAndTag = "debian:10";
   const manifestGlobs = [


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

In distroless node images, a nodejs binary copied into the image is also included in /var/lib/dpkg/status.d/
which results in adding this binary to the dependnecy graph vulnerability data for the binary and dpkg is different to avoid false positives, this removes it from the graph.

 https://github.com/GoogleContainerTools/distroless/blob/main/private/remote/node_archive.bzl#L29

#### Where should the reviewer start?

The added test describes the expected output, where `nodejs` should not be included in the graph, but only in the `keyBinaryHashes` fact.

