### PR TITLE
fix: adds large file support to bufferToSha1 method

### DIFF
--- a/test/lib/buffer-utils.spec.ts
+++ b/test/lib/buffer-utils.spec.ts
@@ -1,10 +1,11 @@
 import { Buffer } from "buffer";
 import * as crypto from "crypto";
+
 import { bufferToSha1 } from "../../lib/buffer-utils";
 
 describe("buffer-utils", () => {
   describe("bufferToSha1", () => {
-    it("should convert Buffer to sha1", () => {
+    it("should convert Buffer to sha1", async () => {
       // Arrange
       const textToConvert = "hello world";
       let hashedText = crypto.createHash("sha1");
@@ -16,10 +17,26 @@ describe("buffer-utils", () => {
       const bufferedText = Buffer.from(textToConvert);
 
       // Act
-      const result = bufferToSha1(bufferedText);
+      const result = await bufferToSha1(bufferedText);
 
       // Assert
       expect(result).toEqual(hashedText);
+    });
+
+    it("should handle large files", async () => {
+      const megabyte = 1024 * 1024;
+      const gigabyte = megabyte * 1024;
+
+      // create a buffer representing a file over 2GB, which would throw
+      // a RangeError if using the update method of a Crypto.Hash object,
+      // instead of the streaming interface which allows us to support
+      // large files
+      const buffer = Buffer.concat([
+        Buffer.alloc(gigabyte * 2),
+        Buffer.alloc(megabyte),
+      ]);
+      const digest = await bufferToSha1(buffer);
+      expect(digest).toEqual(expect.any(String));
     });
   });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds large file support to `bufferToSha1` method.


#### Where should the reviewer start?

The `bufferToSha1` method was failing as the `update` method of the `Crypto.Hash` object uses `Buffer.alloc` which has a limitation of 2G. Any JARs bigger than this would cause a `RangeError` in `Node`.

This fix uses the stream interface of `Crypto.Hash` to stream data for large files in order to generate the Sha1 digest.


#### How should this be manually tested?

Scan any container with a Maven project that contains one or more JAR over 2G in size.


#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/SUP-1997


