### PR TITLE
fix: resets last base image in multistage build when not resolveable

### DIFF
--- a/lib/dockerfile/instruction-parser.ts
+++ b/lib/dockerfile/instruction-parser.ts
@@ -174,19 +174,37 @@ function getDockerfileBaseImageName(
         UnresolvedDockerfileVariableHandling.Abort,
         fromName,
       );
+
       const hasUnresolvedVariables =
         expandedName.split(":").some((name) => !name) ||
         expandedName.split("@").some((name) => !name);
-      // store the resolved stage name
-      if (!hasUnresolvedVariables) {
-        stagesNames.last = stagesNames.aliases[expandedName] || expandedName;
-      }
+
       if (args.length > 2 && args[1].getValue().toUpperCase() === "AS") {
         // the AS alias name
         const aliasName = args[2].getValue();
         // support nested referral
-        stagesNames.aliases[aliasName] = stagesNames.last;
+        if (!expandedName) {
+          stagesNames.aliases[aliasName] = null;
+        } else {
+          stagesNames.aliases[aliasName] =
+            stagesNames.aliases[expandedName] || expandedName;
+        }
       }
+
+      const hasUnresolvedAlias =
+        Object.keys(stagesNames.aliases).includes(expandedName) &&
+        !stagesNames.aliases[expandedName];
+
+      if (expandedName === "" || hasUnresolvedVariables || hasUnresolvedAlias) {
+        return {
+          ...stagesNames,
+          last: undefined,
+        };
+      }
+
+      // store the resolved stage name
+      stagesNames.last = stagesNames.aliases[expandedName] || expandedName;
+
       return stagesNames;
     },
     { last: undefined, aliases: {} },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
When parsing a multistage Dockerfile the last resolved base image was not getting "reset" when a subsequent stage is not resolvable; this results in an incorrect base image being returned.

#### Where should the reviewer start?
The added test cases show examples of Dockerfiles that were previously being incorrectly parsed. We previously tested that non resolvable args were handled but we had no tests to check multi-stage builds where some stages were resolvable and some not. There was also a bug with aliases and not checking that an alias of alias was resolvable.

We now look for unresolved variables in the stage, then look for and attempt to resolve any aliases, and "reset" the last known stage if any of the above checks result in an unresolvable base image name for the stage. We only save the base image name after all checks are complete.

```
ARG runtime
FROM ubuntu
FROM ${runtime}
```

The above Dockerfile previously reported the base image as `ubuntu`, as that was the last resolvable stage, it now fails with the error code `BASE_IMAGE_NON_RESOLVABLE`. The logic has been updated to "reset" the base image on any stage that is no-resolvable. The base image will only be returned if the final stage is fully resolvable.


#### Any background context you want to provide?

Reported to us via #ask-lumos: https://snyk.slack.com/archives/C04HJ3ZD0UC/p1696494324311409


#### What are the relevant tickets?

See Ticket [https://snyksec.atlassian.net/browse/LUM-698](https://snyksec.atlassian.net/browse/LUM-698)
