### PR TITLE
feat: add "parse dockerfile" functionality

### DIFF
--- a/lib/dockerfile/index.ts
+++ b/lib/dockerfile/index.ts
@@ -1,4 +1,4 @@
-import { DockerfileParser } from "dockerfile-ast";
+import { Dockerfile, DockerfileParser } from "dockerfile-ast";
 import * as fs from "fs";
 import { normalize as normalizePath } from "path";
 import {
@@ -18,6 +18,7 @@ export {
   getDockerfileBaseImageName,
   updateDockerfileBaseImageName,
   DockerFileAnalysis,
+  parseDockerfile,
 };
 
 async function readDockerfileAndAnalyse(
@@ -52,4 +53,8 @@ async function readFile(path: string) {
       return err ? reject(err) : resolve(data);
     });
   }) as Promise<string>;
+}
+
+function parseDockerfile(content: string): Dockerfile {
+  return DockerfileParser.parse(content);
 }

--- a/test/lib/dockerfile.spec.ts
+++ b/test/lib/dockerfile.spec.ts
@@ -1,5 +1,7 @@
-import exp from "constants";
+import { DockerfileParser } from "dockerfile-ast";
+import { Dockerfile } from "dockerfile-ast/lib/dockerfile";
 import * as path from "path";
+import { parseDockerfile } from "../../lib/dockerfile";
 
 import * as dockerFile from "../../lib/dockerfile";
 import {
@@ -266,5 +268,25 @@ describe("readDockerfileAndAnalyse() correctly parses...", () => {
         expected.dockerfileLayers[digest],
       );
     });
+  });
+});
+
+describe("parseDockerfile()", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("returns undefined when Dockerfile is not supplied", async () => {
+    const dockerfileContent: string = "some dockerfile content";
+
+    const expectedParsedDockerfile: jest.Mocked<Dockerfile> =
+      jest.mocked(Dockerfile);
+    jest
+      .spyOn(DockerfileParser, "parse")
+      .mockImplementation(() => expectedParsedDockerfile);
+
+    const result = parseDockerfile(dockerfileContent);
+
+    expect(result).toEqual(expectedParsedDockerfile);
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Add "parse dockerfile" functionality.
This functionality should allow clients of `snyk-docker-plugin` to not consume `dockerfile-ast` dep (i.e. `docker-deps`).