### PR TITLE
feat: remove platform from oci distribution metadata

### DIFF
--- a/lib/extractor/oci-distribution-metadata.ts
+++ b/lib/extractor/oci-distribution-metadata.ts
@@ -16,23 +16,18 @@ export interface OCIDistributionMetadata {
   // (Optional) Must match [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127} (https://github.com/opencontainers/distribution-spec/blob/3940529fe6c0a068290b27fb3cd797cf0528bed6/spec.md?plain=1#L160).
   // Max size: 127 bytes.
   imageTag?: string;
-  // Must be a valid OCI Image architecure/os string (https://github.com/opencontainers/image-spec/blob/93f6e65855a1e046b42afbad0ad129a3d44dc971/config.md?plain=1#L103).
-  // Max size: 64 bytes.
-  platform: string;
 }
 
 interface OCIDistributionMetadataConstructorInput {
   imageName: string;
   manifestDigest: string;
   indexDigest?: string;
-  platform: string;
 }
 
 export function constructOCIDisributionMetadata({
   imageName,
   manifestDigest,
   indexDigest,
-  platform,
 }: OCIDistributionMetadataConstructorInput):
   | OCIDistributionMetadata
   | undefined {
@@ -48,7 +43,6 @@ export function constructOCIDisributionMetadata({
       manifestDigest,
       indexDigest,
       imageTag: ref.tag,
-      platform,
     };
 
     if (!ociDistributionMetadataIsValid(metadata)) {
@@ -90,15 +84,6 @@ function ociDistributionMetadataIsValid(
     return false;
   }
 
-  // 64 byte limit is enforced by Snyk for platform stability.
-  // Longer strings may be valid, but the maximum at time of writing is found by combining GOARCH=dragonfly and GOOS=mips64le, and is 18 bytes.
-  if (
-    Buffer.byteLength(data.platform) > 64 ||
-    !platformIsValid(data.platform)
-  ) {
-    return false;
-  }
-
   return true;
 }
 
@@ -117,9 +102,3 @@ const digestIsValid = (digest: string) => /^sha256:[a-f0-9]{64}$/.test(digest);
 // https://github.com/opencontainers/distribution-spec/blob/3940529fe6c0a068290b27fb3cd797cf0528bed6/spec.md?plain=1#L160
 const tagIsValid = (tag: string) =>
   /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/.test(tag);
-
-// Specification Source: OCI Image Spec V1
-// https://github.com/opencontainers/image-spec/blob/93f6e65855a1e046b42afbad0ad129a3d44dc971/config.md?plain=1#L103
-// Regular Expression explanation: platform must be two lowercase alpha-numeric strings separated by a '/' character.
-const platformIsValid = (platform: string) =>
-  /^[a-z0-9]+\/[a-z0-9]+$/.test(platform);

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -63,7 +63,6 @@ export async function analyzeStatically(
       imageName: options.imageNameAndTag,
       manifestDigest: options.digests.manifest,
       indexDigest: options.digests.index,
-      platform: options.platform ?? "linux/amd64",
     });
   }
 

--- a/test/lib/extractor/oci-distribution-metadata.spec.ts
+++ b/test/lib/extractor/oci-distribution-metadata.spec.ts
@@ -11,7 +11,6 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: string;
         manifestDigest: string;
         indexDigest?: string;
-        platform: string;
       },
       OCIDistributionMetadata | undefined,
     ]
@@ -22,14 +21,12 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: "gcr.io/example/repo:test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
       },
       {
         imageTag: "test",
         indexDigest: undefined,
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
         registryHost: "gcr.io",
         repository: "example/repo",
       },
@@ -42,7 +39,6 @@ describe("constructOCIDisributionMetadata should", () => {
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         indexDigest:
           "sha256:8e552c2054fbd598196e35e5d04d4ad3cc1913d49ac5f9ed7235993f442dd9c6",
-        platform: "linux/amd64",
       },
       {
         imageTag: "test",
@@ -50,25 +46,6 @@ describe("constructOCIDisributionMetadata should", () => {
           "sha256:8e552c2054fbd598196e35e5d04d4ad3cc1913d49ac5f9ed7235993f442dd9c6",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
-        registryHost: "gcr.io",
-        repository: "example/repo",
-      },
-    ],
-    [
-      "given a non-default platform include it in the result",
-      {
-        imageName: "gcr.io/example/repo:test",
-        manifestDigest:
-          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/arm64",
-      },
-      {
-        imageTag: "test",
-        indexDigest: undefined,
-        manifestDigest:
-          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/arm64",
         registryHost: "gcr.io",
         repository: "example/repo",
       },
@@ -80,14 +57,12 @@ describe("constructOCIDisributionMetadata should", () => {
           "gcr.io/example/repo@sha256:8e552c2054fbd598196e35e5d04d4ad3cc1913d49ac5f9ed7235993f442dd9c6",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
       },
       {
         imageTag: undefined,
         indexDigest: undefined,
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
         registryHost: "gcr.io",
         repository: "example/repo",
       },
@@ -98,14 +73,12 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: "example/repo:test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
       },
       {
         imageTag: "test",
         indexDigest: undefined,
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
         registryHost: "docker.io",
         repository: "example/repo",
       },
@@ -116,14 +89,12 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: "repo:test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
       },
       {
         imageTag: "test",
         indexDigest: undefined,
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
         registryHost: "docker.io",
         repository: "library/repo",
       },
@@ -135,7 +106,6 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: "a".repeat(256) + ".io/repo:test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
       },
       undefined,
     ],
@@ -146,19 +116,6 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: "gcr.io/" + "a".repeat(2049) + ":test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
-      },
-      undefined,
-    ],
-    [
-      "given a platform that is too long should return undefined",
-      {
-        imageName: "gcr.io/example/repo:test",
-        manifestDigest:
-          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        // 64 is the maximum length, there are 65 characters here
-        platform:
-          "linux/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
       undefined,
     ],
@@ -168,7 +125,6 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: "..io/repo:test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
       },
       undefined,
     ],
@@ -178,7 +134,6 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: "gcr.io/re*&&po:test",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
       },
       undefined,
     ],
@@ -188,7 +143,6 @@ describe("constructOCIDisributionMetadata should", () => {
         imageName: "gcr.io/example/repo:__*image=",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
       },
       undefined,
     ],
@@ -197,7 +151,6 @@ describe("constructOCIDisributionMetadata should", () => {
       {
         imageName: "gcr.io/example/repo:test",
         manifestDigest: "sha256:abc",
-        platform: "linux/amd64",
       },
       undefined,
     ],
@@ -208,17 +161,6 @@ describe("constructOCIDisributionMetadata should", () => {
         indexDigest: "sha256:abc",
         manifestDigest:
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/amd64",
-      },
-      undefined,
-    ],
-    [
-      "given an invalid platform should return undefined",
-      {
-        imageName: "gcr.io/example/repo:test",
-        manifestDigest:
-          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        platform: "linux/unix/amd64",
       },
       undefined,
     ],


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This PR removes the `platform` field from the OCI Distribution Metadata fact; after some discussion it was decided that `platform` is not a property of OCI distribution, but just of the image. 