### PR TITLE
fix: remove empty catch statements [LUM-746]

### DIFF
--- a/test/system/app-os/globs.spec.ts
+++ b/test/system/app-os/globs.spec.ts
@@ -7,7 +7,9 @@ describe("find globs tests", () => {
       "image",
       "rm",
       "debian@sha256:f520e4a80b736389c3de162b8f60608d11c9fa3b2ec619bd40aabfd7e70d3455",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly return manifest files when detected by globs", async () => {

--- a/test/system/bugs/image-layers.spec.ts
+++ b/test/system/bugs/image-layers.spec.ts
@@ -11,7 +11,9 @@ describe("demonstrates a potential bug with image layers", () => {
       "image",
       "rm",
       "debian:stable-20200803-slim",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   /** This bug potentially lies in the pull library. */

--- a/test/system/operating-systems/alpine3.7.spec.ts
+++ b/test/system/operating-systems/alpine3.7.spec.ts
@@ -4,14 +4,14 @@ import { execute } from "../../../lib/sub-process";
 describe("alpine tests", () => {
   afterAll(async () => {
     await execute("docker", ["image", "rm", "alpine:3.7.3"]).catch(() => {
-      /* no-op */
+      console.error(`tests teardown failed to remove docker image`);
     });
     await execute("docker", [
       "image",
       "rm",
       "alpine@sha256:92251458088c638061cda8fd8b403b76d661a4dc6b7ee71b6affcf1872557b2b",
     ]).catch(() => {
-      /* no-op */
+      console.error(`tests teardown failed to remove docker image`);
     });
   });
 

--- a/test/system/operating-systems/busybox1.32.spec.ts
+++ b/test/system/operating-systems/busybox1.32.spec.ts
@@ -7,7 +7,9 @@ describe("busybox tests", () => {
       "image",
       "rm",
       "busybox@sha256:32dc7202280d641c9c0d94a13247195adc83dba83aca0eed383888c01311cfc2",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze a busybox image by sha256", async () => {

--- a/test/system/operating-systems/centos6.spec.ts
+++ b/test/system/operating-systems/centos6.spec.ts
@@ -7,7 +7,9 @@ describe("CentOS 7 tests", () => {
       "image",
       "rm",
       "dokken/centos-6@sha256:494b9b280814f1e661597b48e229156e4dccb60dce198d9210f7572ff22626d2",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("can scan a centos6-based image", async () => {

--- a/test/system/operating-systems/centos7.spec.ts
+++ b/test/system/operating-systems/centos7.spec.ts
@@ -4,14 +4,14 @@ import { execute } from "../../../lib/sub-process";
 describe("centos tests", () => {
   afterAll(async () => {
     await execute("docker", ["image", "rm", "centos:7.8.2003"]).catch(() => {
-      /* no-op */
+      console.error(`tests teardown failed to remove docker image`);
     });
     await execute("docker", [
       "image",
       "rm",
       "centos@sha256:50b9a3bc27378889210f88d6d0695938e45a912aa99b3fdacfb9a0fef511f15a",
     ]).catch(() => {
-      /* no-op */
+      console.error(`tests teardown failed to remove docker image`);
     });
   });
 

--- a/test/system/operating-systems/debian9.spec.ts
+++ b/test/system/operating-systems/debian9.spec.ts
@@ -7,7 +7,9 @@ describe("debian tests", () => {
       "image",
       "rm",
       "debian@sha256:e7157902df9c7549eea5eb7b896cdca02d917e2ba0e339cd4a5087e2b53eb1d7",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze a debian image by sha256", async () => {

--- a/test/system/operating-systems/distroless.spec.ts
+++ b/test/system/operating-systems/distroless.spec.ts
@@ -7,7 +7,9 @@ describe("distroless tests", () => {
       "image",
       "rm",
       "gcr.io/distroless/base-debian10@sha256:8756a25c4c5e902c4fe20322cc69d510a0517b51eab630c614efbd612ed568bf",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze a distroless image by sha256", async () => {

--- a/test/system/operating-systems/oraclelinux8.2.spec.ts
+++ b/test/system/operating-systems/oraclelinux8.2.spec.ts
@@ -7,7 +7,9 @@ describe("oracle linux tests", () => {
       "image",
       "rm",
       "oraclelinux@sha256:652409ec0fd4e79b07ecf82e35ebf50277be69f6b8e873129a55a0bdedf827d0",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze an oracle linux image by sha256", async () => {

--- a/test/system/operating-systems/scratch.spec.ts
+++ b/test/system/operating-systems/scratch.spec.ts
@@ -7,7 +7,9 @@ describe("scratch tests", () => {
       "image",
       "rm",
       "snyk/runtime-fixtures:scratch",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze an scratch image by sha256", async () => {

--- a/test/system/operating-systems/sles15.spec.ts
+++ b/test/system/operating-systems/sles15.spec.ts
@@ -7,7 +7,9 @@ describe("suse linux enterprise server tests", () => {
       "image",
       "rm",
       "registry.suse.com/suse/sle15:15.2.8.2.751",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze an sles image by tag", async () => {

--- a/test/system/operating-systems/ubi8.spec.ts
+++ b/test/system/operating-systems/ubi8.spec.ts
@@ -7,7 +7,9 @@ describe("redhat ubi8 tests", () => {
       "image",
       "rm",
       "registry.access.redhat.com/ubi8/ubi:8.2-347",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze an ubi8 image by tag", async () => {

--- a/test/system/package-managers/apk.spec.ts
+++ b/test/system/package-managers/apk.spec.ts
@@ -3,7 +3,9 @@ import { execute } from "../../../lib/sub-process";
 
 describe("apk package manager tests", () => {
   afterAll(async () => {
-    await execute("docker", ["image", "rm", "alpine:3.12.0"]).catch();
+    await execute("docker", ["image", "rm", "alpine:3.12.0"]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze an apk image", async () => {

--- a/test/system/package-managers/deb.spec.ts
+++ b/test/system/package-managers/deb.spec.ts
@@ -7,7 +7,9 @@ describe("deb package manager tests", () => {
       "image",
       "rm",
       "debian@sha256:89ff9e144a438f6bdf89fba6a1fdcb614b6d03bc14433bbb937088ca7c7a7b6d",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze a deb image", async () => {

--- a/test/system/package-managers/rpm.spec.ts
+++ b/test/system/package-managers/rpm.spec.ts
@@ -8,7 +8,9 @@ describe("rpm package manager tests", () => {
       "rm",
       "amazonlinux:2.0.20200722.0",
       "amazonlinux:2022.0.20220504.1",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly analyze an rpm image", async () => {

--- a/test/system/platforms/amd.spec.ts
+++ b/test/system/platforms/amd.spec.ts
@@ -7,7 +7,9 @@ describe("AMD platform tests", () => {
       "image",
       "rm",
       "redis@sha256:fed4c3c120450b140aaff9b125306cc58aba99876399b081a6ba054c0328a189",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly scan an AMD image and return platform: amd64", async () => {

--- a/test/system/platforms/arm.spec.ts
+++ b/test/system/platforms/arm.spec.ts
@@ -7,7 +7,9 @@ describe("ARM platform tests", () => {
       "image",
       "rm",
       "arm64v8/nginx:1.19.2-alpine",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly scan an ARM image", async () => {

--- a/test/system/platforms/ppc64le.spec.ts
+++ b/test/system/platforms/ppc64le.spec.ts
@@ -7,7 +7,9 @@ describe("PPC64 platform tests", () => {
       "image",
       "rm",
       "ppc64le/php:8.0.0rc1-fpm-alpine3.12",
-    ]).catch();
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
   });
 
   it("should correctly scan a PPC image and return platform: ppc64le", async () => {

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
     "interface-name": false,
     "object-literal-sort-keys": false,
     "no-bitwise": false,
-    "max-classes-per-file": false
+    "max-classes-per-file": false,
+    "no-console": false
   }
 }


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Remove empty catch statements from the code (as they don't work and actually catch the error which cause to tests failures and instability).

Also disable the `no-console` rule to be able to log the error in case of catch, [as recommended for Node.js](https://eslint.org/docs/latest/rules/no-console#when-not-to-use-it).