### PR TITLE
fix: correctly handle tag and digest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules/
 .idea/
+.run/
 bin/
 npm-debug.log
 dist/

--- a/test/lib/analyzer/image-inspector.spec.ts
+++ b/test/lib/analyzer/image-inspector.spec.ts
@@ -40,11 +40,6 @@ describe("extractImageDetails", () => {
       imageName: "library/nginx",
       tag: "1.18",
     }}
-    ${"nginx:1.18"} | ${{
-      hostname: "registry-1.docker.io",
-      imageName: "library/nginx",
-      tag: "1.18",
-    }}
     ${"calico/cni:release-v3.14"} | ${{
       hostname: "registry-1.docker.io",
       imageName: "calico/cni",
@@ -71,6 +66,11 @@ describe("extractImageDetails", () => {
       tag: "sha256:8756a25c4c5e902c4fe20322cc69d510a0517b51eab630c614efbd612ed568bf",
     }}
     ${"localhost:1234/foo/bar@sha256:8756a25c4c5e902c4fe20322cc69d510a0517b51eab630c614efbd612ed568bf"} | ${{
+      hostname: "localhost:1234",
+      imageName: "foo/bar",
+      tag: "sha256:8756a25c4c5e902c4fe20322cc69d510a0517b51eab630c614efbd612ed568bf",
+    }}
+    ${"localhost:1234/foo/bar:alpine3.15@sha256:8756a25c4c5e902c4fe20322cc69d510a0517b51eab630c614efbd612ed568bf"} | ${{
       hostname: "localhost:1234",
       imageName: "foo/bar",
       tag: "sha256:8756a25c4c5e902c4fe20322cc69d510a0517b51eab630c614efbd612ed568bf",


### PR DESCRIPTION
#### What does this PR do?

Fixes the case when the docker daemon is unavailable, and both the image digest and tag are present.

#### Where should the reviewer start?

The reviewer can start with the newly added unit test to better understand the issue.


#### Any background context you want to provide?

Snyk container scanning fails when the docker daemon is unavailable, and both the image tag and digest are passed. This is because of a bug in the code that extracts the image repository from the provided target image argument.
