### PR TITLE
feat: add oci distribution metadata fact [OI-37]

### DIFF
--- a/components/common.yaml
+++ b/components/common.yaml
@@ -32,6 +32,7 @@ schemas:
       - jarFingerprints
       - keyBinariesHashes
       - loadedPackages
+      - ociDistributionMetadata
       - redHatRepositories
       - rootFs
       - testedFiles

--- a/lib/extractor/oci-distribution-metadata.ts
+++ b/lib/extractor/oci-distribution-metadata.ts
@@ -1,0 +1,125 @@
+import { parseAll } from "@swimlane/docker-reference";
+
+export interface OCIDistributionMetadata {
+  // Must be a valid host, including port if one was used to pull the image.
+  // Max size: 255 bytes.
+  registryHost: string;
+  // Must be a valid OCI repository namespace.
+  // Max size: 2048 bytes.
+  repository: string;
+  // Must match sha256:[a-f0-9]{64} (https://github.com/opencontainers/image-spec/blob/d60099175f88c47cd379c4738d158884749ed235/descriptor.md?plain=1#L143).
+  // Max size: 64 bytes.
+  manifestDigest: string;
+  // (Optional) Must match sha256:[a-f0-9]{64} (https://github.com/opencontainers/image-spec/blob/d60099175f88c47cd379c4738d158884749ed235/descriptor.md?plain=1#L143).
+  // Max size: 64 bytes.
+  indexDigest?: string;
+  // (Optional) Must match [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127} (https://github.com/opencontainers/distribution-spec/blob/3940529fe6c0a068290b27fb3cd797cf0528bed6/spec.md?plain=1#L160).
+  // Max size: 127 bytes.
+  imageTag?: string;
+  // Must be a valid OCI Image architecure/os string (https://github.com/opencontainers/image-spec/blob/93f6e65855a1e046b42afbad0ad129a3d44dc971/config.md?plain=1#L103).
+  // Max size: 64 bytes.
+  platform: string;
+}
+
+interface OCIDistributionMetadataConstructorInput {
+  imageName: string;
+  manifestDigest: string;
+  indexDigest?: string;
+  platform: string;
+}
+
+export function constructOCIDisributionMetadata({
+  imageName,
+  manifestDigest,
+  indexDigest,
+  platform,
+}: OCIDistributionMetadataConstructorInput):
+  | OCIDistributionMetadata
+  | undefined {
+  try {
+    const ref = parseAll(imageName);
+    if (!ref.domain || !ref.repository) {
+      return;
+    }
+
+    const metadata: OCIDistributionMetadata = {
+      registryHost: ref.domain,
+      repository: ref.repository,
+      manifestDigest,
+      indexDigest,
+      imageTag: ref.tag,
+      platform,
+    };
+
+    if (!ociDistributionMetadataIsValid(metadata)) {
+      return;
+    }
+
+    return metadata;
+  } catch {
+    return;
+  }
+}
+
+function ociDistributionMetadataIsValid(
+  data: OCIDistributionMetadata,
+): boolean {
+  // 255 byte limit is enforced by RFC 1035.
+  if (Buffer.byteLength(data.registryHost) > 255) {
+    return false;
+  }
+
+  // 2048 byte limit is enforced by Snyk for platform stability.
+  // Longer strings may be valid, but nothing close to this limit has been observed by Snyk at time of writing.
+  if (
+    Buffer.byteLength(data.repository) > 2048 ||
+    !repositoryNameIsValid(data.repository)
+  ) {
+    return false;
+  }
+
+  if (!digestIsValid(data.manifestDigest)) {
+    return false;
+  }
+
+  if (data.indexDigest && !digestIsValid(data.indexDigest)) {
+    return false;
+  }
+
+  if (data.imageTag && !tagIsValid(data.imageTag)) {
+    return false;
+  }
+
+  // 64 byte limit is enforced by Snyk for platform stability.
+  // Longer strings may be valid, but the maximum at time of writing is found by combining GOARCH=dragonfly and GOOS=mips64le, and is 18 bytes.
+  if (
+    Buffer.byteLength(data.platform) > 64 ||
+    !platformIsValid(data.platform)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+// Regular Expression Source: OCI Distribution Spec V1
+// https://github.com/opencontainers/distribution-spec/blob/570d0262abe8ec5e59d8e3fbbd7be4bd784b200e/spec.md?plain=1#L141
+const repositoryNameIsValid = (name: string) =>
+  /^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*$/.test(
+    name,
+  );
+
+// Regular Expression Source: OCI Image Spec V1
+// https://github.com/opencontainers/image-spec/blob/d60099175f88c47cd379c4738d158884749ed235/descriptor.md?plain=1#L143
+const digestIsValid = (digest: string) => /^sha256:[a-f0-9]{64}$/.test(digest);
+
+// Regular Expression Source: OCI Image Spec V1
+// https://github.com/opencontainers/distribution-spec/blob/3940529fe6c0a068290b27fb3cd797cf0528bed6/spec.md?plain=1#L160
+const tagIsValid = (tag: string) =>
+  /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/.test(tag);
+
+// Specification Source: OCI Image Spec V1
+// https://github.com/opencontainers/image-spec/blob/93f6e65855a1e046b42afbad0ad129a3d44dc971/config.md?plain=1#L103
+// Regular Expression explanation: platform must be two lowercase alpha-numeric strings separated by a '/' character.
+const platformIsValid = (platform: string) =>
+  /^[a-z0-9]+\/[a-z0-9]+$/.test(platform);

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -1,6 +1,7 @@
 import { DepGraph } from "@snyk/dep-graph";
 import { JarFingerprint } from "./analyzer/types";
 import { DockerFileAnalysis } from "./dockerfile/types";
+import { OCIDistributionMetadata } from "./extractor/oci-distribution-metadata";
 import {
   AutoDetectedUserInstructions,
   ImageNameInfo,
@@ -90,4 +91,9 @@ export interface ImageCreationTimeFact {
 export interface LoadedPackagesFact {
   type: "loadedPackages";
   data: string;
+}
+
+export interface OCIDistributionMetadataFact {
+  type: "ociDistributionMetadata";
+  data: OCIDistributionMetadata;
 }

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -6,6 +6,7 @@ import * as facts from "./facts";
 
 import { instructionDigest } from "./dockerfile";
 import { DockerFileAnalysis, DockerFilePackages } from "./dockerfile/types";
+import { OCIDistributionMetadata } from "./extractor/oci-distribution-metadata";
 import * as types from "./types";
 
 export { buildResponse };
@@ -18,6 +19,7 @@ async function buildResponse(
   dockerfileAnalysis: DockerFileAnalysis | undefined,
   excludeBaseImageVulns: boolean,
   names?: string[],
+  ociDistributionMetadata?: OCIDistributionMetadata,
 ): Promise<types.PluginResponse> {
   const deps = depsAnalysis.depTree.dependencies;
   const dockerfilePkgs = collectDockerfilePkgs(dockerfileAnalysis, deps);
@@ -182,6 +184,14 @@ async function buildResponse(
       };
       additionalFacts.push(imageNamesFact);
     }
+  }
+
+  if (ociDistributionMetadata) {
+    const metadataFact: facts.OCIDistributionMetadataFact = {
+      type: "ociDistributionMetadata",
+      data: ociDistributionMetadata,
+    };
+    additionalFacts.push(metadataFact);
   }
 
   const scanResults: types.ScanResult[] = [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -68,6 +68,7 @@ export type FactType =
   // Hashes of executables not installed by a package manager (e.g. if they were copied straight onto the image).
   | "keyBinariesHashes"
   | "loadedPackages"
+  | "ociDistributionMetadata"
   | "rootFs"
   // Used for application dependencies scanning; shows which files were used in the analysis of the dependencies.
   | "testedFiles";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "snyk-docker-plugin",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@ampproject/remapping": {
       "version": "2.2.1",
@@ -1580,6 +1580,11 @@
         "tar-fs": "^3.0.4"
       }
     },
+    "@swimlane/docker-reference": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@swimlane/docker-reference/-/docker-reference-2.0.1.tgz",
+      "integrity": "sha512-+mxOe4TwtZJHmvVwq8CnY21wYpYbLXS3IXOWQbgolyfwJhS2vEsNKmNHGdWHd7KUkJTYLs7nmJFVx9OZ2qEVbA=="
+    },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -1998,6 +2003,16 @@
         "micromatch": "^4.0.2",
         "stream-buffers": "^3.0.2",
         "tslib": "^1.13.0"
+      }
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "acorn": {
@@ -2642,8 +2657,8 @@
       "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
       "dev": true,
       "requires": {
-        "is-text-path": "^1.0.1",
         "JSONStream": "^1.3.5",
+        "is-text-path": "^1.0.1",
         "meow": "^8.1.2",
         "split2": "^3.2.2"
       }
@@ -5322,16 +5337,6 @@
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6852,14 +6857,6 @@
         "queue-tick": "^1.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "string-argv": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.1.2.tgz",
@@ -6929,6 +6926,14 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
         "es-abstract": "^1.22.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@snyk/docker-registry-v2-client": "^2.11.0",
     "@snyk/rpm-parser": "3.1.0",
     "@snyk/snyk-docker-pull": "^3.11.0",
+    "@swimlane/docker-reference": "^2.0.1",
     "adm-zip": "^0.5.5",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",

--- a/test/lib/extractor/oci-distribution-metadata.spec.ts
+++ b/test/lib/extractor/oci-distribution-metadata.spec.ts
@@ -1,0 +1,233 @@
+import {
+  constructOCIDisributionMetadata,
+  OCIDistributionMetadata,
+} from "../../../lib/extractor/oci-distribution-metadata";
+
+describe("constructOCIDisributionMetadata should", () => {
+  const testCases: Array<
+    [
+      string,
+      {
+        imageName: string;
+        manifestDigest: string;
+        indexDigest?: string;
+        platform: string;
+      },
+      OCIDistributionMetadata | undefined,
+    ]
+  > = [
+    [
+      "given minimal information produce a valid result",
+      {
+        imageName: "gcr.io/example/repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      {
+        imageTag: "test",
+        indexDigest: undefined,
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+        registryHost: "gcr.io",
+        repository: "example/repo",
+      },
+    ],
+    [
+      "given an index digest include it in the result",
+      {
+        imageName: "gcr.io/example/repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        indexDigest:
+          "sha256:8e552c2054fbd598196e35e5d04d4ad3cc1913d49ac5f9ed7235993f442dd9c6",
+        platform: "linux/amd64",
+      },
+      {
+        imageTag: "test",
+        indexDigest:
+          "sha256:8e552c2054fbd598196e35e5d04d4ad3cc1913d49ac5f9ed7235993f442dd9c6",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+        registryHost: "gcr.io",
+        repository: "example/repo",
+      },
+    ],
+    [
+      "given a non-default platform include it in the result",
+      {
+        imageName: "gcr.io/example/repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/arm64",
+      },
+      {
+        imageTag: "test",
+        indexDigest: undefined,
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/arm64",
+        registryHost: "gcr.io",
+        repository: "example/repo",
+      },
+    ],
+    [
+      "given an image name with a digest it is not included in the result",
+      {
+        imageName:
+          "gcr.io/example/repo@sha256:8e552c2054fbd598196e35e5d04d4ad3cc1913d49ac5f9ed7235993f442dd9c6",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      {
+        imageTag: undefined,
+        indexDigest: undefined,
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+        registryHost: "gcr.io",
+        repository: "example/repo",
+      },
+    ],
+    [
+      "given an image name without a host include the default in the result",
+      {
+        imageName: "example/repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      {
+        imageTag: "test",
+        indexDigest: undefined,
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+        registryHost: "docker.io",
+        repository: "example/repo",
+      },
+    ],
+    [
+      "given an image name without a namespace include the default in the result",
+      {
+        imageName: "repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      {
+        imageTag: "test",
+        indexDigest: undefined,
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+        registryHost: "docker.io",
+        repository: "library/repo",
+      },
+    ],
+    [
+      "given an image name with host that is too long should return undefined",
+      {
+        // 255 is the maxmimum segement length, there are 256 'a's here:
+        imageName:
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.io/repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      undefined,
+    ],
+    [
+      "given an image name with a namespace that is too long should return undefined",
+      {
+        // 2048 is the maxmimum length, there are 2049 'a's here:
+        imageName:
+          "gcr.io/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      undefined,
+    ],
+    [
+      "given a platform that is too long should return undefined",
+      {
+        imageName: "gcr.io/example/repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        // 64 is the maximum length, there are 65 characters here
+        platform:
+          "linux/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+      undefined,
+    ],
+    [
+      "given an image name with an invalid host should return undefined",
+      {
+        imageName: "..io/repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      undefined,
+    ],
+    [
+      "given an image name with an invalid namespace should return undefined",
+      {
+        imageName: "gcr.io/re*&&po:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      undefined,
+    ],
+    [
+      "given an image name with an invalid tag should return undefined",
+      {
+        imageName: "gcr.io/example/repo:__*image=",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      undefined,
+    ],
+    [
+      "given an invalid manifest digest should return undefined",
+      {
+        imageName: "gcr.io/example/repo:test",
+        manifestDigest: "sha256:abc",
+        platform: "linux/amd64",
+      },
+      undefined,
+    ],
+    [
+      "given an invalid index digest should return undefined",
+      {
+        imageName: "gcr.io/example/repo:test",
+        indexDigest: "sha256:abc",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/amd64",
+      },
+      undefined,
+    ],
+    [
+      "given an invalid platform should return undefined",
+      {
+        imageName: "gcr.io/example/repo:test",
+        manifestDigest:
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        platform: "linux/unix/amd64",
+      },
+      undefined,
+    ],
+  ];
+
+  it.each(testCases)("%p", (_, input, expected) => {
+    const result = constructOCIDisributionMetadata(input);
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/test/lib/extractor/oci-distribution-metadata.spec.ts
+++ b/test/lib/extractor/oci-distribution-metadata.spec.ts
@@ -74,7 +74,7 @@ describe("constructOCIDisributionMetadata should", () => {
       },
     ],
     [
-      "given an image name with a digest it is not included in the result",
+      "given an image name with a digest imageTag is not included in the result",
       {
         imageName:
           "gcr.io/example/repo@sha256:8e552c2054fbd598196e35e5d04d4ad3cc1913d49ac5f9ed7235993f442dd9c6",
@@ -111,7 +111,7 @@ describe("constructOCIDisributionMetadata should", () => {
       },
     ],
     [
-      "given an image name without a namespace include the default in the result",
+      "given an image name without a namespace include the default repository in the result",
       {
         imageName: "repo:test",
         manifestDigest:
@@ -131,9 +131,8 @@ describe("constructOCIDisributionMetadata should", () => {
     [
       "given an image name with host that is too long should return undefined",
       {
-        // 255 is the maxmimum segement length, there are 256 'a's here:
-        imageName:
-          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.io/repo:test",
+        // 255 is the maxmimum host length.
+        imageName: "a".repeat(256) + ".io/repo:test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         platform: "linux/amd64",
@@ -143,9 +142,8 @@ describe("constructOCIDisributionMetadata should", () => {
     [
       "given an image name with a namespace that is too long should return undefined",
       {
-        // 2048 is the maxmimum length, there are 2049 'a's here:
-        imageName:
-          "gcr.io/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:test",
+        // 2048 is the maxmimum repository length.
+        imageName: "gcr.io/" + "a".repeat(2049) + ":test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         platform: "linux/amd64",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This PR adds the `ociDistributionMetadata` fact to scan results _provided_ that:
- `manifestDigest` is provided - without it, we cannot determine whether a digest in the image name is an index or a manifest
- An image identifier is present in the `imageNameAndTag` option

#### What are the relevant tickets?

- Jira ticket: https://snyksec.atlassian.net/browse/OI-37