### PR TITLE
fix: added support for semver-like versions for python dependencies.

### DIFF
--- a/lib/python-parser/metadata-parser.ts
+++ b/lib/python-parser/metadata-parser.ts
@@ -30,15 +30,10 @@ export function getPackageInfo(fileContent: string): PythonPackage {
       }
     }
   }
-  const validVersion = semver.coerce(version);
-  if (!validVersion) {
-    throw new PythonInvalidVersionError(
-      `version ${version} is not compatible with semver and cannot be compared`,
-    );
-  }
+  const validVersion = getParseableVersion(version);
   return {
     name: name.toLowerCase(),
-    version: validVersion.toString(),
+    version: validVersion,
     dependencies,
   } as PythonPackage;
 }
@@ -57,6 +52,22 @@ function parseDependency(packageDependency: string): PythonRequirement | null {
     version,
     specifier: correctedSpecifier,
   } as PythonRequirement;
+}
+
+function getParseableVersion(versionString: string): string {
+  const validVersion = semver.coerce(versionString);
+  if (!validVersion) {
+    throw new PythonInvalidVersionError(
+      `version ${versionString} is not compatible with semver and cannot be compared`,
+    );
+  }
+  if (
+    versionString.indexOf(validVersion.version) === 0 &&
+    /^\d+(\.\d+)+$/.test(versionString)
+  ) {
+    return versionString;
+  }
+  return validVersion.version;
 }
 
 export class PythonInvalidVersionError extends Error {}

--- a/test/unit/python-metadata-parser.spec.ts
+++ b/test/unit/python-metadata-parser.spec.ts
@@ -122,4 +122,33 @@ describe("python metadata parser", () => {
       getPackageInfo(fileContent);
     }).toThrow();
   });
+
+  it("Parses a package metadata when version isn't valid semver but has additional sections", () => {
+    const fileContent = `
+      Metadata-Version: 2.1
+      Name: opencv-python
+      Version: 4.8.1.78
+      Summary: Wrapper package for OpenCV python bindings.
+      Home-page: https://github.com/opencv/opencv-python
+      Maintainer: OpenCV Team
+      License: Apache 2.0
+      Platform: UNKNOWN
+      Requires-Python: >=3.6
+      Description-Content-Type: text/markdown
+      License-File: LICENSE-3RD-PARTY.txt
+      License-File: LICENSE.txt
+      Requires-Dist: numpy (>=1.13.3) ; python_version < "3.7"
+      Requires-Dist: numpy (>=1.21.0) ; python_version <= "3.9" and platform_system == "Darwin" and platform_machine == "arm64"
+      Requires-Dist: numpy (>=1.21.2) ; python_version >= "3.10"
+      Requires-Dist: numpy (>=1.21.4) ; python_version >= "3.10" and platform_system == "Darwin"
+      Requires-Dist: numpy (>=1.23.5) ; python_version >= "3.11"
+      Requires-Dist: numpy (>=1.19.3) ; python_version >= "3.6" and platform_system == "Linux" and platform_machine == "aarch64"
+      Requires-Dist: numpy (>=1.17.0) ; python_version >= "3.7"
+      Requires-Dist: numpy (>=1.17.3) ; python_version >= "3.8"
+      Requires-Dist: numpy (>=1.19.3) ; python_version >= "3.9"
+    `;
+    const packageResult = getPackageInfo(fileContent);
+    expect(packageResult.name).toEqual("opencv-python");
+    expect(packageResult.version).toEqual("4.8.1.78");
+  });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
For most python packages, we coerce the version to a valid semver format. This caused a false positive with versions that are similar to semver, but have an additional identifier, such as opencv-python: 4.8.1.78.

This commit adds support for such versions by not coercing them.


#### How should this be manually tested?
Scan a docker image with a requirements.txt file that contains `opencv-python==4.8.1.78` (and run a pip install). 