### PR TITLE
fix: remove tap windows tests step [LUM-739]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,21 +142,11 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.23
       - attach_workspace:
           at: ~/snyk-docker-plugin
       - run: npm test
-  test_windows:
-    <<: *windows_defaults
-    steps:
-      - checkout
-      - install_node_npm:
-          node_version: << parameters.node_version >>
-      - run:
-          name: Use snyk-main npmjs user
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-      - run: npm ci
-      - run: npm run test-windows
   test_jest:
     <<: *defaults
     resource_class: medium
@@ -302,17 +292,6 @@ workflows:
             - Build
           post-steps:
             - *slack-fail-notify
-      - test_windows:
-          name: Test Windows
-          context:
-            - nodejs-install
-            - team-lumos
-            - snyk-bot-slack
-          node_version: "12"
-          requires:
-            - Build
-          post-steps:
-            - *slack-fail-notify
       - test_jest_windows_with_docker:
           name: Test Jest Windows with Docker
           context:
@@ -361,7 +340,6 @@ workflows:
             - Scan Code
             - Scan Dependencies
             - Test
-            - Test Windows
             - Test Jest Windows with Docker
             - Test Jest Windows no Docker
           post-steps:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "format": "prettier --loglevel warn --write '{lib,test}/**/*.ts' && tslint --fix --format stylish '{lib,test}/**/*.ts'",
     "test": "npm run unit-test && npm run test-jest",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage",
-    "test-windows": "tap test/windows/**/*.test.ts -R=spec --timeout=300",
     "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
     "unit-test": "tap test/**/*.test.ts -R=spec --timeout=300",
     "prepare": "npm run build"


### PR DESCRIPTION
Tests are unstable and failing with timeouts. Will remove the step and migrate the tests to jest in follow PR

- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Tap windows tests are unstable and failing with timeouts and blocking the pipeline. Will remove the step and migrate the tests to jest in follow PR.

- Also added fix version to `setup_remote_docker` as the new version pulled (`24.0.6`) causing one test to fail.