### PR TITLE
fix: upgrade eol'd snyk_docker_plugin version - it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - attach_workspace:
           at: ~/snyk-docker-plugin
       - run: npm run test-jest


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
While building registry main on ciecleCI, I found a persistent error, which points to an EOD dependency in `setup_remote_docker` (see [here](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176)).

Tracing the dependency, I reached this as a registry dependency where one of the EOD'd versions (20.10.23) is being used. This needs to be updated, but please let me know if a different version should be used here.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
