### PR TITLE
feat: fix purl generation for container

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -171,14 +171,15 @@ export async function analyze(
   try {
     results = await Promise.all([
       apkAnalyze(targetImage, apkDbFileContent),
-      aptAnalyze(targetImage, aptDbFileContent),
-      rpmAnalyze(targetImage, rpmDbFileContent, redHatRepositories),
+      aptAnalyze(targetImage, aptDbFileContent, osRelease),
+      rpmAnalyze(targetImage, rpmDbFileContent, redHatRepositories, osRelease),
       mapRpmSqlitePackages(
         targetImage,
         rpmSqliteDbFileContent,
         redHatRepositories,
+        osRelease,
       ),
-      aptDistrolessAnalyze(targetImage, distrolessAptFiles),
+      aptDistrolessAnalyze(targetImage, distrolessAptFiles, osRelease),
     ]);
   } catch (err) {
     debug(`Could not detect installed OS packages: ${err.message}`);

--- a/test/system/app-os/__snapshots__/globs.spec.ts.snap
+++ b/test/system/app-os/__snapshots__/globs.spec.ts.snap
@@ -1214,7 +1214,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
-                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit-common@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1222,7 +1222,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
-                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
+                  "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?distro=debian-buster&upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1230,7 +1230,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
-                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit1@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1238,7 +1238,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage-common@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1246,7 +1246,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
+                  "purl": "pkg:deb/debian/libsepol1@2.8-1?distro=debian-buster&upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1254,7 +1254,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage1@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1262,7 +1262,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?distro=debian-buster&upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1270,7 +1270,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam0g@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1278,7 +1278,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1286,7 +1286,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1294,7 +1294,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/passwd@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1302,7 +1302,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.118",
+                  "purl": "pkg:deb/debian/adduser@3.118?distro=debian-buster",
                   "version": "3.118",
                 },
               },
@@ -1310,7 +1310,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?distro=debian-buster&upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1318,7 +1318,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
-                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
+                  "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?distro=debian-buster&upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1326,7 +1326,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
+                  "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?distro=debian-buster&upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1334,7 +1334,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?distro=debian-buster",
                   "version": "1.8.4-5",
                 },
               },
@@ -1342,7 +1342,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@241-7~deb10u4?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u4?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1350,7 +1350,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@241-7~deb10u4?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@241-7~deb10u4?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1358,7 +1358,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2.1",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2.1?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2.1?distro=debian-buster&upstream=apt",
                   "version": "1.8.2.1",
                 },
               },
@@ -1366,7 +1366,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?distro=debian-buster",
                   "version": "2019.1",
                 },
               },
@@ -1374,7 +1374,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.35-1?distro=debian-buster&upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1382,7 +1382,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
+                  "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?distro=debian-buster&upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1390,7 +1390,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
-                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
+                  "purl": "pkg:deb/debian/libgmp10@2:6.1.2%2Bdfsg-4?distro=debian-buster&upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1398,7 +1398,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
-                  "purl": "pkg:deb/libidn2-0@2.0.5-1%2Bdeb10u1?upstream=libidn2",
+                  "purl": "pkg:deb/debian/libidn2-0@2.0.5-1%2Bdeb10u1?distro=debian-buster&upstream=libidn2",
                   "version": "2.0.5-1+deb10u1",
                 },
               },
@@ -1406,7 +1406,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.13-3",
+                  "purl": "pkg:deb/debian/libtasn1-6@4.13-3?distro=debian-buster",
                   "version": "4.13-3",
                 },
               },
@@ -1414,7 +1414,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
-                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
+                  "purl": "pkg:deb/debian/libunistring2@0.9.10-1?distro=debian-buster&upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1422,7 +1422,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libnettle6@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1430,7 +1430,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
-                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1438,7 +1438,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
-                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
+                  "purl": "pkg:deb/debian/libffi6@3.2.1-9?distro=debian-buster&upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1446,7 +1446,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
+                  "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?distro=debian-buster&upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1454,7 +1454,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
-                  "purl": "pkg:deb/libgnutls30@3.6.7-4%2Bdeb10u5?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls30@3.6.7-4%2Bdeb10u5?distro=debian-buster&upstream=gnutls28",
                   "version": "3.6.7-4+deb10u5",
                 },
               },
@@ -1462,7 +1462,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
-                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
+                  "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?distro=debian-buster&upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1470,7 +1470,7 @@ Object {
                 "id": "apt@1.8.2.1",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.8.2.1",
+                  "purl": "pkg:deb/debian/apt@1.8.2.1?distro=debian-buster",
                   "version": "1.8.2.1",
                 },
               },
@@ -1485,7 +1485,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?distro=debian-buster&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1493,7 +1493,7 @@ Object {
                 "id": "base-files@10.3+deb10u6",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u6",
+                  "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u6?distro=debian-buster",
                   "version": "10.3+deb10u6",
                 },
               },
@@ -1501,7 +1501,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.249?distro=debian-buster&upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1509,7 +1509,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.46",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.46?distro=debian-buster",
                   "version": "3.5.46",
                 },
               },
@@ -1517,7 +1517,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.6.1",
+                  "purl": "pkg:deb/debian/debianutils@4.8.6.1?distro=debian-buster",
                   "version": "4.8.6.1",
                 },
               },
@@ -1525,7 +1525,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
-                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1533,7 +1533,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@5.0-4",
+                  "purl": "pkg:deb/debian/bash@5.0-4?distro=debian-buster",
                   "version": "5.0-4",
                 },
               },
@@ -1548,7 +1548,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.30-3",
+                  "purl": "pkg:deb/debian/coreutils@8.30-3?distro=debian-buster",
                   "version": "8.30-3",
                 },
               },
@@ -1556,7 +1556,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.10.2-5",
+                  "purl": "pkg:deb/debian/dash@0.5.10.2-5?distro=debian-buster",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1571,7 +1571,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.7-3",
+                  "purl": "pkg:deb/debian/diffutils@1:3.7-3?distro=debian-buster",
                   "version": "1:3.7-3",
                 },
               },
@@ -1586,7 +1586,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
-                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1594,7 +1594,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
-                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1602,7 +1602,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1610,7 +1610,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1618,7 +1618,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1626,7 +1626,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u3",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u3?distro=debian-buster",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1634,7 +1634,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
+                  "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?distro=debian-buster",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1656,7 +1656,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.28-10?distro=debian-buster&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1671,7 +1671,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@3.3-1",
+                  "purl": "pkg:deb/debian/grep@3.3-1?distro=debian-buster",
                   "version": "3.3-1",
                 },
               },
@@ -1679,7 +1679,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.9-3",
+                  "purl": "pkg:deb/debian/gzip@1.9-3?distro=debian-buster",
                   "version": "1.9-3",
                 },
               },
@@ -1687,7 +1687,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.21",
+                  "purl": "pkg:deb/debian/hostname@3.21?distro=debian-buster",
                   "version": "3.21",
                 },
               },
@@ -1695,7 +1695,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
+                  "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?distro=debian-buster",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1703,7 +1703,7 @@ Object {
                 "id": "elfutils/libelf1@0.176-1.1",
                 "info": Object {
                   "name": "elfutils/libelf1",
-                  "purl": "pkg:deb/libelf1@0.176-1.1?upstream=elfutils",
+                  "purl": "pkg:deb/debian/libelf1@0.176-1.1?distro=debian-buster&upstream=elfutils",
                   "version": "0.176-1.1",
                 },
               },
@@ -1711,7 +1711,7 @@ Object {
                 "id": "iptables/libxtables12@1.8.2-4",
                 "info": Object {
                   "name": "iptables/libxtables12",
-                  "purl": "pkg:deb/libxtables12@1.8.2-4?upstream=iptables",
+                  "purl": "pkg:deb/debian/libxtables12@1.8.2-4?distro=debian-buster&upstream=iptables",
                   "version": "1.8.2-4",
                 },
               },
@@ -1719,7 +1719,7 @@ Object {
                 "id": "libcap2@1:2.25-2",
                 "info": Object {
                   "name": "libcap2",
-                  "purl": "pkg:deb/libcap2@1:2.25-2",
+                  "purl": "pkg:deb/debian/libcap2@1:2.25-2?distro=debian-buster",
                   "version": "1:2.25-2",
                 },
               },
@@ -1727,7 +1727,7 @@ Object {
                 "id": "libcap2/libcap2-bin@1:2.25-2",
                 "info": Object {
                   "name": "libcap2/libcap2-bin",
-                  "purl": "pkg:deb/libcap2-bin@1:2.25-2?upstream=libcap2",
+                  "purl": "pkg:deb/debian/libcap2-bin@1:2.25-2?distro=debian-buster&upstream=libcap2",
                   "version": "1:2.25-2",
                 },
               },
@@ -1735,7 +1735,7 @@ Object {
                 "id": "libmnl/libmnl0@1.0.4-2",
                 "info": Object {
                   "name": "libmnl/libmnl0",
-                  "purl": "pkg:deb/libmnl0@1.0.4-2?upstream=libmnl",
+                  "purl": "pkg:deb/debian/libmnl0@1.0.4-2?distro=debian-buster&upstream=libmnl",
                   "version": "1.0.4-2",
                 },
               },
@@ -1743,7 +1743,7 @@ Object {
                 "id": "iproute2@4.20.0-2",
                 "info": Object {
                   "name": "iproute2",
-                  "purl": "pkg:deb/iproute2@4.20.0-2",
+                  "purl": "pkg:deb/debian/iproute2@4.20.0-2?distro=debian-buster",
                   "version": "4.20.0-2",
                 },
               },
@@ -1751,7 +1751,7 @@ Object {
                 "id": "iputils/iputils-ping@3:20180629-2+deb10u1",
                 "info": Object {
                   "name": "iputils/iputils-ping",
-                  "purl": "pkg:deb/iputils-ping@3:20180629-2%2Bdeb10u1?upstream=iputils",
+                  "purl": "pkg:deb/debian/iputils-ping@3:20180629-2%2Bdeb10u1?distro=debian-buster&upstream=iputils",
                   "version": "3:20180629-2+deb10u1",
                 },
               },
@@ -1766,7 +1766,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
-                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1774,7 +1774,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1782,7 +1782,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1790,7 +1790,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1812,7 +1812,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.7-1",
+                  "purl": "pkg:deb/debian/sed@4.7-1?distro=debian-buster",
                   "version": "4.7-1",
                 },
               },
@@ -1820,7 +1820,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1828,7 +1828,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
+                  "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?distro=debian-buster",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1836,7 +1836,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?distro=debian-buster&upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1851,7 +1851,7 @@ Object {
                 "id": "tzdata@2020d-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2020d-0%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/tzdata@2020d-0%2Bdeb10u1?distro=debian-buster",
                   "version": "2020d-0+deb10u1",
                 },
               },
@@ -1859,7 +1859,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.33.1-0.1?distro=debian-buster&upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1867,7 +1867,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1875,7 +1875,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1883,7 +1883,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1891,7 +1891,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
-                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1899,7 +1899,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/application-scans/__snapshots__/node.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/node.spec.ts.snap
@@ -870,7 +870,7 @@ Object {
                 "id": "amazon-linux-extras@1.6.10-1.amzn2",
                 "info": Object {
                   "name": "amazon-linux-extras",
-                  "purl": "pkg:rpm/amazon-linux-extras@1.6.10-1.amzn2",
+                  "purl": "pkg:rpm/amzn/amazon-linux-extras@1.6.10-1.amzn2?distro=amzn-2",
                   "version": "1.6.10-1.amzn2",
                 },
               },
@@ -878,7 +878,7 @@ Object {
                 "id": "basesystem@10.0-7.amzn2.0.1",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/basesystem@10.0-7.amzn2.0.1?distro=amzn-2",
                   "version": "10.0-7.amzn2.0.1",
                 },
               },
@@ -886,7 +886,7 @@ Object {
                 "id": "bash@4.2.46-33.amzn2",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-33.amzn2",
+                  "purl": "pkg:rpm/amzn/bash@4.2.46-33.amzn2?distro=amzn-2",
                   "version": "4.2.46-33.amzn2",
                 },
               },
@@ -894,7 +894,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.amzn2.0.2",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/bzip2-libs@1.0.6-13.amzn2.0.2?distro=amzn-2",
                   "version": "1.0.6-13.amzn2.0.2",
                 },
               },
@@ -902,7 +902,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.amzn2.0.1",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/ca-certificates@2019.2.32-76.amzn2.0.1?distro=amzn-2",
                   "version": "2019.2.32-76.amzn2.0.1",
                 },
               },
@@ -910,7 +910,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.amzn2.0.2",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/chkconfig@1.7.4-1.amzn2.0.2?distro=amzn-2",
                   "version": "1.7.4-1.amzn2.0.2",
                 },
               },
@@ -918,7 +918,7 @@ Object {
                 "id": "coreutils@8.22-24.amzn2",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.amzn2",
+                  "purl": "pkg:rpm/amzn/coreutils@8.22-24.amzn2?distro=amzn-2",
                   "version": "8.22-24.amzn2",
                 },
               },
@@ -926,7 +926,7 @@ Object {
                 "id": "cpio@2.11-27.amzn2",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.amzn2",
+                  "purl": "pkg:rpm/amzn/cpio@2.11-27.amzn2?distro=amzn-2",
                   "version": "2.11-27.amzn2",
                 },
               },
@@ -934,7 +934,7 @@ Object {
                 "id": "curl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/curl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -942,7 +942,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.amzn2",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.amzn2",
+                  "purl": "pkg:rpm/amzn/cyrus-sasl-lib@2.1.26-23.amzn2?distro=amzn-2",
                   "version": "2.1.26-23.amzn2",
                 },
               },
@@ -950,7 +950,7 @@ Object {
                 "id": "diffutils@3.3-5.amzn2",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/diffutils@3.3-5.amzn2?distro=amzn-2",
                   "version": "3.3-5.amzn2",
                 },
               },
@@ -958,7 +958,7 @@ Object {
                 "id": "elfutils-libelf@0.176-2.amzn2",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-2.amzn2",
+                  "purl": "pkg:rpm/amzn/elfutils-libelf@0.176-2.amzn2?distro=amzn-2",
                   "version": "0.176-2.amzn2",
                 },
               },
@@ -966,7 +966,7 @@ Object {
                 "id": "expat@2.1.0-10.amzn2.0.2",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/expat@2.1.0-10.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-10.amzn2.0.2",
                 },
               },
@@ -974,7 +974,7 @@ Object {
                 "id": "file-libs@5.11-35.amzn2.0.2",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-35.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/file-libs@5.11-35.amzn2.0.2?distro=amzn-2",
                   "version": "5.11-35.amzn2.0.2",
                 },
               },
@@ -982,7 +982,7 @@ Object {
                 "id": "filesystem@3.2-25.amzn2.0.4",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/filesystem@3.2-25.amzn2.0.4?distro=amzn-2",
                   "version": "3.2-25.amzn2.0.4",
                 },
               },
@@ -990,7 +990,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.amzn2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/findutils@1:4.5.11-6.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:4.5.11-6.amzn2",
                 },
               },
@@ -998,7 +998,7 @@ Object {
                 "id": "gawk@4.0.2-4.amzn2.1.2",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.amzn2.1.2",
+                  "purl": "pkg:rpm/amzn/gawk@4.0.2-4.amzn2.1.2?distro=amzn-2",
                   "version": "4.0.2-4.amzn2.1.2",
                 },
               },
@@ -1006,7 +1006,7 @@ Object {
                 "id": "gdbm@1:1.13-6.amzn2.0.2",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.13-6.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gdbm@1:1.13-6.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:1.13-6.amzn2.0.2",
                 },
               },
@@ -1014,7 +1014,7 @@ Object {
                 "id": "glib2@2.56.1-4.amzn2",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-4.amzn2",
+                  "purl": "pkg:rpm/amzn/glib2@2.56.1-4.amzn2?distro=amzn-2",
                   "version": "2.56.1-4.amzn2",
                 },
               },
@@ -1022,7 +1022,7 @@ Object {
                 "id": "glibc@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1030,7 +1030,7 @@ Object {
                 "id": "glibc-common@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-common@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1038,7 +1038,7 @@ Object {
                 "id": "glibc-langpack-en@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/glibc-langpack-en@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-langpack-en@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1046,7 +1046,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-minimal-langpack@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1054,7 +1054,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.amzn2.0.2",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gmp@1:6.0.0-15.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:6.0.0-15.amzn2.0.2",
                 },
               },
@@ -1062,7 +1062,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.amzn2.0.4",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/gnupg2@2.0.22-5.amzn2.0.4?distro=amzn-2",
                   "version": "2.0.22-5.amzn2.0.4",
                 },
               },
@@ -1070,7 +1070,7 @@ Object {
                 "id": "gpg-pubkey@c87f5b1a-593863f8",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@c87f5b1a-593863f8",
+                  "purl": "pkg:rpm/amzn/gpg-pubkey@c87f5b1a-593863f8?distro=amzn-2",
                   "version": "c87f5b1a-593863f8",
                 },
               },
@@ -1078,7 +1078,7 @@ Object {
                 "id": "gpgme@1.3.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/gpgme@1.3.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "1.3.2-5.amzn2.0.2",
                 },
               },
@@ -1086,7 +1086,7 @@ Object {
                 "id": "grep@2.20-3.amzn2.0.2",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/grep@2.20-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.20-3.amzn2.0.2",
                 },
               },
@@ -1094,7 +1094,7 @@ Object {
                 "id": "info@5.1-5.amzn2",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.amzn2",
+                  "purl": "pkg:rpm/amzn/info@5.1-5.amzn2?distro=amzn-2",
                   "version": "5.1-5.amzn2",
                 },
               },
@@ -1102,7 +1102,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.amzn2.0.2",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/keyutils-libs@1.5.8-3.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.8-3.amzn2.0.2",
                 },
               },
@@ -1110,7 +1110,7 @@ Object {
                 "id": "krb5-libs@1.15.1-37.amzn2.2.2",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-37.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/krb5-libs@1.15.1-37.amzn2.2.2?distro=amzn-2",
                   "version": "1.15.1-37.amzn2.2.2",
                 },
               },
@@ -1118,7 +1118,7 @@ Object {
                 "id": "libacl@2.2.51-14.amzn2",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-14.amzn2",
+                  "purl": "pkg:rpm/amzn/libacl@2.2.51-14.amzn2?distro=amzn-2",
                   "version": "2.2.51-14.amzn2",
                 },
               },
@@ -1126,7 +1126,7 @@ Object {
                 "id": "libassuan@2.1.0-3.amzn2.0.2",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libassuan@2.1.0-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-3.amzn2.0.2",
                 },
               },
@@ -1134,7 +1134,7 @@ Object {
                 "id": "libattr@2.4.46-12.amzn2.0.2",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libattr@2.4.46-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.4.46-12.amzn2.0.2",
                 },
               },
@@ -1142,7 +1142,7 @@ Object {
                 "id": "libblkid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libblkid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1150,7 +1150,7 @@ Object {
                 "id": "libcap@2.22-9.amzn2.0.2",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcap@2.22-9.amzn2.0.2?distro=amzn-2",
                   "version": "2.22-9.amzn2.0.2",
                 },
               },
@@ -1158,7 +1158,7 @@ Object {
                 "id": "libcom_err@1.42.9-12.amzn2.0.2",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcom_err@1.42.9-12.amzn2.0.2?distro=amzn-2",
                   "version": "1.42.9-12.amzn2.0.2",
                 },
               },
@@ -1166,7 +1166,7 @@ Object {
                 "id": "libcrypt@2.26-34.amzn2",
                 "info": Object {
                   "name": "libcrypt",
-                  "purl": "pkg:rpm/libcrypt@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/libcrypt@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1174,7 +1174,7 @@ Object {
                 "id": "libcurl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/libcurl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -1182,7 +1182,7 @@ Object {
                 "id": "libdb@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -1190,7 +1190,7 @@ Object {
                 "id": "libdb-utils@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb-utils@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -1198,7 +1198,7 @@ Object {
                 "id": "libffi@3.0.13-18.amzn2.0.2",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-18.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libffi@3.0.13-18.amzn2.0.2?distro=amzn-2",
                   "version": "3.0.13-18.amzn2.0.2",
                 },
               },
@@ -1206,7 +1206,7 @@ Object {
                 "id": "libgcc@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libgcc@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -1214,7 +1214,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.amzn2.0.2",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libgcrypt@1.5.3-14.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.3-14.amzn2.0.2",
                 },
               },
@@ -1222,7 +1222,7 @@ Object {
                 "id": "libgpg-error@1.12-3.amzn2.0.3",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libgpg-error@1.12-3.amzn2.0.3?distro=amzn-2",
                   "version": "1.12-3.amzn2.0.3",
                 },
               },
@@ -1230,7 +1230,7 @@ Object {
                 "id": "libidn2@2.3.0-1.amzn2",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.3.0-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libidn2@2.3.0-1.amzn2?distro=amzn-2",
                   "version": "2.3.0-1.amzn2",
                 },
               },
@@ -1238,7 +1238,7 @@ Object {
                 "id": "libmetalink@0.1.2-7.amzn2.0.2",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.2-7.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libmetalink@0.1.2-7.amzn2.0.2?distro=amzn-2",
                   "version": "0.1.2-7.amzn2.0.2",
                 },
               },
@@ -1246,7 +1246,7 @@ Object {
                 "id": "libmount@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libmount@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1254,7 +1254,7 @@ Object {
                 "id": "libnghttp2@1.39.2-1.amzn2",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.39.2-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libnghttp2@1.39.2-1.amzn2?distro=amzn-2",
                   "version": "1.39.2-1.amzn2",
                 },
               },
@@ -1262,7 +1262,7 @@ Object {
                 "id": "libselinux@2.5-12.amzn2.0.2",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libselinux@2.5-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-12.amzn2.0.2",
                 },
               },
@@ -1270,7 +1270,7 @@ Object {
                 "id": "libsepol@2.5-8.1.amzn2.0.2",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-8.1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libsepol@2.5-8.1.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-8.1.amzn2.0.2",
                 },
               },
@@ -1278,7 +1278,7 @@ Object {
                 "id": "libssh2@1.4.3-12.amzn2.2.2",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.4.3-12.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/libssh2@1.4.3-12.amzn2.2.2?distro=amzn-2",
                   "version": "1.4.3-12.amzn2.2.2",
                 },
               },
@@ -1286,7 +1286,7 @@ Object {
                 "id": "libstdc++@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libstdc%2B%2B@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -1294,7 +1294,7 @@ Object {
                 "id": "libtasn1@4.10-1.amzn2.0.2",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libtasn1@4.10-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.10-1.amzn2.0.2",
                 },
               },
@@ -1302,7 +1302,7 @@ Object {
                 "id": "libunistring@0.9.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libunistring@0.9.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.9.3-9.amzn2.0.2",
                 },
               },
@@ -1310,7 +1310,7 @@ Object {
                 "id": "libuuid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libuuid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1318,7 +1318,7 @@ Object {
                 "id": "libverto@0.2.5-4.amzn2.0.2",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libverto@0.2.5-4.amzn2.0.2?distro=amzn-2",
                   "version": "0.2.5-4.amzn2.0.2",
                 },
               },
@@ -1326,7 +1326,7 @@ Object {
                 "id": "libxml2@2.9.1-6.amzn2.3.3",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.amzn2.3.3",
+                  "purl": "pkg:rpm/amzn/libxml2@2.9.1-6.amzn2.3.3?distro=amzn-2",
                   "version": "2.9.1-6.amzn2.3.3",
                 },
               },
@@ -1334,7 +1334,7 @@ Object {
                 "id": "lua@5.1.4-15.amzn2.0.2",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/lua@5.1.4-15.amzn2.0.2?distro=amzn-2",
                   "version": "5.1.4-15.amzn2.0.2",
                 },
               },
@@ -1342,7 +1342,7 @@ Object {
                 "id": "ncurses@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1350,7 +1350,7 @@ Object {
                 "id": "ncurses-base@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-base@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1358,7 +1358,7 @@ Object {
                 "id": "ncurses-libs@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-libs@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1366,7 +1366,7 @@ Object {
                 "id": "nspr@4.21.0-1.amzn2.0.2",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/nspr@4.21.0-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.21.0-1.amzn2.0.2",
                 },
               },
@@ -1374,7 +1374,7 @@ Object {
                 "id": "nss@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1382,7 +1382,7 @@ Object {
                 "id": "nss-pem@1.0.3-5.amzn2",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-pem@1.0.3-5.amzn2?distro=amzn-2",
                   "version": "1.0.3-5.amzn2",
                 },
               },
@@ -1390,7 +1390,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -1398,7 +1398,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn-freebl@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -1406,7 +1406,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-sysinit@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1414,7 +1414,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-tools@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1422,7 +1422,7 @@ Object {
                 "id": "nss-util@3.44.0-4.amzn2",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-util@3.44.0-4.amzn2?distro=amzn-2",
                   "version": "3.44.0-4.amzn2",
                 },
               },
@@ -1430,7 +1430,7 @@ Object {
                 "id": "openldap@2.4.44-15.amzn2",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-15.amzn2",
+                  "purl": "pkg:rpm/amzn/openldap@2.4.44-15.amzn2?distro=amzn-2",
                   "version": "2.4.44-15.amzn2",
                 },
               },
@@ -1438,7 +1438,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.amzn2.0.3",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.amzn2.0.3?epoch=1",
+                  "purl": "pkg:rpm/amzn/openssl-libs@1:1.0.2k-19.amzn2.0.3?distro=amzn-2&epoch=1",
                   "version": "1:1.0.2k-19.amzn2.0.3",
                 },
               },
@@ -1446,7 +1446,7 @@ Object {
                 "id": "p11-kit@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -1454,7 +1454,7 @@ Object {
                 "id": "p11-kit-trust@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit-trust@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -1462,7 +1462,7 @@ Object {
                 "id": "pcre@8.32-17.amzn2.0.2",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pcre@8.32-17.amzn2.0.2?distro=amzn-2",
                   "version": "8.32-17.amzn2.0.2",
                 },
               },
@@ -1470,7 +1470,7 @@ Object {
                 "id": "pinentry@0.8.1-17.amzn2.0.2",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pinentry@0.8.1-17.amzn2.0.2?distro=amzn-2",
                   "version": "0.8.1-17.amzn2.0.2",
                 },
               },
@@ -1478,7 +1478,7 @@ Object {
                 "id": "popt@1.13-16.amzn2.0.2",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/popt@1.13-16.amzn2.0.2?distro=amzn-2",
                   "version": "1.13-16.amzn2.0.2",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "pth@2.0.7-23.amzn2.0.2",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pth@2.0.7-23.amzn2.0.2?distro=amzn-2",
                   "version": "2.0.7-23.amzn2.0.2",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "pygpgme@0.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pygpgme@0.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.3-9.amzn2.0.2",
                 },
               },
@@ -1502,7 +1502,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.amzn2.0.2",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyliblzma@0.5.3-11.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.3-11.amzn2.0.2",
                 },
               },
@@ -1510,7 +1510,7 @@ Object {
                 "id": "python@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -1518,7 +1518,7 @@ Object {
                 "id": "python-iniparse@0.4-9.amzn2",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.amzn2",
+                  "purl": "pkg:rpm/amzn/python-iniparse@0.4-9.amzn2?distro=amzn-2",
                   "version": "0.4-9.amzn2",
                 },
               },
@@ -1526,7 +1526,7 @@ Object {
                 "id": "python-libs@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python-libs@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -1534,7 +1534,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.amzn2.0.2",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/python-pycurl@7.19.0-19.amzn2.0.2?distro=amzn-2",
                   "version": "7.19.0-19.amzn2.0.2",
                 },
               },
@@ -1542,7 +1542,7 @@ Object {
                 "id": "python-urlgrabber@3.10-9.amzn2.0.1",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-9.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/python-urlgrabber@3.10-9.amzn2.0.1?distro=amzn-2",
                   "version": "3.10-9.amzn2.0.1",
                 },
               },
@@ -1550,7 +1550,7 @@ Object {
                 "id": "python2-rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "python2-rpm",
-                  "purl": "pkg:rpm/python2-rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/python2-rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -1558,7 +1558,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.amzn2.0.2",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyxattr@0.5.1-5.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.1-5.amzn2.0.2",
                 },
               },
@@ -1566,7 +1566,7 @@ Object {
                 "id": "readline@6.2-10.amzn2.0.2",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/readline@6.2-10.amzn2.0.2?distro=amzn-2",
                   "version": "6.2-10.amzn2.0.2",
                 },
               },
@@ -1574,7 +1574,7 @@ Object {
                 "id": "rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -1582,7 +1582,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-build-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -1590,7 +1590,7 @@ Object {
                 "id": "rpm-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -1598,7 +1598,7 @@ Object {
                 "id": "sed@4.2.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/sed@4.2.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "4.2.2-5.amzn2.0.2",
                 },
               },
@@ -1606,7 +1606,7 @@ Object {
                 "id": "setup@2.8.71-10.amzn2.0.1",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-10.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/setup@2.8.71-10.amzn2.0.1?distro=amzn-2",
                   "version": "2.8.71-10.amzn2.0.1",
                 },
               },
@@ -1614,7 +1614,7 @@ Object {
                 "id": "shared-mime-info@1.8-4.amzn2",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-4.amzn2",
+                  "purl": "pkg:rpm/amzn/shared-mime-info@1.8-4.amzn2?distro=amzn-2",
                   "version": "1.8-4.amzn2",
                 },
               },
@@ -1622,7 +1622,7 @@ Object {
                 "id": "sqlite@3.7.17-8.amzn2.1.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.amzn2.1.1",
+                  "purl": "pkg:rpm/amzn/sqlite@3.7.17-8.amzn2.1.1?distro=amzn-2",
                   "version": "3.7.17-8.amzn2.1.1",
                 },
               },
@@ -1630,7 +1630,7 @@ Object {
                 "id": "system-release@1:2-11.amzn2",
                 "info": Object {
                   "name": "system-release",
-                  "purl": "pkg:rpm/system-release@1:2-11.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/system-release@1:2-11.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:2-11.amzn2",
                 },
               },
@@ -1638,7 +1638,7 @@ Object {
                 "id": "tzdata@2019c-1.amzn2",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2019c-1.amzn2",
+                  "purl": "pkg:rpm/amzn/tzdata@2019c-1.amzn2?distro=amzn-2",
                   "version": "2019c-1.amzn2",
                 },
               },
@@ -1646,7 +1646,7 @@ Object {
                 "id": "vim-minimal@2:8.1.1602-1.amzn2",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.1.1602-1.amzn2?epoch=2",
+                  "purl": "pkg:rpm/amzn/vim-minimal@2:8.1.1602-1.amzn2?distro=amzn-2&epoch=2",
                   "version": "2:8.1.1602-1.amzn2",
                 },
               },
@@ -1654,7 +1654,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.amzn2.0.2",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/xz-libs@5.2.2-1.amzn2.0.2?distro=amzn-2",
                   "version": "5.2.2-1.amzn2.0.2",
                 },
               },
@@ -1662,7 +1662,7 @@ Object {
                 "id": "yum@3.4.3-158.amzn2.0.3",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-158.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/yum@3.4.3-158.amzn2.0.3?distro=amzn-2",
                   "version": "3.4.3-158.amzn2.0.3",
                 },
               },
@@ -1670,7 +1670,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.amzn2.0.2",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/yum-metadata-parser@1.1.4-10.amzn2.0.2?distro=amzn-2",
                   "version": "1.1.4-10.amzn2.0.2",
                 },
               },
@@ -1678,7 +1678,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-ovl@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -1686,7 +1686,7 @@ Object {
                 "id": "yum-plugin-priorities@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-priorities",
-                  "purl": "pkg:rpm/yum-plugin-priorities@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-priorities@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "zlib@1.2.7-18.amzn2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.amzn2",
+                  "purl": "pkg:rpm/amzn/zlib@1.2.7-18.amzn2?distro=amzn-2",
                   "version": "1.2.7-18.amzn2",
                 },
               },
@@ -11934,7 +11934,7 @@ Object {
                 "id": "amazon-linux-extras@1.6.10-1.amzn2",
                 "info": Object {
                   "name": "amazon-linux-extras",
-                  "purl": "pkg:rpm/amazon-linux-extras@1.6.10-1.amzn2",
+                  "purl": "pkg:rpm/amzn/amazon-linux-extras@1.6.10-1.amzn2?distro=amzn-2",
                   "version": "1.6.10-1.amzn2",
                 },
               },
@@ -11942,7 +11942,7 @@ Object {
                 "id": "basesystem@10.0-7.amzn2.0.1",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/basesystem@10.0-7.amzn2.0.1?distro=amzn-2",
                   "version": "10.0-7.amzn2.0.1",
                 },
               },
@@ -11950,7 +11950,7 @@ Object {
                 "id": "bash@4.2.46-33.amzn2",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-33.amzn2",
+                  "purl": "pkg:rpm/amzn/bash@4.2.46-33.amzn2?distro=amzn-2",
                   "version": "4.2.46-33.amzn2",
                 },
               },
@@ -11958,7 +11958,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.amzn2.0.2",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/bzip2-libs@1.0.6-13.amzn2.0.2?distro=amzn-2",
                   "version": "1.0.6-13.amzn2.0.2",
                 },
               },
@@ -11966,7 +11966,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.amzn2.0.1",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/ca-certificates@2019.2.32-76.amzn2.0.1?distro=amzn-2",
                   "version": "2019.2.32-76.amzn2.0.1",
                 },
               },
@@ -11974,7 +11974,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.amzn2.0.2",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/chkconfig@1.7.4-1.amzn2.0.2?distro=amzn-2",
                   "version": "1.7.4-1.amzn2.0.2",
                 },
               },
@@ -11982,7 +11982,7 @@ Object {
                 "id": "coreutils@8.22-24.amzn2",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.amzn2",
+                  "purl": "pkg:rpm/amzn/coreutils@8.22-24.amzn2?distro=amzn-2",
                   "version": "8.22-24.amzn2",
                 },
               },
@@ -11990,7 +11990,7 @@ Object {
                 "id": "cpio@2.11-27.amzn2",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.amzn2",
+                  "purl": "pkg:rpm/amzn/cpio@2.11-27.amzn2?distro=amzn-2",
                   "version": "2.11-27.amzn2",
                 },
               },
@@ -11998,7 +11998,7 @@ Object {
                 "id": "curl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/curl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -12006,7 +12006,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.amzn2",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.amzn2",
+                  "purl": "pkg:rpm/amzn/cyrus-sasl-lib@2.1.26-23.amzn2?distro=amzn-2",
                   "version": "2.1.26-23.amzn2",
                 },
               },
@@ -12014,7 +12014,7 @@ Object {
                 "id": "diffutils@3.3-5.amzn2",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/diffutils@3.3-5.amzn2?distro=amzn-2",
                   "version": "3.3-5.amzn2",
                 },
               },
@@ -12022,7 +12022,7 @@ Object {
                 "id": "elfutils-libelf@0.176-2.amzn2",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-2.amzn2",
+                  "purl": "pkg:rpm/amzn/elfutils-libelf@0.176-2.amzn2?distro=amzn-2",
                   "version": "0.176-2.amzn2",
                 },
               },
@@ -12030,7 +12030,7 @@ Object {
                 "id": "expat@2.1.0-10.amzn2.0.2",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/expat@2.1.0-10.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-10.amzn2.0.2",
                 },
               },
@@ -12038,7 +12038,7 @@ Object {
                 "id": "file-libs@5.11-35.amzn2.0.2",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-35.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/file-libs@5.11-35.amzn2.0.2?distro=amzn-2",
                   "version": "5.11-35.amzn2.0.2",
                 },
               },
@@ -12046,7 +12046,7 @@ Object {
                 "id": "filesystem@3.2-25.amzn2.0.4",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/filesystem@3.2-25.amzn2.0.4?distro=amzn-2",
                   "version": "3.2-25.amzn2.0.4",
                 },
               },
@@ -12054,7 +12054,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.amzn2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/findutils@1:4.5.11-6.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:4.5.11-6.amzn2",
                 },
               },
@@ -12062,7 +12062,7 @@ Object {
                 "id": "gawk@4.0.2-4.amzn2.1.2",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.amzn2.1.2",
+                  "purl": "pkg:rpm/amzn/gawk@4.0.2-4.amzn2.1.2?distro=amzn-2",
                   "version": "4.0.2-4.amzn2.1.2",
                 },
               },
@@ -12070,7 +12070,7 @@ Object {
                 "id": "gdbm@1:1.13-6.amzn2.0.2",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.13-6.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gdbm@1:1.13-6.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:1.13-6.amzn2.0.2",
                 },
               },
@@ -12078,7 +12078,7 @@ Object {
                 "id": "glib2@2.56.1-4.amzn2",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-4.amzn2",
+                  "purl": "pkg:rpm/amzn/glib2@2.56.1-4.amzn2?distro=amzn-2",
                   "version": "2.56.1-4.amzn2",
                 },
               },
@@ -12086,7 +12086,7 @@ Object {
                 "id": "glibc@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -12094,7 +12094,7 @@ Object {
                 "id": "glibc-common@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-common@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -12102,7 +12102,7 @@ Object {
                 "id": "glibc-langpack-en@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/glibc-langpack-en@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-langpack-en@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -12110,7 +12110,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-minimal-langpack@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -12118,7 +12118,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.amzn2.0.2",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gmp@1:6.0.0-15.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:6.0.0-15.amzn2.0.2",
                 },
               },
@@ -12126,7 +12126,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.amzn2.0.4",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/gnupg2@2.0.22-5.amzn2.0.4?distro=amzn-2",
                   "version": "2.0.22-5.amzn2.0.4",
                 },
               },
@@ -12134,7 +12134,7 @@ Object {
                 "id": "gpg-pubkey@c87f5b1a-593863f8",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@c87f5b1a-593863f8",
+                  "purl": "pkg:rpm/amzn/gpg-pubkey@c87f5b1a-593863f8?distro=amzn-2",
                   "version": "c87f5b1a-593863f8",
                 },
               },
@@ -12142,7 +12142,7 @@ Object {
                 "id": "gpgme@1.3.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/gpgme@1.3.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "1.3.2-5.amzn2.0.2",
                 },
               },
@@ -12150,7 +12150,7 @@ Object {
                 "id": "grep@2.20-3.amzn2.0.2",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/grep@2.20-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.20-3.amzn2.0.2",
                 },
               },
@@ -12158,7 +12158,7 @@ Object {
                 "id": "info@5.1-5.amzn2",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.amzn2",
+                  "purl": "pkg:rpm/amzn/info@5.1-5.amzn2?distro=amzn-2",
                   "version": "5.1-5.amzn2",
                 },
               },
@@ -12166,7 +12166,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.amzn2.0.2",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/keyutils-libs@1.5.8-3.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.8-3.amzn2.0.2",
                 },
               },
@@ -12174,7 +12174,7 @@ Object {
                 "id": "krb5-libs@1.15.1-37.amzn2.2.2",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-37.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/krb5-libs@1.15.1-37.amzn2.2.2?distro=amzn-2",
                   "version": "1.15.1-37.amzn2.2.2",
                 },
               },
@@ -12182,7 +12182,7 @@ Object {
                 "id": "libacl@2.2.51-14.amzn2",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-14.amzn2",
+                  "purl": "pkg:rpm/amzn/libacl@2.2.51-14.amzn2?distro=amzn-2",
                   "version": "2.2.51-14.amzn2",
                 },
               },
@@ -12190,7 +12190,7 @@ Object {
                 "id": "libassuan@2.1.0-3.amzn2.0.2",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libassuan@2.1.0-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-3.amzn2.0.2",
                 },
               },
@@ -12198,7 +12198,7 @@ Object {
                 "id": "libattr@2.4.46-12.amzn2.0.2",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libattr@2.4.46-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.4.46-12.amzn2.0.2",
                 },
               },
@@ -12206,7 +12206,7 @@ Object {
                 "id": "libblkid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libblkid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -12214,7 +12214,7 @@ Object {
                 "id": "libcap@2.22-9.amzn2.0.2",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcap@2.22-9.amzn2.0.2?distro=amzn-2",
                   "version": "2.22-9.amzn2.0.2",
                 },
               },
@@ -12222,7 +12222,7 @@ Object {
                 "id": "libcom_err@1.42.9-12.amzn2.0.2",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcom_err@1.42.9-12.amzn2.0.2?distro=amzn-2",
                   "version": "1.42.9-12.amzn2.0.2",
                 },
               },
@@ -12230,7 +12230,7 @@ Object {
                 "id": "libcrypt@2.26-34.amzn2",
                 "info": Object {
                   "name": "libcrypt",
-                  "purl": "pkg:rpm/libcrypt@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/libcrypt@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -12238,7 +12238,7 @@ Object {
                 "id": "libcurl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/libcurl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -12246,7 +12246,7 @@ Object {
                 "id": "libdb@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -12254,7 +12254,7 @@ Object {
                 "id": "libdb-utils@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb-utils@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -12262,7 +12262,7 @@ Object {
                 "id": "libffi@3.0.13-18.amzn2.0.2",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-18.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libffi@3.0.13-18.amzn2.0.2?distro=amzn-2",
                   "version": "3.0.13-18.amzn2.0.2",
                 },
               },
@@ -12270,7 +12270,7 @@ Object {
                 "id": "libgcc@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libgcc@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -12278,7 +12278,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.amzn2.0.2",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libgcrypt@1.5.3-14.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.3-14.amzn2.0.2",
                 },
               },
@@ -12286,7 +12286,7 @@ Object {
                 "id": "libgpg-error@1.12-3.amzn2.0.3",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libgpg-error@1.12-3.amzn2.0.3?distro=amzn-2",
                   "version": "1.12-3.amzn2.0.3",
                 },
               },
@@ -12294,7 +12294,7 @@ Object {
                 "id": "libidn2@2.3.0-1.amzn2",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.3.0-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libidn2@2.3.0-1.amzn2?distro=amzn-2",
                   "version": "2.3.0-1.amzn2",
                 },
               },
@@ -12302,7 +12302,7 @@ Object {
                 "id": "libmetalink@0.1.2-7.amzn2.0.2",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.2-7.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libmetalink@0.1.2-7.amzn2.0.2?distro=amzn-2",
                   "version": "0.1.2-7.amzn2.0.2",
                 },
               },
@@ -12310,7 +12310,7 @@ Object {
                 "id": "libmount@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libmount@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -12318,7 +12318,7 @@ Object {
                 "id": "libnghttp2@1.39.2-1.amzn2",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.39.2-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libnghttp2@1.39.2-1.amzn2?distro=amzn-2",
                   "version": "1.39.2-1.amzn2",
                 },
               },
@@ -12326,7 +12326,7 @@ Object {
                 "id": "libselinux@2.5-12.amzn2.0.2",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libselinux@2.5-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-12.amzn2.0.2",
                 },
               },
@@ -12334,7 +12334,7 @@ Object {
                 "id": "libsepol@2.5-8.1.amzn2.0.2",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-8.1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libsepol@2.5-8.1.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-8.1.amzn2.0.2",
                 },
               },
@@ -12342,7 +12342,7 @@ Object {
                 "id": "libssh2@1.4.3-12.amzn2.2.2",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.4.3-12.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/libssh2@1.4.3-12.amzn2.2.2?distro=amzn-2",
                   "version": "1.4.3-12.amzn2.2.2",
                 },
               },
@@ -12350,7 +12350,7 @@ Object {
                 "id": "libstdc++@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libstdc%2B%2B@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -12358,7 +12358,7 @@ Object {
                 "id": "libtasn1@4.10-1.amzn2.0.2",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libtasn1@4.10-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.10-1.amzn2.0.2",
                 },
               },
@@ -12366,7 +12366,7 @@ Object {
                 "id": "libunistring@0.9.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libunistring@0.9.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.9.3-9.amzn2.0.2",
                 },
               },
@@ -12374,7 +12374,7 @@ Object {
                 "id": "libuuid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libuuid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -12382,7 +12382,7 @@ Object {
                 "id": "libverto@0.2.5-4.amzn2.0.2",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libverto@0.2.5-4.amzn2.0.2?distro=amzn-2",
                   "version": "0.2.5-4.amzn2.0.2",
                 },
               },
@@ -12390,7 +12390,7 @@ Object {
                 "id": "libxml2@2.9.1-6.amzn2.3.3",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.amzn2.3.3",
+                  "purl": "pkg:rpm/amzn/libxml2@2.9.1-6.amzn2.3.3?distro=amzn-2",
                   "version": "2.9.1-6.amzn2.3.3",
                 },
               },
@@ -12398,7 +12398,7 @@ Object {
                 "id": "lua@5.1.4-15.amzn2.0.2",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/lua@5.1.4-15.amzn2.0.2?distro=amzn-2",
                   "version": "5.1.4-15.amzn2.0.2",
                 },
               },
@@ -12406,7 +12406,7 @@ Object {
                 "id": "ncurses@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -12414,7 +12414,7 @@ Object {
                 "id": "ncurses-base@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-base@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -12422,7 +12422,7 @@ Object {
                 "id": "ncurses-libs@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-libs@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -12430,7 +12430,7 @@ Object {
                 "id": "nspr@4.21.0-1.amzn2.0.2",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/nspr@4.21.0-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.21.0-1.amzn2.0.2",
                 },
               },
@@ -12438,7 +12438,7 @@ Object {
                 "id": "nss@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -12446,7 +12446,7 @@ Object {
                 "id": "nss-pem@1.0.3-5.amzn2",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-pem@1.0.3-5.amzn2?distro=amzn-2",
                   "version": "1.0.3-5.amzn2",
                 },
               },
@@ -12454,7 +12454,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -12462,7 +12462,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn-freebl@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -12470,7 +12470,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-sysinit@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -12478,7 +12478,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-tools@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -12486,7 +12486,7 @@ Object {
                 "id": "nss-util@3.44.0-4.amzn2",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-util@3.44.0-4.amzn2?distro=amzn-2",
                   "version": "3.44.0-4.amzn2",
                 },
               },
@@ -12494,7 +12494,7 @@ Object {
                 "id": "openldap@2.4.44-15.amzn2",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-15.amzn2",
+                  "purl": "pkg:rpm/amzn/openldap@2.4.44-15.amzn2?distro=amzn-2",
                   "version": "2.4.44-15.amzn2",
                 },
               },
@@ -12502,7 +12502,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.amzn2.0.3",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.amzn2.0.3?epoch=1",
+                  "purl": "pkg:rpm/amzn/openssl-libs@1:1.0.2k-19.amzn2.0.3?distro=amzn-2&epoch=1",
                   "version": "1:1.0.2k-19.amzn2.0.3",
                 },
               },
@@ -12510,7 +12510,7 @@ Object {
                 "id": "p11-kit@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -12518,7 +12518,7 @@ Object {
                 "id": "p11-kit-trust@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit-trust@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -12526,7 +12526,7 @@ Object {
                 "id": "pcre@8.32-17.amzn2.0.2",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pcre@8.32-17.amzn2.0.2?distro=amzn-2",
                   "version": "8.32-17.amzn2.0.2",
                 },
               },
@@ -12534,7 +12534,7 @@ Object {
                 "id": "pinentry@0.8.1-17.amzn2.0.2",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pinentry@0.8.1-17.amzn2.0.2?distro=amzn-2",
                   "version": "0.8.1-17.amzn2.0.2",
                 },
               },
@@ -12542,7 +12542,7 @@ Object {
                 "id": "popt@1.13-16.amzn2.0.2",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/popt@1.13-16.amzn2.0.2?distro=amzn-2",
                   "version": "1.13-16.amzn2.0.2",
                 },
               },
@@ -12550,7 +12550,7 @@ Object {
                 "id": "pth@2.0.7-23.amzn2.0.2",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pth@2.0.7-23.amzn2.0.2?distro=amzn-2",
                   "version": "2.0.7-23.amzn2.0.2",
                 },
               },
@@ -12558,7 +12558,7 @@ Object {
                 "id": "pygpgme@0.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pygpgme@0.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.3-9.amzn2.0.2",
                 },
               },
@@ -12566,7 +12566,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.amzn2.0.2",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyliblzma@0.5.3-11.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.3-11.amzn2.0.2",
                 },
               },
@@ -12574,7 +12574,7 @@ Object {
                 "id": "python@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -12582,7 +12582,7 @@ Object {
                 "id": "python-iniparse@0.4-9.amzn2",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.amzn2",
+                  "purl": "pkg:rpm/amzn/python-iniparse@0.4-9.amzn2?distro=amzn-2",
                   "version": "0.4-9.amzn2",
                 },
               },
@@ -12590,7 +12590,7 @@ Object {
                 "id": "python-libs@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python-libs@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -12598,7 +12598,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.amzn2.0.2",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/python-pycurl@7.19.0-19.amzn2.0.2?distro=amzn-2",
                   "version": "7.19.0-19.amzn2.0.2",
                 },
               },
@@ -12606,7 +12606,7 @@ Object {
                 "id": "python-urlgrabber@3.10-9.amzn2.0.1",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-9.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/python-urlgrabber@3.10-9.amzn2.0.1?distro=amzn-2",
                   "version": "3.10-9.amzn2.0.1",
                 },
               },
@@ -12614,7 +12614,7 @@ Object {
                 "id": "python2-rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "python2-rpm",
-                  "purl": "pkg:rpm/python2-rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/python2-rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -12622,7 +12622,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.amzn2.0.2",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyxattr@0.5.1-5.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.1-5.amzn2.0.2",
                 },
               },
@@ -12630,7 +12630,7 @@ Object {
                 "id": "readline@6.2-10.amzn2.0.2",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/readline@6.2-10.amzn2.0.2?distro=amzn-2",
                   "version": "6.2-10.amzn2.0.2",
                 },
               },
@@ -12638,7 +12638,7 @@ Object {
                 "id": "rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -12646,7 +12646,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-build-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -12654,7 +12654,7 @@ Object {
                 "id": "rpm-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -12662,7 +12662,7 @@ Object {
                 "id": "sed@4.2.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/sed@4.2.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "4.2.2-5.amzn2.0.2",
                 },
               },
@@ -12670,7 +12670,7 @@ Object {
                 "id": "setup@2.8.71-10.amzn2.0.1",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-10.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/setup@2.8.71-10.amzn2.0.1?distro=amzn-2",
                   "version": "2.8.71-10.amzn2.0.1",
                 },
               },
@@ -12678,7 +12678,7 @@ Object {
                 "id": "shared-mime-info@1.8-4.amzn2",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-4.amzn2",
+                  "purl": "pkg:rpm/amzn/shared-mime-info@1.8-4.amzn2?distro=amzn-2",
                   "version": "1.8-4.amzn2",
                 },
               },
@@ -12686,7 +12686,7 @@ Object {
                 "id": "sqlite@3.7.17-8.amzn2.1.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.amzn2.1.1",
+                  "purl": "pkg:rpm/amzn/sqlite@3.7.17-8.amzn2.1.1?distro=amzn-2",
                   "version": "3.7.17-8.amzn2.1.1",
                 },
               },
@@ -12694,7 +12694,7 @@ Object {
                 "id": "system-release@1:2-11.amzn2",
                 "info": Object {
                   "name": "system-release",
-                  "purl": "pkg:rpm/system-release@1:2-11.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/system-release@1:2-11.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:2-11.amzn2",
                 },
               },
@@ -12702,7 +12702,7 @@ Object {
                 "id": "tzdata@2019c-1.amzn2",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2019c-1.amzn2",
+                  "purl": "pkg:rpm/amzn/tzdata@2019c-1.amzn2?distro=amzn-2",
                   "version": "2019c-1.amzn2",
                 },
               },
@@ -12710,7 +12710,7 @@ Object {
                 "id": "vim-minimal@2:8.1.1602-1.amzn2",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.1.1602-1.amzn2?epoch=2",
+                  "purl": "pkg:rpm/amzn/vim-minimal@2:8.1.1602-1.amzn2?distro=amzn-2&epoch=2",
                   "version": "2:8.1.1602-1.amzn2",
                 },
               },
@@ -12718,7 +12718,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.amzn2.0.2",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/xz-libs@5.2.2-1.amzn2.0.2?distro=amzn-2",
                   "version": "5.2.2-1.amzn2.0.2",
                 },
               },
@@ -12726,7 +12726,7 @@ Object {
                 "id": "yum@3.4.3-158.amzn2.0.3",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-158.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/yum@3.4.3-158.amzn2.0.3?distro=amzn-2",
                   "version": "3.4.3-158.amzn2.0.3",
                 },
               },
@@ -12734,7 +12734,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.amzn2.0.2",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/yum-metadata-parser@1.1.4-10.amzn2.0.2?distro=amzn-2",
                   "version": "1.1.4-10.amzn2.0.2",
                 },
               },
@@ -12742,7 +12742,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-ovl@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -12750,7 +12750,7 @@ Object {
                 "id": "yum-plugin-priorities@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-priorities",
-                  "purl": "pkg:rpm/yum-plugin-priorities@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-priorities@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -12758,7 +12758,7 @@ Object {
                 "id": "zlib@1.2.7-18.amzn2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.amzn2",
+                  "purl": "pkg:rpm/amzn/zlib@1.2.7-18.amzn2?distro=amzn-2",
                   "version": "1.2.7-18.amzn2",
                 },
               },

--- a/test/system/bugs/__snapshots__/rpm-transitive-dependencies.spec.ts.snap
+++ b/test/system/bugs/__snapshots__/rpm-transitive-dependencies.spec.ts.snap
@@ -1349,7 +1349,7 @@ Object {
                 "id": "acl@2.2.51-15.el7",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:rpm/acl@2.2.51-15.el7",
+                  "purl": "pkg:rpm/centos/acl@2.2.51-15.el7?distro=centos-7",
                   "version": "2.2.51-15.el7",
                 },
               },
@@ -1357,7 +1357,7 @@ Object {
                 "id": "audit-libs@2.8.5-4.el7",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@2.8.5-4.el7",
+                  "purl": "pkg:rpm/centos/audit-libs@2.8.5-4.el7?distro=centos-7",
                   "version": "2.8.5-4.el7",
                 },
               },
@@ -1365,7 +1365,7 @@ Object {
                 "id": "basesystem@10.0-7.el7.centos",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.el7.centos",
+                  "purl": "pkg:rpm/centos/basesystem@10.0-7.el7.centos?distro=centos-7",
                   "version": "10.0-7.el7.centos",
                 },
               },
@@ -1373,7 +1373,7 @@ Object {
                 "id": "bash@4.2.46-34.el7",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-34.el7",
+                  "purl": "pkg:rpm/centos/bash@4.2.46-34.el7?distro=centos-7",
                   "version": "4.2.46-34.el7",
                 },
               },
@@ -1381,7 +1381,7 @@ Object {
                 "id": "bind-license@32:9.11.4-16.P2.el7_8.2",
                 "info": Object {
                   "name": "bind-license",
-                  "purl": "pkg:rpm/bind-license@32:9.11.4-16.P2.el7_8.2?epoch=32",
+                  "purl": "pkg:rpm/centos/bind-license@32:9.11.4-16.P2.el7_8.2?distro=centos-7&epoch=32",
                   "version": "32:9.11.4-16.P2.el7_8.2",
                 },
               },
@@ -1389,7 +1389,7 @@ Object {
                 "id": "binutils@2.27-43.base.el7",
                 "info": Object {
                   "name": "binutils",
-                  "purl": "pkg:rpm/binutils@2.27-43.base.el7",
+                  "purl": "pkg:rpm/centos/binutils@2.27-43.base.el7?distro=centos-7",
                   "version": "2.27-43.base.el7",
                 },
               },
@@ -1397,7 +1397,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.el7",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.el7",
+                  "purl": "pkg:rpm/centos/bzip2-libs@1.0.6-13.el7?distro=centos-7",
                   "version": "1.0.6-13.el7",
                 },
               },
@@ -1405,7 +1405,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.el7_7",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.el7_7",
+                  "purl": "pkg:rpm/centos/ca-certificates@2019.2.32-76.el7_7?distro=centos-7",
                   "version": "2019.2.32-76.el7_7",
                 },
               },
@@ -1413,7 +1413,7 @@ Object {
                 "id": "centos-release@7-8.2003.0.el7.centos",
                 "info": Object {
                   "name": "centos-release",
-                  "purl": "pkg:rpm/centos-release@7-8.2003.0.el7.centos",
+                  "purl": "pkg:rpm/centos/centos-release@7-8.2003.0.el7.centos?distro=centos-7",
                   "version": "7-8.2003.0.el7.centos",
                 },
               },
@@ -1421,7 +1421,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.el7",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.el7",
+                  "purl": "pkg:rpm/centos/chkconfig@1.7.4-1.el7?distro=centos-7",
                   "version": "1.7.4-1.el7",
                 },
               },
@@ -1429,7 +1429,7 @@ Object {
                 "id": "coreutils@8.22-24.el7",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.el7",
+                  "purl": "pkg:rpm/centos/coreutils@8.22-24.el7?distro=centos-7",
                   "version": "8.22-24.el7",
                 },
               },
@@ -1437,7 +1437,7 @@ Object {
                 "id": "cpio@2.11-27.el7",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.el7",
+                  "purl": "pkg:rpm/centos/cpio@2.11-27.el7?distro=centos-7",
                   "version": "2.11-27.el7",
                 },
               },
@@ -1445,7 +1445,7 @@ Object {
                 "id": "cpp@4.8.5-39.el7",
                 "info": Object {
                   "name": "cpp",
-                  "purl": "pkg:rpm/cpp@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/cpp@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -1453,7 +1453,7 @@ Object {
                 "id": "cracklib@2.9.0-11.el7",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.0-11.el7",
+                  "purl": "pkg:rpm/centos/cracklib@2.9.0-11.el7?distro=centos-7",
                   "version": "2.9.0-11.el7",
                 },
               },
@@ -1461,7 +1461,7 @@ Object {
                 "id": "cracklib-dicts@2.9.0-11.el7",
                 "info": Object {
                   "name": "cracklib-dicts",
-                  "purl": "pkg:rpm/cracklib-dicts@2.9.0-11.el7",
+                  "purl": "pkg:rpm/centos/cracklib-dicts@2.9.0-11.el7?distro=centos-7",
                   "version": "2.9.0-11.el7",
                 },
               },
@@ -1469,7 +1469,7 @@ Object {
                 "id": "cryptsetup-libs@2.0.3-6.el7",
                 "info": Object {
                   "name": "cryptsetup-libs",
-                  "purl": "pkg:rpm/cryptsetup-libs@2.0.3-6.el7",
+                  "purl": "pkg:rpm/centos/cryptsetup-libs@2.0.3-6.el7?distro=centos-7",
                   "version": "2.0.3-6.el7",
                 },
               },
@@ -1477,7 +1477,7 @@ Object {
                 "id": "curl@7.29.0-57.el7",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.29.0-57.el7",
+                  "purl": "pkg:rpm/centos/curl@7.29.0-57.el7?distro=centos-7",
                   "version": "7.29.0-57.el7",
                 },
               },
@@ -1485,7 +1485,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.el7",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.el7",
+                  "purl": "pkg:rpm/centos/cyrus-sasl-lib@2.1.26-23.el7?distro=centos-7",
                   "version": "2.1.26-23.el7",
                 },
               },
@@ -1493,7 +1493,7 @@ Object {
                 "id": "dbus@1:1.10.24-13.el7_6",
                 "info": Object {
                   "name": "dbus",
-                  "purl": "pkg:rpm/dbus@1:1.10.24-13.el7_6?epoch=1",
+                  "purl": "pkg:rpm/centos/dbus@1:1.10.24-13.el7_6?distro=centos-7&epoch=1",
                   "version": "1:1.10.24-13.el7_6",
                 },
               },
@@ -1501,7 +1501,7 @@ Object {
                 "id": "dbus-glib@0.100-7.el7",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.100-7.el7",
+                  "purl": "pkg:rpm/centos/dbus-glib@0.100-7.el7?distro=centos-7",
                   "version": "0.100-7.el7",
                 },
               },
@@ -1509,7 +1509,7 @@ Object {
                 "id": "dbus-libs@1:1.10.24-13.el7_6",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.10.24-13.el7_6?epoch=1",
+                  "purl": "pkg:rpm/centos/dbus-libs@1:1.10.24-13.el7_6?distro=centos-7&epoch=1",
                   "version": "1:1.10.24-13.el7_6",
                 },
               },
@@ -1517,7 +1517,7 @@ Object {
                 "id": "dbus-python@1.1.1-9.el7",
                 "info": Object {
                   "name": "dbus-python",
-                  "purl": "pkg:rpm/dbus-python@1.1.1-9.el7",
+                  "purl": "pkg:rpm/centos/dbus-python@1.1.1-9.el7?distro=centos-7",
                   "version": "1.1.1-9.el7",
                 },
               },
@@ -1525,7 +1525,7 @@ Object {
                 "id": "device-mapper@7:1.02.164-7.el7_8.1",
                 "info": Object {
                   "name": "device-mapper",
-                  "purl": "pkg:rpm/device-mapper@7:1.02.164-7.el7_8.1?epoch=7",
+                  "purl": "pkg:rpm/centos/device-mapper@7:1.02.164-7.el7_8.1?distro=centos-7&epoch=7",
                   "version": "7:1.02.164-7.el7_8.1",
                 },
               },
@@ -1533,7 +1533,7 @@ Object {
                 "id": "device-mapper-libs@7:1.02.164-7.el7_8.1",
                 "info": Object {
                   "name": "device-mapper-libs",
-                  "purl": "pkg:rpm/device-mapper-libs@7:1.02.164-7.el7_8.1?epoch=7",
+                  "purl": "pkg:rpm/centos/device-mapper-libs@7:1.02.164-7.el7_8.1?distro=centos-7&epoch=7",
                   "version": "7:1.02.164-7.el7_8.1",
                 },
               },
@@ -1541,7 +1541,7 @@ Object {
                 "id": "diffutils@3.3-5.el7",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.el7",
+                  "purl": "pkg:rpm/centos/diffutils@3.3-5.el7?distro=centos-7",
                   "version": "3.3-5.el7",
                 },
               },
@@ -1549,7 +1549,7 @@ Object {
                 "id": "dracut@033-568.el7",
                 "info": Object {
                   "name": "dracut",
-                  "purl": "pkg:rpm/dracut@033-568.el7",
+                  "purl": "pkg:rpm/centos/dracut@033-568.el7?distro=centos-7",
                   "version": "033-568.el7",
                 },
               },
@@ -1557,7 +1557,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-default-yama-scope@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -1565,7 +1565,7 @@ Object {
                 "id": "elfutils-libelf@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-libelf@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -1573,7 +1573,7 @@ Object {
                 "id": "elfutils-libs@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-libs@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -1581,7 +1581,7 @@ Object {
                 "id": "expat@2.1.0-11.el7",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-11.el7",
+                  "purl": "pkg:rpm/centos/expat@2.1.0-11.el7?distro=centos-7",
                   "version": "2.1.0-11.el7",
                 },
               },
@@ -1589,7 +1589,7 @@ Object {
                 "id": "file-libs@5.11-36.el7",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-36.el7",
+                  "purl": "pkg:rpm/centos/file-libs@5.11-36.el7?distro=centos-7",
                   "version": "5.11-36.el7",
                 },
               },
@@ -1597,7 +1597,7 @@ Object {
                 "id": "filesystem@3.2-25.el7",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.el7",
+                  "purl": "pkg:rpm/centos/filesystem@3.2-25.el7?distro=centos-7",
                   "version": "3.2-25.el7",
                 },
               },
@@ -1605,7 +1605,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.el7",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/findutils@1:4.5.11-6.el7?distro=centos-7&epoch=1",
                   "version": "1:4.5.11-6.el7",
                 },
               },
@@ -1613,7 +1613,7 @@ Object {
                 "id": "gawk@4.0.2-4.el7_3.1",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.el7_3.1",
+                  "purl": "pkg:rpm/centos/gawk@4.0.2-4.el7_3.1?distro=centos-7",
                   "version": "4.0.2-4.el7_3.1",
                 },
               },
@@ -1621,7 +1621,7 @@ Object {
                 "id": "gcc@4.8.5-39.el7",
                 "info": Object {
                   "name": "gcc",
-                  "purl": "pkg:rpm/gcc@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/gcc@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -1629,7 +1629,7 @@ Object {
                 "id": "gcc-c++@4.8.5-39.el7",
                 "info": Object {
                   "name": "gcc-c++",
-                  "purl": "pkg:rpm/gcc-c%2B%2B@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/gcc-c%2B%2B@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -1637,7 +1637,7 @@ Object {
                 "id": "gdbm@1.10-8.el7",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1.10-8.el7",
+                  "purl": "pkg:rpm/centos/gdbm@1.10-8.el7?distro=centos-7",
                   "version": "1.10-8.el7",
                 },
               },
@@ -1645,7 +1645,7 @@ Object {
                 "id": "geoipupdate@2.5.0-1.el7",
                 "info": Object {
                   "name": "geoipupdate",
-                  "purl": "pkg:rpm/geoipupdate@2.5.0-1.el7",
+                  "purl": "pkg:rpm/centos/geoipupdate@2.5.0-1.el7?distro=centos-7",
                   "version": "2.5.0-1.el7",
                 },
               },
@@ -1653,7 +1653,7 @@ Object {
                 "id": "glib2@2.56.1-5.el7",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-5.el7",
+                  "purl": "pkg:rpm/centos/glib2@2.56.1-5.el7?distro=centos-7",
                   "version": "2.56.1-5.el7",
                 },
               },
@@ -1661,7 +1661,7 @@ Object {
                 "id": "glibc@2.17-307.el7.1",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.17-307.el7.1",
+                  "purl": "pkg:rpm/centos/glibc@2.17-307.el7.1?distro=centos-7",
                   "version": "2.17-307.el7.1",
                 },
               },
@@ -1669,7 +1669,7 @@ Object {
                 "id": "glibc-common@2.17-307.el7.1",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.17-307.el7.1",
+                  "purl": "pkg:rpm/centos/glibc-common@2.17-307.el7.1?distro=centos-7",
                   "version": "2.17-307.el7.1",
                 },
               },
@@ -1677,7 +1677,7 @@ Object {
                 "id": "glibc-devel@2.17-307.el7.1",
                 "info": Object {
                   "name": "glibc-devel",
-                  "purl": "pkg:rpm/glibc-devel@2.17-307.el7.1",
+                  "purl": "pkg:rpm/centos/glibc-devel@2.17-307.el7.1?distro=centos-7",
                   "version": "2.17-307.el7.1",
                 },
               },
@@ -1685,7 +1685,7 @@ Object {
                 "id": "glibc-headers@2.17-307.el7.1",
                 "info": Object {
                   "name": "glibc-headers",
-                  "purl": "pkg:rpm/glibc-headers@2.17-307.el7.1",
+                  "purl": "pkg:rpm/centos/glibc-headers@2.17-307.el7.1?distro=centos-7",
                   "version": "2.17-307.el7.1",
                 },
               },
@@ -1693,7 +1693,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.el7",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/gmp@1:6.0.0-15.el7?distro=centos-7&epoch=1",
                   "version": "1:6.0.0-15.el7",
                 },
               },
@@ -1701,7 +1701,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.el7_5",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.el7_5",
+                  "purl": "pkg:rpm/centos/gnupg2@2.0.22-5.el7_5?distro=centos-7",
                   "version": "2.0.22-5.el7_5",
                 },
               },
@@ -1709,7 +1709,7 @@ Object {
                 "id": "gobject-introspection@1.56.1-1.el7",
                 "info": Object {
                   "name": "gobject-introspection",
-                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el7",
+                  "purl": "pkg:rpm/centos/gobject-introspection@1.56.1-1.el7?distro=centos-7",
                   "version": "1.56.1-1.el7",
                 },
               },
@@ -1717,7 +1717,7 @@ Object {
                 "id": "gpg-pubkey@34fa74dd-540237d4",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@34fa74dd-540237d4",
+                  "purl": "pkg:rpm/centos/gpg-pubkey@34fa74dd-540237d4?distro=centos-7",
                   "version": "34fa74dd-540237d4",
                 },
               },
@@ -1725,7 +1725,7 @@ Object {
                 "id": "gpgme@1.3.2-5.el7",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.el7",
+                  "purl": "pkg:rpm/centos/gpgme@1.3.2-5.el7?distro=centos-7",
                   "version": "1.3.2-5.el7",
                 },
               },
@@ -1733,7 +1733,7 @@ Object {
                 "id": "grep@2.20-3.el7",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.el7",
+                  "purl": "pkg:rpm/centos/grep@2.20-3.el7?distro=centos-7",
                   "version": "2.20-3.el7",
                 },
               },
@@ -1741,7 +1741,7 @@ Object {
                 "id": "gzip@1.5-10.el7",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.5-10.el7",
+                  "purl": "pkg:rpm/centos/gzip@1.5-10.el7?distro=centos-7",
                   "version": "1.5-10.el7",
                 },
               },
@@ -1749,7 +1749,7 @@ Object {
                 "id": "hardlink@1:1.0-19.el7",
                 "info": Object {
                   "name": "hardlink",
-                  "purl": "pkg:rpm/hardlink@1:1.0-19.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/hardlink@1:1.0-19.el7?distro=centos-7&epoch=1",
                   "version": "1:1.0-19.el7",
                 },
               },
@@ -1757,7 +1757,7 @@ Object {
                 "id": "hostname@3.13-3.el7_7.1",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:rpm/hostname@3.13-3.el7_7.1",
+                  "purl": "pkg:rpm/centos/hostname@3.13-3.el7_7.1?distro=centos-7",
                   "version": "3.13-3.el7_7.1",
                 },
               },
@@ -1765,7 +1765,7 @@ Object {
                 "id": "info@5.1-5.el7",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.el7",
+                  "purl": "pkg:rpm/centos/info@5.1-5.el7?distro=centos-7",
                   "version": "5.1-5.el7",
                 },
               },
@@ -1773,7 +1773,7 @@ Object {
                 "id": "iputils@20160308-10.el7",
                 "info": Object {
                   "name": "iputils",
-                  "purl": "pkg:rpm/iputils@20160308-10.el7",
+                  "purl": "pkg:rpm/centos/iputils@20160308-10.el7?distro=centos-7",
                   "version": "20160308-10.el7",
                 },
               },
@@ -1781,7 +1781,7 @@ Object {
                 "id": "json-c@0.11-4.el7_0",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.11-4.el7_0",
+                  "purl": "pkg:rpm/centos/json-c@0.11-4.el7_0?distro=centos-7",
                   "version": "0.11-4.el7_0",
                 },
               },
@@ -1789,7 +1789,7 @@ Object {
                 "id": "kernel-headers@3.10.0-1127.10.1.el7",
                 "info": Object {
                   "name": "kernel-headers",
-                  "purl": "pkg:rpm/kernel-headers@3.10.0-1127.10.1.el7",
+                  "purl": "pkg:rpm/centos/kernel-headers@3.10.0-1127.10.1.el7?distro=centos-7",
                   "version": "3.10.0-1127.10.1.el7",
                 },
               },
@@ -1797,7 +1797,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.el7",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.el7",
+                  "purl": "pkg:rpm/centos/keyutils-libs@1.5.8-3.el7?distro=centos-7",
                   "version": "1.5.8-3.el7",
                 },
               },
@@ -1805,7 +1805,7 @@ Object {
                 "id": "kmod@20-28.el7",
                 "info": Object {
                   "name": "kmod",
-                  "purl": "pkg:rpm/kmod@20-28.el7",
+                  "purl": "pkg:rpm/centos/kmod@20-28.el7?distro=centos-7",
                   "version": "20-28.el7",
                 },
               },
@@ -1813,7 +1813,7 @@ Object {
                 "id": "kmod-libs@20-28.el7",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/kmod-libs@20-28.el7",
+                  "purl": "pkg:rpm/centos/kmod-libs@20-28.el7?distro=centos-7",
                   "version": "20-28.el7",
                 },
               },
@@ -1821,7 +1821,7 @@ Object {
                 "id": "kpartx@0.4.9-131.el7",
                 "info": Object {
                   "name": "kpartx",
-                  "purl": "pkg:rpm/kpartx@0.4.9-131.el7",
+                  "purl": "pkg:rpm/centos/kpartx@0.4.9-131.el7?distro=centos-7",
                   "version": "0.4.9-131.el7",
                 },
               },
@@ -1829,7 +1829,7 @@ Object {
                 "id": "krb5-libs@1.15.1-46.el7",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-46.el7",
+                  "purl": "pkg:rpm/centos/krb5-libs@1.15.1-46.el7?distro=centos-7",
                   "version": "1.15.1-46.el7",
                 },
               },
@@ -1837,7 +1837,7 @@ Object {
                 "id": "libacl@2.2.51-15.el7",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-15.el7",
+                  "purl": "pkg:rpm/centos/libacl@2.2.51-15.el7?distro=centos-7",
                   "version": "2.2.51-15.el7",
                 },
               },
@@ -1845,7 +1845,7 @@ Object {
                 "id": "libassuan@2.1.0-3.el7",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.el7",
+                  "purl": "pkg:rpm/centos/libassuan@2.1.0-3.el7?distro=centos-7",
                   "version": "2.1.0-3.el7",
                 },
               },
@@ -1853,7 +1853,7 @@ Object {
                 "id": "libattr@2.4.46-13.el7",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-13.el7",
+                  "purl": "pkg:rpm/centos/libattr@2.4.46-13.el7?distro=centos-7",
                   "version": "2.4.46-13.el7",
                 },
               },
@@ -1861,7 +1861,7 @@ Object {
                 "id": "libblkid@2.23.2-63.el7",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libblkid@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -1869,7 +1869,7 @@ Object {
                 "id": "libcap@2.22-11.el7",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-11.el7",
+                  "purl": "pkg:rpm/centos/libcap@2.22-11.el7?distro=centos-7",
                   "version": "2.22-11.el7",
                 },
               },
@@ -1877,7 +1877,7 @@ Object {
                 "id": "libcap-ng@0.7.5-4.el7",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.7.5-4.el7",
+                  "purl": "pkg:rpm/centos/libcap-ng@0.7.5-4.el7?distro=centos-7",
                   "version": "0.7.5-4.el7",
                 },
               },
@@ -1885,7 +1885,7 @@ Object {
                 "id": "libcom_err@1.42.9-17.el7",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-17.el7",
+                  "purl": "pkg:rpm/centos/libcom_err@1.42.9-17.el7?distro=centos-7",
                   "version": "1.42.9-17.el7",
                 },
               },
@@ -1893,7 +1893,7 @@ Object {
                 "id": "libcurl@7.29.0-57.el7",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.29.0-57.el7",
+                  "purl": "pkg:rpm/centos/libcurl@7.29.0-57.el7?distro=centos-7",
                   "version": "7.29.0-57.el7",
                 },
               },
@@ -1901,7 +1901,7 @@ Object {
                 "id": "libdb@5.3.21-25.el7",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-25.el7",
+                  "purl": "pkg:rpm/centos/libdb@5.3.21-25.el7?distro=centos-7",
                   "version": "5.3.21-25.el7",
                 },
               },
@@ -1909,7 +1909,7 @@ Object {
                 "id": "libdb-utils@5.3.21-25.el7",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-25.el7",
+                  "purl": "pkg:rpm/centos/libdb-utils@5.3.21-25.el7?distro=centos-7",
                   "version": "5.3.21-25.el7",
                 },
               },
@@ -1917,7 +1917,7 @@ Object {
                 "id": "libffi@3.0.13-19.el7",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-19.el7",
+                  "purl": "pkg:rpm/centos/libffi@3.0.13-19.el7?distro=centos-7",
                   "version": "3.0.13-19.el7",
                 },
               },
@@ -1925,7 +1925,7 @@ Object {
                 "id": "libgcc@4.8.5-39.el7",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/libgcc@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -1933,7 +1933,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.el7",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.el7",
+                  "purl": "pkg:rpm/centos/libgcrypt@1.5.3-14.el7?distro=centos-7",
                   "version": "1.5.3-14.el7",
                 },
               },
@@ -1941,7 +1941,7 @@ Object {
                 "id": "libgomp@4.8.5-39.el7",
                 "info": Object {
                   "name": "libgomp",
-                  "purl": "pkg:rpm/libgomp@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/libgomp@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -1949,7 +1949,7 @@ Object {
                 "id": "libgpg-error@1.12-3.el7",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.el7",
+                  "purl": "pkg:rpm/centos/libgpg-error@1.12-3.el7?distro=centos-7",
                   "version": "1.12-3.el7",
                 },
               },
@@ -1957,7 +1957,7 @@ Object {
                 "id": "libidn@1.28-4.el7",
                 "info": Object {
                   "name": "libidn",
-                  "purl": "pkg:rpm/libidn@1.28-4.el7",
+                  "purl": "pkg:rpm/centos/libidn@1.28-4.el7?distro=centos-7",
                   "version": "1.28-4.el7",
                 },
               },
@@ -1965,7 +1965,7 @@ Object {
                 "id": "libmount@2.23.2-63.el7",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libmount@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -1973,7 +1973,7 @@ Object {
                 "id": "libmpc@1.0.1-3.el7",
                 "info": Object {
                   "name": "libmpc",
-                  "purl": "pkg:rpm/libmpc@1.0.1-3.el7",
+                  "purl": "pkg:rpm/centos/libmpc@1.0.1-3.el7?distro=centos-7",
                   "version": "1.0.1-3.el7",
                 },
               },
@@ -1981,7 +1981,7 @@ Object {
                 "id": "libpwquality@1.2.3-5.el7",
                 "info": Object {
                   "name": "libpwquality",
-                  "purl": "pkg:rpm/libpwquality@1.2.3-5.el7",
+                  "purl": "pkg:rpm/centos/libpwquality@1.2.3-5.el7?distro=centos-7",
                   "version": "1.2.3-5.el7",
                 },
               },
@@ -1989,7 +1989,7 @@ Object {
                 "id": "libselinux@2.5-15.el7",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-15.el7",
+                  "purl": "pkg:rpm/centos/libselinux@2.5-15.el7?distro=centos-7",
                   "version": "2.5-15.el7",
                 },
               },
@@ -1997,7 +1997,7 @@ Object {
                 "id": "libsemanage@2.5-14.el7",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.5-14.el7",
+                  "purl": "pkg:rpm/centos/libsemanage@2.5-14.el7?distro=centos-7",
                   "version": "2.5-14.el7",
                 },
               },
@@ -2005,7 +2005,7 @@ Object {
                 "id": "libsepol@2.5-10.el7",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-10.el7",
+                  "purl": "pkg:rpm/centos/libsepol@2.5-10.el7?distro=centos-7",
                   "version": "2.5-10.el7",
                 },
               },
@@ -2013,7 +2013,7 @@ Object {
                 "id": "libsmartcols@2.23.2-63.el7",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libsmartcols@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -2021,7 +2021,7 @@ Object {
                 "id": "libssh2@1.8.0-3.el7",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.8.0-3.el7",
+                  "purl": "pkg:rpm/centos/libssh2@1.8.0-3.el7?distro=centos-7",
                   "version": "1.8.0-3.el7",
                 },
               },
@@ -2029,7 +2029,7 @@ Object {
                 "id": "libstdc++@4.8.5-39.el7",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/libstdc%2B%2B@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -2037,7 +2037,7 @@ Object {
                 "id": "libstdc++-devel@4.8.5-39.el7",
                 "info": Object {
                   "name": "libstdc++-devel",
-                  "purl": "pkg:rpm/libstdc%2B%2B-devel@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/libstdc%2B%2B-devel@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -2045,7 +2045,7 @@ Object {
                 "id": "libtasn1@4.10-1.el7",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.el7",
+                  "purl": "pkg:rpm/centos/libtasn1@4.10-1.el7?distro=centos-7",
                   "version": "4.10-1.el7",
                 },
               },
@@ -2053,7 +2053,7 @@ Object {
                 "id": "libuser@0.60-9.el7",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.60-9.el7",
+                  "purl": "pkg:rpm/centos/libuser@0.60-9.el7?distro=centos-7",
                   "version": "0.60-9.el7",
                 },
               },
@@ -2061,7 +2061,7 @@ Object {
                 "id": "libutempter@1.1.6-4.el7",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.6-4.el7",
+                  "purl": "pkg:rpm/centos/libutempter@1.1.6-4.el7?distro=centos-7",
                   "version": "1.1.6-4.el7",
                 },
               },
@@ -2069,7 +2069,7 @@ Object {
                 "id": "libuuid@2.23.2-63.el7",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libuuid@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -2077,7 +2077,7 @@ Object {
                 "id": "libverto@0.2.5-4.el7",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.el7",
+                  "purl": "pkg:rpm/centos/libverto@0.2.5-4.el7?distro=centos-7",
                   "version": "0.2.5-4.el7",
                 },
               },
@@ -2085,7 +2085,7 @@ Object {
                 "id": "libxml2@2.9.1-6.el7.4",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.el7.4",
+                  "purl": "pkg:rpm/centos/libxml2@2.9.1-6.el7.4?distro=centos-7",
                   "version": "2.9.1-6.el7.4",
                 },
               },
@@ -2093,7 +2093,7 @@ Object {
                 "id": "libxml2-python@2.9.1-6.el7.4",
                 "info": Object {
                   "name": "libxml2-python",
-                  "purl": "pkg:rpm/libxml2-python@2.9.1-6.el7.4",
+                  "purl": "pkg:rpm/centos/libxml2-python@2.9.1-6.el7.4?distro=centos-7",
                   "version": "2.9.1-6.el7.4",
                 },
               },
@@ -2101,7 +2101,7 @@ Object {
                 "id": "lua@5.1.4-15.el7",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.el7",
+                  "purl": "pkg:rpm/centos/lua@5.1.4-15.el7?distro=centos-7",
                   "version": "5.1.4-15.el7",
                 },
               },
@@ -2109,7 +2109,7 @@ Object {
                 "id": "lz4@1.7.5-3.el7",
                 "info": Object {
                   "name": "lz4",
-                  "purl": "pkg:rpm/lz4@1.7.5-3.el7",
+                  "purl": "pkg:rpm/centos/lz4@1.7.5-3.el7?distro=centos-7",
                   "version": "1.7.5-3.el7",
                 },
               },
@@ -2117,7 +2117,7 @@ Object {
                 "id": "make@1:3.82-24.el7",
                 "info": Object {
                   "name": "make",
-                  "purl": "pkg:rpm/make@1:3.82-24.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/make@1:3.82-24.el7?distro=centos-7&epoch=1",
                   "version": "1:3.82-24.el7",
                 },
               },
@@ -2125,7 +2125,7 @@ Object {
                 "id": "mpfr@3.1.1-4.el7",
                 "info": Object {
                   "name": "mpfr",
-                  "purl": "pkg:rpm/mpfr@3.1.1-4.el7",
+                  "purl": "pkg:rpm/centos/mpfr@3.1.1-4.el7?distro=centos-7",
                   "version": "3.1.1-4.el7",
                 },
               },
@@ -2133,7 +2133,7 @@ Object {
                 "id": "ncurses@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -2141,7 +2141,7 @@ Object {
                 "id": "ncurses-base@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses-base@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -2149,7 +2149,7 @@ Object {
                 "id": "ncurses-libs@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses-libs@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -2157,7 +2157,7 @@ Object {
                 "id": "nodejs@2:10.15.3-1nodesource",
                 "info": Object {
                   "name": "nodejs",
-                  "purl": "pkg:rpm/nodejs@2:10.15.3-1nodesource?epoch=2",
+                  "purl": "pkg:rpm/centos/nodejs@2:10.15.3-1nodesource?distro=centos-7&epoch=2",
                   "version": "2:10.15.3-1nodesource",
                 },
               },
@@ -2165,7 +2165,7 @@ Object {
                 "id": "nodesource-release@el7-1",
                 "info": Object {
                   "name": "nodesource-release",
-                  "purl": "pkg:rpm/nodesource-release@el7-1",
+                  "purl": "pkg:rpm/centos/nodesource-release@el7-1?distro=centos-7",
                   "version": "el7-1",
                 },
               },
@@ -2173,7 +2173,7 @@ Object {
                 "id": "nspr@4.21.0-1.el7",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.el7",
+                  "purl": "pkg:rpm/centos/nspr@4.21.0-1.el7?distro=centos-7",
                   "version": "4.21.0-1.el7",
                 },
               },
@@ -2181,7 +2181,7 @@ Object {
                 "id": "nss@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -2189,7 +2189,7 @@ Object {
                 "id": "nss-pem@1.0.3-7.el7",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-7.el7",
+                  "purl": "pkg:rpm/centos/nss-pem@1.0.3-7.el7?distro=centos-7",
                   "version": "1.0.3-7.el7",
                 },
               },
@@ -2197,7 +2197,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.el7_7",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.el7_7",
+                  "purl": "pkg:rpm/centos/nss-softokn@3.44.0-8.el7_7?distro=centos-7",
                   "version": "3.44.0-8.el7_7",
                 },
               },
@@ -2205,7 +2205,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.el7_7",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.el7_7",
+                  "purl": "pkg:rpm/centos/nss-softokn-freebl@3.44.0-8.el7_7?distro=centos-7",
                   "version": "3.44.0-8.el7_7",
                 },
               },
@@ -2213,7 +2213,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss-sysinit@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -2221,7 +2221,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss-tools@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -2229,7 +2229,7 @@ Object {
                 "id": "nss-util@3.44.0-4.el7_7",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.el7_7",
+                  "purl": "pkg:rpm/centos/nss-util@3.44.0-4.el7_7?distro=centos-7",
                   "version": "3.44.0-4.el7_7",
                 },
               },
@@ -2237,7 +2237,7 @@ Object {
                 "id": "openldap@2.4.44-21.el7_6",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-21.el7_6",
+                  "purl": "pkg:rpm/centos/openldap@2.4.44-21.el7_6?distro=centos-7",
                   "version": "2.4.44-21.el7_6",
                 },
               },
@@ -2245,7 +2245,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.el7",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/openssl-libs@1:1.0.2k-19.el7?distro=centos-7&epoch=1",
                   "version": "1:1.0.2k-19.el7",
                 },
               },
@@ -2253,7 +2253,7 @@ Object {
                 "id": "p11-kit@0.23.5-3.el7",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.5-3.el7",
+                  "purl": "pkg:rpm/centos/p11-kit@0.23.5-3.el7?distro=centos-7",
                   "version": "0.23.5-3.el7",
                 },
               },
@@ -2261,7 +2261,7 @@ Object {
                 "id": "p11-kit-trust@0.23.5-3.el7",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.5-3.el7",
+                  "purl": "pkg:rpm/centos/p11-kit-trust@0.23.5-3.el7?distro=centos-7",
                   "version": "0.23.5-3.el7",
                 },
               },
@@ -2269,7 +2269,7 @@ Object {
                 "id": "pam@1.1.8-23.el7",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.1.8-23.el7",
+                  "purl": "pkg:rpm/centos/pam@1.1.8-23.el7?distro=centos-7",
                   "version": "1.1.8-23.el7",
                 },
               },
@@ -2277,7 +2277,7 @@ Object {
                 "id": "passwd@0.79-6.el7",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.79-6.el7",
+                  "purl": "pkg:rpm/centos/passwd@0.79-6.el7?distro=centos-7",
                   "version": "0.79-6.el7",
                 },
               },
@@ -2285,7 +2285,7 @@ Object {
                 "id": "pcre@8.32-17.el7",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.el7",
+                  "purl": "pkg:rpm/centos/pcre@8.32-17.el7?distro=centos-7",
                   "version": "8.32-17.el7",
                 },
               },
@@ -2293,7 +2293,7 @@ Object {
                 "id": "pinentry@0.8.1-17.el7",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.el7",
+                  "purl": "pkg:rpm/centos/pinentry@0.8.1-17.el7?distro=centos-7",
                   "version": "0.8.1-17.el7",
                 },
               },
@@ -2301,7 +2301,7 @@ Object {
                 "id": "pkgconfig@1:0.27.1-4.el7",
                 "info": Object {
                   "name": "pkgconfig",
-                  "purl": "pkg:rpm/pkgconfig@1:0.27.1-4.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/pkgconfig@1:0.27.1-4.el7?distro=centos-7&epoch=1",
                   "version": "1:0.27.1-4.el7",
                 },
               },
@@ -2309,7 +2309,7 @@ Object {
                 "id": "popt@1.13-16.el7",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.el7",
+                  "purl": "pkg:rpm/centos/popt@1.13-16.el7?distro=centos-7",
                   "version": "1.13-16.el7",
                 },
               },
@@ -2317,7 +2317,7 @@ Object {
                 "id": "procps-ng@3.3.10-27.el7",
                 "info": Object {
                   "name": "procps-ng",
-                  "purl": "pkg:rpm/procps-ng@3.3.10-27.el7",
+                  "purl": "pkg:rpm/centos/procps-ng@3.3.10-27.el7?distro=centos-7",
                   "version": "3.3.10-27.el7",
                 },
               },
@@ -2325,7 +2325,7 @@ Object {
                 "id": "pth@2.0.7-23.el7",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.el7",
+                  "purl": "pkg:rpm/centos/pth@2.0.7-23.el7?distro=centos-7",
                   "version": "2.0.7-23.el7",
                 },
               },
@@ -2333,7 +2333,7 @@ Object {
                 "id": "pygpgme@0.3-9.el7",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.el7",
+                  "purl": "pkg:rpm/centos/pygpgme@0.3-9.el7?distro=centos-7",
                   "version": "0.3-9.el7",
                 },
               },
@@ -2341,7 +2341,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.el7",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.el7",
+                  "purl": "pkg:rpm/centos/pyliblzma@0.5.3-11.el7?distro=centos-7",
                   "version": "0.5.3-11.el7",
                 },
               },
@@ -2349,7 +2349,7 @@ Object {
                 "id": "python@2.7.5-88.el7",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.5-88.el7",
+                  "purl": "pkg:rpm/centos/python@2.7.5-88.el7?distro=centos-7",
                   "version": "2.7.5-88.el7",
                 },
               },
@@ -2357,7 +2357,7 @@ Object {
                 "id": "python-chardet@2.2.1-3.el7",
                 "info": Object {
                   "name": "python-chardet",
-                  "purl": "pkg:rpm/python-chardet@2.2.1-3.el7",
+                  "purl": "pkg:rpm/centos/python-chardet@2.2.1-3.el7?distro=centos-7",
                   "version": "2.2.1-3.el7",
                 },
               },
@@ -2365,7 +2365,7 @@ Object {
                 "id": "python-gobject-base@3.22.0-1.el7_4.1",
                 "info": Object {
                   "name": "python-gobject-base",
-                  "purl": "pkg:rpm/python-gobject-base@3.22.0-1.el7_4.1",
+                  "purl": "pkg:rpm/centos/python-gobject-base@3.22.0-1.el7_4.1?distro=centos-7",
                   "version": "3.22.0-1.el7_4.1",
                 },
               },
@@ -2373,7 +2373,7 @@ Object {
                 "id": "python-iniparse@0.4-9.el7",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.el7",
+                  "purl": "pkg:rpm/centos/python-iniparse@0.4-9.el7?distro=centos-7",
                   "version": "0.4-9.el7",
                 },
               },
@@ -2381,7 +2381,7 @@ Object {
                 "id": "python-kitchen@1.1.1-5.el7",
                 "info": Object {
                   "name": "python-kitchen",
-                  "purl": "pkg:rpm/python-kitchen@1.1.1-5.el7",
+                  "purl": "pkg:rpm/centos/python-kitchen@1.1.1-5.el7?distro=centos-7",
                   "version": "1.1.1-5.el7",
                 },
               },
@@ -2389,7 +2389,7 @@ Object {
                 "id": "python-libs@2.7.5-88.el7",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.5-88.el7",
+                  "purl": "pkg:rpm/centos/python-libs@2.7.5-88.el7?distro=centos-7",
                   "version": "2.7.5-88.el7",
                 },
               },
@@ -2397,7 +2397,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.el7",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.el7",
+                  "purl": "pkg:rpm/centos/python-pycurl@7.19.0-19.el7?distro=centos-7",
                   "version": "7.19.0-19.el7",
                 },
               },
@@ -2405,7 +2405,7 @@ Object {
                 "id": "python-urlgrabber@3.10-10.el7",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-10.el7",
+                  "purl": "pkg:rpm/centos/python-urlgrabber@3.10-10.el7?distro=centos-7",
                   "version": "3.10-10.el7",
                 },
               },
@@ -2413,7 +2413,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.el7",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.el7",
+                  "purl": "pkg:rpm/centos/pyxattr@0.5.1-5.el7?distro=centos-7",
                   "version": "0.5.1-5.el7",
                 },
               },
@@ -2421,7 +2421,7 @@ Object {
                 "id": "qrencode-libs@3.4.1-3.el7",
                 "info": Object {
                   "name": "qrencode-libs",
-                  "purl": "pkg:rpm/qrencode-libs@3.4.1-3.el7",
+                  "purl": "pkg:rpm/centos/qrencode-libs@3.4.1-3.el7?distro=centos-7",
                   "version": "3.4.1-3.el7",
                 },
               },
@@ -2429,7 +2429,7 @@ Object {
                 "id": "readline@6.2-11.el7",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-11.el7",
+                  "purl": "pkg:rpm/centos/readline@6.2-11.el7?distro=centos-7",
                   "version": "6.2-11.el7",
                 },
               },
@@ -2437,7 +2437,7 @@ Object {
                 "id": "rootfiles@8.1-11.el7",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-11.el7",
+                  "purl": "pkg:rpm/centos/rootfiles@8.1-11.el7?distro=centos-7",
                   "version": "8.1-11.el7",
                 },
               },
@@ -2445,7 +2445,7 @@ Object {
                 "id": "rpm@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -2453,7 +2453,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-build-libs@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -2461,7 +2461,7 @@ Object {
                 "id": "rpm-libs@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-libs@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -2469,7 +2469,7 @@ Object {
                 "id": "rpm-python@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-python",
-                  "purl": "pkg:rpm/rpm-python@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-python@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -2477,7 +2477,7 @@ Object {
                 "id": "sed@4.2.2-6.el7",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-6.el7",
+                  "purl": "pkg:rpm/centos/sed@4.2.2-6.el7?distro=centos-7",
                   "version": "4.2.2-6.el7",
                 },
               },
@@ -2485,7 +2485,7 @@ Object {
                 "id": "setup@2.8.71-11.el7",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-11.el7",
+                  "purl": "pkg:rpm/centos/setup@2.8.71-11.el7?distro=centos-7",
                   "version": "2.8.71-11.el7",
                 },
               },
@@ -2493,7 +2493,7 @@ Object {
                 "id": "shadow-utils@2:4.6-5.el7",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.6-5.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/shadow-utils@2:4.6-5.el7?distro=centos-7&epoch=2",
                   "version": "2:4.6-5.el7",
                 },
               },
@@ -2501,7 +2501,7 @@ Object {
                 "id": "shared-mime-info@1.8-5.el7",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-5.el7",
+                  "purl": "pkg:rpm/centos/shared-mime-info@1.8-5.el7?distro=centos-7",
                   "version": "1.8-5.el7",
                 },
               },
@@ -2509,7 +2509,7 @@ Object {
                 "id": "sqlite@3.7.17-8.el7_7.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.el7_7.1",
+                  "purl": "pkg:rpm/centos/sqlite@3.7.17-8.el7_7.1?distro=centos-7",
                   "version": "3.7.17-8.el7_7.1",
                 },
               },
@@ -2517,7 +2517,7 @@ Object {
                 "id": "systemd@219-73.el7_8.5",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/systemd@219-73.el7_8.5",
+                  "purl": "pkg:rpm/centos/systemd@219-73.el7_8.5?distro=centos-7",
                   "version": "219-73.el7_8.5",
                 },
               },
@@ -2525,7 +2525,7 @@ Object {
                 "id": "systemd-libs@219-73.el7_8.5",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@219-73.el7_8.5",
+                  "purl": "pkg:rpm/centos/systemd-libs@219-73.el7_8.5?distro=centos-7",
                   "version": "219-73.el7_8.5",
                 },
               },
@@ -2533,7 +2533,7 @@ Object {
                 "id": "tar@2:1.26-35.el7",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.26-35.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/tar@2:1.26-35.el7?distro=centos-7&epoch=2",
                   "version": "2:1.26-35.el7",
                 },
               },
@@ -2541,7 +2541,7 @@ Object {
                 "id": "tzdata@2020a-1.el7",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2020a-1.el7",
+                  "purl": "pkg:rpm/centos/tzdata@2020a-1.el7?distro=centos-7",
                   "version": "2020a-1.el7",
                 },
               },
@@ -2549,7 +2549,7 @@ Object {
                 "id": "ustr@1.0.4-16.el7",
                 "info": Object {
                   "name": "ustr",
-                  "purl": "pkg:rpm/ustr@1.0.4-16.el7",
+                  "purl": "pkg:rpm/centos/ustr@1.0.4-16.el7?distro=centos-7",
                   "version": "1.0.4-16.el7",
                 },
               },
@@ -2557,7 +2557,7 @@ Object {
                 "id": "util-linux@2.23.2-63.el7",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/util-linux@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -2565,7 +2565,7 @@ Object {
                 "id": "vim-minimal@2:7.4.629-6.el7",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:7.4.629-6.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/vim-minimal@2:7.4.629-6.el7?distro=centos-7&epoch=2",
                   "version": "2:7.4.629-6.el7",
                 },
               },
@@ -2573,7 +2573,7 @@ Object {
                 "id": "xz@5.2.2-1.el7",
                 "info": Object {
                   "name": "xz",
-                  "purl": "pkg:rpm/xz@5.2.2-1.el7",
+                  "purl": "pkg:rpm/centos/xz@5.2.2-1.el7?distro=centos-7",
                   "version": "5.2.2-1.el7",
                 },
               },
@@ -2581,7 +2581,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.el7",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.el7",
+                  "purl": "pkg:rpm/centos/xz-libs@5.2.2-1.el7?distro=centos-7",
                   "version": "5.2.2-1.el7",
                 },
               },
@@ -2589,7 +2589,7 @@ Object {
                 "id": "yarn@1.22.4-1",
                 "info": Object {
                   "name": "yarn",
-                  "purl": "pkg:rpm/yarn@1.22.4-1",
+                  "purl": "pkg:rpm/centos/yarn@1.22.4-1?distro=centos-7",
                   "version": "1.22.4-1",
                 },
               },
@@ -2597,7 +2597,7 @@ Object {
                 "id": "yum@3.4.3-167.el7.centos",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-167.el7.centos",
+                  "purl": "pkg:rpm/centos/yum@3.4.3-167.el7.centos?distro=centos-7",
                   "version": "3.4.3-167.el7.centos",
                 },
               },
@@ -2605,7 +2605,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.el7",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.el7",
+                  "purl": "pkg:rpm/centos/yum-metadata-parser@1.1.4-10.el7?distro=centos-7",
                   "version": "1.1.4-10.el7",
                 },
               },
@@ -2613,7 +2613,7 @@ Object {
                 "id": "yum-plugin-fastestmirror@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-plugin-fastestmirror",
-                  "purl": "pkg:rpm/yum-plugin-fastestmirror@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-plugin-fastestmirror@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -2621,7 +2621,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-plugin-ovl@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -2629,7 +2629,7 @@ Object {
                 "id": "yum-utils@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-utils",
-                  "purl": "pkg:rpm/yum-utils@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-utils@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -2637,7 +2637,7 @@ Object {
                 "id": "zlib@1.2.7-18.el7",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.el7",
+                  "purl": "pkg:rpm/centos/zlib@1.2.7-18.el7?distro=centos-7",
                   "version": "1.2.7-18.el7",
                 },
               },

--- a/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
+++ b/test/system/dockerfile-analysis/__snapshots__/dockerfile.spec.ts.snap
@@ -4913,7 +4913,7 @@ Object {
                 "id": "acl@2.2.52-2",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:deb/acl@2.2.52-2",
+                  "purl": "pkg:deb/debian/acl@2.2.52-2?distro=debian-jessie",
                   "version": "2.2.52-2",
                 },
               },
@@ -4928,7 +4928,7 @@ Object {
                 "id": "apt/libapt-pkg4.12@1.0.9.8.4",
                 "info": Object {
                   "name": "apt/libapt-pkg4.12",
-                  "purl": "pkg:deb/libapt-pkg4.12@1.0.9.8.4?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg4.12@1.0.9.8.4?distro=debian-jessie&upstream=apt",
                   "version": "1.0.9.8.4",
                 },
               },
@@ -4936,7 +4936,7 @@ Object {
                 "id": "debian-archive-keyring@2017.5~deb8u1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2017.5~deb8u1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2017.5~deb8u1?distro=debian-jessie",
                   "version": "2017.5~deb8u1",
                 },
               },
@@ -4944,7 +4944,7 @@ Object {
                 "id": "gnupg@1.4.18-7+deb8u4",
                 "info": Object {
                   "name": "gnupg",
-                  "purl": "pkg:deb/gnupg@1.4.18-7%2Bdeb8u4",
+                  "purl": "pkg:deb/debian/gnupg@1.4.18-7%2Bdeb8u4?distro=debian-jessie",
                   "version": "1.4.18-7+deb8u4",
                 },
               },
@@ -4952,7 +4952,7 @@ Object {
                 "id": "apt@1.0.9.8.4",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.0.9.8.4",
+                  "purl": "pkg:deb/debian/apt@1.0.9.8.4?distro=debian-jessie",
                   "version": "1.0.9.8.4",
                 },
               },
@@ -4981,7 +4981,7 @@ Object {
                 "id": "libsigsegv/libsigsegv2@2.10-4+b1",
                 "info": Object {
                   "name": "libsigsegv/libsigsegv2",
-                  "purl": "pkg:deb/libsigsegv2@2.10-4%2Bb1?upstream=libsigsegv%402.10-4",
+                  "purl": "pkg:deb/debian/libsigsegv2@2.10-4%2Bb1?distro=debian-jessie&upstream=libsigsegv%402.10-4",
                   "version": "2.10-4+b1",
                 },
               },
@@ -4989,7 +4989,7 @@ Object {
                 "id": "m4@1.4.17-4",
                 "info": Object {
                   "name": "m4",
-                  "purl": "pkg:deb/m4@1.4.17-4",
+                  "purl": "pkg:deb/debian/m4@1.4.17-4?distro=debian-jessie",
                   "version": "1.4.17-4",
                 },
               },
@@ -4997,7 +4997,7 @@ Object {
                 "id": "gdbm/libgdbm3@1.8.3-13.1",
                 "info": Object {
                   "name": "gdbm/libgdbm3",
-                  "purl": "pkg:deb/libgdbm3@1.8.3-13.1?upstream=gdbm",
+                  "purl": "pkg:deb/debian/libgdbm3@1.8.3-13.1?distro=debian-jessie&upstream=gdbm",
                   "version": "1.8.3-13.1",
                 },
               },
@@ -5005,7 +5005,7 @@ Object {
                 "id": "perl/perl-modules@5.20.2-3+deb8u10",
                 "info": Object {
                   "name": "perl/perl-modules",
-                  "purl": "pkg:deb/perl-modules@5.20.2-3%2Bdeb8u10?upstream=perl",
+                  "purl": "pkg:deb/debian/perl-modules@5.20.2-3%2Bdeb8u10?distro=debian-jessie&upstream=perl",
                   "version": "5.20.2-3+deb8u10",
                 },
               },
@@ -5013,7 +5013,7 @@ Object {
                 "id": "perl@5.20.2-3+deb8u10",
                 "info": Object {
                   "name": "perl",
-                  "purl": "pkg:deb/perl@5.20.2-3%2Bdeb8u10",
+                  "purl": "pkg:deb/debian/perl@5.20.2-3%2Bdeb8u10?distro=debian-jessie",
                   "version": "5.20.2-3+deb8u10",
                 },
               },
@@ -5021,7 +5021,7 @@ Object {
                 "id": "autoconf@2.69-8",
                 "info": Object {
                   "name": "autoconf",
-                  "purl": "pkg:deb/autoconf@2.69-8",
+                  "purl": "pkg:deb/debian/autoconf@2.69-8?distro=debian-jessie",
                   "version": "2.69-8",
                 },
               },
@@ -5029,7 +5029,7 @@ Object {
                 "id": "autotools-dev@20140911.1",
                 "info": Object {
                   "name": "autotools-dev",
-                  "purl": "pkg:deb/autotools-dev@20140911.1",
+                  "purl": "pkg:deb/debian/autotools-dev@20140911.1?distro=debian-jessie",
                   "version": "20140911.1",
                 },
               },
@@ -5037,7 +5037,7 @@ Object {
                 "id": "automake-1.14/automake@1:1.14.1-4+deb8u1",
                 "info": Object {
                   "name": "automake-1.14/automake",
-                  "purl": "pkg:deb/automake@1:1.14.1-4%2Bdeb8u1?upstream=automake-1.14",
+                  "purl": "pkg:deb/debian/automake@1:1.14.1-4%2Bdeb8u1?distro=debian-jessie&upstream=automake-1.14",
                   "version": "1:1.14.1-4+deb8u1",
                 },
               },
@@ -5045,7 +5045,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.192",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.192?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.192?distro=debian-jessie&upstream=cdebconf",
                   "version": "0.192",
                 },
               },
@@ -5053,7 +5053,7 @@ Object {
                 "id": "base-passwd@3.5.37",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.37",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.37?distro=debian-jessie",
                   "version": "3.5.37",
                 },
               },
@@ -5061,7 +5061,7 @@ Object {
                 "id": "base-files@8+deb8u10",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@8%2Bdeb8u10",
+                  "purl": "pkg:deb/debian/base-files@8%2Bdeb8u10?distro=debian-jessie",
                   "version": "8+deb8u10",
                 },
               },
@@ -5069,7 +5069,7 @@ Object {
                 "id": "dash/dash@0.5.7-4+b1",
                 "info": Object {
                   "name": "dash/dash",
-                  "purl": "pkg:deb/dash@0.5.7-4%2Bb1?upstream=dash%400.5.7-4",
+                  "purl": "pkg:deb/debian/dash@0.5.7-4%2Bb1?distro=debian-jessie&upstream=dash%400.5.7-4",
                   "version": "0.5.7-4+b1",
                 },
               },
@@ -5077,7 +5077,7 @@ Object {
                 "id": "ncurses/libncurses5@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libncurses5",
-                  "purl": "pkg:deb/libncurses5@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncurses5@5.9%2B20140913-1%2Bdeb8u2?distro=debian-jessie&upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -5085,7 +5085,7 @@ Object {
                 "id": "bash@4.3-11+deb8u1",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@4.3-11%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/bash@4.3-11%2Bdeb8u1?distro=debian-jessie",
                   "version": "4.3-11+deb8u1",
                 },
               },
@@ -5093,7 +5093,7 @@ Object {
                 "id": "bzip2/bzip2@1.0.6-7+b3",
                 "info": Object {
                   "name": "bzip2/bzip2",
-                  "purl": "pkg:deb/bzip2@1.0.6-7%2Bb3?upstream=bzip2%401.0.6-7",
+                  "purl": "pkg:deb/debian/bzip2@1.0.6-7%2Bb3?distro=debian-jessie&upstream=bzip2%401.0.6-7",
                   "version": "1.0.6-7+b3",
                 },
               },
@@ -5108,7 +5108,7 @@ Object {
                 "id": "bzip2/libbz2-dev@1.0.6-7+b3",
                 "info": Object {
                   "name": "bzip2/libbz2-dev",
-                  "purl": "pkg:deb/libbz2-dev@1.0.6-7%2Bb3?upstream=bzip2%401.0.6-7",
+                  "purl": "pkg:deb/debian/libbz2-dev@1.0.6-7%2Bb3?distro=debian-jessie&upstream=bzip2%401.0.6-7",
                   "version": "1.0.6-7+b3",
                 },
               },
@@ -5116,7 +5116,7 @@ Object {
                 "id": "python2.7/libpython2.7-stdlib@2.7.9-2+deb8u1",
                 "info": Object {
                   "name": "python2.7/libpython2.7-stdlib",
-                  "purl": "pkg:deb/libpython2.7-stdlib@2.7.9-2%2Bdeb8u1?upstream=python2.7",
+                  "purl": "pkg:deb/debian/libpython2.7-stdlib@2.7.9-2%2Bdeb8u1?distro=debian-jessie&upstream=python2.7",
                   "version": "2.7.9-2+deb8u1",
                 },
               },
@@ -5124,7 +5124,7 @@ Object {
                 "id": "python-defaults/libpython-stdlib@2.7.9-1",
                 "info": Object {
                   "name": "python-defaults/libpython-stdlib",
-                  "purl": "pkg:deb/libpython-stdlib@2.7.9-1?upstream=python-defaults",
+                  "purl": "pkg:deb/debian/libpython-stdlib@2.7.9-1?distro=debian-jessie&upstream=python-defaults",
                   "version": "2.7.9-1",
                 },
               },
@@ -5132,7 +5132,7 @@ Object {
                 "id": "python2.7/python2.7-minimal@2.7.9-2+deb8u1",
                 "info": Object {
                   "name": "python2.7/python2.7-minimal",
-                  "purl": "pkg:deb/python2.7-minimal@2.7.9-2%2Bdeb8u1?upstream=python2.7",
+                  "purl": "pkg:deb/debian/python2.7-minimal@2.7.9-2%2Bdeb8u1?distro=debian-jessie&upstream=python2.7",
                   "version": "2.7.9-2+deb8u1",
                 },
               },
@@ -5140,7 +5140,7 @@ Object {
                 "id": "python-defaults/python-minimal@2.7.9-1",
                 "info": Object {
                   "name": "python-defaults/python-minimal",
-                  "purl": "pkg:deb/python-minimal@2.7.9-1?upstream=python-defaults",
+                  "purl": "pkg:deb/debian/python-minimal@2.7.9-1?distro=debian-jessie&upstream=python-defaults",
                   "version": "2.7.9-1",
                 },
               },
@@ -5148,7 +5148,7 @@ Object {
                 "id": "mime-support@3.58",
                 "info": Object {
                   "name": "mime-support",
-                  "purl": "pkg:deb/mime-support@3.58",
+                  "purl": "pkg:deb/debian/mime-support@3.58?distro=debian-jessie",
                   "version": "3.58",
                 },
               },
@@ -5156,7 +5156,7 @@ Object {
                 "id": "ncurses/libncursesw5@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libncursesw5",
-                  "purl": "pkg:deb/libncursesw5@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw5@5.9%2B20140913-1%2Bdeb8u2?distro=debian-jessie&upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -5164,7 +5164,7 @@ Object {
                 "id": "openssl/libssl1.0.0@1.0.1t-1+deb8u8",
                 "info": Object {
                   "name": "openssl/libssl1.0.0",
-                  "purl": "pkg:deb/libssl1.0.0@1.0.1t-1%2Bdeb8u8?upstream=openssl",
+                  "purl": "pkg:deb/debian/libssl1.0.0@1.0.1t-1%2Bdeb8u8?distro=debian-jessie&upstream=openssl",
                   "version": "1.0.1t-1+deb8u8",
                 },
               },
@@ -5172,7 +5172,7 @@ Object {
                 "id": "python2.7/libpython2.7-minimal@2.7.9-2+deb8u1",
                 "info": Object {
                   "name": "python2.7/libpython2.7-minimal",
-                  "purl": "pkg:deb/libpython2.7-minimal@2.7.9-2%2Bdeb8u1?upstream=python2.7",
+                  "purl": "pkg:deb/debian/libpython2.7-minimal@2.7.9-2%2Bdeb8u1?distro=debian-jessie&upstream=python2.7",
                   "version": "2.7.9-2+deb8u1",
                 },
               },
@@ -5180,7 +5180,7 @@ Object {
                 "id": "readline6/readline-common@6.3-8",
                 "info": Object {
                   "name": "readline6/readline-common",
-                  "purl": "pkg:deb/readline-common@6.3-8?upstream=readline6",
+                  "purl": "pkg:deb/debian/readline-common@6.3-8?distro=debian-jessie&upstream=readline6",
                   "version": "6.3-8",
                 },
               },
@@ -5188,7 +5188,7 @@ Object {
                 "id": "readline6/libreadline6@6.3-8+b3",
                 "info": Object {
                   "name": "readline6/libreadline6",
-                  "purl": "pkg:deb/libreadline6@6.3-8%2Bb3?upstream=readline6%406.3-8",
+                  "purl": "pkg:deb/debian/libreadline6@6.3-8%2Bb3?distro=debian-jessie&upstream=readline6%406.3-8",
                   "version": "6.3-8+b3",
                 },
               },
@@ -5196,7 +5196,7 @@ Object {
                 "id": "sqlite3/libsqlite3-0@3.8.7.1-1+deb8u2",
                 "info": Object {
                   "name": "sqlite3/libsqlite3-0",
-                  "purl": "pkg:deb/libsqlite3-0@3.8.7.1-1%2Bdeb8u2?upstream=sqlite3",
+                  "purl": "pkg:deb/debian/libsqlite3-0@3.8.7.1-1%2Bdeb8u2?distro=debian-jessie&upstream=sqlite3",
                   "version": "3.8.7.1-1+deb8u2",
                 },
               },
@@ -5204,7 +5204,7 @@ Object {
                 "id": "python2.7@2.7.9-2+deb8u1",
                 "info": Object {
                   "name": "python2.7",
-                  "purl": "pkg:deb/python2.7@2.7.9-2%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/python2.7@2.7.9-2%2Bdeb8u1?distro=debian-jessie",
                   "version": "2.7.9-2+deb8u1",
                 },
               },
@@ -5212,7 +5212,7 @@ Object {
                 "id": "python-defaults/python@2.7.9-1",
                 "info": Object {
                   "name": "python-defaults/python",
-                  "purl": "pkg:deb/python@2.7.9-1?upstream=python-defaults",
+                  "purl": "pkg:deb/debian/python@2.7.9-1?distro=debian-jessie&upstream=python-defaults",
                   "version": "2.7.9-1",
                 },
               },
@@ -5220,7 +5220,7 @@ Object {
                 "id": "six/python-six@1.8.0-1",
                 "info": Object {
                   "name": "six/python-six",
-                  "purl": "pkg:deb/python-six@1.8.0-1?upstream=six",
+                  "purl": "pkg:deb/debian/python-six@1.8.0-1?distro=debian-jessie&upstream=six",
                   "version": "1.8.0-1",
                 },
               },
@@ -5228,7 +5228,7 @@ Object {
                 "id": "configobj/python-configobj@5.0.6-1",
                 "info": Object {
                   "name": "configobj/python-configobj",
-                  "purl": "pkg:deb/python-configobj@5.0.6-1?upstream=configobj",
+                  "purl": "pkg:deb/debian/python-configobj@5.0.6-1?distro=debian-jessie&upstream=configobj",
                   "version": "5.0.6-1",
                 },
               },
@@ -5236,7 +5236,7 @@ Object {
                 "id": "bzr/python-bzrlib@2.6.0+bzr6595-6+deb8u1",
                 "info": Object {
                   "name": "bzr/python-bzrlib",
-                  "purl": "pkg:deb/python-bzrlib@2.6.0%2Bbzr6595-6%2Bdeb8u1?upstream=bzr",
+                  "purl": "pkg:deb/debian/python-bzrlib@2.6.0%2Bbzr6595-6%2Bdeb8u1?distro=debian-jessie&upstream=bzr",
                   "version": "2.6.0+bzr6595-6+deb8u1",
                 },
               },
@@ -5244,7 +5244,7 @@ Object {
                 "id": "bzr@2.6.0+bzr6595-6+deb8u1",
                 "info": Object {
                   "name": "bzr",
-                  "purl": "pkg:deb/bzr@2.6.0%2Bbzr6595-6%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/bzr@2.6.0%2Bbzr6595-6%2Bdeb8u1?distro=debian-jessie",
                   "version": "2.6.0+bzr6595-6+deb8u1",
                 },
               },
@@ -5252,7 +5252,7 @@ Object {
                 "id": "openssl@1.0.1t-1+deb8u8",
                 "info": Object {
                   "name": "openssl",
-                  "purl": "pkg:deb/openssl@1.0.1t-1%2Bdeb8u8",
+                  "purl": "pkg:deb/debian/openssl@1.0.1t-1%2Bdeb8u8?distro=debian-jessie",
                   "version": "1.0.1t-1+deb8u8",
                 },
               },
@@ -5260,7 +5260,7 @@ Object {
                 "id": "ca-certificates@20141019+deb8u3",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:deb/ca-certificates@20141019%2Bdeb8u3",
+                  "purl": "pkg:deb/debian/ca-certificates@20141019%2Bdeb8u3?distro=debian-jessie",
                   "version": "20141019+deb8u3",
                 },
               },
@@ -5282,7 +5282,7 @@ Object {
                 "id": "cryptsetup/libcryptsetup4@2:1.6.6-5",
                 "info": Object {
                   "name": "cryptsetup/libcryptsetup4",
-                  "purl": "pkg:deb/libcryptsetup4@2:1.6.6-5?upstream=cryptsetup",
+                  "purl": "pkg:deb/debian/libcryptsetup4@2:1.6.6-5?distro=debian-jessie&upstream=cryptsetup",
                   "version": "2:1.6.6-5",
                 },
               },
@@ -5290,7 +5290,7 @@ Object {
                 "id": "krb5/libgssapi-krb5-2@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libgssapi-krb5-2",
-                  "purl": "pkg:deb/libgssapi-krb5-2@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
+                  "purl": "pkg:deb/debian/libgssapi-krb5-2@1.12.1%2Bdfsg-19%2Bdeb8u4?distro=debian-jessie&upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -5298,7 +5298,7 @@ Object {
                 "id": "krb5/libkrb5-3@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkrb5-3",
-                  "purl": "pkg:deb/libkrb5-3@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
+                  "purl": "pkg:deb/debian/libkrb5-3@1.12.1%2Bdfsg-19%2Bdeb8u4?distro=debian-jessie&upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -5306,7 +5306,7 @@ Object {
                 "id": "libidn/libidn11@1.29-1+deb8u2",
                 "info": Object {
                   "name": "libidn/libidn11",
-                  "purl": "pkg:deb/libidn11@1.29-1%2Bdeb8u2?upstream=libidn",
+                  "purl": "pkg:deb/debian/libidn11@1.29-1%2Bdeb8u2?distro=debian-jessie&upstream=libidn",
                   "version": "1.29-1+deb8u2",
                 },
               },
@@ -5314,7 +5314,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.17-3",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.17-3?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.17-3?distro=debian-jessie&upstream=libgpg-error",
                   "version": "1.17-3",
                 },
               },
@@ -5322,7 +5322,7 @@ Object {
                 "id": "libgcrypt20@1.6.3-2+deb8u4",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.6.3-2%2Bdeb8u4",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.6.3-2%2Bdeb8u4?distro=debian-jessie",
                   "version": "1.6.3-2+deb8u4",
                 },
               },
@@ -5330,7 +5330,7 @@ Object {
                 "id": "libssh2/libssh2-1@1.4.3-4.1+deb8u1",
                 "info": Object {
                   "name": "libssh2/libssh2-1",
-                  "purl": "pkg:deb/libssh2-1@1.4.3-4.1%2Bdeb8u1?upstream=libssh2",
+                  "purl": "pkg:deb/debian/libssh2-1@1.4.3-4.1%2Bdeb8u1?distro=debian-jessie&upstream=libssh2",
                   "version": "1.4.3-4.1+deb8u1",
                 },
               },
@@ -5338,7 +5338,7 @@ Object {
                 "id": "openldap/libldap-2.4-2@2.4.40+dfsg-1+deb8u3",
                 "info": Object {
                   "name": "openldap/libldap-2.4-2",
-                  "purl": "pkg:deb/libldap-2.4-2@2.4.40%2Bdfsg-1%2Bdeb8u3?upstream=openldap",
+                  "purl": "pkg:deb/debian/libldap-2.4-2@2.4.40%2Bdfsg-1%2Bdeb8u3?distro=debian-jessie&upstream=openldap",
                   "version": "2.4.40+dfsg-1+deb8u3",
                 },
               },
@@ -5346,7 +5346,7 @@ Object {
                 "id": "gnutls28/libgnutls-deb0-28@3.3.8-6+deb8u7",
                 "info": Object {
                   "name": "gnutls28/libgnutls-deb0-28",
-                  "purl": "pkg:deb/libgnutls-deb0-28@3.3.8-6%2Bdeb8u7?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls-deb0-28@3.3.8-6%2Bdeb8u7?distro=debian-jessie&upstream=gnutls28",
                   "version": "3.3.8-6+deb8u7",
                 },
               },
@@ -5354,7 +5354,7 @@ Object {
                 "id": "nettle/libhogweed2@2.7.1-5+deb8u2",
                 "info": Object {
                   "name": "nettle/libhogweed2",
-                  "purl": "pkg:deb/libhogweed2@2.7.1-5%2Bdeb8u2?upstream=nettle",
+                  "purl": "pkg:deb/debian/libhogweed2@2.7.1-5%2Bdeb8u2?distro=debian-jessie&upstream=nettle",
                   "version": "2.7.1-5+deb8u2",
                 },
               },
@@ -5362,7 +5362,7 @@ Object {
                 "id": "nettle/libnettle4@2.7.1-5+deb8u2",
                 "info": Object {
                   "name": "nettle/libnettle4",
-                  "purl": "pkg:deb/libnettle4@2.7.1-5%2Bdeb8u2?upstream=nettle",
+                  "purl": "pkg:deb/debian/libnettle4@2.7.1-5%2Bdeb8u2?distro=debian-jessie&upstream=nettle",
                   "version": "2.7.1-5+deb8u2",
                 },
               },
@@ -5370,7 +5370,7 @@ Object {
                 "id": "rtmpdump/librtmp1@2.4+20150115.gita107cef-1+deb8u1",
                 "info": Object {
                   "name": "rtmpdump/librtmp1",
-                  "purl": "pkg:deb/librtmp1@2.4%2B20150115.gita107cef-1%2Bdeb8u1?upstream=rtmpdump",
+                  "purl": "pkg:deb/debian/librtmp1@2.4%2B20150115.gita107cef-1%2Bdeb8u1?distro=debian-jessie&upstream=rtmpdump",
                   "version": "2.4+20150115.gita107cef-1+deb8u1",
                 },
               },
@@ -5378,7 +5378,7 @@ Object {
                 "id": "curl/libcurl3@7.38.0-4+deb8u11",
                 "info": Object {
                   "name": "curl/libcurl3",
-                  "purl": "pkg:deb/libcurl3@7.38.0-4%2Bdeb8u11?upstream=curl",
+                  "purl": "pkg:deb/debian/libcurl3@7.38.0-4%2Bdeb8u11?distro=debian-jessie&upstream=curl",
                   "version": "7.38.0-4+deb8u11",
                 },
               },
@@ -5386,7 +5386,7 @@ Object {
                 "id": "curl@7.38.0-4+deb8u11",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:deb/curl@7.38.0-4%2Bdeb8u11",
+                  "purl": "pkg:deb/debian/curl@7.38.0-4%2Bdeb8u11?distro=debian-jessie",
                   "version": "7.38.0-4+deb8u11",
                 },
               },
@@ -5394,7 +5394,7 @@ Object {
                 "id": "curl/libcurl4-openssl-dev@7.38.0-4+deb8u11",
                 "info": Object {
                   "name": "curl/libcurl4-openssl-dev",
-                  "purl": "pkg:deb/libcurl4-openssl-dev@7.38.0-4%2Bdeb8u11?upstream=curl",
+                  "purl": "pkg:deb/debian/libcurl4-openssl-dev@7.38.0-4%2Bdeb8u11?distro=debian-jessie&upstream=curl",
                   "version": "7.38.0-4+deb8u11",
                 },
               },
@@ -5402,7 +5402,7 @@ Object {
                 "id": "db5.3/libdb5.3-dev@5.3.28-9+deb8u1",
                 "info": Object {
                   "name": "db5.3/libdb5.3-dev",
-                  "purl": "pkg:deb/libdb5.3-dev@5.3.28-9%2Bdeb8u1?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3-dev@5.3.28-9%2Bdeb8u1?distro=debian-jessie&upstream=db5.3",
                   "version": "5.3.28-9+deb8u1",
                 },
               },
@@ -5410,7 +5410,7 @@ Object {
                 "id": "db-defaults/libdb-dev@5.3.0+b1",
                 "info": Object {
                   "name": "db-defaults/libdb-dev",
-                  "purl": "pkg:deb/libdb-dev@5.3.0%2Bb1?upstream=db-defaults%405.3.0",
+                  "purl": "pkg:deb/debian/libdb-dev@5.3.0%2Bb1?distro=debian-jessie&upstream=db-defaults%405.3.0",
                   "version": "5.3.0+b1",
                 },
               },
@@ -5432,7 +5432,7 @@ Object {
                 "id": "liblocale-gettext-perl/liblocale-gettext-perl@1.05-8+b1",
                 "info": Object {
                   "name": "liblocale-gettext-perl/liblocale-gettext-perl",
-                  "purl": "pkg:deb/liblocale-gettext-perl@1.05-8%2Bb1?upstream=liblocale-gettext-perl%401.05-8",
+                  "purl": "pkg:deb/debian/liblocale-gettext-perl@1.05-8%2Bb1?distro=debian-jessie&upstream=liblocale-gettext-perl%401.05-8",
                   "version": "1.05-8+b1",
                 },
               },
@@ -5440,7 +5440,7 @@ Object {
                 "id": "libtext-charwidth-perl/libtext-charwidth-perl@0.04-7+b3",
                 "info": Object {
                   "name": "libtext-charwidth-perl/libtext-charwidth-perl",
-                  "purl": "pkg:deb/libtext-charwidth-perl@0.04-7%2Bb3?upstream=libtext-charwidth-perl%400.04-7",
+                  "purl": "pkg:deb/debian/libtext-charwidth-perl@0.04-7%2Bb3?distro=debian-jessie&upstream=libtext-charwidth-perl%400.04-7",
                   "version": "0.04-7+b3",
                 },
               },
@@ -5448,7 +5448,7 @@ Object {
                 "id": "libtext-iconv-perl/libtext-iconv-perl@1.7-5+b2",
                 "info": Object {
                   "name": "libtext-iconv-perl/libtext-iconv-perl",
-                  "purl": "pkg:deb/libtext-iconv-perl@1.7-5%2Bb2?upstream=libtext-iconv-perl%401.7-5",
+                  "purl": "pkg:deb/debian/libtext-iconv-perl@1.7-5%2Bb2?distro=debian-jessie&upstream=libtext-iconv-perl%401.7-5",
                   "version": "1.7-5+b2",
                 },
               },
@@ -5456,7 +5456,7 @@ Object {
                 "id": "libtext-wrapi18n-perl@0.06-7",
                 "info": Object {
                   "name": "libtext-wrapi18n-perl",
-                  "purl": "pkg:deb/libtext-wrapi18n-perl@0.06-7",
+                  "purl": "pkg:deb/debian/libtext-wrapi18n-perl@0.06-7?distro=debian-jessie",
                   "version": "0.06-7",
                 },
               },
@@ -5464,7 +5464,7 @@ Object {
                 "id": "debconf/debconf-i18n@1.5.56+deb8u1",
                 "info": Object {
                   "name": "debconf/debconf-i18n",
-                  "purl": "pkg:deb/debconf-i18n@1.5.56%2Bdeb8u1?upstream=debconf",
+                  "purl": "pkg:deb/debian/debconf-i18n@1.5.56%2Bdeb8u1?distro=debian-jessie&upstream=debconf",
                   "version": "1.5.56+deb8u1",
                 },
               },
@@ -5472,7 +5472,7 @@ Object {
                 "id": "gnupg/gpgv@1.4.18-7+deb8u4",
                 "info": Object {
                   "name": "gnupg/gpgv",
-                  "purl": "pkg:deb/gpgv@1.4.18-7%2Bdeb8u4?upstream=gnupg",
+                  "purl": "pkg:deb/debian/gpgv@1.4.18-7%2Bdeb8u4?distro=debian-jessie&upstream=gnupg",
                   "version": "1.4.18-7+deb8u4",
                 },
               },
@@ -5487,7 +5487,7 @@ Object {
                 "id": "diffutils/diffutils@1:3.3-1+b1",
                 "info": Object {
                   "name": "diffutils/diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.3-1%2Bb1?upstream=diffutils%401%3A3.3-1",
+                  "purl": "pkg:deb/debian/diffutils@1:3.3-1%2Bb1?distro=debian-jessie&upstream=diffutils%401%3A3.3-1",
                   "version": "1:3.3-1+b1",
                 },
               },
@@ -5502,7 +5502,7 @@ Object {
                 "id": "mawk@1.3.3-17",
                 "info": Object {
                   "name": "mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17?distro=debian-jessie",
                   "version": "1.3.3-17",
                 },
               },
@@ -5510,7 +5510,7 @@ Object {
                 "id": "binutils@2.25-5+deb8u1",
                 "info": Object {
                   "name": "binutils",
-                  "purl": "pkg:deb/binutils@2.25-5%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/binutils@2.25-5%2Bdeb8u1?distro=debian-jessie",
                   "version": "2.25-5+deb8u1",
                 },
               },
@@ -5518,7 +5518,7 @@ Object {
                 "id": "libtimedate-perl@2.3000-2",
                 "info": Object {
                   "name": "libtimedate-perl",
-                  "purl": "pkg:deb/libtimedate-perl@2.3000-2",
+                  "purl": "pkg:deb/debian/libtimedate-perl@2.3000-2?distro=debian-jessie",
                   "version": "2.3000-2",
                 },
               },
@@ -5526,7 +5526,7 @@ Object {
                 "id": "dpkg/libdpkg-perl@1.17.27",
                 "info": Object {
                   "name": "dpkg/libdpkg-perl",
-                  "purl": "pkg:deb/libdpkg-perl@1.17.27?upstream=dpkg",
+                  "purl": "pkg:deb/debian/libdpkg-perl@1.17.27?distro=debian-jessie&upstream=dpkg",
                   "version": "1.17.27",
                 },
               },
@@ -5534,7 +5534,7 @@ Object {
                 "id": "make-dfsg/make@4.0-8.1",
                 "info": Object {
                   "name": "make-dfsg/make",
-                  "purl": "pkg:deb/make@4.0-8.1?upstream=make-dfsg",
+                  "purl": "pkg:deb/debian/make@4.0-8.1?distro=debian-jessie&upstream=make-dfsg",
                   "version": "4.0-8.1",
                 },
               },
@@ -5542,7 +5542,7 @@ Object {
                 "id": "patch@2.7.5-1",
                 "info": Object {
                   "name": "patch",
-                  "purl": "pkg:deb/patch@2.7.5-1",
+                  "purl": "pkg:deb/debian/patch@2.7.5-1?distro=debian-jessie",
                   "version": "2.7.5-1",
                 },
               },
@@ -5550,7 +5550,7 @@ Object {
                 "id": "xz-utils/xz-utils@5.1.1alpha+20120614-2+b3",
                 "info": Object {
                   "name": "xz-utils/xz-utils",
-                  "purl": "pkg:deb/xz-utils@5.1.1alpha%2B20120614-2%2Bb3?upstream=xz-utils%405.1.1alpha%2B20120614-2",
+                  "purl": "pkg:deb/debian/xz-utils@5.1.1alpha%2B20120614-2%2Bb3?distro=debian-jessie&upstream=xz-utils%405.1.1alpha%2B20120614-2",
                   "version": "5.1.1alpha+20120614-2+b3",
                 },
               },
@@ -5558,7 +5558,7 @@ Object {
                 "id": "dpkg/dpkg-dev@1.17.27",
                 "info": Object {
                   "name": "dpkg/dpkg-dev",
-                  "purl": "pkg:deb/dpkg-dev@1.17.27?upstream=dpkg",
+                  "purl": "pkg:deb/debian/dpkg-dev@1.17.27?distro=debian-jessie&upstream=dpkg",
                   "version": "1.17.27",
                 },
               },
@@ -5566,7 +5566,7 @@ Object {
                 "id": "e2fsprogs/e2fslibs@1.42.12-2+b1",
                 "info": Object {
                   "name": "e2fsprogs/e2fslibs",
-                  "purl": "pkg:deb/e2fslibs@1.42.12-2%2Bb1?upstream=e2fsprogs%401.42.12-2",
+                  "purl": "pkg:deb/debian/e2fslibs@1.42.12-2%2Bb1?distro=debian-jessie&upstream=e2fsprogs%401.42.12-2",
                   "version": "1.42.12-2+b1",
                 },
               },
@@ -5574,7 +5574,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.42.12-2+b1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.42.12-2%2Bb1?upstream=e2fsprogs%401.42.12-2",
+                  "purl": "pkg:deb/debian/libss2@1.42.12-2%2Bb1?distro=debian-jessie&upstream=e2fsprogs%401.42.12-2",
                   "version": "1.42.12-2+b1",
                 },
               },
@@ -5582,7 +5582,7 @@ Object {
                 "id": "util-linux@2.25.2-6",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.25.2-6",
+                  "purl": "pkg:deb/debian/util-linux@2.25.2-6?distro=debian-jessie",
                   "version": "2.25.2-6",
                 },
               },
@@ -5590,7 +5590,7 @@ Object {
                 "id": "util-linux/libblkid1@2.25.2-6",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.25.2-6?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.25.2-6?distro=debian-jessie&upstream=util-linux",
                   "version": "2.25.2-6",
                 },
               },
@@ -5598,7 +5598,7 @@ Object {
                 "id": "e2fsprogs/e2fsprogs@1.42.12-2+b1",
                 "info": Object {
                   "name": "e2fsprogs/e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.42.12-2%2Bb1?upstream=e2fsprogs%401.42.12-2",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.42.12-2%2Bb1?distro=debian-jessie&upstream=e2fsprogs%401.42.12-2",
                   "version": "1.42.12-2+b1",
                 },
               },
@@ -5620,7 +5620,7 @@ Object {
                 "id": "file@1:5.22+15-2+deb8u3",
                 "info": Object {
                   "name": "file",
-                  "purl": "pkg:deb/file@1:5.22%2B15-2%2Bdeb8u3",
+                  "purl": "pkg:deb/debian/file@1:5.22%2B15-2%2Bdeb8u3?distro=debian-jessie",
                   "version": "1:5.22+15-2+deb8u3",
                 },
               },
@@ -5628,7 +5628,7 @@ Object {
                 "id": "findutils/findutils@4.4.2-9+b1",
                 "info": Object {
                   "name": "findutils/findutils",
-                  "purl": "pkg:deb/findutils@4.4.2-9%2Bb1?upstream=findutils%404.4.2-9",
+                  "purl": "pkg:deb/debian/findutils@4.4.2-9%2Bb1?distro=debian-jessie&upstream=findutils%404.4.2-9",
                   "version": "4.4.2-9+b1",
                 },
               },
@@ -5671,7 +5671,7 @@ Object {
                 "id": "gcc-4.8/gcc-4.8-base@4.8.4-1",
                 "info": Object {
                   "name": "gcc-4.8/gcc-4.8-base",
-                  "purl": "pkg:deb/gcc-4.8-base@4.8.4-1?upstream=gcc-4.8",
+                  "purl": "pkg:deb/debian/gcc-4.8-base@4.8.4-1?distro=debian-jessie&upstream=gcc-4.8",
                   "version": "4.8.4-1",
                 },
               },
@@ -5700,7 +5700,7 @@ Object {
                 "id": "gcc-4.9@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9",
-                  "purl": "pkg:deb/gcc-4.9@4.9.2-10%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/gcc-4.9@4.9.2-10%2Bdeb8u1?distro=debian-jessie",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5708,7 +5708,7 @@ Object {
                 "id": "cloog/libcloog-isl4@0.18.2-1+b2",
                 "info": Object {
                   "name": "cloog/libcloog-isl4",
-                  "purl": "pkg:deb/libcloog-isl4@0.18.2-1%2Bb2?upstream=cloog%400.18.2-1",
+                  "purl": "pkg:deb/debian/libcloog-isl4@0.18.2-1%2Bb2?distro=debian-jessie&upstream=cloog%400.18.2-1",
                   "version": "0.18.2-1+b2",
                 },
               },
@@ -5716,7 +5716,7 @@ Object {
                 "id": "gcc-4.9/libgcc-4.9-dev@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libgcc-4.9-dev",
-                  "purl": "pkg:deb/libgcc-4.9-dev@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libgcc-4.9-dev@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5724,7 +5724,7 @@ Object {
                 "id": "gcc-4.9/libstdc++-4.9-dev@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libstdc++-4.9-dev",
-                  "purl": "pkg:deb/libstdc%2B%2B-4.9-dev@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B-4.9-dev@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5732,7 +5732,7 @@ Object {
                 "id": "isl/libisl10@0.12.2-2",
                 "info": Object {
                   "name": "isl/libisl10",
-                  "purl": "pkg:deb/libisl10@0.12.2-2?upstream=isl",
+                  "purl": "pkg:deb/debian/libisl10@0.12.2-2?distro=debian-jessie&upstream=isl",
                   "version": "0.12.2-2",
                 },
               },
@@ -5740,7 +5740,7 @@ Object {
                 "id": "mpclib3/libmpc3@1.0.2-1",
                 "info": Object {
                   "name": "mpclib3/libmpc3",
-                  "purl": "pkg:deb/libmpc3@1.0.2-1?upstream=mpclib3",
+                  "purl": "pkg:deb/debian/libmpc3@1.0.2-1?distro=debian-jessie&upstream=mpclib3",
                   "version": "1.0.2-1",
                 },
               },
@@ -5748,7 +5748,7 @@ Object {
                 "id": "mpfr4/libmpfr4@3.1.2-2",
                 "info": Object {
                   "name": "mpfr4/libmpfr4",
-                  "purl": "pkg:deb/libmpfr4@3.1.2-2?upstream=mpfr4",
+                  "purl": "pkg:deb/debian/libmpfr4@3.1.2-2?distro=debian-jessie&upstream=mpfr4",
                   "version": "3.1.2-2",
                 },
               },
@@ -5756,7 +5756,7 @@ Object {
                 "id": "gcc-4.9/g++-4.9@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/g++-4.9",
-                  "purl": "pkg:deb/g%2B%2B-4.9@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/g%2B%2B-4.9@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -5764,7 +5764,7 @@ Object {
                 "id": "gcc-defaults/cpp@4:4.9.2-2",
                 "info": Object {
                   "name": "gcc-defaults/cpp",
-                  "purl": "pkg:deb/cpp@4:4.9.2-2?upstream=gcc-defaults%401.136",
+                  "purl": "pkg:deb/debian/cpp@4:4.9.2-2?distro=debian-jessie&upstream=gcc-defaults%401.136",
                   "version": "4:4.9.2-2",
                 },
               },
@@ -5772,7 +5772,7 @@ Object {
                 "id": "gcc-defaults/gcc@4:4.9.2-2",
                 "info": Object {
                   "name": "gcc-defaults/gcc",
-                  "purl": "pkg:deb/gcc@4:4.9.2-2?upstream=gcc-defaults%401.136",
+                  "purl": "pkg:deb/debian/gcc@4:4.9.2-2?distro=debian-jessie&upstream=gcc-defaults%401.136",
                   "version": "4:4.9.2-2",
                 },
               },
@@ -5780,7 +5780,7 @@ Object {
                 "id": "gcc-defaults/g++@4:4.9.2-2",
                 "info": Object {
                   "name": "gcc-defaults/g++",
-                  "purl": "pkg:deb/g%2B%2B@4:4.9.2-2?upstream=gcc-defaults%401.136",
+                  "purl": "pkg:deb/debian/g%2B%2B@4:4.9.2-2?distro=debian-jessie&upstream=gcc-defaults%401.136",
                   "version": "4:4.9.2-2",
                 },
               },
@@ -5788,7 +5788,7 @@ Object {
                 "id": "gdbm/libgdbm-dev@1.8.3-13.1",
                 "info": Object {
                   "name": "gdbm/libgdbm-dev",
-                  "purl": "pkg:deb/libgdbm-dev@1.8.3-13.1?upstream=gdbm",
+                  "purl": "pkg:deb/debian/libgdbm-dev@1.8.3-13.1?distro=debian-jessie&upstream=gdbm",
                   "version": "1.8.3-13.1",
                 },
               },
@@ -5796,7 +5796,7 @@ Object {
                 "id": "geoip/libgeoip1@1.6.2-4",
                 "info": Object {
                   "name": "geoip/libgeoip1",
-                  "purl": "pkg:deb/libgeoip1@1.6.2-4?upstream=geoip",
+                  "purl": "pkg:deb/debian/libgeoip1@1.6.2-4?distro=debian-jessie&upstream=geoip",
                   "version": "1.6.2-4",
                 },
               },
@@ -5804,7 +5804,7 @@ Object {
                 "id": "geoip/geoip-bin@1.6.2-4",
                 "info": Object {
                   "name": "geoip/geoip-bin",
-                  "purl": "pkg:deb/geoip-bin@1.6.2-4?upstream=geoip",
+                  "purl": "pkg:deb/debian/geoip-bin@1.6.2-4?distro=debian-jessie&upstream=geoip",
                   "version": "1.6.2-4",
                 },
               },
@@ -5812,7 +5812,7 @@ Object {
                 "id": "geoip/libgeoip-dev@1.6.2-4",
                 "info": Object {
                   "name": "geoip/libgeoip-dev",
-                  "purl": "pkg:deb/libgeoip-dev@1.6.2-4?upstream=geoip",
+                  "purl": "pkg:deb/debian/libgeoip-dev@1.6.2-4?distro=debian-jessie&upstream=geoip",
                   "version": "1.6.2-4",
                 },
               },
@@ -5820,7 +5820,7 @@ Object {
                 "id": "curl/libcurl3-gnutls@7.38.0-4+deb8u11",
                 "info": Object {
                   "name": "curl/libcurl3-gnutls",
-                  "purl": "pkg:deb/libcurl3-gnutls@7.38.0-4%2Bdeb8u11?upstream=curl",
+                  "purl": "pkg:deb/debian/libcurl3-gnutls@7.38.0-4%2Bdeb8u11?distro=debian-jessie&upstream=curl",
                   "version": "7.38.0-4+deb8u11",
                 },
               },
@@ -5828,7 +5828,7 @@ Object {
                 "id": "git/git-man@1:2.1.4-2.1+deb8u6",
                 "info": Object {
                   "name": "git/git-man",
-                  "purl": "pkg:deb/git-man@1:2.1.4-2.1%2Bdeb8u6?upstream=git",
+                  "purl": "pkg:deb/debian/git-man@1:2.1.4-2.1%2Bdeb8u6?distro=debian-jessie&upstream=git",
                   "version": "1:2.1.4-2.1+deb8u6",
                 },
               },
@@ -5836,7 +5836,7 @@ Object {
                 "id": "liberror-perl@0.17-1.1",
                 "info": Object {
                   "name": "liberror-perl",
-                  "purl": "pkg:deb/liberror-perl@0.17-1.1",
+                  "purl": "pkg:deb/debian/liberror-perl@0.17-1.1?distro=debian-jessie",
                   "version": "0.17-1.1",
                 },
               },
@@ -5844,7 +5844,7 @@ Object {
                 "id": "git@1:2.1.4-2.1+deb8u6",
                 "info": Object {
                   "name": "git",
-                  "purl": "pkg:deb/git@1:2.1.4-2.1%2Bdeb8u6",
+                  "purl": "pkg:deb/debian/git@1:2.1.4-2.1%2Bdeb8u6?distro=debian-jessie",
                   "version": "1:2.1.4-2.1+deb8u6",
                 },
               },
@@ -5859,7 +5859,7 @@ Object {
                 "id": "glib2.0/libglib2.0-dev@2.42.1-1+b1",
                 "info": Object {
                   "name": "glib2.0/libglib2.0-dev",
-                  "purl": "pkg:deb/libglib2.0-dev@2.42.1-1%2Bb1?upstream=glib2.0%402.42.1-1",
+                  "purl": "pkg:deb/debian/libglib2.0-dev@2.42.1-1%2Bb1?distro=debian-jessie&upstream=glib2.0%402.42.1-1",
                   "version": "2.42.1-1+b1",
                 },
               },
@@ -5867,7 +5867,7 @@ Object {
                 "id": "glibc/libc-bin@2.19-18+deb8u10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.19-18%2Bdeb8u10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.19-18%2Bdeb8u10?distro=debian-jessie&upstream=glibc",
                   "version": "2.19-18+deb8u10",
                 },
               },
@@ -5910,7 +5910,7 @@ Object {
                 "id": "libusb/libusb-0.1-4@2:0.1.12-25",
                 "info": Object {
                   "name": "libusb/libusb-0.1-4",
-                  "purl": "pkg:deb/libusb-0.1-4@2:0.1.12-25?upstream=libusb",
+                  "purl": "pkg:deb/debian/libusb-0.1-4@2:0.1.12-25?distro=debian-jessie&upstream=libusb",
                   "version": "2:0.1.12-25",
                 },
               },
@@ -5918,7 +5918,7 @@ Object {
                 "id": "grep@2.20-4.1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@2.20-4.1",
+                  "purl": "pkg:deb/debian/grep@2.20-4.1?distro=debian-jessie",
                   "version": "2.20-4.1",
                 },
               },
@@ -5926,7 +5926,7 @@ Object {
                 "id": "gzip@1.6-4",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.6-4",
+                  "purl": "pkg:deb/debian/gzip@1.6-4?distro=debian-jessie",
                   "version": "1.6-4",
                 },
               },
@@ -5934,7 +5934,7 @@ Object {
                 "id": "hostname@3.15",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.15",
+                  "purl": "pkg:deb/debian/hostname@3.15?distro=debian-jessie",
                   "version": "3.15",
                 },
               },
@@ -5942,7 +5942,7 @@ Object {
                 "id": "hicolor-icon-theme@0.13-1",
                 "info": Object {
                   "name": "hicolor-icon-theme",
-                  "purl": "pkg:deb/hicolor-icon-theme@0.13-1",
+                  "purl": "pkg:deb/debian/hicolor-icon-theme@0.13-1?distro=debian-jessie",
                   "version": "0.13-1",
                 },
               },
@@ -5950,7 +5950,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6.q16-2@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6.q16-2",
-                  "purl": "pkg:deb/libmagickcore-6.q16-2@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickcore-6.q16-2@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5958,7 +5958,7 @@ Object {
                 "id": "imagemagick/libmagickwand-6.q16-2@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickwand-6.q16-2",
-                  "purl": "pkg:deb/libmagickwand-6.q16-2@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickwand-6.q16-2@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5966,7 +5966,7 @@ Object {
                 "id": "imagemagick/imagemagick-6.q16@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/imagemagick-6.q16",
-                  "purl": "pkg:deb/imagemagick-6.q16@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/imagemagick-6.q16@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5974,7 +5974,7 @@ Object {
                 "id": "imagemagick@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick",
-                  "purl": "pkg:deb/imagemagick@8:6.8.9.9-5%2Bdeb8u12",
+                  "purl": "pkg:deb/debian/imagemagick@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -5982,7 +5982,7 @@ Object {
                 "id": "djvulibre/libdjvulibre21@3.5.25.4-4+b1",
                 "info": Object {
                   "name": "djvulibre/libdjvulibre21",
-                  "purl": "pkg:deb/libdjvulibre21@3.5.25.4-4%2Bb1?upstream=djvulibre%403.5.25.4-4",
+                  "purl": "pkg:deb/debian/libdjvulibre21@3.5.25.4-4%2Bb1?distro=debian-jessie&upstream=djvulibre%403.5.25.4-4",
                   "version": "3.5.25.4-4+b1",
                 },
               },
@@ -5990,7 +5990,7 @@ Object {
                 "id": "libjpeg-turbo/libjpeg62-turbo-dev@1:1.3.1-12",
                 "info": Object {
                   "name": "libjpeg-turbo/libjpeg62-turbo-dev",
-                  "purl": "pkg:deb/libjpeg62-turbo-dev@1:1.3.1-12?upstream=libjpeg-turbo",
+                  "purl": "pkg:deb/debian/libjpeg62-turbo-dev@1:1.3.1-12?distro=debian-jessie&upstream=libjpeg-turbo",
                   "version": "1:1.3.1-12",
                 },
               },
@@ -5998,7 +5998,7 @@ Object {
                 "id": "libjpeg-turbo/libjpeg-dev@1:1.3.1-12",
                 "info": Object {
                   "name": "libjpeg-turbo/libjpeg-dev",
-                  "purl": "pkg:deb/libjpeg-dev@1:1.3.1-12?upstream=libjpeg-turbo",
+                  "purl": "pkg:deb/debian/libjpeg-dev@1:1.3.1-12?distro=debian-jessie&upstream=libjpeg-turbo",
                   "version": "1:1.3.1-12",
                 },
               },
@@ -6006,7 +6006,7 @@ Object {
                 "id": "djvulibre/libdjvulibre-dev@3.5.25.4-4+b1",
                 "info": Object {
                   "name": "djvulibre/libdjvulibre-dev",
-                  "purl": "pkg:deb/libdjvulibre-dev@3.5.25.4-4%2Bb1?upstream=djvulibre%403.5.25.4-4",
+                  "purl": "pkg:deb/debian/libdjvulibre-dev@3.5.25.4-4%2Bb1?distro=debian-jessie&upstream=djvulibre%403.5.25.4-4",
                   "version": "3.5.25.4-4+b1",
                 },
               },
@@ -6014,7 +6014,7 @@ Object {
                 "id": "libpng/libpng12-dev@1.2.50-2+deb8u3",
                 "info": Object {
                   "name": "libpng/libpng12-dev",
-                  "purl": "pkg:deb/libpng12-dev@1.2.50-2%2Bdeb8u3?upstream=libpng",
+                  "purl": "pkg:deb/debian/libpng12-dev@1.2.50-2%2Bdeb8u3?distro=debian-jessie&upstream=libpng",
                   "version": "1.2.50-2+deb8u3",
                 },
               },
@@ -6022,7 +6022,7 @@ Object {
                 "id": "freetype/libfreetype6-dev@2.5.2-3+deb8u2",
                 "info": Object {
                   "name": "freetype/libfreetype6-dev",
-                  "purl": "pkg:deb/libfreetype6-dev@2.5.2-3%2Bdeb8u2?upstream=freetype",
+                  "purl": "pkg:deb/debian/libfreetype6-dev@2.5.2-3%2Bdeb8u2?distro=debian-jessie&upstream=freetype",
                   "version": "2.5.2-3+deb8u2",
                 },
               },
@@ -6030,7 +6030,7 @@ Object {
                 "id": "expat/libexpat1-dev@2.1.0-6+deb8u4",
                 "info": Object {
                   "name": "expat/libexpat1-dev",
-                  "purl": "pkg:deb/libexpat1-dev@2.1.0-6%2Bdeb8u4?upstream=expat",
+                  "purl": "pkg:deb/debian/libexpat1-dev@2.1.0-6%2Bdeb8u4?distro=debian-jessie&upstream=expat",
                   "version": "2.1.0-6+deb8u4",
                 },
               },
@@ -6038,7 +6038,7 @@ Object {
                 "id": "graphviz/libcdt5@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libcdt5",
-                  "purl": "pkg:deb/libcdt5@2.38.0-7?upstream=graphviz",
+                  "purl": "pkg:deb/debian/libcdt5@2.38.0-7?distro=debian-jessie&upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -6046,7 +6046,7 @@ Object {
                 "id": "graphviz/libcgraph6@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libcgraph6",
-                  "purl": "pkg:deb/libcgraph6@2.38.0-7?upstream=graphviz",
+                  "purl": "pkg:deb/debian/libcgraph6@2.38.0-7?distro=debian-jessie&upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -6054,7 +6054,7 @@ Object {
                 "id": "graphviz/libpathplan4@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libpathplan4",
-                  "purl": "pkg:deb/libpathplan4@2.38.0-7?upstream=graphviz",
+                  "purl": "pkg:deb/debian/libpathplan4@2.38.0-7?distro=debian-jessie&upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -6062,7 +6062,7 @@ Object {
                 "id": "graphviz/libxdot4@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libxdot4",
-                  "purl": "pkg:deb/libxdot4@2.38.0-7?upstream=graphviz",
+                  "purl": "pkg:deb/debian/libxdot4@2.38.0-7?distro=debian-jessie&upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -6070,7 +6070,7 @@ Object {
                 "id": "libvpx/libvpx1@1.3.0-3+deb8u1",
                 "info": Object {
                   "name": "libvpx/libvpx1",
-                  "purl": "pkg:deb/libvpx1@1.3.0-3%2Bdeb8u1?upstream=libvpx",
+                  "purl": "pkg:deb/debian/libvpx1@1.3.0-3%2Bdeb8u1?distro=debian-jessie&upstream=libvpx",
                   "version": "1.3.0-3+deb8u1",
                 },
               },
@@ -6078,7 +6078,7 @@ Object {
                 "id": "libxpm/libxpm4@1:3.5.12-0+deb8u1",
                 "info": Object {
                   "name": "libxpm/libxpm4",
-                  "purl": "pkg:deb/libxpm4@1:3.5.12-0%2Bdeb8u1?upstream=libxpm",
+                  "purl": "pkg:deb/debian/libxpm4@1:3.5.12-0%2Bdeb8u1?distro=debian-jessie&upstream=libxpm",
                   "version": "1:3.5.12-0+deb8u1",
                 },
               },
@@ -6086,7 +6086,7 @@ Object {
                 "id": "libgd2/libgd3@2.1.0-5+deb8u11",
                 "info": Object {
                   "name": "libgd2/libgd3",
-                  "purl": "pkg:deb/libgd3@2.1.0-5%2Bdeb8u11?upstream=libgd2",
+                  "purl": "pkg:deb/debian/libgd3@2.1.0-5%2Bdeb8u11?distro=debian-jessie&upstream=libgd2",
                   "version": "2.1.0-5+deb8u11",
                 },
               },
@@ -6094,7 +6094,7 @@ Object {
                 "id": "libtool/libltdl7@2.4.2-1.11+b1",
                 "info": Object {
                   "name": "libtool/libltdl7",
-                  "purl": "pkg:deb/libltdl7@2.4.2-1.11%2Bb1?upstream=libtool%402.4.2-1.11",
+                  "purl": "pkg:deb/debian/libltdl7@2.4.2-1.11%2Bb1?distro=debian-jessie&upstream=libtool%402.4.2-1.11",
                   "version": "2.4.2-1.11+b1",
                 },
               },
@@ -6102,7 +6102,7 @@ Object {
                 "id": "pango1.0/libpangocairo-1.0-0@1.36.8-3",
                 "info": Object {
                   "name": "pango1.0/libpangocairo-1.0-0",
-                  "purl": "pkg:deb/libpangocairo-1.0-0@1.36.8-3?upstream=pango1.0",
+                  "purl": "pkg:deb/debian/libpangocairo-1.0-0@1.36.8-3?distro=debian-jessie&upstream=pango1.0",
                   "version": "1.36.8-3",
                 },
               },
@@ -6110,7 +6110,7 @@ Object {
                 "id": "pango1.0/libpangoft2-1.0-0@1.36.8-3",
                 "info": Object {
                   "name": "pango1.0/libpangoft2-1.0-0",
-                  "purl": "pkg:deb/libpangoft2-1.0-0@1.36.8-3?upstream=pango1.0",
+                  "purl": "pkg:deb/debian/libpangoft2-1.0-0@1.36.8-3?distro=debian-jessie&upstream=pango1.0",
                   "version": "1.36.8-3",
                 },
               },
@@ -6118,7 +6118,7 @@ Object {
                 "id": "graphviz/libgvc6@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libgvc6",
-                  "purl": "pkg:deb/libgvc6@2.38.0-7?upstream=graphviz",
+                  "purl": "pkg:deb/debian/libgvc6@2.38.0-7?distro=debian-jessie&upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -6126,7 +6126,7 @@ Object {
                 "id": "graphviz/libgvpr2@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libgvpr2",
-                  "purl": "pkg:deb/libgvpr2@2.38.0-7?upstream=graphviz",
+                  "purl": "pkg:deb/debian/libgvpr2@2.38.0-7?distro=debian-jessie&upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -6134,7 +6134,7 @@ Object {
                 "id": "libtool/libltdl-dev@2.4.2-1.11+b1",
                 "info": Object {
                   "name": "libtool/libltdl-dev",
-                  "purl": "pkg:deb/libltdl-dev@2.4.2-1.11%2Bb1?upstream=libtool%402.4.2-1.11",
+                  "purl": "pkg:deb/debian/libltdl-dev@2.4.2-1.11%2Bb1?distro=debian-jessie&upstream=libtool%402.4.2-1.11",
                   "version": "2.4.2-1.11+b1",
                 },
               },
@@ -6142,7 +6142,7 @@ Object {
                 "id": "graphviz/libgraphviz-dev@2.38.0-7",
                 "info": Object {
                   "name": "graphviz/libgraphviz-dev",
-                  "purl": "pkg:deb/libgraphviz-dev@2.38.0-7?upstream=graphviz",
+                  "purl": "pkg:deb/debian/libgraphviz-dev@2.38.0-7?distro=debian-jessie&upstream=graphviz",
                   "version": "2.38.0-7",
                 },
               },
@@ -6150,7 +6150,7 @@ Object {
                 "id": "imagemagick/imagemagick-common@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/imagemagick-common",
-                  "purl": "pkg:deb/imagemagick-common@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/imagemagick-common@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6158,7 +6158,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6-arch-config@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6-arch-config",
-                  "purl": "pkg:deb/libmagickcore-6-arch-config@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickcore-6-arch-config@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6166,7 +6166,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6-headers@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6-headers",
-                  "purl": "pkg:deb/libmagickcore-6-headers@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickcore-6-headers@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6174,7 +6174,7 @@ Object {
                 "id": "gcc-4.9/libgomp1@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libgomp1",
-                  "purl": "pkg:deb/libgomp1@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libgomp1@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -6182,7 +6182,7 @@ Object {
                 "id": "fftw3/libfftw3-double3@3.3.4-2",
                 "info": Object {
                   "name": "fftw3/libfftw3-double3",
-                  "purl": "pkg:deb/libfftw3-double3@3.3.4-2?upstream=fftw3",
+                  "purl": "pkg:deb/debian/libfftw3-double3@3.3.4-2?distro=debian-jessie&upstream=fftw3",
                   "version": "3.3.4-2",
                 },
               },
@@ -6190,7 +6190,7 @@ Object {
                 "id": "lcms2/liblcms2-2@2.6-3+deb8u1",
                 "info": Object {
                   "name": "lcms2/liblcms2-2",
-                  "purl": "pkg:deb/liblcms2-2@2.6-3%2Bdeb8u1?upstream=lcms2",
+                  "purl": "pkg:deb/debian/liblcms2-2@2.6-3%2Bdeb8u1?distro=debian-jessie&upstream=lcms2",
                   "version": "2.6-3+deb8u1",
                 },
               },
@@ -6198,7 +6198,7 @@ Object {
                 "id": "liblqr/liblqr-1-0@0.4.2-2",
                 "info": Object {
                   "name": "liblqr/liblqr-1-0",
-                  "purl": "pkg:deb/liblqr-1-0@0.4.2-2?upstream=liblqr",
+                  "purl": "pkg:deb/debian/liblqr-1-0@0.4.2-2?distro=debian-jessie&upstream=liblqr",
                   "version": "0.4.2-2",
                 },
               },
@@ -6206,7 +6206,7 @@ Object {
                 "id": "libxml2@2.9.1+dfsg1-5+deb8u6",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:deb/libxml2@2.9.1%2Bdfsg1-5%2Bdeb8u6",
+                  "purl": "pkg:deb/debian/libxml2@2.9.1%2Bdfsg1-5%2Bdeb8u6?distro=debian-jessie",
                   "version": "2.9.1+dfsg1-5+deb8u6",
                 },
               },
@@ -6214,7 +6214,7 @@ Object {
                 "id": "djvulibre/libdjvulibre-text@3.5.25.4-4",
                 "info": Object {
                   "name": "djvulibre/libdjvulibre-text",
-                  "purl": "pkg:deb/libdjvulibre-text@3.5.25.4-4?upstream=djvulibre",
+                  "purl": "pkg:deb/debian/libdjvulibre-text@3.5.25.4-4?distro=debian-jessie&upstream=djvulibre",
                   "version": "3.5.25.4-4",
                 },
               },
@@ -6222,7 +6222,7 @@ Object {
                 "id": "gdk-pixbuf/libgdk-pixbuf2.0-common@2.31.1-2+deb8u7",
                 "info": Object {
                   "name": "gdk-pixbuf/libgdk-pixbuf2.0-common",
-                  "purl": "pkg:deb/libgdk-pixbuf2.0-common@2.31.1-2%2Bdeb8u7?upstream=gdk-pixbuf",
+                  "purl": "pkg:deb/debian/libgdk-pixbuf2.0-common@2.31.1-2%2Bdeb8u7?distro=debian-jessie&upstream=gdk-pixbuf",
                   "version": "2.31.1-2+deb8u7",
                 },
               },
@@ -6230,7 +6230,7 @@ Object {
                 "id": "jasper/libjasper1@1.900.1-debian1-2.4+deb8u3",
                 "info": Object {
                   "name": "jasper/libjasper1",
-                  "purl": "pkg:deb/libjasper1@1.900.1-debian1-2.4%2Bdeb8u3?upstream=jasper",
+                  "purl": "pkg:deb/debian/libjasper1@1.900.1-debian1-2.4%2Bdeb8u3?distro=debian-jessie&upstream=jasper",
                   "version": "1.900.1-debian1-2.4+deb8u3",
                 },
               },
@@ -6238,7 +6238,7 @@ Object {
                 "id": "gdk-pixbuf/libgdk-pixbuf2.0-0@2.31.1-2+deb8u7",
                 "info": Object {
                   "name": "gdk-pixbuf/libgdk-pixbuf2.0-0",
-                  "purl": "pkg:deb/libgdk-pixbuf2.0-0@2.31.1-2%2Bdeb8u7?upstream=gdk-pixbuf",
+                  "purl": "pkg:deb/debian/libgdk-pixbuf2.0-0@2.31.1-2%2Bdeb8u7?distro=debian-jessie&upstream=gdk-pixbuf",
                   "version": "2.31.1-2+deb8u7",
                 },
               },
@@ -6246,7 +6246,7 @@ Object {
                 "id": "libcroco/libcroco3@0.6.8-3+b1",
                 "info": Object {
                   "name": "libcroco/libcroco3",
-                  "purl": "pkg:deb/libcroco3@0.6.8-3%2Bb1?upstream=libcroco%400.6.8-3",
+                  "purl": "pkg:deb/debian/libcroco3@0.6.8-3%2Bb1?distro=debian-jessie&upstream=libcroco%400.6.8-3",
                   "version": "0.6.8-3+b1",
                 },
               },
@@ -6254,7 +6254,7 @@ Object {
                 "id": "librsvg/librsvg2-2@2.40.5-1+deb8u2",
                 "info": Object {
                   "name": "librsvg/librsvg2-2",
-                  "purl": "pkg:deb/librsvg2-2@2.40.5-1%2Bdeb8u2?upstream=librsvg",
+                  "purl": "pkg:deb/debian/librsvg2-2@2.40.5-1%2Bdeb8u2?distro=debian-jessie&upstream=librsvg",
                   "version": "2.40.5-1+deb8u2",
                 },
               },
@@ -6262,7 +6262,7 @@ Object {
                 "id": "libwmf/libwmf0.2-7@0.2.8.4-10.3+deb8u2",
                 "info": Object {
                   "name": "libwmf/libwmf0.2-7",
-                  "purl": "pkg:deb/libwmf0.2-7@0.2.8.4-10.3%2Bdeb8u2?upstream=libwmf",
+                  "purl": "pkg:deb/debian/libwmf0.2-7@0.2.8.4-10.3%2Bdeb8u2?distro=debian-jessie&upstream=libwmf",
                   "version": "0.2.8.4-10.3+deb8u2",
                 },
               },
@@ -6270,7 +6270,7 @@ Object {
                 "id": "ilmbase/libilmbase6@1.0.1-6.1",
                 "info": Object {
                   "name": "ilmbase/libilmbase6",
-                  "purl": "pkg:deb/libilmbase6@1.0.1-6.1?upstream=ilmbase",
+                  "purl": "pkg:deb/debian/libilmbase6@1.0.1-6.1?distro=debian-jessie&upstream=ilmbase",
                   "version": "1.0.1-6.1",
                 },
               },
@@ -6278,7 +6278,7 @@ Object {
                 "id": "openexr/libopenexr6@1.6.1-8",
                 "info": Object {
                   "name": "openexr/libopenexr6",
-                  "purl": "pkg:deb/libopenexr6@1.6.1-8?upstream=openexr",
+                  "purl": "pkg:deb/debian/libopenexr6@1.6.1-8?distro=debian-jessie&upstream=openexr",
                   "version": "1.6.1-8",
                 },
               },
@@ -6286,7 +6286,7 @@ Object {
                 "id": "graphite2/libgraphite2-3@1.3.10-1~deb8u1",
                 "info": Object {
                   "name": "graphite2/libgraphite2-3",
-                  "purl": "pkg:deb/libgraphite2-3@1.3.10-1~deb8u1?upstream=graphite2",
+                  "purl": "pkg:deb/debian/libgraphite2-3@1.3.10-1~deb8u1?distro=debian-jessie&upstream=graphite2",
                   "version": "1.3.10-1~deb8u1",
                 },
               },
@@ -6294,7 +6294,7 @@ Object {
                 "id": "harfbuzz/libharfbuzz0b@0.9.35-2",
                 "info": Object {
                   "name": "harfbuzz/libharfbuzz0b",
-                  "purl": "pkg:deb/libharfbuzz0b@0.9.35-2?upstream=harfbuzz",
+                  "purl": "pkg:deb/debian/libharfbuzz0b@0.9.35-2?distro=debian-jessie&upstream=harfbuzz",
                   "version": "0.9.35-2",
                 },
               },
@@ -6302,7 +6302,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6.q16-2-extra@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6.q16-2-extra",
-                  "purl": "pkg:deb/libmagickcore-6.q16-2-extra@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickcore-6.q16-2-extra@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6310,7 +6310,7 @@ Object {
                 "id": "jasper/libjasper-dev@1.900.1-debian1-2.4+deb8u3",
                 "info": Object {
                   "name": "jasper/libjasper-dev",
-                  "purl": "pkg:deb/libjasper-dev@1.900.1-debian1-2.4%2Bdeb8u3?upstream=jasper",
+                  "purl": "pkg:deb/debian/libjasper-dev@1.900.1-debian1-2.4%2Bdeb8u3?distro=debian-jessie&upstream=jasper",
                   "version": "1.900.1-debian1-2.4+deb8u3",
                 },
               },
@@ -6318,7 +6318,7 @@ Object {
                 "id": "lcms2/liblcms2-dev@2.6-3+deb8u1",
                 "info": Object {
                   "name": "lcms2/liblcms2-dev",
-                  "purl": "pkg:deb/liblcms2-dev@2.6-3%2Bdeb8u1?upstream=lcms2",
+                  "purl": "pkg:deb/debian/liblcms2-dev@2.6-3%2Bdeb8u1?distro=debian-jessie&upstream=lcms2",
                   "version": "2.6-3+deb8u1",
                 },
               },
@@ -6326,7 +6326,7 @@ Object {
                 "id": "jquery/libjs-jquery@1.7.2+dfsg-3.2",
                 "info": Object {
                   "name": "jquery/libjs-jquery",
-                  "purl": "pkg:deb/libjs-jquery@1.7.2%2Bdfsg-3.2?upstream=jquery",
+                  "purl": "pkg:deb/debian/libjs-jquery@1.7.2%2Bdfsg-3.2?distro=debian-jessie&upstream=jquery",
                   "version": "1.7.2+dfsg-3.2",
                 },
               },
@@ -6334,7 +6334,7 @@ Object {
                 "id": "libexif/libexif12@0.6.21-2",
                 "info": Object {
                   "name": "libexif/libexif12",
-                  "purl": "pkg:deb/libexif12@0.6.21-2?upstream=libexif",
+                  "purl": "pkg:deb/debian/libexif12@0.6.21-2?distro=debian-jessie&upstream=libexif",
                   "version": "0.6.21-2",
                 },
               },
@@ -6342,7 +6342,7 @@ Object {
                 "id": "libexif/libexif-dev@0.6.21-2",
                 "info": Object {
                   "name": "libexif/libexif-dev",
-                  "purl": "pkg:deb/libexif-dev@0.6.21-2?upstream=libexif",
+                  "purl": "pkg:deb/debian/libexif-dev@0.6.21-2?distro=debian-jessie&upstream=libexif",
                   "version": "0.6.21-2",
                 },
               },
@@ -6350,7 +6350,7 @@ Object {
                 "id": "liblqr/liblqr-1-0-dev@0.4.2-2",
                 "info": Object {
                   "name": "liblqr/liblqr-1-0-dev",
-                  "purl": "pkg:deb/liblqr-1-0-dev@0.4.2-2?upstream=liblqr",
+                  "purl": "pkg:deb/debian/liblqr-1-0-dev@0.4.2-2?distro=debian-jessie&upstream=liblqr",
                   "version": "0.4.2-2",
                 },
               },
@@ -6358,7 +6358,7 @@ Object {
                 "id": "cairo/libcairo-gobject2@1.14.0-2.1+deb8u2",
                 "info": Object {
                   "name": "cairo/libcairo-gobject2",
-                  "purl": "pkg:deb/libcairo-gobject2@1.14.0-2.1%2Bdeb8u2?upstream=cairo",
+                  "purl": "pkg:deb/debian/libcairo-gobject2@1.14.0-2.1%2Bdeb8u2?distro=debian-jessie&upstream=cairo",
                   "version": "1.14.0-2.1+deb8u2",
                 },
               },
@@ -6366,7 +6366,7 @@ Object {
                 "id": "lzo2/liblzo2-2@2.08-1.2",
                 "info": Object {
                   "name": "lzo2/liblzo2-2",
-                  "purl": "pkg:deb/liblzo2-2@2.08-1.2?upstream=lzo2",
+                  "purl": "pkg:deb/debian/liblzo2-2@2.08-1.2?distro=debian-jessie&upstream=lzo2",
                   "version": "2.08-1.2",
                 },
               },
@@ -6374,7 +6374,7 @@ Object {
                 "id": "cairo/libcairo-script-interpreter2@1.14.0-2.1+deb8u2",
                 "info": Object {
                   "name": "cairo/libcairo-script-interpreter2",
-                  "purl": "pkg:deb/libcairo-script-interpreter2@1.14.0-2.1%2Bdeb8u2?upstream=cairo",
+                  "purl": "pkg:deb/debian/libcairo-script-interpreter2@1.14.0-2.1%2Bdeb8u2?distro=debian-jessie&upstream=cairo",
                   "version": "1.14.0-2.1+deb8u2",
                 },
               },
@@ -6382,7 +6382,7 @@ Object {
                 "id": "pkg-config@0.28-1",
                 "info": Object {
                   "name": "pkg-config",
-                  "purl": "pkg:deb/pkg-config@0.28-1",
+                  "purl": "pkg:deb/debian/pkg-config@0.28-1?distro=debian-jessie",
                   "version": "0.28-1",
                 },
               },
@@ -6390,7 +6390,7 @@ Object {
                 "id": "fontconfig/libfontconfig1-dev@2.11.0-6.3+deb8u1",
                 "info": Object {
                   "name": "fontconfig/libfontconfig1-dev",
-                  "purl": "pkg:deb/libfontconfig1-dev@2.11.0-6.3%2Bdeb8u1?upstream=fontconfig",
+                  "purl": "pkg:deb/debian/libfontconfig1-dev@2.11.0-6.3%2Bdeb8u1?distro=debian-jessie&upstream=fontconfig",
                   "version": "2.11.0-6.3+deb8u1",
                 },
               },
@@ -6398,7 +6398,7 @@ Object {
                 "id": "libice/libice6@2:1.0.9-1+b1",
                 "info": Object {
                   "name": "libice/libice6",
-                  "purl": "pkg:deb/libice6@2:1.0.9-1%2Bb1?upstream=libice%402%3A1.0.9-1",
+                  "purl": "pkg:deb/debian/libice6@2:1.0.9-1%2Bb1?distro=debian-jessie&upstream=libice%402%3A1.0.9-1",
                   "version": "2:1.0.9-1+b1",
                 },
               },
@@ -6406,7 +6406,7 @@ Object {
                 "id": "libice/libice-dev@2:1.0.9-1+b1",
                 "info": Object {
                   "name": "libice/libice-dev",
-                  "purl": "pkg:deb/libice-dev@2:1.0.9-1%2Bb1?upstream=libice%402%3A1.0.9-1",
+                  "purl": "pkg:deb/debian/libice-dev@2:1.0.9-1%2Bb1?distro=debian-jessie&upstream=libice%402%3A1.0.9-1",
                   "version": "2:1.0.9-1+b1",
                 },
               },
@@ -6414,7 +6414,7 @@ Object {
                 "id": "lsb/lsb-base@4.1+Debian13+nmu1",
                 "info": Object {
                   "name": "lsb/lsb-base",
-                  "purl": "pkg:deb/lsb-base@4.1%2BDebian13%2Bnmu1?upstream=lsb",
+                  "purl": "pkg:deb/debian/lsb-base@4.1%2BDebian13%2Bnmu1?distro=debian-jessie&upstream=lsb",
                   "version": "4.1+Debian13+nmu1",
                 },
               },
@@ -6422,7 +6422,7 @@ Object {
                 "id": "xorg/x11-common@1:7.7+7",
                 "info": Object {
                   "name": "xorg/x11-common",
-                  "purl": "pkg:deb/x11-common@1:7.7%2B7?upstream=xorg",
+                  "purl": "pkg:deb/debian/x11-common@1:7.7%2B7?distro=debian-jessie&upstream=xorg",
                   "version": "1:7.7+7",
                 },
               },
@@ -6430,7 +6430,7 @@ Object {
                 "id": "libsm/libsm6@2:1.2.2-1+b1",
                 "info": Object {
                   "name": "libsm/libsm6",
-                  "purl": "pkg:deb/libsm6@2:1.2.2-1%2Bb1?upstream=libsm%402%3A1.2.2-1",
+                  "purl": "pkg:deb/debian/libsm6@2:1.2.2-1%2Bb1?distro=debian-jessie&upstream=libsm%402%3A1.2.2-1",
                   "version": "2:1.2.2-1+b1",
                 },
               },
@@ -6438,7 +6438,7 @@ Object {
                 "id": "libsm/libsm-dev@2:1.2.2-1+b1",
                 "info": Object {
                   "name": "libsm/libsm-dev",
-                  "purl": "pkg:deb/libsm-dev@2:1.2.2-1%2Bb1?upstream=libsm%402%3A1.2.2-1",
+                  "purl": "pkg:deb/debian/libsm-dev@2:1.2.2-1%2Bb1?distro=debian-jessie&upstream=libsm%402%3A1.2.2-1",
                   "version": "2:1.2.2-1+b1",
                 },
               },
@@ -6446,7 +6446,7 @@ Object {
                 "id": "libx11/libx11-dev@2:1.6.2-3+deb8u1",
                 "info": Object {
                   "name": "libx11/libx11-dev",
-                  "purl": "pkg:deb/libx11-dev@2:1.6.2-3%2Bdeb8u1?upstream=libx11",
+                  "purl": "pkg:deb/debian/libx11-dev@2:1.6.2-3%2Bdeb8u1?distro=debian-jessie&upstream=libx11",
                   "version": "2:1.6.2-3+deb8u1",
                 },
               },
@@ -6454,7 +6454,7 @@ Object {
                 "id": "libxcb/libxcb1-dev@1.10-3+b1",
                 "info": Object {
                   "name": "libxcb/libxcb1-dev",
-                  "purl": "pkg:deb/libxcb1-dev@1.10-3%2Bb1?upstream=libxcb%401.10-3",
+                  "purl": "pkg:deb/debian/libxcb1-dev@1.10-3%2Bb1?distro=debian-jessie&upstream=libxcb%401.10-3",
                   "version": "1.10-3+b1",
                 },
               },
@@ -6462,7 +6462,7 @@ Object {
                 "id": "libxcb/libxcb-render0-dev@1.10-3+b1",
                 "info": Object {
                   "name": "libxcb/libxcb-render0-dev",
-                  "purl": "pkg:deb/libxcb-render0-dev@1.10-3%2Bb1?upstream=libxcb%401.10-3",
+                  "purl": "pkg:deb/debian/libxcb-render0-dev@1.10-3%2Bb1?distro=debian-jessie&upstream=libxcb%401.10-3",
                   "version": "1.10-3+b1",
                 },
               },
@@ -6470,7 +6470,7 @@ Object {
                 "id": "libxcb/libxcb-shm0-dev@1.10-3+b1",
                 "info": Object {
                   "name": "libxcb/libxcb-shm0-dev",
-                  "purl": "pkg:deb/libxcb-shm0-dev@1.10-3%2Bb1?upstream=libxcb%401.10-3",
+                  "purl": "pkg:deb/debian/libxcb-shm0-dev@1.10-3%2Bb1?distro=debian-jessie&upstream=libxcb%401.10-3",
                   "version": "1.10-3+b1",
                 },
               },
@@ -6478,7 +6478,7 @@ Object {
                 "id": "x11proto-input/x11proto-input-dev@2.3.1-1",
                 "info": Object {
                   "name": "x11proto-input/x11proto-input-dev",
-                  "purl": "pkg:deb/x11proto-input-dev@2.3.1-1?upstream=x11proto-input",
+                  "purl": "pkg:deb/debian/x11proto-input-dev@2.3.1-1?distro=debian-jessie&upstream=x11proto-input",
                   "version": "2.3.1-1",
                 },
               },
@@ -6486,7 +6486,7 @@ Object {
                 "id": "x11proto-xext/x11proto-xext-dev@7.3.0-1",
                 "info": Object {
                   "name": "x11proto-xext/x11proto-xext-dev",
-                  "purl": "pkg:deb/x11proto-xext-dev@7.3.0-1?upstream=x11proto-xext",
+                  "purl": "pkg:deb/debian/x11proto-xext-dev@7.3.0-1?distro=debian-jessie&upstream=x11proto-xext",
                   "version": "7.3.0-1",
                 },
               },
@@ -6494,7 +6494,7 @@ Object {
                 "id": "libxext/libxext-dev@2:1.3.3-1",
                 "info": Object {
                   "name": "libxext/libxext-dev",
-                  "purl": "pkg:deb/libxext-dev@2:1.3.3-1?upstream=libxext",
+                  "purl": "pkg:deb/debian/libxext-dev@2:1.3.3-1?distro=debian-jessie&upstream=libxext",
                   "version": "2:1.3.3-1",
                 },
               },
@@ -6502,7 +6502,7 @@ Object {
                 "id": "x11proto-render/x11proto-render-dev@2:0.11.1-2",
                 "info": Object {
                   "name": "x11proto-render/x11proto-render-dev",
-                  "purl": "pkg:deb/x11proto-render-dev@2:0.11.1-2?upstream=x11proto-render",
+                  "purl": "pkg:deb/debian/x11proto-render-dev@2:0.11.1-2?distro=debian-jessie&upstream=x11proto-render",
                   "version": "2:0.11.1-2",
                 },
               },
@@ -6510,7 +6510,7 @@ Object {
                 "id": "libxrender/libxrender-dev@1:0.9.8-1+b1",
                 "info": Object {
                   "name": "libxrender/libxrender-dev",
-                  "purl": "pkg:deb/libxrender-dev@1:0.9.8-1%2Bb1?upstream=libxrender%401%3A0.9.8-1",
+                  "purl": "pkg:deb/debian/libxrender-dev@1:0.9.8-1%2Bb1?distro=debian-jessie&upstream=libxrender%401%3A0.9.8-1",
                   "version": "1:0.9.8-1+b1",
                 },
               },
@@ -6518,7 +6518,7 @@ Object {
                 "id": "pixman/libpixman-1-dev@0.32.6-3",
                 "info": Object {
                   "name": "pixman/libpixman-1-dev",
-                  "purl": "pkg:deb/libpixman-1-dev@0.32.6-3?upstream=pixman",
+                  "purl": "pkg:deb/debian/libpixman-1-dev@0.32.6-3?distro=debian-jessie&upstream=pixman",
                   "version": "0.32.6-3",
                 },
               },
@@ -6526,7 +6526,7 @@ Object {
                 "id": "cairo/libcairo2-dev@1.14.0-2.1+deb8u2",
                 "info": Object {
                   "name": "cairo/libcairo2-dev",
-                  "purl": "pkg:deb/libcairo2-dev@1.14.0-2.1%2Bdeb8u2?upstream=cairo",
+                  "purl": "pkg:deb/debian/libcairo2-dev@1.14.0-2.1%2Bdeb8u2?distro=debian-jessie&upstream=cairo",
                   "version": "1.14.0-2.1+deb8u2",
                 },
               },
@@ -6534,7 +6534,7 @@ Object {
                 "id": "gdk-pixbuf/gir1.2-gdkpixbuf-2.0@2.31.1-2+deb8u7",
                 "info": Object {
                   "name": "gdk-pixbuf/gir1.2-gdkpixbuf-2.0",
-                  "purl": "pkg:deb/gir1.2-gdkpixbuf-2.0@2.31.1-2%2Bdeb8u7?upstream=gdk-pixbuf",
+                  "purl": "pkg:deb/debian/gir1.2-gdkpixbuf-2.0@2.31.1-2%2Bdeb8u7?distro=debian-jessie&upstream=gdk-pixbuf",
                   "version": "2.31.1-2+deb8u7",
                 },
               },
@@ -6542,7 +6542,7 @@ Object {
                 "id": "libpthread-stubs/libpthread-stubs0-dev@0.3-4",
                 "info": Object {
                   "name": "libpthread-stubs/libpthread-stubs0-dev",
-                  "purl": "pkg:deb/libpthread-stubs0-dev@0.3-4?upstream=libpthread-stubs",
+                  "purl": "pkg:deb/debian/libpthread-stubs0-dev@0.3-4?distro=debian-jessie&upstream=libpthread-stubs",
                   "version": "0.3-4",
                 },
               },
@@ -6550,7 +6550,7 @@ Object {
                 "id": "x11proto-kb/x11proto-kb-dev@1.0.6-2",
                 "info": Object {
                   "name": "x11proto-kb/x11proto-kb-dev",
-                  "purl": "pkg:deb/x11proto-kb-dev@1.0.6-2?upstream=x11proto-kb",
+                  "purl": "pkg:deb/debian/x11proto-kb-dev@1.0.6-2?distro=debian-jessie&upstream=x11proto-kb",
                   "version": "1.0.6-2",
                 },
               },
@@ -6558,7 +6558,7 @@ Object {
                 "id": "xtrans/xtrans-dev@1.3.4-1",
                 "info": Object {
                   "name": "xtrans/xtrans-dev",
-                  "purl": "pkg:deb/xtrans-dev@1.3.4-1?upstream=xtrans",
+                  "purl": "pkg:deb/debian/xtrans-dev@1.3.4-1?distro=debian-jessie&upstream=xtrans",
                   "version": "1.3.4-1",
                 },
               },
@@ -6566,7 +6566,7 @@ Object {
                 "id": "shared-mime-info@1.3-1",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:deb/shared-mime-info@1.3-1",
+                  "purl": "pkg:deb/debian/shared-mime-info@1.3-1?distro=debian-jessie",
                   "version": "1.3-1",
                 },
               },
@@ -6574,7 +6574,7 @@ Object {
                 "id": "gdk-pixbuf/libgdk-pixbuf2.0-dev@2.31.1-2+deb8u7",
                 "info": Object {
                   "name": "gdk-pixbuf/libgdk-pixbuf2.0-dev",
-                  "purl": "pkg:deb/libgdk-pixbuf2.0-dev@2.31.1-2%2Bdeb8u7?upstream=gdk-pixbuf",
+                  "purl": "pkg:deb/debian/libgdk-pixbuf2.0-dev@2.31.1-2%2Bdeb8u7?distro=debian-jessie&upstream=gdk-pixbuf",
                   "version": "2.31.1-2+deb8u7",
                 },
               },
@@ -6582,7 +6582,7 @@ Object {
                 "id": "glib2.0/libglib2.0-data@2.42.1-1",
                 "info": Object {
                   "name": "glib2.0/libglib2.0-data",
-                  "purl": "pkg:deb/libglib2.0-data@2.42.1-1?upstream=glib2.0",
+                  "purl": "pkg:deb/debian/libglib2.0-data@2.42.1-1?distro=debian-jessie&upstream=glib2.0",
                   "version": "2.42.1-1",
                 },
               },
@@ -6590,7 +6590,7 @@ Object {
                 "id": "libelf/libelfg0@0.8.13-5",
                 "info": Object {
                   "name": "libelf/libelfg0",
-                  "purl": "pkg:deb/libelfg0@0.8.13-5?upstream=libelf",
+                  "purl": "pkg:deb/debian/libelfg0@0.8.13-5?distro=debian-jessie&upstream=libelf",
                   "version": "0.8.13-5",
                 },
               },
@@ -6598,7 +6598,7 @@ Object {
                 "id": "glib2.0/libglib2.0-bin@2.42.1-1+b1",
                 "info": Object {
                   "name": "glib2.0/libglib2.0-bin",
-                  "purl": "pkg:deb/libglib2.0-bin@2.42.1-1%2Bb1?upstream=glib2.0%402.42.1-1",
+                  "purl": "pkg:deb/debian/libglib2.0-bin@2.42.1-1%2Bb1?distro=debian-jessie&upstream=glib2.0%402.42.1-1",
                   "version": "2.42.1-1+b1",
                 },
               },
@@ -6606,7 +6606,7 @@ Object {
                 "id": "pcre3/libpcrecpp0@2:8.35-3.3+deb8u4",
                 "info": Object {
                   "name": "pcre3/libpcrecpp0",
-                  "purl": "pkg:deb/libpcrecpp0@2:8.35-3.3%2Bdeb8u4?upstream=pcre3",
+                  "purl": "pkg:deb/debian/libpcrecpp0@2:8.35-3.3%2Bdeb8u4?distro=debian-jessie&upstream=pcre3",
                   "version": "2:8.35-3.3+deb8u4",
                 },
               },
@@ -6614,7 +6614,7 @@ Object {
                 "id": "pcre3/libpcre3-dev@2:8.35-3.3+deb8u4",
                 "info": Object {
                   "name": "pcre3/libpcre3-dev",
-                  "purl": "pkg:deb/libpcre3-dev@2:8.35-3.3%2Bdeb8u4?upstream=pcre3",
+                  "purl": "pkg:deb/debian/libpcre3-dev@2:8.35-3.3%2Bdeb8u4?distro=debian-jessie&upstream=pcre3",
                   "version": "2:8.35-3.3+deb8u4",
                 },
               },
@@ -6622,7 +6622,7 @@ Object {
                 "id": "gobject-introspection/gir1.2-glib-2.0@1.42.0-2.2",
                 "info": Object {
                   "name": "gobject-introspection/gir1.2-glib-2.0",
-                  "purl": "pkg:deb/gir1.2-glib-2.0@1.42.0-2.2?upstream=gobject-introspection",
+                  "purl": "pkg:deb/debian/gir1.2-glib-2.0@1.42.0-2.2?distro=debian-jessie&upstream=gobject-introspection",
                   "version": "1.42.0-2.2",
                 },
               },
@@ -6630,7 +6630,7 @@ Object {
                 "id": "gobject-introspection/libgirepository-1.0-1@1.42.0-2.2",
                 "info": Object {
                   "name": "gobject-introspection/libgirepository-1.0-1",
-                  "purl": "pkg:deb/libgirepository-1.0-1@1.42.0-2.2?upstream=gobject-introspection",
+                  "purl": "pkg:deb/debian/libgirepository-1.0-1@1.42.0-2.2?distro=debian-jessie&upstream=gobject-introspection",
                   "version": "1.42.0-2.2",
                 },
               },
@@ -6638,7 +6638,7 @@ Object {
                 "id": "gobject-introspection/gir1.2-freedesktop@1.42.0-2.2",
                 "info": Object {
                   "name": "gobject-introspection/gir1.2-freedesktop",
-                  "purl": "pkg:deb/gir1.2-freedesktop@1.42.0-2.2?upstream=gobject-introspection",
+                  "purl": "pkg:deb/debian/gir1.2-freedesktop@1.42.0-2.2?distro=debian-jessie&upstream=gobject-introspection",
                   "version": "1.42.0-2.2",
                 },
               },
@@ -6646,7 +6646,7 @@ Object {
                 "id": "librsvg/gir1.2-rsvg-2.0@2.40.5-1+deb8u2",
                 "info": Object {
                   "name": "librsvg/gir1.2-rsvg-2.0",
-                  "purl": "pkg:deb/gir1.2-rsvg-2.0@2.40.5-1%2Bdeb8u2?upstream=librsvg",
+                  "purl": "pkg:deb/debian/gir1.2-rsvg-2.0@2.40.5-1%2Bdeb8u2?distro=debian-jessie&upstream=librsvg",
                   "version": "2.40.5-1+deb8u2",
                 },
               },
@@ -6654,7 +6654,7 @@ Object {
                 "id": "librsvg/librsvg2-common@2.40.5-1+deb8u2",
                 "info": Object {
                   "name": "librsvg/librsvg2-common",
-                  "purl": "pkg:deb/librsvg2-common@2.40.5-1%2Bdeb8u2?upstream=librsvg",
+                  "purl": "pkg:deb/debian/librsvg2-common@2.40.5-1%2Bdeb8u2?distro=debian-jessie&upstream=librsvg",
                   "version": "2.40.5-1+deb8u2",
                 },
               },
@@ -6662,7 +6662,7 @@ Object {
                 "id": "librsvg/librsvg2-dev@2.40.5-1+deb8u2",
                 "info": Object {
                   "name": "librsvg/librsvg2-dev",
-                  "purl": "pkg:deb/librsvg2-dev@2.40.5-1%2Bdeb8u2?upstream=librsvg",
+                  "purl": "pkg:deb/debian/librsvg2-dev@2.40.5-1%2Bdeb8u2?distro=debian-jessie&upstream=librsvg",
                   "version": "2.40.5-1+deb8u2",
                 },
               },
@@ -6670,7 +6670,7 @@ Object {
                 "id": "libwmf/libwmf-dev@0.2.8.4-10.3+deb8u2",
                 "info": Object {
                   "name": "libwmf/libwmf-dev",
-                  "purl": "pkg:deb/libwmf-dev@0.2.8.4-10.3%2Bdeb8u2?upstream=libwmf",
+                  "purl": "pkg:deb/debian/libwmf-dev@0.2.8.4-10.3%2Bdeb8u2?distro=debian-jessie&upstream=libwmf",
                   "version": "0.2.8.4-10.3+deb8u2",
                 },
               },
@@ -6678,7 +6678,7 @@ Object {
                 "id": "libxml2/libxml2-dev@2.9.1+dfsg1-5+deb8u6",
                 "info": Object {
                   "name": "libxml2/libxml2-dev",
-                  "purl": "pkg:deb/libxml2-dev@2.9.1%2Bdfsg1-5%2Bdeb8u6?upstream=libxml2",
+                  "purl": "pkg:deb/debian/libxml2-dev@2.9.1%2Bdfsg1-5%2Bdeb8u6?distro=debian-jessie&upstream=libxml2",
                   "version": "2.9.1+dfsg1-5+deb8u6",
                 },
               },
@@ -6686,7 +6686,7 @@ Object {
                 "id": "libxt/libxt6@1:1.1.4-1+b1",
                 "info": Object {
                   "name": "libxt/libxt6",
-                  "purl": "pkg:deb/libxt6@1:1.1.4-1%2Bb1?upstream=libxt%401%3A1.1.4-1",
+                  "purl": "pkg:deb/debian/libxt6@1:1.1.4-1%2Bb1?distro=debian-jessie&upstream=libxt%401%3A1.1.4-1",
                   "version": "1:1.1.4-1+b1",
                 },
               },
@@ -6694,7 +6694,7 @@ Object {
                 "id": "libxt/libxt-dev@1:1.1.4-1+b1",
                 "info": Object {
                   "name": "libxt/libxt-dev",
-                  "purl": "pkg:deb/libxt-dev@1:1.1.4-1%2Bb1?upstream=libxt%401%3A1.1.4-1",
+                  "purl": "pkg:deb/debian/libxt-dev@1:1.1.4-1%2Bb1?distro=debian-jessie&upstream=libxt%401%3A1.1.4-1",
                   "version": "1:1.1.4-1+b1",
                 },
               },
@@ -6702,7 +6702,7 @@ Object {
                 "id": "ilmbase/libilmbase-dev@1.0.1-6.1",
                 "info": Object {
                   "name": "ilmbase/libilmbase-dev",
-                  "purl": "pkg:deb/libilmbase-dev@1.0.1-6.1?upstream=ilmbase",
+                  "purl": "pkg:deb/debian/libilmbase-dev@1.0.1-6.1?distro=debian-jessie&upstream=ilmbase",
                   "version": "1.0.1-6.1",
                 },
               },
@@ -6710,7 +6710,7 @@ Object {
                 "id": "openexr/libopenexr-dev@1.6.1-8",
                 "info": Object {
                   "name": "openexr/libopenexr-dev",
-                  "purl": "pkg:deb/libopenexr-dev@1.6.1-8?upstream=openexr",
+                  "purl": "pkg:deb/debian/libopenexr-dev@1.6.1-8?distro=debian-jessie&upstream=openexr",
                   "version": "1.6.1-8",
                 },
               },
@@ -6718,7 +6718,7 @@ Object {
                 "id": "jbigkit/libjbig-dev@2.1-3.1",
                 "info": Object {
                   "name": "jbigkit/libjbig-dev",
-                  "purl": "pkg:deb/libjbig-dev@2.1-3.1?upstream=jbigkit",
+                  "purl": "pkg:deb/debian/libjbig-dev@2.1-3.1?distro=debian-jessie&upstream=jbigkit",
                   "version": "2.1-3.1",
                 },
               },
@@ -6726,7 +6726,7 @@ Object {
                 "id": "tiff/libtiffxx5@4.0.3-12.3+deb8u5",
                 "info": Object {
                   "name": "tiff/libtiffxx5",
-                  "purl": "pkg:deb/libtiffxx5@4.0.3-12.3%2Bdeb8u5?upstream=tiff",
+                  "purl": "pkg:deb/debian/libtiffxx5@4.0.3-12.3%2Bdeb8u5?distro=debian-jessie&upstream=tiff",
                   "version": "4.0.3-12.3+deb8u5",
                 },
               },
@@ -6734,7 +6734,7 @@ Object {
                 "id": "xz-utils/liblzma-dev@5.1.1alpha+20120614-2+b3",
                 "info": Object {
                   "name": "xz-utils/liblzma-dev",
-                  "purl": "pkg:deb/liblzma-dev@5.1.1alpha%2B20120614-2%2Bb3?upstream=xz-utils%405.1.1alpha%2B20120614-2",
+                  "purl": "pkg:deb/debian/liblzma-dev@5.1.1alpha%2B20120614-2%2Bb3?distro=debian-jessie&upstream=xz-utils%405.1.1alpha%2B20120614-2",
                   "version": "5.1.1alpha+20120614-2+b3",
                 },
               },
@@ -6742,7 +6742,7 @@ Object {
                 "id": "tiff/libtiff5-dev@4.0.3-12.3+deb8u5",
                 "info": Object {
                   "name": "tiff/libtiff5-dev",
-                  "purl": "pkg:deb/libtiff5-dev@4.0.3-12.3%2Bdeb8u5?upstream=tiff",
+                  "purl": "pkg:deb/debian/libtiff5-dev@4.0.3-12.3%2Bdeb8u5?distro=debian-jessie&upstream=tiff",
                   "version": "4.0.3-12.3+deb8u5",
                 },
               },
@@ -6750,7 +6750,7 @@ Object {
                 "id": "imagemagick/libmagickcore-6.q16-dev@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-6.q16-dev",
-                  "purl": "pkg:deb/libmagickcore-6.q16-dev@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickcore-6.q16-dev@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6758,7 +6758,7 @@ Object {
                 "id": "imagemagick/libmagickcore-dev@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickcore-dev",
-                  "purl": "pkg:deb/libmagickcore-dev@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickcore-dev@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6766,7 +6766,7 @@ Object {
                 "id": "imagemagick/libmagickwand-6-headers@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickwand-6-headers",
-                  "purl": "pkg:deb/libmagickwand-6-headers@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickwand-6-headers@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6774,7 +6774,7 @@ Object {
                 "id": "imagemagick/libmagickwand-6.q16-dev@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickwand-6.q16-dev",
-                  "purl": "pkg:deb/libmagickwand-6.q16-dev@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickwand-6.q16-dev@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6782,7 +6782,7 @@ Object {
                 "id": "imagemagick/libmagickwand-dev@8:6.8.9.9-5+deb8u12",
                 "info": Object {
                   "name": "imagemagick/libmagickwand-dev",
-                  "purl": "pkg:deb/libmagickwand-dev@8:6.8.9.9-5%2Bdeb8u12?upstream=imagemagick",
+                  "purl": "pkg:deb/debian/libmagickwand-dev@8:6.8.9.9-5%2Bdeb8u12?distro=debian-jessie&upstream=imagemagick",
                   "version": "8:6.8.9.9-5+deb8u12",
                 },
               },
@@ -6790,7 +6790,7 @@ Object {
                 "id": "adduser@3.113+nmu3",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.113%2Bnmu3",
+                  "purl": "pkg:deb/debian/adduser@3.113%2Bnmu3?distro=debian-jessie",
                   "version": "3.113+nmu3",
                 },
               },
@@ -6798,7 +6798,7 @@ Object {
                 "id": "slang2/libslang2@2.3.0-2",
                 "info": Object {
                   "name": "slang2/libslang2",
-                  "purl": "pkg:deb/libslang2@2.3.0-2?upstream=slang2",
+                  "purl": "pkg:deb/debian/libslang2@2.3.0-2?distro=debian-jessie&upstream=slang2",
                   "version": "2.3.0-2",
                 },
               },
@@ -6806,7 +6806,7 @@ Object {
                 "id": "insserv@1.14.0-5",
                 "info": Object {
                   "name": "insserv",
-                  "purl": "pkg:deb/insserv@1.14.0-5",
+                  "purl": "pkg:deb/debian/insserv@1.14.0-5?distro=debian-jessie",
                   "version": "1.14.0-5",
                 },
               },
@@ -6814,7 +6814,7 @@ Object {
                 "id": "startpar@0.59-3",
                 "info": Object {
                   "name": "startpar",
-                  "purl": "pkg:deb/startpar@0.59-3",
+                  "purl": "pkg:deb/debian/startpar@0.59-3?distro=debian-jessie",
                   "version": "0.59-3",
                 },
               },
@@ -6822,7 +6822,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.88dsf-59",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.88dsf-59?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.88dsf-59?distro=debian-jessie&upstream=sysvinit",
                   "version": "2.88dsf-59",
                 },
               },
@@ -6830,7 +6830,7 @@ Object {
                 "id": "sysvinit/sysv-rc@2.88dsf-59",
                 "info": Object {
                   "name": "sysvinit/sysv-rc",
-                  "purl": "pkg:deb/sysv-rc@2.88dsf-59?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysv-rc@2.88dsf-59?distro=debian-jessie&upstream=sysvinit",
                   "version": "2.88dsf-59",
                 },
               },
@@ -6838,7 +6838,7 @@ Object {
                 "id": "util-linux/libmount1@2.25.2-6",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.25.2-6?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.25.2-6?distro=debian-jessie&upstream=util-linux",
                   "version": "2.25.2-6",
                 },
               },
@@ -6846,7 +6846,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.25.2-6",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.25.2-6?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.25.2-6?distro=debian-jessie&upstream=util-linux",
                   "version": "2.25.2-6",
                 },
               },
@@ -6854,7 +6854,7 @@ Object {
                 "id": "util-linux/mount@2.25.2-6",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.25.2-6?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.25.2-6?distro=debian-jessie&upstream=util-linux",
                   "version": "2.25.2-6",
                 },
               },
@@ -6862,7 +6862,7 @@ Object {
                 "id": "sysvinit/initscripts@2.88dsf-59",
                 "info": Object {
                   "name": "sysvinit/initscripts",
-                  "purl": "pkg:deb/initscripts@2.88dsf-59?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/initscripts@2.88dsf-59?distro=debian-jessie&upstream=sysvinit",
                   "version": "2.88dsf-59",
                 },
               },
@@ -6870,7 +6870,7 @@ Object {
                 "id": "tzdata@2018d-0+deb8u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2018d-0%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/tzdata@2018d-0%2Bdeb8u1?distro=debian-jessie",
                   "version": "2018d-0+deb8u1",
                 },
               },
@@ -6878,7 +6878,7 @@ Object {
                 "id": "lvm2/dmsetup@2:1.02.90-2.2+deb8u1",
                 "info": Object {
                   "name": "lvm2/dmsetup",
-                  "purl": "pkg:deb/dmsetup@2:1.02.90-2.2%2Bdeb8u1?upstream=lvm2%402.02.111-2.2%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/dmsetup@2:1.02.90-2.2%2Bdeb8u1?distro=debian-jessie&upstream=lvm2%402.02.111-2.2%2Bdeb8u1",
                   "version": "2:1.02.90-2.2+deb8u1",
                 },
               },
@@ -6886,7 +6886,7 @@ Object {
                 "id": "systemd/libudev1@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@215-17%2Bdeb8u7?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@215-17%2Bdeb8u7?distro=debian-jessie&upstream=systemd",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6894,7 +6894,7 @@ Object {
                 "id": "lvm2/libdevmapper1.02.1@2:1.02.90-2.2+deb8u1",
                 "info": Object {
                   "name": "lvm2/libdevmapper1.02.1",
-                  "purl": "pkg:deb/libdevmapper1.02.1@2:1.02.90-2.2%2Bdeb8u1?upstream=lvm2%402.02.111-2.2%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/libdevmapper1.02.1@2:1.02.90-2.2%2Bdeb8u1?distro=debian-jessie&upstream=lvm2%402.02.111-2.2%2Bdeb8u1",
                   "version": "2:1.02.90-2.2+deb8u1",
                 },
               },
@@ -6902,7 +6902,7 @@ Object {
                 "id": "kmod/libkmod2@18-3",
                 "info": Object {
                   "name": "kmod/libkmod2",
-                  "purl": "pkg:deb/libkmod2@18-3?upstream=kmod",
+                  "purl": "pkg:deb/debian/libkmod2@18-3?distro=debian-jessie&upstream=kmod",
                   "version": "18-3",
                 },
               },
@@ -6910,7 +6910,7 @@ Object {
                 "id": "libcap2@1:2.24-8",
                 "info": Object {
                   "name": "libcap2",
-                  "purl": "pkg:deb/libcap2@1:2.24-8",
+                  "purl": "pkg:deb/debian/libcap2@1:2.24-8?distro=debian-jessie",
                   "version": "1:2.24-8",
                 },
               },
@@ -6918,7 +6918,7 @@ Object {
                 "id": "libcap2/libcap2-bin@1:2.24-8",
                 "info": Object {
                   "name": "libcap2/libcap2-bin",
-                  "purl": "pkg:deb/libcap2-bin@1:2.24-8?upstream=libcap2",
+                  "purl": "pkg:deb/debian/libcap2-bin@1:2.24-8?distro=debian-jessie&upstream=libcap2",
                   "version": "1:2.24-8",
                 },
               },
@@ -6926,7 +6926,7 @@ Object {
                 "id": "systemd/libsystemd0@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@215-17%2Bdeb8u7?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@215-17%2Bdeb8u7?distro=debian-jessie&upstream=systemd",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6934,7 +6934,7 @@ Object {
                 "id": "procps/libprocps3@2:3.3.9-9",
                 "info": Object {
                   "name": "procps/libprocps3",
-                  "purl": "pkg:deb/libprocps3@2:3.3.9-9?upstream=procps",
+                  "purl": "pkg:deb/debian/libprocps3@2:3.3.9-9?distro=debian-jessie&upstream=procps",
                   "version": "2:3.3.9-9",
                 },
               },
@@ -6942,7 +6942,7 @@ Object {
                 "id": "procps@2:3.3.9-9+deb8u1",
                 "info": Object {
                   "name": "procps",
-                  "purl": "pkg:deb/procps@2:3.3.9-9%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/procps@2:3.3.9-9%2Bdeb8u1?distro=debian-jessie",
                   "version": "2:3.3.9-9+deb8u1",
                 },
               },
@@ -6950,7 +6950,7 @@ Object {
                 "id": "systemd/udev@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd/udev",
-                  "purl": "pkg:deb/udev@215-17%2Bdeb8u7?upstream=systemd",
+                  "purl": "pkg:deb/debian/udev@215-17%2Bdeb8u7?distro=debian-jessie&upstream=systemd",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6958,7 +6958,7 @@ Object {
                 "id": "systemd@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:deb/systemd@215-17%2Bdeb8u7",
+                  "purl": "pkg:deb/debian/systemd@215-17%2Bdeb8u7?distro=debian-jessie",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6966,7 +6966,7 @@ Object {
                 "id": "systemd/systemd-sysv@215-17+deb8u7",
                 "info": Object {
                   "name": "systemd/systemd-sysv",
-                  "purl": "pkg:deb/systemd-sysv@215-17%2Bdeb8u7?upstream=systemd",
+                  "purl": "pkg:deb/debian/systemd-sysv@215-17%2Bdeb8u7?distro=debian-jessie&upstream=systemd",
                   "version": "215-17+deb8u7",
                 },
               },
@@ -6974,7 +6974,7 @@ Object {
                 "id": "init-system-helpers/init@1.22",
                 "info": Object {
                   "name": "init-system-helpers/init",
-                  "purl": "pkg:deb/init@1.22?upstream=init-system-helpers",
+                  "purl": "pkg:deb/debian/init@1.22?distro=debian-jessie&upstream=init-system-helpers",
                   "version": "1.22",
                 },
               },
@@ -6982,7 +6982,7 @@ Object {
                 "id": "iproute2@3.16.0-2",
                 "info": Object {
                   "name": "iproute2",
-                  "purl": "pkg:deb/iproute2@3.16.0-2",
+                  "purl": "pkg:deb/debian/iproute2@3.16.0-2?distro=debian-jessie",
                   "version": "3.16.0-2",
                 },
               },
@@ -6990,7 +6990,7 @@ Object {
                 "id": "libtasn1-6@4.2-3+deb8u3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.2-3%2Bdeb8u3",
+                  "purl": "pkg:deb/debian/libtasn1-6@4.2-3%2Bdeb8u3?distro=debian-jessie",
                   "version": "4.2-3+deb8u3",
                 },
               },
@@ -6998,7 +6998,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.20.7-1",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.20.7-1?upstream=p11-kit",
+                  "purl": "pkg:deb/debian/libp11-kit0@0.20.7-1?distro=debian-jessie&upstream=p11-kit",
                   "version": "0.20.7-1",
                 },
               },
@@ -7006,7 +7006,7 @@ Object {
                 "id": "gnutls28/libgnutls-openssl27@3.3.8-6+deb8u7",
                 "info": Object {
                   "name": "gnutls28/libgnutls-openssl27",
-                  "purl": "pkg:deb/libgnutls-openssl27@3.3.8-6%2Bdeb8u7?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls-openssl27@3.3.8-6%2Bdeb8u7?distro=debian-jessie&upstream=gnutls28",
                   "version": "3.3.8-6+deb8u7",
                 },
               },
@@ -7014,7 +7014,7 @@ Object {
                 "id": "iputils/iputils-ping@3:20121221-5+b2",
                 "info": Object {
                   "name": "iputils/iputils-ping",
-                  "purl": "pkg:deb/iputils-ping@3:20121221-5%2Bb2?upstream=iputils%403%3A20121221-5",
+                  "purl": "pkg:deb/debian/iputils-ping@3:20121221-5%2Bb2?distro=debian-jessie&upstream=iputils%403%3A20121221-5",
                   "version": "3:20121221-5+b2",
                 },
               },
@@ -7043,7 +7043,7 @@ Object {
                 "id": "krb5/krb5-multidev@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/krb5-multidev",
-                  "purl": "pkg:deb/krb5-multidev@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
+                  "purl": "pkg:deb/debian/krb5-multidev@1.12.1%2Bdfsg-19%2Bdeb8u4?distro=debian-jessie&upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7051,7 +7051,7 @@ Object {
                 "id": "krb5/libkrb5-dev@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkrb5-dev",
-                  "purl": "pkg:deb/libkrb5-dev@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
+                  "purl": "pkg:deb/debian/libkrb5-dev@1.12.1%2Bdfsg-19%2Bdeb8u4?distro=debian-jessie&upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7073,7 +7073,7 @@ Object {
                 "id": "libevent/libevent-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-2.0-5",
-                  "purl": "pkg:deb/libevent-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
+                  "purl": "pkg:deb/debian/libevent-2.0-5@2.0.21-stable-2%2Bdeb8u1?distro=debian-jessie&upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -7081,7 +7081,7 @@ Object {
                 "id": "libevent/libevent-core-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-core-2.0-5",
-                  "purl": "pkg:deb/libevent-core-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
+                  "purl": "pkg:deb/debian/libevent-core-2.0-5@2.0.21-stable-2%2Bdeb8u1?distro=debian-jessie&upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -7089,7 +7089,7 @@ Object {
                 "id": "libevent/libevent-extra-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-extra-2.0-5",
-                  "purl": "pkg:deb/libevent-extra-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
+                  "purl": "pkg:deb/debian/libevent-extra-2.0-5@2.0.21-stable-2%2Bdeb8u1?distro=debian-jessie&upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -7097,7 +7097,7 @@ Object {
                 "id": "libevent/libevent-openssl-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-openssl-2.0-5",
-                  "purl": "pkg:deb/libevent-openssl-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
+                  "purl": "pkg:deb/debian/libevent-openssl-2.0-5@2.0.21-stable-2%2Bdeb8u1?distro=debian-jessie&upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -7105,7 +7105,7 @@ Object {
                 "id": "libevent/libevent-pthreads-2.0-5@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-pthreads-2.0-5",
-                  "purl": "pkg:deb/libevent-pthreads-2.0-5@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
+                  "purl": "pkg:deb/debian/libevent-pthreads-2.0-5@2.0.21-stable-2%2Bdeb8u1?distro=debian-jessie&upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -7113,7 +7113,7 @@ Object {
                 "id": "libevent/libevent-dev@2.0.21-stable-2+deb8u1",
                 "info": Object {
                   "name": "libevent/libevent-dev",
-                  "purl": "pkg:deb/libevent-dev@2.0.21-stable-2%2Bdeb8u1?upstream=libevent",
+                  "purl": "pkg:deb/debian/libevent-dev@2.0.21-stable-2%2Bdeb8u1?distro=debian-jessie&upstream=libevent",
                   "version": "2.0.21-stable-2+deb8u1",
                 },
               },
@@ -7121,7 +7121,7 @@ Object {
                 "id": "libffi/libffi-dev@3.1-2+deb8u1",
                 "info": Object {
                   "name": "libffi/libffi-dev",
-                  "purl": "pkg:deb/libffi-dev@3.1-2%2Bdeb8u1?upstream=libffi",
+                  "purl": "pkg:deb/debian/libffi-dev@3.1-2%2Bdeb8u1?distro=debian-jessie&upstream=libffi",
                   "version": "3.1-2+deb8u1",
                 },
               },
@@ -7192,7 +7192,7 @@ Object {
                 "id": "file/libmagic1@1:5.22+15-2+deb8u3",
                 "info": Object {
                   "name": "file/libmagic1",
-                  "purl": "pkg:deb/libmagic1@1:5.22%2B15-2%2Bdeb8u3?upstream=file",
+                  "purl": "pkg:deb/debian/libmagic1@1:5.22%2B15-2%2Bdeb8u3?distro=debian-jessie&upstream=file",
                   "version": "1:5.22+15-2+deb8u3",
                 },
               },
@@ -7200,7 +7200,7 @@ Object {
                 "id": "gcc-4.9/cpp-4.9@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/cpp-4.9",
-                  "purl": "pkg:deb/cpp-4.9@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/cpp-4.9@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7208,7 +7208,7 @@ Object {
                 "id": "gcc-4.9/libasan1@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libasan1",
-                  "purl": "pkg:deb/libasan1@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libasan1@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7216,7 +7216,7 @@ Object {
                 "id": "gcc-4.9/libatomic1@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libatomic1",
-                  "purl": "pkg:deb/libatomic1@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libatomic1@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7224,7 +7224,7 @@ Object {
                 "id": "gcc-4.9/libcilkrts5@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libcilkrts5",
-                  "purl": "pkg:deb/libcilkrts5@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libcilkrts5@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7232,7 +7232,7 @@ Object {
                 "id": "gcc-4.9/libitm1@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libitm1",
-                  "purl": "pkg:deb/libitm1@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libitm1@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7240,7 +7240,7 @@ Object {
                 "id": "gcc-4.9/liblsan0@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/liblsan0",
-                  "purl": "pkg:deb/liblsan0@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/liblsan0@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7248,7 +7248,7 @@ Object {
                 "id": "gcc-4.9/libquadmath0@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libquadmath0",
-                  "purl": "pkg:deb/libquadmath0@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libquadmath0@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7256,7 +7256,7 @@ Object {
                 "id": "gcc-4.9/libtsan0@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libtsan0",
-                  "purl": "pkg:deb/libtsan0@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libtsan0@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7264,7 +7264,7 @@ Object {
                 "id": "gcc-4.9/libubsan0@4.9.2-10+deb8u1",
                 "info": Object {
                   "name": "gcc-4.9/libubsan0",
-                  "purl": "pkg:deb/libubsan0@4.9.2-10%2Bdeb8u1?upstream=gcc-4.9",
+                  "purl": "pkg:deb/debian/libubsan0@4.9.2-10%2Bdeb8u1?distro=debian-jessie&upstream=gcc-4.9",
                   "version": "4.9.2-10+deb8u1",
                 },
               },
@@ -7272,7 +7272,7 @@ Object {
                 "id": "libtool@2.4.2-1.11",
                 "info": Object {
                   "name": "libtool",
-                  "purl": "pkg:deb/libtool@2.4.2-1.11",
+                  "purl": "pkg:deb/debian/libtool@2.4.2-1.11?distro=debian-jessie",
                   "version": "2.4.2-1.11",
                 },
               },
@@ -7280,7 +7280,7 @@ Object {
                 "id": "libwebp/libwebp5@0.4.1-1.2+b2",
                 "info": Object {
                   "name": "libwebp/libwebp5",
-                  "purl": "pkg:deb/libwebp5@0.4.1-1.2%2Bb2?upstream=libwebp%400.4.1-1.2",
+                  "purl": "pkg:deb/debian/libwebp5@0.4.1-1.2%2Bb2?distro=debian-jessie&upstream=libwebp%400.4.1-1.2",
                   "version": "0.4.1-1.2+b2",
                 },
               },
@@ -7288,7 +7288,7 @@ Object {
                 "id": "libwebp/libwebpdemux1@0.4.1-1.2+b2",
                 "info": Object {
                   "name": "libwebp/libwebpdemux1",
-                  "purl": "pkg:deb/libwebpdemux1@0.4.1-1.2%2Bb2?upstream=libwebp%400.4.1-1.2",
+                  "purl": "pkg:deb/debian/libwebpdemux1@0.4.1-1.2%2Bb2?distro=debian-jessie&upstream=libwebp%400.4.1-1.2",
                   "version": "0.4.1-1.2+b2",
                 },
               },
@@ -7296,7 +7296,7 @@ Object {
                 "id": "libwebp/libwebpmux1@0.4.1-1.2+b2",
                 "info": Object {
                   "name": "libwebp/libwebpmux1",
-                  "purl": "pkg:deb/libwebpmux1@0.4.1-1.2%2Bb2?upstream=libwebp%400.4.1-1.2",
+                  "purl": "pkg:deb/debian/libwebpmux1@0.4.1-1.2%2Bb2?distro=debian-jessie&upstream=libwebp%400.4.1-1.2",
                   "version": "0.4.1-1.2+b2",
                 },
               },
@@ -7304,7 +7304,7 @@ Object {
                 "id": "libwebp/libwebp-dev@0.4.1-1.2+b2",
                 "info": Object {
                   "name": "libwebp/libwebp-dev",
-                  "purl": "pkg:deb/libwebp-dev@0.4.1-1.2%2Bb2?upstream=libwebp%400.4.1-1.2",
+                  "purl": "pkg:deb/debian/libwebp-dev@0.4.1-1.2%2Bb2?distro=debian-jessie&upstream=libwebp%400.4.1-1.2",
                   "version": "0.4.1-1.2+b2",
                 },
               },
@@ -7389,7 +7389,7 @@ Object {
                 "id": "libxslt/libxslt1.1@1.1.28-2+deb8u3",
                 "info": Object {
                   "name": "libxslt/libxslt1.1",
-                  "purl": "pkg:deb/libxslt1.1@1.1.28-2%2Bdeb8u3?upstream=libxslt",
+                  "purl": "pkg:deb/debian/libxslt1.1@1.1.28-2%2Bdeb8u3?distro=debian-jessie&upstream=libxslt",
                   "version": "1.1.28-2+deb8u3",
                 },
               },
@@ -7397,7 +7397,7 @@ Object {
                 "id": "libxslt/libxslt1-dev@1.1.28-2+deb8u3",
                 "info": Object {
                   "name": "libxslt/libxslt1-dev",
-                  "purl": "pkg:deb/libxslt1-dev@1.1.28-2%2Bdeb8u3?upstream=libxslt",
+                  "purl": "pkg:deb/debian/libxslt1-dev@1.1.28-2%2Bdeb8u3?distro=debian-jessie&upstream=libxslt",
                   "version": "1.1.28-2+deb8u3",
                 },
               },
@@ -7405,7 +7405,7 @@ Object {
                 "id": "libyaml/libyaml-0-2@0.1.6-3",
                 "info": Object {
                   "name": "libyaml/libyaml-0-2",
-                  "purl": "pkg:deb/libyaml-0-2@0.1.6-3?upstream=libyaml",
+                  "purl": "pkg:deb/debian/libyaml-0-2@0.1.6-3?distro=debian-jessie&upstream=libyaml",
                   "version": "0.1.6-3",
                 },
               },
@@ -7413,7 +7413,7 @@ Object {
                 "id": "libyaml/libyaml-dev@0.1.6-3",
                 "info": Object {
                   "name": "libyaml/libyaml-dev",
-                  "purl": "pkg:deb/libyaml-dev@0.1.6-3?upstream=libyaml",
+                  "purl": "pkg:deb/debian/libyaml-dev@0.1.6-3?distro=debian-jessie&upstream=libyaml",
                   "version": "0.1.6-3",
                 },
               },
@@ -7428,7 +7428,7 @@ Object {
                 "id": "explorercanvas/libjs-excanvas@0.r3-3",
                 "info": Object {
                   "name": "explorercanvas/libjs-excanvas",
-                  "purl": "pkg:deb/libjs-excanvas@0.r3-3?upstream=explorercanvas",
+                  "purl": "pkg:deb/debian/libjs-excanvas@0.r3-3?distro=debian-jessie&upstream=explorercanvas",
                   "version": "0.r3-3",
                 },
               },
@@ -7436,7 +7436,7 @@ Object {
                 "id": "mercurial/mercurial-common@3.1.2-2+deb8u4",
                 "info": Object {
                   "name": "mercurial/mercurial-common",
-                  "purl": "pkg:deb/mercurial-common@3.1.2-2%2Bdeb8u4?upstream=mercurial",
+                  "purl": "pkg:deb/debian/mercurial-common@3.1.2-2%2Bdeb8u4?distro=debian-jessie&upstream=mercurial",
                   "version": "3.1.2-2+deb8u4",
                 },
               },
@@ -7444,7 +7444,7 @@ Object {
                 "id": "mercurial@3.1.2-2+deb8u4",
                 "info": Object {
                   "name": "mercurial",
-                  "purl": "pkg:deb/mercurial@3.1.2-2%2Bdeb8u4",
+                  "purl": "pkg:deb/debian/mercurial@3.1.2-2%2Bdeb8u4?distro=debian-jessie",
                   "version": "3.1.2-2+deb8u4",
                 },
               },
@@ -7452,7 +7452,7 @@ Object {
                 "id": "mysql-5.5/mysql-common@5.5.60-0+deb8u1",
                 "info": Object {
                   "name": "mysql-5.5/mysql-common",
-                  "purl": "pkg:deb/mysql-common@5.5.60-0%2Bdeb8u1?upstream=mysql-5.5",
+                  "purl": "pkg:deb/debian/mysql-common@5.5.60-0%2Bdeb8u1?distro=debian-jessie&upstream=mysql-5.5",
                   "version": "5.5.60-0+deb8u1",
                 },
               },
@@ -7460,7 +7460,7 @@ Object {
                 "id": "mysql-5.5/libmysqlclient18@5.5.60-0+deb8u1",
                 "info": Object {
                   "name": "mysql-5.5/libmysqlclient18",
-                  "purl": "pkg:deb/libmysqlclient18@5.5.60-0%2Bdeb8u1?upstream=mysql-5.5",
+                  "purl": "pkg:deb/debian/libmysqlclient18@5.5.60-0%2Bdeb8u1?distro=debian-jessie&upstream=mysql-5.5",
                   "version": "5.5.60-0+deb8u1",
                 },
               },
@@ -7468,7 +7468,7 @@ Object {
                 "id": "mysql-5.5/libmysqlclient-dev@5.5.60-0+deb8u1",
                 "info": Object {
                   "name": "mysql-5.5/libmysqlclient-dev",
-                  "purl": "pkg:deb/libmysqlclient-dev@5.5.60-0%2Bdeb8u1?upstream=mysql-5.5",
+                  "purl": "pkg:deb/debian/libmysqlclient-dev@5.5.60-0%2Bdeb8u1?distro=debian-jessie&upstream=mysql-5.5",
                   "version": "5.5.60-0+deb8u1",
                 },
               },
@@ -7476,7 +7476,7 @@ Object {
                 "id": "ncurses/libtinfo-dev@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libtinfo-dev",
-                  "purl": "pkg:deb/libtinfo-dev@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo-dev@5.9%2B20140913-1%2Bdeb8u2?distro=debian-jessie&upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7484,7 +7484,7 @@ Object {
                 "id": "ncurses/ncurses-bin@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@5.9%2B20140913-1%2Bdeb8u2?distro=debian-jessie&upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7492,7 +7492,7 @@ Object {
                 "id": "ncurses/libncurses5-dev@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libncurses5-dev",
-                  "purl": "pkg:deb/libncurses5-dev@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncurses5-dev@5.9%2B20140913-1%2Bdeb8u2?distro=debian-jessie&upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7500,7 +7500,7 @@ Object {
                 "id": "ncurses/libncursesw5-dev@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/libncursesw5-dev",
-                  "purl": "pkg:deb/libncursesw5-dev@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw5-dev@5.9%2B20140913-1%2Bdeb8u2?distro=debian-jessie&upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7515,7 +7515,7 @@ Object {
                 "id": "ncurses/ncurses-base@5.9+20140913-1+deb8u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@5.9%2B20140913-1%2Bdeb8u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@5.9%2B20140913-1%2Bdeb8u2?distro=debian-jessie&upstream=ncurses",
                   "version": "5.9+20140913-1+deb8u2",
                 },
               },
@@ -7523,7 +7523,7 @@ Object {
                 "id": "netbase@5.3",
                 "info": Object {
                   "name": "netbase",
-                  "purl": "pkg:deb/netbase@5.3",
+                  "purl": "pkg:deb/debian/netbase@5.3?distro=debian-jessie",
                   "version": "5.3",
                 },
               },
@@ -7531,7 +7531,7 @@ Object {
                 "id": "libbsd/libbsd0@0.7.0-2",
                 "info": Object {
                   "name": "libbsd/libbsd0",
-                  "purl": "pkg:deb/libbsd0@0.7.0-2?upstream=libbsd",
+                  "purl": "pkg:deb/debian/libbsd0@0.7.0-2?distro=debian-jessie&upstream=libbsd",
                   "version": "0.7.0-2",
                 },
               },
@@ -7539,7 +7539,7 @@ Object {
                 "id": "libedit/libedit2@3.1-20140620-2",
                 "info": Object {
                   "name": "libedit/libedit2",
-                  "purl": "pkg:deb/libedit2@3.1-20140620-2?upstream=libedit",
+                  "purl": "pkg:deb/debian/libedit2@3.1-20140620-2?distro=debian-jessie&upstream=libedit",
                   "version": "3.1-20140620-2",
                 },
               },
@@ -7547,7 +7547,7 @@ Object {
                 "id": "openssh/openssh-client@1:6.7p1-5+deb8u4",
                 "info": Object {
                   "name": "openssh/openssh-client",
-                  "purl": "pkg:deb/openssh-client@1:6.7p1-5%2Bdeb8u4?upstream=openssh",
+                  "purl": "pkg:deb/debian/openssh-client@1:6.7p1-5%2Bdeb8u4?distro=debian-jessie&upstream=openssh",
                   "version": "1:6.7p1-5+deb8u4",
                 },
               },
@@ -7555,7 +7555,7 @@ Object {
                 "id": "openssl/libssl-dev@1.0.1t-1+deb8u8",
                 "info": Object {
                   "name": "openssl/libssl-dev",
-                  "purl": "pkg:deb/libssl-dev@1.0.1t-1%2Bdeb8u8?upstream=openssl",
+                  "purl": "pkg:deb/debian/libssl-dev@1.0.1t-1%2Bdeb8u8?distro=debian-jessie&upstream=openssl",
                   "version": "1.0.1t-1+deb8u8",
                 },
               },
@@ -7577,7 +7577,7 @@ Object {
                 "id": "pam/libpam-runtime@1.1.8-3.1+deb8u2",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.1.8-3.1%2Bdeb8u2?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.1.8-3.1%2Bdeb8u2?distro=debian-jessie&upstream=pam",
                   "version": "1.1.8-3.1+deb8u2",
                 },
               },
@@ -7620,7 +7620,7 @@ Object {
                 "id": "e2fsprogs/comerr-dev@2.1-1.42.12-2+b1",
                 "info": Object {
                   "name": "e2fsprogs/comerr-dev",
-                  "purl": "pkg:deb/comerr-dev@2.1-1.42.12-2%2Bb1?upstream=e2fsprogs%401.42.12-2",
+                  "purl": "pkg:deb/debian/comerr-dev@2.1-1.42.12-2%2Bb1?distro=debian-jessie&upstream=e2fsprogs%401.42.12-2",
                   "version": "2.1-1.42.12-2+b1",
                 },
               },
@@ -7628,7 +7628,7 @@ Object {
                 "id": "krb5/libgssrpc4@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libgssrpc4",
-                  "purl": "pkg:deb/libgssrpc4@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
+                  "purl": "pkg:deb/debian/libgssrpc4@1.12.1%2Bdfsg-19%2Bdeb8u4?distro=debian-jessie&upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7636,7 +7636,7 @@ Object {
                 "id": "krb5/libkadm5clnt-mit9@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkadm5clnt-mit9",
-                  "purl": "pkg:deb/libkadm5clnt-mit9@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
+                  "purl": "pkg:deb/debian/libkadm5clnt-mit9@1.12.1%2Bdfsg-19%2Bdeb8u4?distro=debian-jessie&upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7644,7 +7644,7 @@ Object {
                 "id": "krb5/libkdb5-7@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkdb5-7",
-                  "purl": "pkg:deb/libkdb5-7@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
+                  "purl": "pkg:deb/debian/libkdb5-7@1.12.1%2Bdfsg-19%2Bdeb8u4?distro=debian-jessie&upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7652,7 +7652,7 @@ Object {
                 "id": "krb5/libkadm5srv-mit9@1.12.1+dfsg-19+deb8u4",
                 "info": Object {
                   "name": "krb5/libkadm5srv-mit9",
-                  "purl": "pkg:deb/libkadm5srv-mit9@1.12.1%2Bdfsg-19%2Bdeb8u4?upstream=krb5",
+                  "purl": "pkg:deb/debian/libkadm5srv-mit9@1.12.1%2Bdfsg-19%2Bdeb8u4?distro=debian-jessie&upstream=krb5",
                   "version": "1.12.1+dfsg-19+deb8u4",
                 },
               },
@@ -7660,7 +7660,7 @@ Object {
                 "id": "cyrus-sasl2/libsasl2-modules-db@2.1.26.dfsg1-13+deb8u1",
                 "info": Object {
                   "name": "cyrus-sasl2/libsasl2-modules-db",
-                  "purl": "pkg:deb/libsasl2-modules-db@2.1.26.dfsg1-13%2Bdeb8u1?upstream=cyrus-sasl2",
+                  "purl": "pkg:deb/debian/libsasl2-modules-db@2.1.26.dfsg1-13%2Bdeb8u1?distro=debian-jessie&upstream=cyrus-sasl2",
                   "version": "2.1.26.dfsg1-13+deb8u1",
                 },
               },
@@ -7668,7 +7668,7 @@ Object {
                 "id": "cyrus-sasl2/libsasl2-2@2.1.26.dfsg1-13+deb8u1",
                 "info": Object {
                   "name": "cyrus-sasl2/libsasl2-2",
-                  "purl": "pkg:deb/libsasl2-2@2.1.26.dfsg1-13%2Bdeb8u1?upstream=cyrus-sasl2",
+                  "purl": "pkg:deb/debian/libsasl2-2@2.1.26.dfsg1-13%2Bdeb8u1?distro=debian-jessie&upstream=cyrus-sasl2",
                   "version": "2.1.26.dfsg1-13+deb8u1",
                 },
               },
@@ -7676,7 +7676,7 @@ Object {
                 "id": "postgresql-9.4/libpq5@9.4.15-0+deb8u1",
                 "info": Object {
                   "name": "postgresql-9.4/libpq5",
-                  "purl": "pkg:deb/libpq5@9.4.15-0%2Bdeb8u1?upstream=postgresql-9.4",
+                  "purl": "pkg:deb/debian/libpq5@9.4.15-0%2Bdeb8u1?distro=debian-jessie&upstream=postgresql-9.4",
                   "version": "9.4.15-0+deb8u1",
                 },
               },
@@ -7684,7 +7684,7 @@ Object {
                 "id": "postgresql-9.4/libpq-dev@9.4.15-0+deb8u1",
                 "info": Object {
                   "name": "postgresql-9.4/libpq-dev",
-                  "purl": "pkg:deb/libpq-dev@9.4.15-0%2Bdeb8u1?upstream=postgresql-9.4",
+                  "purl": "pkg:deb/debian/libpq-dev@9.4.15-0%2Bdeb8u1?distro=debian-jessie&upstream=postgresql-9.4",
                   "version": "9.4.15-0+deb8u1",
                 },
               },
@@ -7692,7 +7692,7 @@ Object {
                 "id": "readline6/libreadline6-dev@6.3-8+b3",
                 "info": Object {
                   "name": "readline6/libreadline6-dev",
-                  "purl": "pkg:deb/libreadline6-dev@6.3-8%2Bb3?upstream=readline6%406.3-8",
+                  "purl": "pkg:deb/debian/libreadline6-dev@6.3-8%2Bb3?distro=debian-jessie&upstream=readline6%406.3-8",
                   "version": "6.3-8+b3",
                 },
               },
@@ -7700,7 +7700,7 @@ Object {
                 "id": "readline6/libreadline-dev@6.3-8+b3",
                 "info": Object {
                   "name": "readline6/libreadline-dev",
-                  "purl": "pkg:deb/libreadline-dev@6.3-8%2Bb3?upstream=readline6%406.3-8",
+                  "purl": "pkg:deb/debian/libreadline-dev@6.3-8%2Bb3?distro=debian-jessie&upstream=readline6%406.3-8",
                   "version": "6.3-8+b3",
                 },
               },
@@ -7708,7 +7708,7 @@ Object {
                 "id": "sed@4.2.2-4+deb8u1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.2.2-4%2Bdeb8u1",
+                  "purl": "pkg:deb/debian/sed@4.2.2-4%2Bdeb8u1?distro=debian-jessie",
                   "version": "4.2.2-4+deb8u1",
                 },
               },
@@ -7723,7 +7723,7 @@ Object {
                 "id": "shadow/login@1:4.2-3+deb8u4",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.2-3%2Bdeb8u4?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.2-3%2Bdeb8u4?distro=debian-jessie&upstream=shadow",
                   "version": "1:4.2-3+deb8u4",
                 },
               },
@@ -7738,7 +7738,7 @@ Object {
                 "id": "sqlite3/libsqlite3-dev@3.8.7.1-1+deb8u2",
                 "info": Object {
                   "name": "sqlite3/libsqlite3-dev",
-                  "purl": "pkg:deb/libsqlite3-dev@3.8.7.1-1%2Bdeb8u2?upstream=sqlite3",
+                  "purl": "pkg:deb/debian/libsqlite3-dev@3.8.7.1-1%2Bdeb8u2?distro=debian-jessie&upstream=sqlite3",
                   "version": "3.8.7.1-1+deb8u2",
                 },
               },
@@ -7746,7 +7746,7 @@ Object {
                 "id": "apr-util/libaprutil1@1.5.4-1",
                 "info": Object {
                   "name": "apr-util/libaprutil1",
-                  "purl": "pkg:deb/libaprutil1@1.5.4-1?upstream=apr-util",
+                  "purl": "pkg:deb/debian/libaprutil1@1.5.4-1?distro=debian-jessie&upstream=apr-util",
                   "version": "1.5.4-1",
                 },
               },
@@ -7754,7 +7754,7 @@ Object {
                 "id": "apr/libapr1@1.5.1-3",
                 "info": Object {
                   "name": "apr/libapr1",
-                  "purl": "pkg:deb/libapr1@1.5.1-3?upstream=apr",
+                  "purl": "pkg:deb/debian/libapr1@1.5.1-3?distro=debian-jessie&upstream=apr",
                   "version": "1.5.1-3",
                 },
               },
@@ -7762,7 +7762,7 @@ Object {
                 "id": "serf/libserf-1-1@1.3.8-1",
                 "info": Object {
                   "name": "serf/libserf-1-1",
-                  "purl": "pkg:deb/libserf-1-1@1.3.8-1?upstream=serf",
+                  "purl": "pkg:deb/debian/libserf-1-1@1.3.8-1?distro=debian-jessie&upstream=serf",
                   "version": "1.3.8-1",
                 },
               },
@@ -7770,7 +7770,7 @@ Object {
                 "id": "subversion/libsvn1@1.8.10-6+deb8u5",
                 "info": Object {
                   "name": "subversion/libsvn1",
-                  "purl": "pkg:deb/libsvn1@1.8.10-6%2Bdeb8u5?upstream=subversion",
+                  "purl": "pkg:deb/debian/libsvn1@1.8.10-6%2Bdeb8u5?distro=debian-jessie&upstream=subversion",
                   "version": "1.8.10-6+deb8u5",
                 },
               },
@@ -7778,7 +7778,7 @@ Object {
                 "id": "subversion@1.8.10-6+deb8u5",
                 "info": Object {
                   "name": "subversion",
-                  "purl": "pkg:deb/subversion@1.8.10-6%2Bdeb8u5",
+                  "purl": "pkg:deb/debian/subversion@1.8.10-6%2Bdeb8u5?distro=debian-jessie",
                   "version": "1.8.10-6+deb8u5",
                 },
               },
@@ -7814,7 +7814,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.25.2-6",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.25.2-6?upstream=util-linux%402.25.2-6",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.25.2-6?distro=debian-jessie&upstream=util-linux%402.25.2-6",
                   "version": "1:2.25.2-6",
                 },
               },
@@ -7829,7 +7829,7 @@ Object {
                 "id": "icu/libicu52@52.1-8+deb8u7",
                 "info": Object {
                   "name": "icu/libicu52",
-                  "purl": "pkg:deb/libicu52@52.1-8%2Bdeb8u7?upstream=icu",
+                  "purl": "pkg:deb/debian/libicu52@52.1-8%2Bdeb8u7?distro=debian-jessie&upstream=icu",
                   "version": "52.1-8+deb8u7",
                 },
               },
@@ -7837,7 +7837,7 @@ Object {
                 "id": "libpsl/libpsl0@0.5.1-1",
                 "info": Object {
                   "name": "libpsl/libpsl0",
-                  "purl": "pkg:deb/libpsl0@0.5.1-1?upstream=libpsl",
+                  "purl": "pkg:deb/debian/libpsl0@0.5.1-1?distro=debian-jessie&upstream=libpsl",
                   "version": "0.5.1-1",
                 },
               },
@@ -7845,7 +7845,7 @@ Object {
                 "id": "wget@1.16-1+deb8u5",
                 "info": Object {
                   "name": "wget",
-                  "purl": "pkg:deb/wget@1.16-1%2Bdeb8u5",
+                  "purl": "pkg:deb/debian/wget@1.16-1%2Bdeb8u5?distro=debian-jessie",
                   "version": "1.16-1+deb8u5",
                 },
               },

--- a/test/system/flags/__snapshots__/app-vulns.spec.ts.snap
+++ b/test/system/flags/__snapshots__/app-vulns.spec.ts.snap
@@ -870,7 +870,7 @@ Object {
                 "id": "amazon-linux-extras@1.6.10-1.amzn2",
                 "info": Object {
                   "name": "amazon-linux-extras",
-                  "purl": "pkg:rpm/amazon-linux-extras@1.6.10-1.amzn2",
+                  "purl": "pkg:rpm/amzn/amazon-linux-extras@1.6.10-1.amzn2?distro=amzn-2",
                   "version": "1.6.10-1.amzn2",
                 },
               },
@@ -878,7 +878,7 @@ Object {
                 "id": "basesystem@10.0-7.amzn2.0.1",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/basesystem@10.0-7.amzn2.0.1?distro=amzn-2",
                   "version": "10.0-7.amzn2.0.1",
                 },
               },
@@ -886,7 +886,7 @@ Object {
                 "id": "bash@4.2.46-33.amzn2",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-33.amzn2",
+                  "purl": "pkg:rpm/amzn/bash@4.2.46-33.amzn2?distro=amzn-2",
                   "version": "4.2.46-33.amzn2",
                 },
               },
@@ -894,7 +894,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.amzn2.0.2",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/bzip2-libs@1.0.6-13.amzn2.0.2?distro=amzn-2",
                   "version": "1.0.6-13.amzn2.0.2",
                 },
               },
@@ -902,7 +902,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.amzn2.0.1",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/ca-certificates@2019.2.32-76.amzn2.0.1?distro=amzn-2",
                   "version": "2019.2.32-76.amzn2.0.1",
                 },
               },
@@ -910,7 +910,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.amzn2.0.2",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/chkconfig@1.7.4-1.amzn2.0.2?distro=amzn-2",
                   "version": "1.7.4-1.amzn2.0.2",
                 },
               },
@@ -918,7 +918,7 @@ Object {
                 "id": "coreutils@8.22-24.amzn2",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.amzn2",
+                  "purl": "pkg:rpm/amzn/coreutils@8.22-24.amzn2?distro=amzn-2",
                   "version": "8.22-24.amzn2",
                 },
               },
@@ -926,7 +926,7 @@ Object {
                 "id": "cpio@2.11-27.amzn2",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.amzn2",
+                  "purl": "pkg:rpm/amzn/cpio@2.11-27.amzn2?distro=amzn-2",
                   "version": "2.11-27.amzn2",
                 },
               },
@@ -934,7 +934,7 @@ Object {
                 "id": "curl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/curl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -942,7 +942,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.amzn2",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.amzn2",
+                  "purl": "pkg:rpm/amzn/cyrus-sasl-lib@2.1.26-23.amzn2?distro=amzn-2",
                   "version": "2.1.26-23.amzn2",
                 },
               },
@@ -950,7 +950,7 @@ Object {
                 "id": "diffutils@3.3-5.amzn2",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/diffutils@3.3-5.amzn2?distro=amzn-2",
                   "version": "3.3-5.amzn2",
                 },
               },
@@ -958,7 +958,7 @@ Object {
                 "id": "elfutils-libelf@0.176-2.amzn2",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-2.amzn2",
+                  "purl": "pkg:rpm/amzn/elfutils-libelf@0.176-2.amzn2?distro=amzn-2",
                   "version": "0.176-2.amzn2",
                 },
               },
@@ -966,7 +966,7 @@ Object {
                 "id": "expat@2.1.0-10.amzn2.0.2",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/expat@2.1.0-10.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-10.amzn2.0.2",
                 },
               },
@@ -974,7 +974,7 @@ Object {
                 "id": "file-libs@5.11-35.amzn2.0.2",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-35.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/file-libs@5.11-35.amzn2.0.2?distro=amzn-2",
                   "version": "5.11-35.amzn2.0.2",
                 },
               },
@@ -982,7 +982,7 @@ Object {
                 "id": "filesystem@3.2-25.amzn2.0.4",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/filesystem@3.2-25.amzn2.0.4?distro=amzn-2",
                   "version": "3.2-25.amzn2.0.4",
                 },
               },
@@ -990,7 +990,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.amzn2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/findutils@1:4.5.11-6.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:4.5.11-6.amzn2",
                 },
               },
@@ -998,7 +998,7 @@ Object {
                 "id": "gawk@4.0.2-4.amzn2.1.2",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.amzn2.1.2",
+                  "purl": "pkg:rpm/amzn/gawk@4.0.2-4.amzn2.1.2?distro=amzn-2",
                   "version": "4.0.2-4.amzn2.1.2",
                 },
               },
@@ -1006,7 +1006,7 @@ Object {
                 "id": "gdbm@1:1.13-6.amzn2.0.2",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.13-6.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gdbm@1:1.13-6.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:1.13-6.amzn2.0.2",
                 },
               },
@@ -1014,7 +1014,7 @@ Object {
                 "id": "glib2@2.56.1-4.amzn2",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-4.amzn2",
+                  "purl": "pkg:rpm/amzn/glib2@2.56.1-4.amzn2?distro=amzn-2",
                   "version": "2.56.1-4.amzn2",
                 },
               },
@@ -1022,7 +1022,7 @@ Object {
                 "id": "glibc@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1030,7 +1030,7 @@ Object {
                 "id": "glibc-common@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-common@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1038,7 +1038,7 @@ Object {
                 "id": "glibc-langpack-en@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/glibc-langpack-en@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-langpack-en@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1046,7 +1046,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-minimal-langpack@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1054,7 +1054,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.amzn2.0.2",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gmp@1:6.0.0-15.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:6.0.0-15.amzn2.0.2",
                 },
               },
@@ -1062,7 +1062,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.amzn2.0.4",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/gnupg2@2.0.22-5.amzn2.0.4?distro=amzn-2",
                   "version": "2.0.22-5.amzn2.0.4",
                 },
               },
@@ -1070,7 +1070,7 @@ Object {
                 "id": "gpg-pubkey@c87f5b1a-593863f8",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@c87f5b1a-593863f8",
+                  "purl": "pkg:rpm/amzn/gpg-pubkey@c87f5b1a-593863f8?distro=amzn-2",
                   "version": "c87f5b1a-593863f8",
                 },
               },
@@ -1078,7 +1078,7 @@ Object {
                 "id": "gpgme@1.3.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/gpgme@1.3.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "1.3.2-5.amzn2.0.2",
                 },
               },
@@ -1086,7 +1086,7 @@ Object {
                 "id": "grep@2.20-3.amzn2.0.2",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/grep@2.20-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.20-3.amzn2.0.2",
                 },
               },
@@ -1094,7 +1094,7 @@ Object {
                 "id": "info@5.1-5.amzn2",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.amzn2",
+                  "purl": "pkg:rpm/amzn/info@5.1-5.amzn2?distro=amzn-2",
                   "version": "5.1-5.amzn2",
                 },
               },
@@ -1102,7 +1102,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.amzn2.0.2",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/keyutils-libs@1.5.8-3.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.8-3.amzn2.0.2",
                 },
               },
@@ -1110,7 +1110,7 @@ Object {
                 "id": "krb5-libs@1.15.1-37.amzn2.2.2",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-37.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/krb5-libs@1.15.1-37.amzn2.2.2?distro=amzn-2",
                   "version": "1.15.1-37.amzn2.2.2",
                 },
               },
@@ -1118,7 +1118,7 @@ Object {
                 "id": "libacl@2.2.51-14.amzn2",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-14.amzn2",
+                  "purl": "pkg:rpm/amzn/libacl@2.2.51-14.amzn2?distro=amzn-2",
                   "version": "2.2.51-14.amzn2",
                 },
               },
@@ -1126,7 +1126,7 @@ Object {
                 "id": "libassuan@2.1.0-3.amzn2.0.2",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libassuan@2.1.0-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-3.amzn2.0.2",
                 },
               },
@@ -1134,7 +1134,7 @@ Object {
                 "id": "libattr@2.4.46-12.amzn2.0.2",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libattr@2.4.46-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.4.46-12.amzn2.0.2",
                 },
               },
@@ -1142,7 +1142,7 @@ Object {
                 "id": "libblkid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libblkid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1150,7 +1150,7 @@ Object {
                 "id": "libcap@2.22-9.amzn2.0.2",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcap@2.22-9.amzn2.0.2?distro=amzn-2",
                   "version": "2.22-9.amzn2.0.2",
                 },
               },
@@ -1158,7 +1158,7 @@ Object {
                 "id": "libcom_err@1.42.9-12.amzn2.0.2",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcom_err@1.42.9-12.amzn2.0.2?distro=amzn-2",
                   "version": "1.42.9-12.amzn2.0.2",
                 },
               },
@@ -1166,7 +1166,7 @@ Object {
                 "id": "libcrypt@2.26-34.amzn2",
                 "info": Object {
                   "name": "libcrypt",
-                  "purl": "pkg:rpm/libcrypt@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/libcrypt@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -1174,7 +1174,7 @@ Object {
                 "id": "libcurl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/libcurl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -1182,7 +1182,7 @@ Object {
                 "id": "libdb@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -1190,7 +1190,7 @@ Object {
                 "id": "libdb-utils@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb-utils@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -1198,7 +1198,7 @@ Object {
                 "id": "libffi@3.0.13-18.amzn2.0.2",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-18.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libffi@3.0.13-18.amzn2.0.2?distro=amzn-2",
                   "version": "3.0.13-18.amzn2.0.2",
                 },
               },
@@ -1206,7 +1206,7 @@ Object {
                 "id": "libgcc@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libgcc@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -1214,7 +1214,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.amzn2.0.2",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libgcrypt@1.5.3-14.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.3-14.amzn2.0.2",
                 },
               },
@@ -1222,7 +1222,7 @@ Object {
                 "id": "libgpg-error@1.12-3.amzn2.0.3",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libgpg-error@1.12-3.amzn2.0.3?distro=amzn-2",
                   "version": "1.12-3.amzn2.0.3",
                 },
               },
@@ -1230,7 +1230,7 @@ Object {
                 "id": "libidn2@2.3.0-1.amzn2",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.3.0-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libidn2@2.3.0-1.amzn2?distro=amzn-2",
                   "version": "2.3.0-1.amzn2",
                 },
               },
@@ -1238,7 +1238,7 @@ Object {
                 "id": "libmetalink@0.1.2-7.amzn2.0.2",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.2-7.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libmetalink@0.1.2-7.amzn2.0.2?distro=amzn-2",
                   "version": "0.1.2-7.amzn2.0.2",
                 },
               },
@@ -1246,7 +1246,7 @@ Object {
                 "id": "libmount@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libmount@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1254,7 +1254,7 @@ Object {
                 "id": "libnghttp2@1.39.2-1.amzn2",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.39.2-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libnghttp2@1.39.2-1.amzn2?distro=amzn-2",
                   "version": "1.39.2-1.amzn2",
                 },
               },
@@ -1262,7 +1262,7 @@ Object {
                 "id": "libselinux@2.5-12.amzn2.0.2",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libselinux@2.5-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-12.amzn2.0.2",
                 },
               },
@@ -1270,7 +1270,7 @@ Object {
                 "id": "libsepol@2.5-8.1.amzn2.0.2",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-8.1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libsepol@2.5-8.1.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-8.1.amzn2.0.2",
                 },
               },
@@ -1278,7 +1278,7 @@ Object {
                 "id": "libssh2@1.4.3-12.amzn2.2.2",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.4.3-12.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/libssh2@1.4.3-12.amzn2.2.2?distro=amzn-2",
                   "version": "1.4.3-12.amzn2.2.2",
                 },
               },
@@ -1286,7 +1286,7 @@ Object {
                 "id": "libstdc++@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libstdc%2B%2B@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -1294,7 +1294,7 @@ Object {
                 "id": "libtasn1@4.10-1.amzn2.0.2",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libtasn1@4.10-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.10-1.amzn2.0.2",
                 },
               },
@@ -1302,7 +1302,7 @@ Object {
                 "id": "libunistring@0.9.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libunistring@0.9.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.9.3-9.amzn2.0.2",
                 },
               },
@@ -1310,7 +1310,7 @@ Object {
                 "id": "libuuid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libuuid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1318,7 +1318,7 @@ Object {
                 "id": "libverto@0.2.5-4.amzn2.0.2",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libverto@0.2.5-4.amzn2.0.2?distro=amzn-2",
                   "version": "0.2.5-4.amzn2.0.2",
                 },
               },
@@ -1326,7 +1326,7 @@ Object {
                 "id": "libxml2@2.9.1-6.amzn2.3.3",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.amzn2.3.3",
+                  "purl": "pkg:rpm/amzn/libxml2@2.9.1-6.amzn2.3.3?distro=amzn-2",
                   "version": "2.9.1-6.amzn2.3.3",
                 },
               },
@@ -1334,7 +1334,7 @@ Object {
                 "id": "lua@5.1.4-15.amzn2.0.2",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/lua@5.1.4-15.amzn2.0.2?distro=amzn-2",
                   "version": "5.1.4-15.amzn2.0.2",
                 },
               },
@@ -1342,7 +1342,7 @@ Object {
                 "id": "ncurses@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1350,7 +1350,7 @@ Object {
                 "id": "ncurses-base@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-base@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1358,7 +1358,7 @@ Object {
                 "id": "ncurses-libs@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-libs@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1366,7 +1366,7 @@ Object {
                 "id": "nspr@4.21.0-1.amzn2.0.2",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/nspr@4.21.0-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.21.0-1.amzn2.0.2",
                 },
               },
@@ -1374,7 +1374,7 @@ Object {
                 "id": "nss@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1382,7 +1382,7 @@ Object {
                 "id": "nss-pem@1.0.3-5.amzn2",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-pem@1.0.3-5.amzn2?distro=amzn-2",
                   "version": "1.0.3-5.amzn2",
                 },
               },
@@ -1390,7 +1390,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -1398,7 +1398,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn-freebl@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -1406,7 +1406,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-sysinit@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1414,7 +1414,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-tools@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1422,7 +1422,7 @@ Object {
                 "id": "nss-util@3.44.0-4.amzn2",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-util@3.44.0-4.amzn2?distro=amzn-2",
                   "version": "3.44.0-4.amzn2",
                 },
               },
@@ -1430,7 +1430,7 @@ Object {
                 "id": "openldap@2.4.44-15.amzn2",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-15.amzn2",
+                  "purl": "pkg:rpm/amzn/openldap@2.4.44-15.amzn2?distro=amzn-2",
                   "version": "2.4.44-15.amzn2",
                 },
               },
@@ -1438,7 +1438,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.amzn2.0.3",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.amzn2.0.3?epoch=1",
+                  "purl": "pkg:rpm/amzn/openssl-libs@1:1.0.2k-19.amzn2.0.3?distro=amzn-2&epoch=1",
                   "version": "1:1.0.2k-19.amzn2.0.3",
                 },
               },
@@ -1446,7 +1446,7 @@ Object {
                 "id": "p11-kit@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -1454,7 +1454,7 @@ Object {
                 "id": "p11-kit-trust@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit-trust@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -1462,7 +1462,7 @@ Object {
                 "id": "pcre@8.32-17.amzn2.0.2",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pcre@8.32-17.amzn2.0.2?distro=amzn-2",
                   "version": "8.32-17.amzn2.0.2",
                 },
               },
@@ -1470,7 +1470,7 @@ Object {
                 "id": "pinentry@0.8.1-17.amzn2.0.2",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pinentry@0.8.1-17.amzn2.0.2?distro=amzn-2",
                   "version": "0.8.1-17.amzn2.0.2",
                 },
               },
@@ -1478,7 +1478,7 @@ Object {
                 "id": "popt@1.13-16.amzn2.0.2",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/popt@1.13-16.amzn2.0.2?distro=amzn-2",
                   "version": "1.13-16.amzn2.0.2",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "pth@2.0.7-23.amzn2.0.2",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pth@2.0.7-23.amzn2.0.2?distro=amzn-2",
                   "version": "2.0.7-23.amzn2.0.2",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "pygpgme@0.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pygpgme@0.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.3-9.amzn2.0.2",
                 },
               },
@@ -1502,7 +1502,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.amzn2.0.2",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyliblzma@0.5.3-11.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.3-11.amzn2.0.2",
                 },
               },
@@ -1510,7 +1510,7 @@ Object {
                 "id": "python@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -1518,7 +1518,7 @@ Object {
                 "id": "python-iniparse@0.4-9.amzn2",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.amzn2",
+                  "purl": "pkg:rpm/amzn/python-iniparse@0.4-9.amzn2?distro=amzn-2",
                   "version": "0.4-9.amzn2",
                 },
               },
@@ -1526,7 +1526,7 @@ Object {
                 "id": "python-libs@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python-libs@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -1534,7 +1534,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.amzn2.0.2",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/python-pycurl@7.19.0-19.amzn2.0.2?distro=amzn-2",
                   "version": "7.19.0-19.amzn2.0.2",
                 },
               },
@@ -1542,7 +1542,7 @@ Object {
                 "id": "python-urlgrabber@3.10-9.amzn2.0.1",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-9.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/python-urlgrabber@3.10-9.amzn2.0.1?distro=amzn-2",
                   "version": "3.10-9.amzn2.0.1",
                 },
               },
@@ -1550,7 +1550,7 @@ Object {
                 "id": "python2-rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "python2-rpm",
-                  "purl": "pkg:rpm/python2-rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/python2-rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -1558,7 +1558,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.amzn2.0.2",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyxattr@0.5.1-5.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.1-5.amzn2.0.2",
                 },
               },
@@ -1566,7 +1566,7 @@ Object {
                 "id": "readline@6.2-10.amzn2.0.2",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/readline@6.2-10.amzn2.0.2?distro=amzn-2",
                   "version": "6.2-10.amzn2.0.2",
                 },
               },
@@ -1574,7 +1574,7 @@ Object {
                 "id": "rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -1582,7 +1582,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-build-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -1590,7 +1590,7 @@ Object {
                 "id": "rpm-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -1598,7 +1598,7 @@ Object {
                 "id": "sed@4.2.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/sed@4.2.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "4.2.2-5.amzn2.0.2",
                 },
               },
@@ -1606,7 +1606,7 @@ Object {
                 "id": "setup@2.8.71-10.amzn2.0.1",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-10.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/setup@2.8.71-10.amzn2.0.1?distro=amzn-2",
                   "version": "2.8.71-10.amzn2.0.1",
                 },
               },
@@ -1614,7 +1614,7 @@ Object {
                 "id": "shared-mime-info@1.8-4.amzn2",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-4.amzn2",
+                  "purl": "pkg:rpm/amzn/shared-mime-info@1.8-4.amzn2?distro=amzn-2",
                   "version": "1.8-4.amzn2",
                 },
               },
@@ -1622,7 +1622,7 @@ Object {
                 "id": "sqlite@3.7.17-8.amzn2.1.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.amzn2.1.1",
+                  "purl": "pkg:rpm/amzn/sqlite@3.7.17-8.amzn2.1.1?distro=amzn-2",
                   "version": "3.7.17-8.amzn2.1.1",
                 },
               },
@@ -1630,7 +1630,7 @@ Object {
                 "id": "system-release@1:2-11.amzn2",
                 "info": Object {
                   "name": "system-release",
-                  "purl": "pkg:rpm/system-release@1:2-11.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/system-release@1:2-11.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:2-11.amzn2",
                 },
               },
@@ -1638,7 +1638,7 @@ Object {
                 "id": "tzdata@2019c-1.amzn2",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2019c-1.amzn2",
+                  "purl": "pkg:rpm/amzn/tzdata@2019c-1.amzn2?distro=amzn-2",
                   "version": "2019c-1.amzn2",
                 },
               },
@@ -1646,7 +1646,7 @@ Object {
                 "id": "vim-minimal@2:8.1.1602-1.amzn2",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.1.1602-1.amzn2?epoch=2",
+                  "purl": "pkg:rpm/amzn/vim-minimal@2:8.1.1602-1.amzn2?distro=amzn-2&epoch=2",
                   "version": "2:8.1.1602-1.amzn2",
                 },
               },
@@ -1654,7 +1654,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.amzn2.0.2",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/xz-libs@5.2.2-1.amzn2.0.2?distro=amzn-2",
                   "version": "5.2.2-1.amzn2.0.2",
                 },
               },
@@ -1662,7 +1662,7 @@ Object {
                 "id": "yum@3.4.3-158.amzn2.0.3",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-158.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/yum@3.4.3-158.amzn2.0.3?distro=amzn-2",
                   "version": "3.4.3-158.amzn2.0.3",
                 },
               },
@@ -1670,7 +1670,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.amzn2.0.2",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/yum-metadata-parser@1.1.4-10.amzn2.0.2?distro=amzn-2",
                   "version": "1.1.4-10.amzn2.0.2",
                 },
               },
@@ -1678,7 +1678,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-ovl@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -1686,7 +1686,7 @@ Object {
                 "id": "yum-plugin-priorities@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-priorities",
-                  "purl": "pkg:rpm/yum-plugin-priorities@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-priorities@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "zlib@1.2.7-18.amzn2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.amzn2",
+                  "purl": "pkg:rpm/amzn/zlib@1.2.7-18.amzn2?distro=amzn-2",
                   "version": "1.2.7-18.amzn2",
                 },
               },
@@ -2612,7 +2612,7 @@ Object {
                 "id": "amazon-linux-extras@1.6.10-1.amzn2",
                 "info": Object {
                   "name": "amazon-linux-extras",
-                  "purl": "pkg:rpm/amazon-linux-extras@1.6.10-1.amzn2",
+                  "purl": "pkg:rpm/amzn/amazon-linux-extras@1.6.10-1.amzn2?distro=amzn-2",
                   "version": "1.6.10-1.amzn2",
                 },
               },
@@ -2620,7 +2620,7 @@ Object {
                 "id": "basesystem@10.0-7.amzn2.0.1",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/basesystem@10.0-7.amzn2.0.1?distro=amzn-2",
                   "version": "10.0-7.amzn2.0.1",
                 },
               },
@@ -2628,7 +2628,7 @@ Object {
                 "id": "bash@4.2.46-33.amzn2",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-33.amzn2",
+                  "purl": "pkg:rpm/amzn/bash@4.2.46-33.amzn2?distro=amzn-2",
                   "version": "4.2.46-33.amzn2",
                 },
               },
@@ -2636,7 +2636,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.amzn2.0.2",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/bzip2-libs@1.0.6-13.amzn2.0.2?distro=amzn-2",
                   "version": "1.0.6-13.amzn2.0.2",
                 },
               },
@@ -2644,7 +2644,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.amzn2.0.1",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/ca-certificates@2019.2.32-76.amzn2.0.1?distro=amzn-2",
                   "version": "2019.2.32-76.amzn2.0.1",
                 },
               },
@@ -2652,7 +2652,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.amzn2.0.2",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/chkconfig@1.7.4-1.amzn2.0.2?distro=amzn-2",
                   "version": "1.7.4-1.amzn2.0.2",
                 },
               },
@@ -2660,7 +2660,7 @@ Object {
                 "id": "coreutils@8.22-24.amzn2",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.amzn2",
+                  "purl": "pkg:rpm/amzn/coreutils@8.22-24.amzn2?distro=amzn-2",
                   "version": "8.22-24.amzn2",
                 },
               },
@@ -2668,7 +2668,7 @@ Object {
                 "id": "cpio@2.11-27.amzn2",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.amzn2",
+                  "purl": "pkg:rpm/amzn/cpio@2.11-27.amzn2?distro=amzn-2",
                   "version": "2.11-27.amzn2",
                 },
               },
@@ -2676,7 +2676,7 @@ Object {
                 "id": "curl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/curl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -2684,7 +2684,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.amzn2",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.amzn2",
+                  "purl": "pkg:rpm/amzn/cyrus-sasl-lib@2.1.26-23.amzn2?distro=amzn-2",
                   "version": "2.1.26-23.amzn2",
                 },
               },
@@ -2692,7 +2692,7 @@ Object {
                 "id": "diffutils@3.3-5.amzn2",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/diffutils@3.3-5.amzn2?distro=amzn-2",
                   "version": "3.3-5.amzn2",
                 },
               },
@@ -2700,7 +2700,7 @@ Object {
                 "id": "elfutils-libelf@0.176-2.amzn2",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-2.amzn2",
+                  "purl": "pkg:rpm/amzn/elfutils-libelf@0.176-2.amzn2?distro=amzn-2",
                   "version": "0.176-2.amzn2",
                 },
               },
@@ -2708,7 +2708,7 @@ Object {
                 "id": "expat@2.1.0-10.amzn2.0.2",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/expat@2.1.0-10.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-10.amzn2.0.2",
                 },
               },
@@ -2716,7 +2716,7 @@ Object {
                 "id": "file-libs@5.11-35.amzn2.0.2",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-35.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/file-libs@5.11-35.amzn2.0.2?distro=amzn-2",
                   "version": "5.11-35.amzn2.0.2",
                 },
               },
@@ -2724,7 +2724,7 @@ Object {
                 "id": "filesystem@3.2-25.amzn2.0.4",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/filesystem@3.2-25.amzn2.0.4?distro=amzn-2",
                   "version": "3.2-25.amzn2.0.4",
                 },
               },
@@ -2732,7 +2732,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.amzn2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/findutils@1:4.5.11-6.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:4.5.11-6.amzn2",
                 },
               },
@@ -2740,7 +2740,7 @@ Object {
                 "id": "gawk@4.0.2-4.amzn2.1.2",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.amzn2.1.2",
+                  "purl": "pkg:rpm/amzn/gawk@4.0.2-4.amzn2.1.2?distro=amzn-2",
                   "version": "4.0.2-4.amzn2.1.2",
                 },
               },
@@ -2748,7 +2748,7 @@ Object {
                 "id": "gdbm@1:1.13-6.amzn2.0.2",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.13-6.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gdbm@1:1.13-6.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:1.13-6.amzn2.0.2",
                 },
               },
@@ -2756,7 +2756,7 @@ Object {
                 "id": "glib2@2.56.1-4.amzn2",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-4.amzn2",
+                  "purl": "pkg:rpm/amzn/glib2@2.56.1-4.amzn2?distro=amzn-2",
                   "version": "2.56.1-4.amzn2",
                 },
               },
@@ -2764,7 +2764,7 @@ Object {
                 "id": "glibc@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -2772,7 +2772,7 @@ Object {
                 "id": "glibc-common@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-common@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -2780,7 +2780,7 @@ Object {
                 "id": "glibc-langpack-en@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/glibc-langpack-en@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-langpack-en@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -2788,7 +2788,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-minimal-langpack@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -2796,7 +2796,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.amzn2.0.2",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gmp@1:6.0.0-15.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:6.0.0-15.amzn2.0.2",
                 },
               },
@@ -2804,7 +2804,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.amzn2.0.4",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/gnupg2@2.0.22-5.amzn2.0.4?distro=amzn-2",
                   "version": "2.0.22-5.amzn2.0.4",
                 },
               },
@@ -2812,7 +2812,7 @@ Object {
                 "id": "gpg-pubkey@c87f5b1a-593863f8",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@c87f5b1a-593863f8",
+                  "purl": "pkg:rpm/amzn/gpg-pubkey@c87f5b1a-593863f8?distro=amzn-2",
                   "version": "c87f5b1a-593863f8",
                 },
               },
@@ -2820,7 +2820,7 @@ Object {
                 "id": "gpgme@1.3.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/gpgme@1.3.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "1.3.2-5.amzn2.0.2",
                 },
               },
@@ -2828,7 +2828,7 @@ Object {
                 "id": "grep@2.20-3.amzn2.0.2",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/grep@2.20-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.20-3.amzn2.0.2",
                 },
               },
@@ -2836,7 +2836,7 @@ Object {
                 "id": "info@5.1-5.amzn2",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.amzn2",
+                  "purl": "pkg:rpm/amzn/info@5.1-5.amzn2?distro=amzn-2",
                   "version": "5.1-5.amzn2",
                 },
               },
@@ -2844,7 +2844,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.amzn2.0.2",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/keyutils-libs@1.5.8-3.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.8-3.amzn2.0.2",
                 },
               },
@@ -2852,7 +2852,7 @@ Object {
                 "id": "krb5-libs@1.15.1-37.amzn2.2.2",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-37.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/krb5-libs@1.15.1-37.amzn2.2.2?distro=amzn-2",
                   "version": "1.15.1-37.amzn2.2.2",
                 },
               },
@@ -2860,7 +2860,7 @@ Object {
                 "id": "libacl@2.2.51-14.amzn2",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-14.amzn2",
+                  "purl": "pkg:rpm/amzn/libacl@2.2.51-14.amzn2?distro=amzn-2",
                   "version": "2.2.51-14.amzn2",
                 },
               },
@@ -2868,7 +2868,7 @@ Object {
                 "id": "libassuan@2.1.0-3.amzn2.0.2",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libassuan@2.1.0-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-3.amzn2.0.2",
                 },
               },
@@ -2876,7 +2876,7 @@ Object {
                 "id": "libattr@2.4.46-12.amzn2.0.2",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libattr@2.4.46-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.4.46-12.amzn2.0.2",
                 },
               },
@@ -2884,7 +2884,7 @@ Object {
                 "id": "libblkid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libblkid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -2892,7 +2892,7 @@ Object {
                 "id": "libcap@2.22-9.amzn2.0.2",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcap@2.22-9.amzn2.0.2?distro=amzn-2",
                   "version": "2.22-9.amzn2.0.2",
                 },
               },
@@ -2900,7 +2900,7 @@ Object {
                 "id": "libcom_err@1.42.9-12.amzn2.0.2",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcom_err@1.42.9-12.amzn2.0.2?distro=amzn-2",
                   "version": "1.42.9-12.amzn2.0.2",
                 },
               },
@@ -2908,7 +2908,7 @@ Object {
                 "id": "libcrypt@2.26-34.amzn2",
                 "info": Object {
                   "name": "libcrypt",
-                  "purl": "pkg:rpm/libcrypt@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/libcrypt@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -2916,7 +2916,7 @@ Object {
                 "id": "libcurl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/libcurl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -2924,7 +2924,7 @@ Object {
                 "id": "libdb@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -2932,7 +2932,7 @@ Object {
                 "id": "libdb-utils@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb-utils@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -2940,7 +2940,7 @@ Object {
                 "id": "libffi@3.0.13-18.amzn2.0.2",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-18.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libffi@3.0.13-18.amzn2.0.2?distro=amzn-2",
                   "version": "3.0.13-18.amzn2.0.2",
                 },
               },
@@ -2948,7 +2948,7 @@ Object {
                 "id": "libgcc@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libgcc@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -2956,7 +2956,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.amzn2.0.2",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libgcrypt@1.5.3-14.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.3-14.amzn2.0.2",
                 },
               },
@@ -2964,7 +2964,7 @@ Object {
                 "id": "libgpg-error@1.12-3.amzn2.0.3",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libgpg-error@1.12-3.amzn2.0.3?distro=amzn-2",
                   "version": "1.12-3.amzn2.0.3",
                 },
               },
@@ -2972,7 +2972,7 @@ Object {
                 "id": "libidn2@2.3.0-1.amzn2",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.3.0-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libidn2@2.3.0-1.amzn2?distro=amzn-2",
                   "version": "2.3.0-1.amzn2",
                 },
               },
@@ -2980,7 +2980,7 @@ Object {
                 "id": "libmetalink@0.1.2-7.amzn2.0.2",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.2-7.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libmetalink@0.1.2-7.amzn2.0.2?distro=amzn-2",
                   "version": "0.1.2-7.amzn2.0.2",
                 },
               },
@@ -2988,7 +2988,7 @@ Object {
                 "id": "libmount@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libmount@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -2996,7 +2996,7 @@ Object {
                 "id": "libnghttp2@1.39.2-1.amzn2",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.39.2-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libnghttp2@1.39.2-1.amzn2?distro=amzn-2",
                   "version": "1.39.2-1.amzn2",
                 },
               },
@@ -3004,7 +3004,7 @@ Object {
                 "id": "libselinux@2.5-12.amzn2.0.2",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libselinux@2.5-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-12.amzn2.0.2",
                 },
               },
@@ -3012,7 +3012,7 @@ Object {
                 "id": "libsepol@2.5-8.1.amzn2.0.2",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-8.1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libsepol@2.5-8.1.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-8.1.amzn2.0.2",
                 },
               },
@@ -3020,7 +3020,7 @@ Object {
                 "id": "libssh2@1.4.3-12.amzn2.2.2",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.4.3-12.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/libssh2@1.4.3-12.amzn2.2.2?distro=amzn-2",
                   "version": "1.4.3-12.amzn2.2.2",
                 },
               },
@@ -3028,7 +3028,7 @@ Object {
                 "id": "libstdc++@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libstdc%2B%2B@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -3036,7 +3036,7 @@ Object {
                 "id": "libtasn1@4.10-1.amzn2.0.2",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libtasn1@4.10-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.10-1.amzn2.0.2",
                 },
               },
@@ -3044,7 +3044,7 @@ Object {
                 "id": "libunistring@0.9.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libunistring@0.9.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.9.3-9.amzn2.0.2",
                 },
               },
@@ -3052,7 +3052,7 @@ Object {
                 "id": "libuuid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libuuid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -3060,7 +3060,7 @@ Object {
                 "id": "libverto@0.2.5-4.amzn2.0.2",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libverto@0.2.5-4.amzn2.0.2?distro=amzn-2",
                   "version": "0.2.5-4.amzn2.0.2",
                 },
               },
@@ -3068,7 +3068,7 @@ Object {
                 "id": "libxml2@2.9.1-6.amzn2.3.3",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.amzn2.3.3",
+                  "purl": "pkg:rpm/amzn/libxml2@2.9.1-6.amzn2.3.3?distro=amzn-2",
                   "version": "2.9.1-6.amzn2.3.3",
                 },
               },
@@ -3076,7 +3076,7 @@ Object {
                 "id": "lua@5.1.4-15.amzn2.0.2",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/lua@5.1.4-15.amzn2.0.2?distro=amzn-2",
                   "version": "5.1.4-15.amzn2.0.2",
                 },
               },
@@ -3084,7 +3084,7 @@ Object {
                 "id": "ncurses@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -3092,7 +3092,7 @@ Object {
                 "id": "ncurses-base@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-base@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -3100,7 +3100,7 @@ Object {
                 "id": "ncurses-libs@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-libs@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -3108,7 +3108,7 @@ Object {
                 "id": "nspr@4.21.0-1.amzn2.0.2",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/nspr@4.21.0-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.21.0-1.amzn2.0.2",
                 },
               },
@@ -3116,7 +3116,7 @@ Object {
                 "id": "nss@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -3124,7 +3124,7 @@ Object {
                 "id": "nss-pem@1.0.3-5.amzn2",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-pem@1.0.3-5.amzn2?distro=amzn-2",
                   "version": "1.0.3-5.amzn2",
                 },
               },
@@ -3132,7 +3132,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -3140,7 +3140,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn-freebl@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -3148,7 +3148,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-sysinit@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -3156,7 +3156,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-tools@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -3164,7 +3164,7 @@ Object {
                 "id": "nss-util@3.44.0-4.amzn2",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-util@3.44.0-4.amzn2?distro=amzn-2",
                   "version": "3.44.0-4.amzn2",
                 },
               },
@@ -3172,7 +3172,7 @@ Object {
                 "id": "openldap@2.4.44-15.amzn2",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-15.amzn2",
+                  "purl": "pkg:rpm/amzn/openldap@2.4.44-15.amzn2?distro=amzn-2",
                   "version": "2.4.44-15.amzn2",
                 },
               },
@@ -3180,7 +3180,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.amzn2.0.3",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.amzn2.0.3?epoch=1",
+                  "purl": "pkg:rpm/amzn/openssl-libs@1:1.0.2k-19.amzn2.0.3?distro=amzn-2&epoch=1",
                   "version": "1:1.0.2k-19.amzn2.0.3",
                 },
               },
@@ -3188,7 +3188,7 @@ Object {
                 "id": "p11-kit@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -3196,7 +3196,7 @@ Object {
                 "id": "p11-kit-trust@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit-trust@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -3204,7 +3204,7 @@ Object {
                 "id": "pcre@8.32-17.amzn2.0.2",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pcre@8.32-17.amzn2.0.2?distro=amzn-2",
                   "version": "8.32-17.amzn2.0.2",
                 },
               },
@@ -3212,7 +3212,7 @@ Object {
                 "id": "pinentry@0.8.1-17.amzn2.0.2",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pinentry@0.8.1-17.amzn2.0.2?distro=amzn-2",
                   "version": "0.8.1-17.amzn2.0.2",
                 },
               },
@@ -3220,7 +3220,7 @@ Object {
                 "id": "popt@1.13-16.amzn2.0.2",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/popt@1.13-16.amzn2.0.2?distro=amzn-2",
                   "version": "1.13-16.amzn2.0.2",
                 },
               },
@@ -3228,7 +3228,7 @@ Object {
                 "id": "pth@2.0.7-23.amzn2.0.2",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pth@2.0.7-23.amzn2.0.2?distro=amzn-2",
                   "version": "2.0.7-23.amzn2.0.2",
                 },
               },
@@ -3236,7 +3236,7 @@ Object {
                 "id": "pygpgme@0.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pygpgme@0.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.3-9.amzn2.0.2",
                 },
               },
@@ -3244,7 +3244,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.amzn2.0.2",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyliblzma@0.5.3-11.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.3-11.amzn2.0.2",
                 },
               },
@@ -3252,7 +3252,7 @@ Object {
                 "id": "python@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -3260,7 +3260,7 @@ Object {
                 "id": "python-iniparse@0.4-9.amzn2",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.amzn2",
+                  "purl": "pkg:rpm/amzn/python-iniparse@0.4-9.amzn2?distro=amzn-2",
                   "version": "0.4-9.amzn2",
                 },
               },
@@ -3268,7 +3268,7 @@ Object {
                 "id": "python-libs@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python-libs@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -3276,7 +3276,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.amzn2.0.2",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/python-pycurl@7.19.0-19.amzn2.0.2?distro=amzn-2",
                   "version": "7.19.0-19.amzn2.0.2",
                 },
               },
@@ -3284,7 +3284,7 @@ Object {
                 "id": "python-urlgrabber@3.10-9.amzn2.0.1",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-9.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/python-urlgrabber@3.10-9.amzn2.0.1?distro=amzn-2",
                   "version": "3.10-9.amzn2.0.1",
                 },
               },
@@ -3292,7 +3292,7 @@ Object {
                 "id": "python2-rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "python2-rpm",
-                  "purl": "pkg:rpm/python2-rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/python2-rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -3300,7 +3300,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.amzn2.0.2",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyxattr@0.5.1-5.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.1-5.amzn2.0.2",
                 },
               },
@@ -3308,7 +3308,7 @@ Object {
                 "id": "readline@6.2-10.amzn2.0.2",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/readline@6.2-10.amzn2.0.2?distro=amzn-2",
                   "version": "6.2-10.amzn2.0.2",
                 },
               },
@@ -3316,7 +3316,7 @@ Object {
                 "id": "rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -3324,7 +3324,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-build-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -3332,7 +3332,7 @@ Object {
                 "id": "rpm-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -3340,7 +3340,7 @@ Object {
                 "id": "sed@4.2.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/sed@4.2.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "4.2.2-5.amzn2.0.2",
                 },
               },
@@ -3348,7 +3348,7 @@ Object {
                 "id": "setup@2.8.71-10.amzn2.0.1",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-10.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/setup@2.8.71-10.amzn2.0.1?distro=amzn-2",
                   "version": "2.8.71-10.amzn2.0.1",
                 },
               },
@@ -3356,7 +3356,7 @@ Object {
                 "id": "shared-mime-info@1.8-4.amzn2",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-4.amzn2",
+                  "purl": "pkg:rpm/amzn/shared-mime-info@1.8-4.amzn2?distro=amzn-2",
                   "version": "1.8-4.amzn2",
                 },
               },
@@ -3364,7 +3364,7 @@ Object {
                 "id": "sqlite@3.7.17-8.amzn2.1.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.amzn2.1.1",
+                  "purl": "pkg:rpm/amzn/sqlite@3.7.17-8.amzn2.1.1?distro=amzn-2",
                   "version": "3.7.17-8.amzn2.1.1",
                 },
               },
@@ -3372,7 +3372,7 @@ Object {
                 "id": "system-release@1:2-11.amzn2",
                 "info": Object {
                   "name": "system-release",
-                  "purl": "pkg:rpm/system-release@1:2-11.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/system-release@1:2-11.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:2-11.amzn2",
                 },
               },
@@ -3380,7 +3380,7 @@ Object {
                 "id": "tzdata@2019c-1.amzn2",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2019c-1.amzn2",
+                  "purl": "pkg:rpm/amzn/tzdata@2019c-1.amzn2?distro=amzn-2",
                   "version": "2019c-1.amzn2",
                 },
               },
@@ -3388,7 +3388,7 @@ Object {
                 "id": "vim-minimal@2:8.1.1602-1.amzn2",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.1.1602-1.amzn2?epoch=2",
+                  "purl": "pkg:rpm/amzn/vim-minimal@2:8.1.1602-1.amzn2?distro=amzn-2&epoch=2",
                   "version": "2:8.1.1602-1.amzn2",
                 },
               },
@@ -3396,7 +3396,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.amzn2.0.2",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/xz-libs@5.2.2-1.amzn2.0.2?distro=amzn-2",
                   "version": "5.2.2-1.amzn2.0.2",
                 },
               },
@@ -3404,7 +3404,7 @@ Object {
                 "id": "yum@3.4.3-158.amzn2.0.3",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-158.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/yum@3.4.3-158.amzn2.0.3?distro=amzn-2",
                   "version": "3.4.3-158.amzn2.0.3",
                 },
               },
@@ -3412,7 +3412,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.amzn2.0.2",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/yum-metadata-parser@1.1.4-10.amzn2.0.2?distro=amzn-2",
                   "version": "1.1.4-10.amzn2.0.2",
                 },
               },
@@ -3420,7 +3420,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-ovl@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -3428,7 +3428,7 @@ Object {
                 "id": "yum-plugin-priorities@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-priorities",
-                  "purl": "pkg:rpm/yum-plugin-priorities@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-priorities@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -3436,7 +3436,7 @@ Object {
                 "id": "zlib@1.2.7-18.amzn2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.amzn2",
+                  "purl": "pkg:rpm/amzn/zlib@1.2.7-18.amzn2?distro=amzn-2",
                   "version": "1.2.7-18.amzn2",
                 },
               },

--- a/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/compressed-archive.spec.ts.snap
@@ -1152,7 +1152,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
-                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit-common@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1160,7 +1160,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
-                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
+                  "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?distro=debian-buster&upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1168,7 +1168,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
-                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit1@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1176,7 +1176,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage-common@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1184,7 +1184,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
+                  "purl": "pkg:deb/debian/libsepol1@2.8-1?distro=debian-buster&upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1192,7 +1192,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage1@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1200,7 +1200,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?distro=debian-buster&upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1208,7 +1208,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam0g@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1216,7 +1216,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1224,7 +1224,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1232,7 +1232,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/passwd@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1240,7 +1240,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.118",
+                  "purl": "pkg:deb/debian/adduser@3.118?distro=debian-buster",
                   "version": "3.118",
                 },
               },
@@ -1248,7 +1248,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?distro=debian-buster&upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1256,7 +1256,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
-                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
+                  "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?distro=debian-buster&upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1264,7 +1264,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
+                  "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?distro=debian-buster&upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1272,7 +1272,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?distro=debian-buster",
                   "version": "1.8.4-5",
                 },
               },
@@ -1280,7 +1280,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@241-7~deb10u1?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u1?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1288,7 +1288,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@241-7~deb10u1?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@241-7~deb10u1?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1296,7 +1296,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2?distro=debian-buster&upstream=apt",
                   "version": "1.8.2",
                 },
               },
@@ -1304,7 +1304,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?distro=debian-buster",
                   "version": "2019.1",
                 },
               },
@@ -1312,7 +1312,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.35-1?distro=debian-buster&upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1320,7 +1320,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
+                  "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?distro=debian-buster&upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1328,7 +1328,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
-                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
+                  "purl": "pkg:deb/debian/libgmp10@2:6.1.2%2Bdfsg-4?distro=debian-buster&upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1336,7 +1336,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
-                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
+                  "purl": "pkg:deb/debian/libunistring2@0.9.10-1?distro=debian-buster&upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1344,7 +1344,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
-                  "purl": "pkg:deb/libidn2-0@2.0.5-1?upstream=libidn2",
+                  "purl": "pkg:deb/debian/libidn2-0@2.0.5-1?distro=debian-buster&upstream=libidn2",
                   "version": "2.0.5-1",
                 },
               },
@@ -1352,7 +1352,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.13-3",
+                  "purl": "pkg:deb/debian/libtasn1-6@4.13-3?distro=debian-buster",
                   "version": "4.13-3",
                 },
               },
@@ -1360,7 +1360,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libnettle6@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1368,7 +1368,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
-                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1376,7 +1376,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
-                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
+                  "purl": "pkg:deb/debian/libffi6@3.2.1-9?distro=debian-buster&upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1384,7 +1384,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
+                  "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?distro=debian-buster&upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1392,7 +1392,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
-                  "purl": "pkg:deb/libgnutls30@3.6.7-4?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls30@3.6.7-4?distro=debian-buster&upstream=gnutls28",
                   "version": "3.6.7-4",
                 },
               },
@@ -1400,7 +1400,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
-                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
+                  "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?distro=debian-buster&upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1408,7 +1408,7 @@ Object {
                 "id": "apt@1.8.2",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.8.2",
+                  "purl": "pkg:deb/debian/apt@1.8.2?distro=debian-buster",
                   "version": "1.8.2",
                 },
               },
@@ -1423,7 +1423,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?distro=debian-buster&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1431,7 +1431,7 @@ Object {
                 "id": "base-files@10.3+deb10u1",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u1?distro=debian-buster",
                   "version": "10.3+deb10u1",
                 },
               },
@@ -1439,7 +1439,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.249?distro=debian-buster&upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1447,7 +1447,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.46",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.46?distro=debian-buster",
                   "version": "3.5.46",
                 },
               },
@@ -1455,7 +1455,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.6.1",
+                  "purl": "pkg:deb/debian/debianutils@4.8.6.1?distro=debian-buster",
                   "version": "4.8.6.1",
                 },
               },
@@ -1463,7 +1463,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
-                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1471,7 +1471,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@5.0-4",
+                  "purl": "pkg:deb/debian/bash@5.0-4?distro=debian-buster",
                   "version": "5.0-4",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.30-3",
+                  "purl": "pkg:deb/debian/coreutils@8.30-3?distro=debian-buster",
                   "version": "8.30-3",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.10.2-5",
+                  "purl": "pkg:deb/debian/dash@0.5.10.2-5?distro=debian-buster",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1509,7 +1509,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.7-3",
+                  "purl": "pkg:deb/debian/diffutils@1:3.7-3?distro=debian-buster",
                   "version": "1:3.7-3",
                 },
               },
@@ -1524,7 +1524,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
-                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1532,7 +1532,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
-                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1540,7 +1540,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1548,7 +1548,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1556,7 +1556,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1564,7 +1564,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u1?distro=debian-buster",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1572,7 +1572,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
+                  "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?distro=debian-buster",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1594,7 +1594,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.28-10?distro=debian-buster&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1609,7 +1609,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@3.3-1",
+                  "purl": "pkg:deb/debian/grep@3.3-1?distro=debian-buster",
                   "version": "3.3-1",
                 },
               },
@@ -1617,7 +1617,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.9-3",
+                  "purl": "pkg:deb/debian/gzip@1.9-3?distro=debian-buster",
                   "version": "1.9-3",
                 },
               },
@@ -1625,7 +1625,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.21",
+                  "purl": "pkg:deb/debian/hostname@3.21?distro=debian-buster",
                   "version": "3.21",
                 },
               },
@@ -1633,7 +1633,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
+                  "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?distro=debian-buster",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1648,7 +1648,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
-                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1656,7 +1656,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1664,7 +1664,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1672,7 +1672,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.7-1",
+                  "purl": "pkg:deb/debian/sed@4.7-1?distro=debian-buster",
                   "version": "4.7-1",
                 },
               },
@@ -1702,7 +1702,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1710,7 +1710,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
+                  "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?distro=debian-buster",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1718,7 +1718,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?distro=debian-buster&upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1733,7 +1733,7 @@ Object {
                 "id": "tzdata@2019b-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2019b-0%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/tzdata@2019b-0%2Bdeb10u1?distro=debian-buster",
                   "version": "2019b-0+deb10u1",
                 },
               },
@@ -1741,7 +1741,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.33.1-0.1?distro=debian-buster&upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1749,7 +1749,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1757,7 +1757,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1765,7 +1765,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1773,7 +1773,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
-                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1781,7 +1781,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
+++ b/test/system/image-type/__snapshots__/docker-archive.spec.ts.snap
@@ -1152,7 +1152,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
-                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit-common@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1160,7 +1160,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
-                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
+                  "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?distro=debian-buster&upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1168,7 +1168,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
-                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit1@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1176,7 +1176,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage-common@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1184,7 +1184,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
+                  "purl": "pkg:deb/debian/libsepol1@2.8-1?distro=debian-buster&upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1192,7 +1192,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage1@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1200,7 +1200,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?distro=debian-buster&upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1208,7 +1208,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam0g@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1216,7 +1216,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1224,7 +1224,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1232,7 +1232,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/passwd@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1240,7 +1240,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.118",
+                  "purl": "pkg:deb/debian/adduser@3.118?distro=debian-buster",
                   "version": "3.118",
                 },
               },
@@ -1248,7 +1248,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?distro=debian-buster&upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1256,7 +1256,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
-                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
+                  "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?distro=debian-buster&upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1264,7 +1264,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
+                  "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?distro=debian-buster&upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1272,7 +1272,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?distro=debian-buster",
                   "version": "1.8.4-5",
                 },
               },
@@ -1280,7 +1280,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@241-7~deb10u1?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u1?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1288,7 +1288,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@241-7~deb10u1?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@241-7~deb10u1?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1296,7 +1296,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2?distro=debian-buster&upstream=apt",
                   "version": "1.8.2",
                 },
               },
@@ -1304,7 +1304,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?distro=debian-buster",
                   "version": "2019.1",
                 },
               },
@@ -1312,7 +1312,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.35-1?distro=debian-buster&upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1320,7 +1320,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
+                  "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?distro=debian-buster&upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1328,7 +1328,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
-                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
+                  "purl": "pkg:deb/debian/libgmp10@2:6.1.2%2Bdfsg-4?distro=debian-buster&upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1336,7 +1336,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
-                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
+                  "purl": "pkg:deb/debian/libunistring2@0.9.10-1?distro=debian-buster&upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1344,7 +1344,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
-                  "purl": "pkg:deb/libidn2-0@2.0.5-1?upstream=libidn2",
+                  "purl": "pkg:deb/debian/libidn2-0@2.0.5-1?distro=debian-buster&upstream=libidn2",
                   "version": "2.0.5-1",
                 },
               },
@@ -1352,7 +1352,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.13-3",
+                  "purl": "pkg:deb/debian/libtasn1-6@4.13-3?distro=debian-buster",
                   "version": "4.13-3",
                 },
               },
@@ -1360,7 +1360,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libnettle6@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1368,7 +1368,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
-                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1376,7 +1376,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
-                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
+                  "purl": "pkg:deb/debian/libffi6@3.2.1-9?distro=debian-buster&upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1384,7 +1384,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
+                  "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?distro=debian-buster&upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1392,7 +1392,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
-                  "purl": "pkg:deb/libgnutls30@3.6.7-4?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls30@3.6.7-4?distro=debian-buster&upstream=gnutls28",
                   "version": "3.6.7-4",
                 },
               },
@@ -1400,7 +1400,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
-                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
+                  "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?distro=debian-buster&upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1408,7 +1408,7 @@ Object {
                 "id": "apt@1.8.2",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.8.2",
+                  "purl": "pkg:deb/debian/apt@1.8.2?distro=debian-buster",
                   "version": "1.8.2",
                 },
               },
@@ -1423,7 +1423,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?distro=debian-buster&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1431,7 +1431,7 @@ Object {
                 "id": "base-files@10.3+deb10u1",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u1?distro=debian-buster",
                   "version": "10.3+deb10u1",
                 },
               },
@@ -1439,7 +1439,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.249?distro=debian-buster&upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1447,7 +1447,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.46",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.46?distro=debian-buster",
                   "version": "3.5.46",
                 },
               },
@@ -1455,7 +1455,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.6.1",
+                  "purl": "pkg:deb/debian/debianutils@4.8.6.1?distro=debian-buster",
                   "version": "4.8.6.1",
                 },
               },
@@ -1463,7 +1463,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
-                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1471,7 +1471,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@5.0-4",
+                  "purl": "pkg:deb/debian/bash@5.0-4?distro=debian-buster",
                   "version": "5.0-4",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.30-3",
+                  "purl": "pkg:deb/debian/coreutils@8.30-3?distro=debian-buster",
                   "version": "8.30-3",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.10.2-5",
+                  "purl": "pkg:deb/debian/dash@0.5.10.2-5?distro=debian-buster",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1509,7 +1509,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.7-3",
+                  "purl": "pkg:deb/debian/diffutils@1:3.7-3?distro=debian-buster",
                   "version": "1:3.7-3",
                 },
               },
@@ -1524,7 +1524,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
-                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1532,7 +1532,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
-                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1540,7 +1540,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1548,7 +1548,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1556,7 +1556,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1564,7 +1564,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u1?distro=debian-buster",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1572,7 +1572,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
+                  "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?distro=debian-buster",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1594,7 +1594,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.28-10?distro=debian-buster&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1609,7 +1609,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@3.3-1",
+                  "purl": "pkg:deb/debian/grep@3.3-1?distro=debian-buster",
                   "version": "3.3-1",
                 },
               },
@@ -1617,7 +1617,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.9-3",
+                  "purl": "pkg:deb/debian/gzip@1.9-3?distro=debian-buster",
                   "version": "1.9-3",
                 },
               },
@@ -1625,7 +1625,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.21",
+                  "purl": "pkg:deb/debian/hostname@3.21?distro=debian-buster",
                   "version": "3.21",
                 },
               },
@@ -1633,7 +1633,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
+                  "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?distro=debian-buster",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1648,7 +1648,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
-                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1656,7 +1656,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1664,7 +1664,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1672,7 +1672,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.7-1",
+                  "purl": "pkg:deb/debian/sed@4.7-1?distro=debian-buster",
                   "version": "4.7-1",
                 },
               },
@@ -1702,7 +1702,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1710,7 +1710,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
+                  "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?distro=debian-buster",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1718,7 +1718,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?distro=debian-buster&upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1733,7 +1733,7 @@ Object {
                 "id": "tzdata@2019b-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2019b-0%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/tzdata@2019b-0%2Bdeb10u1?distro=debian-buster",
                   "version": "2019b-0+deb10u1",
                 },
               },
@@ -1741,7 +1741,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.33.1-0.1?distro=debian-buster&upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1749,7 +1749,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1757,7 +1757,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1765,7 +1765,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1773,7 +1773,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
-                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1781,7 +1781,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
+++ b/test/system/key-binaries-hashes/__snapshots__/hashes.spec.ts.snap
@@ -1231,7 +1231,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
-                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/shesek/libaudit-common@1:2.8.4-3?distro=shesek-0.0.1&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1239,7 +1239,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
-                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
+                  "purl": "pkg:deb/shesek/libcap-ng0@0.7.9-2?distro=shesek-0.0.1&upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1247,7 +1247,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
-                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/shesek/libaudit1@1:2.8.4-3?distro=shesek-0.0.1&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1255,7 +1255,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/shesek/libsemanage-common@2.8-2?distro=shesek-0.0.1&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1263,7 +1263,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
+                  "purl": "pkg:deb/shesek/libsepol1@2.8-1?distro=shesek-0.0.1&upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1271,7 +1271,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/shesek/libsemanage1@2.8-2?distro=shesek-0.0.1&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1279,7 +1279,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
+                  "purl": "pkg:deb/shesek/libdb5.3@5.3.28%2Bdfsg1-0.5?distro=shesek-0.0.1&upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1287,7 +1287,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/shesek/libpam0g@1.3.1-5?distro=shesek-0.0.1&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1295,7 +1295,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/shesek/libpam-modules-bin@1.3.1-5?distro=shesek-0.0.1&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1303,7 +1303,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/shesek/libpam-modules@1.3.1-5?distro=shesek-0.0.1&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1311,7 +1311,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/shesek/passwd@1:4.5-1.1?distro=shesek-0.0.1&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1319,7 +1319,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.118",
+                  "purl": "pkg:deb/shesek/adduser@3.118?distro=shesek-0.0.1",
                   "version": "3.118",
                 },
               },
@@ -1327,7 +1327,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
+                  "purl": "pkg:deb/shesek/libstdc%2B%2B6@8.3.0-6?distro=shesek-0.0.1&upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1335,7 +1335,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
-                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
+                  "purl": "pkg:deb/shesek/libzstd1@1.3.8%2Bdfsg-3?distro=shesek-0.0.1&upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1343,7 +1343,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
+                  "purl": "pkg:deb/shesek/liblz4-1@1.8.3-1?distro=shesek-0.0.1&upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1351,7 +1351,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
+                  "purl": "pkg:deb/shesek/libgcrypt20@1.8.4-5?distro=shesek-0.0.1",
                   "version": "1.8.4-5",
                 },
               },
@@ -1359,7 +1359,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@241-7~deb10u1?upstream=systemd",
+                  "purl": "pkg:deb/shesek/libsystemd0@241-7~deb10u1?distro=shesek-0.0.1&upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1367,7 +1367,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@241-7~deb10u1?upstream=systemd",
+                  "purl": "pkg:deb/shesek/libudev1@241-7~deb10u1?distro=shesek-0.0.1&upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1375,7 +1375,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2?upstream=apt",
+                  "purl": "pkg:deb/shesek/libapt-pkg5.0@1.8.2?distro=shesek-0.0.1&upstream=apt",
                   "version": "1.8.2",
                 },
               },
@@ -1383,7 +1383,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
+                  "purl": "pkg:deb/shesek/debian-archive-keyring@2019.1?distro=shesek-0.0.1",
                   "version": "2019.1",
                 },
               },
@@ -1391,7 +1391,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
+                  "purl": "pkg:deb/shesek/libgpg-error0@1.35-1?distro=shesek-0.0.1&upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1399,7 +1399,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
+                  "purl": "pkg:deb/shesek/gpgv@2.2.12-1%2Bdeb10u1?distro=shesek-0.0.1&upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1407,7 +1407,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
-                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
+                  "purl": "pkg:deb/shesek/libgmp10@2:6.1.2%2Bdfsg-4?distro=shesek-0.0.1&upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1415,7 +1415,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
-                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
+                  "purl": "pkg:deb/shesek/libunistring2@0.9.10-1?distro=shesek-0.0.1&upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1423,7 +1423,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
-                  "purl": "pkg:deb/libidn2-0@2.0.5-1?upstream=libidn2",
+                  "purl": "pkg:deb/shesek/libidn2-0@2.0.5-1?distro=shesek-0.0.1&upstream=libidn2",
                   "version": "2.0.5-1",
                 },
               },
@@ -1431,7 +1431,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.13-3",
+                  "purl": "pkg:deb/shesek/libtasn1-6@4.13-3?distro=shesek-0.0.1",
                   "version": "4.13-3",
                 },
               },
@@ -1439,7 +1439,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/shesek/libnettle6@3.4.1-1?distro=shesek-0.0.1&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1447,7 +1447,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
-                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/shesek/libhogweed4@3.4.1-1?distro=shesek-0.0.1&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1455,7 +1455,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
-                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
+                  "purl": "pkg:deb/shesek/libffi6@3.2.1-9?distro=shesek-0.0.1&upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1463,7 +1463,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
+                  "purl": "pkg:deb/shesek/libp11-kit0@0.23.15-2?distro=shesek-0.0.1&upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1471,7 +1471,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
-                  "purl": "pkg:deb/libgnutls30@3.6.7-4?upstream=gnutls28",
+                  "purl": "pkg:deb/shesek/libgnutls30@3.6.7-4?distro=shesek-0.0.1&upstream=gnutls28",
                   "version": "3.6.7-4",
                 },
               },
@@ -1479,7 +1479,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
-                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
+                  "purl": "pkg:deb/shesek/libseccomp2@2.3.3-4?distro=shesek-0.0.1&upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1487,7 +1487,7 @@ Object {
                 "id": "apt@1.8.2",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.8.2",
+                  "purl": "pkg:deb/shesek/apt@1.8.2?distro=shesek-0.0.1",
                   "version": "1.8.2",
                 },
               },
@@ -1502,7 +1502,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/shesek/mawk@1.3.3-17%2Bb3?distro=shesek-0.0.1&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1510,7 +1510,7 @@ Object {
                 "id": "base-files@10.3+deb10u1",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u1",
+                  "purl": "pkg:deb/shesek/base-files@10.3%2Bdeb10u1?distro=shesek-0.0.1",
                   "version": "10.3+deb10u1",
                 },
               },
@@ -1518,7 +1518,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
+                  "purl": "pkg:deb/shesek/libdebconfclient0@0.249?distro=shesek-0.0.1&upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1526,7 +1526,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.46",
+                  "purl": "pkg:deb/shesek/base-passwd@3.5.46?distro=shesek-0.0.1",
                   "version": "3.5.46",
                 },
               },
@@ -1534,7 +1534,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.6.1",
+                  "purl": "pkg:deb/shesek/debianutils@4.8.6.1?distro=shesek-0.0.1",
                   "version": "4.8.6.1",
                 },
               },
@@ -1542,7 +1542,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
-                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/shesek/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?distro=shesek-0.0.1&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1550,7 +1550,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@5.0-4",
+                  "purl": "pkg:deb/shesek/bash@5.0-4?distro=shesek-0.0.1",
                   "version": "5.0-4",
                 },
               },
@@ -1565,7 +1565,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.30-3",
+                  "purl": "pkg:deb/shesek/coreutils@8.30-3?distro=shesek-0.0.1",
                   "version": "8.30-3",
                 },
               },
@@ -1573,7 +1573,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.10.2-5",
+                  "purl": "pkg:deb/shesek/dash@0.5.10.2-5?distro=shesek-0.0.1",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1588,7 +1588,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.7-3",
+                  "purl": "pkg:deb/shesek/diffutils@1:3.7-3?distro=shesek-0.0.1",
                   "version": "1:3.7-3",
                 },
               },
@@ -1603,7 +1603,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
-                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/shesek/libcom-err2@1.44.5-1%2Bdeb10u1?distro=shesek-0.0.1&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1611,7 +1611,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
-                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/shesek/libext2fs2@1.44.5-1%2Bdeb10u1?distro=shesek-0.0.1&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1619,7 +1619,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/shesek/libss2@1.44.5-1%2Bdeb10u1?distro=shesek-0.0.1&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1627,7 +1627,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/shesek/libuuid1@2.33.1-0.1?distro=shesek-0.0.1&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1635,7 +1635,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/shesek/libblkid1@2.33.1-0.1?distro=shesek-0.0.1&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1643,7 +1643,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u1",
+                  "purl": "pkg:deb/shesek/e2fsprogs@1.44.5-1%2Bdeb10u1?distro=shesek-0.0.1",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1651,7 +1651,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
+                  "purl": "pkg:deb/shesek/findutils@4.6.0%2Bgit%2B20190209-2?distro=shesek-0.0.1",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1673,7 +1673,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/shesek/libc-bin@2.28-10?distro=shesek-0.0.1&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1688,7 +1688,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@3.3-1",
+                  "purl": "pkg:deb/shesek/grep@3.3-1?distro=shesek-0.0.1",
                   "version": "3.3-1",
                 },
               },
@@ -1696,7 +1696,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.9-3",
+                  "purl": "pkg:deb/shesek/gzip@1.9-3?distro=shesek-0.0.1",
                   "version": "1.9-3",
                 },
               },
@@ -1704,7 +1704,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.21",
+                  "purl": "pkg:deb/shesek/hostname@3.21?distro=shesek-0.0.1",
                   "version": "3.21",
                 },
               },
@@ -1712,7 +1712,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
+                  "purl": "pkg:deb/shesek/init-system-helpers@1.56%2Bnmu1?distro=shesek-0.0.1",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1727,7 +1727,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
-                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/shesek/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?distro=shesek-0.0.1&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1735,7 +1735,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/shesek/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?distro=shesek-0.0.1&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1743,7 +1743,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/shesek/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?distro=shesek-0.0.1&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1751,7 +1751,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/shesek/libpam-runtime@1.3.1-5?distro=shesek-0.0.1&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1773,7 +1773,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.7-1",
+                  "purl": "pkg:deb/shesek/sed@4.7-1?distro=shesek-0.0.1",
                   "version": "4.7-1",
                 },
               },
@@ -1781,7 +1781,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/shesek/login@1:4.5-1.1?distro=shesek-0.0.1&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1789,7 +1789,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
+                  "purl": "pkg:deb/shesek/util-linux@2.33.1-0.1?distro=shesek-0.0.1",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1797,7 +1797,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
+                  "purl": "pkg:deb/shesek/sysvinit-utils@2.93-8?distro=shesek-0.0.1&upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1812,7 +1812,7 @@ Object {
                 "id": "tzdata@2019b-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2019b-0%2Bdeb10u1",
+                  "purl": "pkg:deb/shesek/tzdata@2019b-0%2Bdeb10u1?distro=shesek-0.0.1",
                   "version": "2019b-0+deb10u1",
                 },
               },
@@ -1820,7 +1820,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
+                  "purl": "pkg:deb/shesek/bsdutils@1:2.33.1-0.1?distro=shesek-0.0.1&upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1828,7 +1828,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/shesek/libfdisk1@2.33.1-0.1?distro=shesek-0.0.1&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1836,7 +1836,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/shesek/libmount1@2.33.1-0.1?distro=shesek-0.0.1&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1844,7 +1844,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/shesek/libsmartcols1@2.33.1-0.1?distro=shesek-0.0.1&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1852,7 +1852,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
-                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/shesek/fdisk@2.33.1-0.1?distro=shesek-0.0.1&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1860,7 +1860,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/shesek/mount@2.33.1-0.1?distro=shesek-0.0.1&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/centos6.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/centos6.spec.ts.snap
@@ -1606,7 +1606,7 @@ Object {
                 "id": "MAKEDEV@3.24-6.el6",
                 "info": Object {
                   "name": "MAKEDEV",
-                  "purl": "pkg:rpm/MAKEDEV@3.24-6.el6",
+                  "purl": "pkg:rpm/centos/MAKEDEV@3.24-6.el6?distro=centos-6",
                   "version": "3.24-6.el6",
                 },
               },
@@ -1614,7 +1614,7 @@ Object {
                 "id": "at@3.1.10-49.el6",
                 "info": Object {
                   "name": "at",
-                  "purl": "pkg:rpm/at@3.1.10-49.el6",
+                  "purl": "pkg:rpm/centos/at@3.1.10-49.el6?distro=centos-6",
                   "version": "3.1.10-49.el6",
                 },
               },
@@ -1622,7 +1622,7 @@ Object {
                 "id": "audit-libs@2.4.5-6.el6",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@2.4.5-6.el6",
+                  "purl": "pkg:rpm/centos/audit-libs@2.4.5-6.el6?distro=centos-6",
                   "version": "2.4.5-6.el6",
                 },
               },
@@ -1630,7 +1630,7 @@ Object {
                 "id": "basesystem@10.0-4.el6",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-4.el6",
+                  "purl": "pkg:rpm/centos/basesystem@10.0-4.el6?distro=centos-6",
                   "version": "10.0-4.el6",
                 },
               },
@@ -1638,7 +1638,7 @@ Object {
                 "id": "bash@4.1.2-48.el6",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.1.2-48.el6",
+                  "purl": "pkg:rpm/centos/bash@4.1.2-48.el6?distro=centos-6",
                   "version": "4.1.2-48.el6",
                 },
               },
@@ -1646,7 +1646,7 @@ Object {
                 "id": "bc@1.06.95-1.el6",
                 "info": Object {
                   "name": "bc",
-                  "purl": "pkg:rpm/bc@1.06.95-1.el6",
+                  "purl": "pkg:rpm/centos/bc@1.06.95-1.el6?distro=centos-6",
                   "version": "1.06.95-1.el6",
                 },
               },
@@ -1654,7 +1654,7 @@ Object {
                 "id": "bind-libs@32:9.8.2-0.68.rc1.el6_10.1",
                 "info": Object {
                   "name": "bind-libs",
-                  "purl": "pkg:rpm/bind-libs@32:9.8.2-0.68.rc1.el6_10.1?epoch=32",
+                  "purl": "pkg:rpm/centos/bind-libs@32:9.8.2-0.68.rc1.el6_10.1?distro=centos-6&epoch=32",
                   "version": "32:9.8.2-0.68.rc1.el6_10.1",
                 },
               },
@@ -1662,7 +1662,7 @@ Object {
                 "id": "bind-utils@32:9.8.2-0.68.rc1.el6_10.1",
                 "info": Object {
                   "name": "bind-utils",
-                  "purl": "pkg:rpm/bind-utils@32:9.8.2-0.68.rc1.el6_10.1?epoch=32",
+                  "purl": "pkg:rpm/centos/bind-utils@32:9.8.2-0.68.rc1.el6_10.1?distro=centos-6&epoch=32",
                   "version": "32:9.8.2-0.68.rc1.el6_10.1",
                 },
               },
@@ -1670,7 +1670,7 @@ Object {
                 "id": "binutils@2.20.51.0.2-5.48.el6",
                 "info": Object {
                   "name": "binutils",
-                  "purl": "pkg:rpm/binutils@2.20.51.0.2-5.48.el6",
+                  "purl": "pkg:rpm/centos/binutils@2.20.51.0.2-5.48.el6?distro=centos-6",
                   "version": "2.20.51.0.2-5.48.el6",
                 },
               },
@@ -1678,7 +1678,7 @@ Object {
                 "id": "bzip2@1.0.5-7.el6_0",
                 "info": Object {
                   "name": "bzip2",
-                  "purl": "pkg:rpm/bzip2@1.0.5-7.el6_0",
+                  "purl": "pkg:rpm/centos/bzip2@1.0.5-7.el6_0?distro=centos-6",
                   "version": "1.0.5-7.el6_0",
                 },
               },
@@ -1686,7 +1686,7 @@ Object {
                 "id": "bzip2-libs@1.0.5-7.el6_0",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.5-7.el6_0",
+                  "purl": "pkg:rpm/centos/bzip2-libs@1.0.5-7.el6_0?distro=centos-6",
                   "version": "1.0.5-7.el6_0",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "ca-certificates@2020.2.41-65.1.el6_10",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2020.2.41-65.1.el6_10",
+                  "purl": "pkg:rpm/centos/ca-certificates@2020.2.41-65.1.el6_10?distro=centos-6",
                   "version": "2020.2.41-65.1.el6_10",
                 },
               },
@@ -1702,7 +1702,7 @@ Object {
                 "id": "centos-release@6-10.el6.centos.12.3",
                 "info": Object {
                   "name": "centos-release",
-                  "purl": "pkg:rpm/centos-release@6-10.el6.centos.12.3",
+                  "purl": "pkg:rpm/centos/centos-release@6-10.el6.centos.12.3?distro=centos-6",
                   "version": "6-10.el6.centos.12.3",
                 },
               },
@@ -1710,7 +1710,7 @@ Object {
                 "id": "checkpolicy@2.0.22-1.el6",
                 "info": Object {
                   "name": "checkpolicy",
-                  "purl": "pkg:rpm/checkpolicy@2.0.22-1.el6",
+                  "purl": "pkg:rpm/centos/checkpolicy@2.0.22-1.el6?distro=centos-6",
                   "version": "2.0.22-1.el6",
                 },
               },
@@ -1718,7 +1718,7 @@ Object {
                 "id": "chkconfig@1.3.49.5-1.el6",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.3.49.5-1.el6",
+                  "purl": "pkg:rpm/centos/chkconfig@1.3.49.5-1.el6?distro=centos-6",
                   "version": "1.3.49.5-1.el6",
                 },
               },
@@ -1726,7 +1726,7 @@ Object {
                 "id": "coreutils@8.4-47.el6",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.4-47.el6",
+                  "purl": "pkg:rpm/centos/coreutils@8.4-47.el6?distro=centos-6",
                   "version": "8.4-47.el6",
                 },
               },
@@ -1734,7 +1734,7 @@ Object {
                 "id": "coreutils-libs@8.4-47.el6",
                 "info": Object {
                   "name": "coreutils-libs",
-                  "purl": "pkg:rpm/coreutils-libs@8.4-47.el6",
+                  "purl": "pkg:rpm/centos/coreutils-libs@8.4-47.el6?distro=centos-6",
                   "version": "8.4-47.el6",
                 },
               },
@@ -1742,7 +1742,7 @@ Object {
                 "id": "cpio@2.10-13.el6",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.10-13.el6",
+                  "purl": "pkg:rpm/centos/cpio@2.10-13.el6?distro=centos-6",
                   "version": "2.10-13.el6",
                 },
               },
@@ -1750,7 +1750,7 @@ Object {
                 "id": "cracklib@2.8.16-4.el6",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.8.16-4.el6",
+                  "purl": "pkg:rpm/centos/cracklib@2.8.16-4.el6?distro=centos-6",
                   "version": "2.8.16-4.el6",
                 },
               },
@@ -1758,7 +1758,7 @@ Object {
                 "id": "cracklib-dicts@2.8.16-4.el6",
                 "info": Object {
                   "name": "cracklib-dicts",
-                  "purl": "pkg:rpm/cracklib-dicts@2.8.16-4.el6",
+                  "purl": "pkg:rpm/centos/cracklib-dicts@2.8.16-4.el6?distro=centos-6",
                   "version": "2.8.16-4.el6",
                 },
               },
@@ -1766,7 +1766,7 @@ Object {
                 "id": "cronie@1.4.4-16.el6_8.2",
                 "info": Object {
                   "name": "cronie",
-                  "purl": "pkg:rpm/cronie@1.4.4-16.el6_8.2",
+                  "purl": "pkg:rpm/centos/cronie@1.4.4-16.el6_8.2?distro=centos-6",
                   "version": "1.4.4-16.el6_8.2",
                 },
               },
@@ -1774,7 +1774,7 @@ Object {
                 "id": "cronie-anacron@1.4.4-16.el6_8.2",
                 "info": Object {
                   "name": "cronie-anacron",
-                  "purl": "pkg:rpm/cronie-anacron@1.4.4-16.el6_8.2",
+                  "purl": "pkg:rpm/centos/cronie-anacron@1.4.4-16.el6_8.2?distro=centos-6",
                   "version": "1.4.4-16.el6_8.2",
                 },
               },
@@ -1782,7 +1782,7 @@ Object {
                 "id": "crontabs@1.10-33.el6",
                 "info": Object {
                   "name": "crontabs",
-                  "purl": "pkg:rpm/crontabs@1.10-33.el6",
+                  "purl": "pkg:rpm/centos/crontabs@1.10-33.el6?distro=centos-6",
                   "version": "1.10-33.el6",
                 },
               },
@@ -1790,7 +1790,7 @@ Object {
                 "id": "curl@7.19.7-54.el6_10",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.19.7-54.el6_10",
+                  "purl": "pkg:rpm/centos/curl@7.19.7-54.el6_10?distro=centos-6",
                   "version": "7.19.7-54.el6_10",
                 },
               },
@@ -1798,7 +1798,7 @@ Object {
                 "id": "cvs@1.11.23-16.el6",
                 "info": Object {
                   "name": "cvs",
-                  "purl": "pkg:rpm/cvs@1.11.23-16.el6",
+                  "purl": "pkg:rpm/centos/cvs@1.11.23-16.el6?distro=centos-6",
                   "version": "1.11.23-16.el6",
                 },
               },
@@ -1806,7 +1806,7 @@ Object {
                 "id": "cyrus-sasl@2.1.23-15.el6_6.2",
                 "info": Object {
                   "name": "cyrus-sasl",
-                  "purl": "pkg:rpm/cyrus-sasl@2.1.23-15.el6_6.2",
+                  "purl": "pkg:rpm/centos/cyrus-sasl@2.1.23-15.el6_6.2?distro=centos-6",
                   "version": "2.1.23-15.el6_6.2",
                 },
               },
@@ -1814,7 +1814,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.23-15.el6_6.2",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.23-15.el6_6.2",
+                  "purl": "pkg:rpm/centos/cyrus-sasl-lib@2.1.23-15.el6_6.2?distro=centos-6",
                   "version": "2.1.23-15.el6_6.2",
                 },
               },
@@ -1822,7 +1822,7 @@ Object {
                 "id": "dash@0.5.5.1-4.el6",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:rpm/dash@0.5.5.1-4.el6",
+                  "purl": "pkg:rpm/centos/dash@0.5.5.1-4.el6?distro=centos-6",
                   "version": "0.5.5.1-4.el6",
                 },
               },
@@ -1830,7 +1830,7 @@ Object {
                 "id": "db4@4.7.25-22.el6",
                 "info": Object {
                   "name": "db4",
-                  "purl": "pkg:rpm/db4@4.7.25-22.el6",
+                  "purl": "pkg:rpm/centos/db4@4.7.25-22.el6?distro=centos-6",
                   "version": "4.7.25-22.el6",
                 },
               },
@@ -1838,7 +1838,7 @@ Object {
                 "id": "db4-cxx@4.7.25-22.el6",
                 "info": Object {
                   "name": "db4-cxx",
-                  "purl": "pkg:rpm/db4-cxx@4.7.25-22.el6",
+                  "purl": "pkg:rpm/centos/db4-cxx@4.7.25-22.el6?distro=centos-6",
                   "version": "4.7.25-22.el6",
                 },
               },
@@ -1846,7 +1846,7 @@ Object {
                 "id": "db4-devel@4.7.25-22.el6",
                 "info": Object {
                   "name": "db4-devel",
-                  "purl": "pkg:rpm/db4-devel@4.7.25-22.el6",
+                  "purl": "pkg:rpm/centos/db4-devel@4.7.25-22.el6?distro=centos-6",
                   "version": "4.7.25-22.el6",
                 },
               },
@@ -1854,7 +1854,7 @@ Object {
                 "id": "db4-utils@4.7.25-22.el6",
                 "info": Object {
                   "name": "db4-utils",
-                  "purl": "pkg:rpm/db4-utils@4.7.25-22.el6",
+                  "purl": "pkg:rpm/centos/db4-utils@4.7.25-22.el6?distro=centos-6",
                   "version": "4.7.25-22.el6",
                 },
               },
@@ -1862,7 +1862,7 @@ Object {
                 "id": "dbus-glib@0.86-6.el6",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.86-6.el6",
+                  "purl": "pkg:rpm/centos/dbus-glib@0.86-6.el6?distro=centos-6",
                   "version": "0.86-6.el6",
                 },
               },
@@ -1870,7 +1870,7 @@ Object {
                 "id": "dbus-libs@1:1.2.24-9.el6",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.2.24-9.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/dbus-libs@1:1.2.24-9.el6?distro=centos-6&epoch=1",
                   "version": "1:1.2.24-9.el6",
                 },
               },
@@ -1878,7 +1878,7 @@ Object {
                 "id": "diffutils@2.8.1-28.el6",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@2.8.1-28.el6",
+                  "purl": "pkg:rpm/centos/diffutils@2.8.1-28.el6?distro=centos-6",
                   "version": "2.8.1-28.el6",
                 },
               },
@@ -1886,7 +1886,7 @@ Object {
                 "id": "dmidecode@1:2.12-7.el6",
                 "info": Object {
                   "name": "dmidecode",
-                  "purl": "pkg:rpm/dmidecode@1:2.12-7.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/dmidecode@1:2.12-7.el6?distro=centos-6&epoch=1",
                   "version": "1:2.12-7.el6",
                 },
               },
@@ -1894,7 +1894,7 @@ Object {
                 "id": "ed@1.1-3.3.el6",
                 "info": Object {
                   "name": "ed",
-                  "purl": "pkg:rpm/ed@1.1-3.3.el6",
+                  "purl": "pkg:rpm/centos/ed@1.1-3.3.el6?distro=centos-6",
                   "version": "1.1-3.3.el6",
                 },
               },
@@ -1902,7 +1902,7 @@ Object {
                 "id": "elfutils-libelf@0.164-2.el6",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.164-2.el6",
+                  "purl": "pkg:rpm/centos/elfutils-libelf@0.164-2.el6?distro=centos-6",
                   "version": "0.164-2.el6",
                 },
               },
@@ -1910,7 +1910,7 @@ Object {
                 "id": "ethtool@2:3.5-6.el6",
                 "info": Object {
                   "name": "ethtool",
-                  "purl": "pkg:rpm/ethtool@2:3.5-6.el6?epoch=2",
+                  "purl": "pkg:rpm/centos/ethtool@2:3.5-6.el6?distro=centos-6&epoch=2",
                   "version": "2:3.5-6.el6",
                 },
               },
@@ -1918,7 +1918,7 @@ Object {
                 "id": "expat@2.0.1-13.el6_8",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.0.1-13.el6_8",
+                  "purl": "pkg:rpm/centos/expat@2.0.1-13.el6_8?distro=centos-6",
                   "version": "2.0.1-13.el6_8",
                 },
               },
@@ -1926,7 +1926,7 @@ Object {
                 "id": "file@5.04-30.el6",
                 "info": Object {
                   "name": "file",
-                  "purl": "pkg:rpm/file@5.04-30.el6",
+                  "purl": "pkg:rpm/centos/file@5.04-30.el6?distro=centos-6",
                   "version": "5.04-30.el6",
                 },
               },
@@ -1934,7 +1934,7 @@ Object {
                 "id": "file-libs@5.04-30.el6",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.04-30.el6",
+                  "purl": "pkg:rpm/centos/file-libs@5.04-30.el6?distro=centos-6",
                   "version": "5.04-30.el6",
                 },
               },
@@ -1942,7 +1942,7 @@ Object {
                 "id": "filesystem@2.4.30-3.el6",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@2.4.30-3.el6",
+                  "purl": "pkg:rpm/centos/filesystem@2.4.30-3.el6?distro=centos-6",
                   "version": "2.4.30-3.el6",
                 },
               },
@@ -1950,7 +1950,7 @@ Object {
                 "id": "findutils@1:4.4.2-9.el6",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.4.2-9.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/findutils@1:4.4.2-9.el6?distro=centos-6&epoch=1",
                   "version": "1:4.4.2-9.el6",
                 },
               },
@@ -1958,7 +1958,7 @@ Object {
                 "id": "gamin@0.1.10-9.el6",
                 "info": Object {
                   "name": "gamin",
-                  "purl": "pkg:rpm/gamin@0.1.10-9.el6",
+                  "purl": "pkg:rpm/centos/gamin@0.1.10-9.el6?distro=centos-6",
                   "version": "0.1.10-9.el6",
                 },
               },
@@ -1966,7 +1966,7 @@ Object {
                 "id": "gawk@3.1.7-10.el6_7.3",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@3.1.7-10.el6_7.3",
+                  "purl": "pkg:rpm/centos/gawk@3.1.7-10.el6_7.3?distro=centos-6",
                   "version": "3.1.7-10.el6_7.3",
                 },
               },
@@ -1974,7 +1974,7 @@ Object {
                 "id": "gdbm@1.8.0-39.el6",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1.8.0-39.el6",
+                  "purl": "pkg:rpm/centos/gdbm@1.8.0-39.el6?distro=centos-6",
                   "version": "1.8.0-39.el6",
                 },
               },
@@ -1982,7 +1982,7 @@ Object {
                 "id": "gdbm-devel@1.8.0-39.el6",
                 "info": Object {
                   "name": "gdbm-devel",
-                  "purl": "pkg:rpm/gdbm-devel@1.8.0-39.el6",
+                  "purl": "pkg:rpm/centos/gdbm-devel@1.8.0-39.el6?distro=centos-6",
                   "version": "1.8.0-39.el6",
                 },
               },
@@ -1990,7 +1990,7 @@ Object {
                 "id": "gettext@0.17-18.el6",
                 "info": Object {
                   "name": "gettext",
-                  "purl": "pkg:rpm/gettext@0.17-18.el6",
+                  "purl": "pkg:rpm/centos/gettext@0.17-18.el6?distro=centos-6",
                   "version": "0.17-18.el6",
                 },
               },
@@ -1998,7 +1998,7 @@ Object {
                 "id": "glib2@2.28.8-10.el6",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.28.8-10.el6",
+                  "purl": "pkg:rpm/centos/glib2@2.28.8-10.el6?distro=centos-6",
                   "version": "2.28.8-10.el6",
                 },
               },
@@ -2006,7 +2006,7 @@ Object {
                 "id": "glibc@2.12-1.212.el6_10.3",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.12-1.212.el6_10.3",
+                  "purl": "pkg:rpm/centos/glibc@2.12-1.212.el6_10.3?distro=centos-6",
                   "version": "2.12-1.212.el6_10.3",
                 },
               },
@@ -2014,7 +2014,7 @@ Object {
                 "id": "glibc-common@2.12-1.212.el6_10.3",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.12-1.212.el6_10.3",
+                  "purl": "pkg:rpm/centos/glibc-common@2.12-1.212.el6_10.3?distro=centos-6",
                   "version": "2.12-1.212.el6_10.3",
                 },
               },
@@ -2022,7 +2022,7 @@ Object {
                 "id": "glibc-devel@2.12-1.212.el6_10.3",
                 "info": Object {
                   "name": "glibc-devel",
-                  "purl": "pkg:rpm/glibc-devel@2.12-1.212.el6_10.3",
+                  "purl": "pkg:rpm/centos/glibc-devel@2.12-1.212.el6_10.3?distro=centos-6",
                   "version": "2.12-1.212.el6_10.3",
                 },
               },
@@ -2030,7 +2030,7 @@ Object {
                 "id": "glibc-headers@2.12-1.212.el6_10.3",
                 "info": Object {
                   "name": "glibc-headers",
-                  "purl": "pkg:rpm/glibc-headers@2.12-1.212.el6_10.3",
+                  "purl": "pkg:rpm/centos/glibc-headers@2.12-1.212.el6_10.3?distro=centos-6",
                   "version": "2.12-1.212.el6_10.3",
                 },
               },
@@ -2038,7 +2038,7 @@ Object {
                 "id": "gmp@4.3.1-13.el6",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@4.3.1-13.el6",
+                  "purl": "pkg:rpm/centos/gmp@4.3.1-13.el6?distro=centos-6",
                   "version": "4.3.1-13.el6",
                 },
               },
@@ -2046,7 +2046,7 @@ Object {
                 "id": "gnupg2@2.0.14-9.el6_10",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.14-9.el6_10",
+                  "purl": "pkg:rpm/centos/gnupg2@2.0.14-9.el6_10?distro=centos-6",
                   "version": "2.0.14-9.el6_10",
                 },
               },
@@ -2054,7 +2054,7 @@ Object {
                 "id": "gpg-pubkey@c105b9de-4e0fd3a3",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@c105b9de-4e0fd3a3",
+                  "purl": "pkg:rpm/centos/gpg-pubkey@c105b9de-4e0fd3a3?distro=centos-6",
                   "version": "c105b9de-4e0fd3a3",
                 },
               },
@@ -2062,7 +2062,7 @@ Object {
                 "id": "gpgme@1.1.8-3.el6",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.1.8-3.el6",
+                  "purl": "pkg:rpm/centos/gpgme@1.1.8-3.el6?distro=centos-6",
                   "version": "1.1.8-3.el6",
                 },
               },
@@ -2070,7 +2070,7 @@ Object {
                 "id": "grep@2.20-6.el6",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-6.el6",
+                  "purl": "pkg:rpm/centos/grep@2.20-6.el6?distro=centos-6",
                   "version": "2.20-6.el6",
                 },
               },
@@ -2078,7 +2078,7 @@ Object {
                 "id": "groff@1.18.1.4-21.el6",
                 "info": Object {
                   "name": "groff",
-                  "purl": "pkg:rpm/groff@1.18.1.4-21.el6",
+                  "purl": "pkg:rpm/centos/groff@1.18.1.4-21.el6?distro=centos-6",
                   "version": "1.18.1.4-21.el6",
                 },
               },
@@ -2086,7 +2086,7 @@ Object {
                 "id": "gzip@1.3.12-24.el6",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.3.12-24.el6",
+                  "purl": "pkg:rpm/centos/gzip@1.3.12-24.el6?distro=centos-6",
                   "version": "1.3.12-24.el6",
                 },
               },
@@ -2094,7 +2094,7 @@ Object {
                 "id": "hwdata@0.233-20.1.el6",
                 "info": Object {
                   "name": "hwdata",
-                  "purl": "pkg:rpm/hwdata@0.233-20.1.el6",
+                  "purl": "pkg:rpm/centos/hwdata@0.233-20.1.el6?distro=centos-6",
                   "version": "0.233-20.1.el6",
                 },
               },
@@ -2102,7 +2102,7 @@ Object {
                 "id": "info@4.13a-8.el6",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@4.13a-8.el6",
+                  "purl": "pkg:rpm/centos/info@4.13a-8.el6?distro=centos-6",
                   "version": "4.13a-8.el6",
                 },
               },
@@ -2110,7 +2110,7 @@ Object {
                 "id": "initscripts@9.03.61-1.el6.centos",
                 "info": Object {
                   "name": "initscripts",
-                  "purl": "pkg:rpm/initscripts@9.03.61-1.el6.centos",
+                  "purl": "pkg:rpm/centos/initscripts@9.03.61-1.el6.centos?distro=centos-6",
                   "version": "9.03.61-1.el6.centos",
                 },
               },
@@ -2118,7 +2118,7 @@ Object {
                 "id": "iproute@2.6.32-57.el6",
                 "info": Object {
                   "name": "iproute",
-                  "purl": "pkg:rpm/iproute@2.6.32-57.el6",
+                  "purl": "pkg:rpm/centos/iproute@2.6.32-57.el6?distro=centos-6",
                   "version": "2.6.32-57.el6",
                 },
               },
@@ -2126,7 +2126,7 @@ Object {
                 "id": "iptables@1.4.7-19.el6",
                 "info": Object {
                   "name": "iptables",
-                  "purl": "pkg:rpm/iptables@1.4.7-19.el6",
+                  "purl": "pkg:rpm/centos/iptables@1.4.7-19.el6?distro=centos-6",
                   "version": "1.4.7-19.el6",
                 },
               },
@@ -2134,7 +2134,7 @@ Object {
                 "id": "iputils@20071127-24.el6",
                 "info": Object {
                   "name": "iputils",
-                  "purl": "pkg:rpm/iputils@20071127-24.el6",
+                  "purl": "pkg:rpm/centos/iputils@20071127-24.el6?distro=centos-6",
                   "version": "20071127-24.el6",
                 },
               },
@@ -2142,7 +2142,7 @@ Object {
                 "id": "kernel-headers@2.6.32-754.35.1.el6",
                 "info": Object {
                   "name": "kernel-headers",
-                  "purl": "pkg:rpm/kernel-headers@2.6.32-754.35.1.el6",
+                  "purl": "pkg:rpm/centos/kernel-headers@2.6.32-754.35.1.el6?distro=centos-6",
                   "version": "2.6.32-754.35.1.el6",
                 },
               },
@@ -2150,7 +2150,7 @@ Object {
                 "id": "keyutils-libs@1.4-5.el6",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.4-5.el6",
+                  "purl": "pkg:rpm/centos/keyutils-libs@1.4-5.el6?distro=centos-6",
                   "version": "1.4-5.el6",
                 },
               },
@@ -2158,7 +2158,7 @@ Object {
                 "id": "krb5-libs@1.10.3-65.el6",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.10.3-65.el6",
+                  "purl": "pkg:rpm/centos/krb5-libs@1.10.3-65.el6?distro=centos-6",
                   "version": "1.10.3-65.el6",
                 },
               },
@@ -2166,7 +2166,7 @@ Object {
                 "id": "less@436-13.el6",
                 "info": Object {
                   "name": "less",
-                  "purl": "pkg:rpm/less@436-13.el6",
+                  "purl": "pkg:rpm/centos/less@436-13.el6?distro=centos-6",
                   "version": "436-13.el6",
                 },
               },
@@ -2174,7 +2174,7 @@ Object {
                 "id": "libacl@2.2.49-7.el6_9.1",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.49-7.el6_9.1",
+                  "purl": "pkg:rpm/centos/libacl@2.2.49-7.el6_9.1?distro=centos-6",
                   "version": "2.2.49-7.el6_9.1",
                 },
               },
@@ -2182,7 +2182,7 @@ Object {
                 "id": "libattr@2.4.44-7.el6",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.44-7.el6",
+                  "purl": "pkg:rpm/centos/libattr@2.4.44-7.el6?distro=centos-6",
                   "version": "2.4.44-7.el6",
                 },
               },
@@ -2190,7 +2190,7 @@ Object {
                 "id": "libblkid@2.17.2-12.28.el6_9.2",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.17.2-12.28.el6_9.2",
+                  "purl": "pkg:rpm/centos/libblkid@2.17.2-12.28.el6_9.2?distro=centos-6",
                   "version": "2.17.2-12.28.el6_9.2",
                 },
               },
@@ -2198,7 +2198,7 @@ Object {
                 "id": "libcap@2.16-5.5.el6",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.16-5.5.el6",
+                  "purl": "pkg:rpm/centos/libcap@2.16-5.5.el6?distro=centos-6",
                   "version": "2.16-5.5.el6",
                 },
               },
@@ -2206,7 +2206,7 @@ Object {
                 "id": "libcom_err@1.41.12-24.el6",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.41.12-24.el6",
+                  "purl": "pkg:rpm/centos/libcom_err@1.41.12-24.el6?distro=centos-6",
                   "version": "1.41.12-24.el6",
                 },
               },
@@ -2214,7 +2214,7 @@ Object {
                 "id": "libcurl@7.19.7-54.el6_10",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.19.7-54.el6_10",
+                  "purl": "pkg:rpm/centos/libcurl@7.19.7-54.el6_10?distro=centos-6",
                   "version": "7.19.7-54.el6_10",
                 },
               },
@@ -2222,7 +2222,7 @@ Object {
                 "id": "libdrm@2.4.65-2.el6",
                 "info": Object {
                   "name": "libdrm",
-                  "purl": "pkg:rpm/libdrm@2.4.65-2.el6",
+                  "purl": "pkg:rpm/centos/libdrm@2.4.65-2.el6?distro=centos-6",
                   "version": "2.4.65-2.el6",
                 },
               },
@@ -2230,7 +2230,7 @@ Object {
                 "id": "libffi@3.0.5-3.2.el6",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.5-3.2.el6",
+                  "purl": "pkg:rpm/centos/libffi@3.0.5-3.2.el6?distro=centos-6",
                   "version": "3.0.5-3.2.el6",
                 },
               },
@@ -2238,7 +2238,7 @@ Object {
                 "id": "libgcc@4.4.7-23.el6",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@4.4.7-23.el6",
+                  "purl": "pkg:rpm/centos/libgcc@4.4.7-23.el6?distro=centos-6",
                   "version": "4.4.7-23.el6",
                 },
               },
@@ -2246,7 +2246,7 @@ Object {
                 "id": "libgcrypt@1.4.5-12.el6_8",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.4.5-12.el6_8",
+                  "purl": "pkg:rpm/centos/libgcrypt@1.4.5-12.el6_8?distro=centos-6",
                   "version": "1.4.5-12.el6_8",
                 },
               },
@@ -2254,7 +2254,7 @@ Object {
                 "id": "libgomp@4.4.7-23.el6",
                 "info": Object {
                   "name": "libgomp",
-                  "purl": "pkg:rpm/libgomp@4.4.7-23.el6",
+                  "purl": "pkg:rpm/centos/libgomp@4.4.7-23.el6?distro=centos-6",
                   "version": "4.4.7-23.el6",
                 },
               },
@@ -2262,7 +2262,7 @@ Object {
                 "id": "libgpg-error@1.7-4.el6",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.7-4.el6",
+                  "purl": "pkg:rpm/centos/libgpg-error@1.7-4.el6?distro=centos-6",
                   "version": "1.7-4.el6",
                 },
               },
@@ -2270,7 +2270,7 @@ Object {
                 "id": "libidn@1.18-2.el6",
                 "info": Object {
                   "name": "libidn",
-                  "purl": "pkg:rpm/libidn@1.18-2.el6",
+                  "purl": "pkg:rpm/centos/libidn@1.18-2.el6?distro=centos-6",
                   "version": "1.18-2.el6",
                 },
               },
@@ -2278,7 +2278,7 @@ Object {
                 "id": "libnih@1.0.1-8.el6",
                 "info": Object {
                   "name": "libnih",
-                  "purl": "pkg:rpm/libnih@1.0.1-8.el6",
+                  "purl": "pkg:rpm/centos/libnih@1.0.1-8.el6?distro=centos-6",
                   "version": "1.0.1-8.el6",
                 },
               },
@@ -2286,7 +2286,7 @@ Object {
                 "id": "libpcap@14:1.4.0-4.20130826git2dbcaa1.el6",
                 "info": Object {
                   "name": "libpcap",
-                  "purl": "pkg:rpm/libpcap@14:1.4.0-4.20130826git2dbcaa1.el6?epoch=14",
+                  "purl": "pkg:rpm/centos/libpcap@14:1.4.0-4.20130826git2dbcaa1.el6?distro=centos-6&epoch=14",
                   "version": "14:1.4.0-4.20130826git2dbcaa1.el6",
                 },
               },
@@ -2294,7 +2294,7 @@ Object {
                 "id": "libpciaccess@0.13.4-1.el6",
                 "info": Object {
                   "name": "libpciaccess",
-                  "purl": "pkg:rpm/libpciaccess@0.13.4-1.el6",
+                  "purl": "pkg:rpm/centos/libpciaccess@0.13.4-1.el6?distro=centos-6",
                   "version": "0.13.4-1.el6",
                 },
               },
@@ -2302,7 +2302,7 @@ Object {
                 "id": "libselinux@2.0.94-7.el6",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.0.94-7.el6",
+                  "purl": "pkg:rpm/centos/libselinux@2.0.94-7.el6?distro=centos-6",
                   "version": "2.0.94-7.el6",
                 },
               },
@@ -2310,7 +2310,7 @@ Object {
                 "id": "libselinux-utils@2.0.94-7.el6",
                 "info": Object {
                   "name": "libselinux-utils",
-                  "purl": "pkg:rpm/libselinux-utils@2.0.94-7.el6",
+                  "purl": "pkg:rpm/centos/libselinux-utils@2.0.94-7.el6?distro=centos-6",
                   "version": "2.0.94-7.el6",
                 },
               },
@@ -2318,7 +2318,7 @@ Object {
                 "id": "libsemanage@2.0.43-5.1.el6",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.0.43-5.1.el6",
+                  "purl": "pkg:rpm/centos/libsemanage@2.0.43-5.1.el6?distro=centos-6",
                   "version": "2.0.43-5.1.el6",
                 },
               },
@@ -2326,7 +2326,7 @@ Object {
                 "id": "libsepol@2.0.41-4.el6",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.0.41-4.el6",
+                  "purl": "pkg:rpm/centos/libsepol@2.0.41-4.el6?distro=centos-6",
                   "version": "2.0.41-4.el6",
                 },
               },
@@ -2334,7 +2334,7 @@ Object {
                 "id": "libssh2@1.4.2-2.el6_7.1",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.4.2-2.el6_7.1",
+                  "purl": "pkg:rpm/centos/libssh2@1.4.2-2.el6_7.1?distro=centos-6",
                   "version": "1.4.2-2.el6_7.1",
                 },
               },
@@ -2342,7 +2342,7 @@ Object {
                 "id": "libstdc++@4.4.7-23.el6",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@4.4.7-23.el6",
+                  "purl": "pkg:rpm/centos/libstdc%2B%2B@4.4.7-23.el6?distro=centos-6",
                   "version": "4.4.7-23.el6",
                 },
               },
@@ -2350,7 +2350,7 @@ Object {
                 "id": "libtasn1@2.3-6.el6_5",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@2.3-6.el6_5",
+                  "purl": "pkg:rpm/centos/libtasn1@2.3-6.el6_5?distro=centos-6",
                   "version": "2.3-6.el6_5",
                 },
               },
@@ -2358,7 +2358,7 @@ Object {
                 "id": "libusb@0.1.12-23.el6",
                 "info": Object {
                   "name": "libusb",
-                  "purl": "pkg:rpm/libusb@0.1.12-23.el6",
+                  "purl": "pkg:rpm/centos/libusb@0.1.12-23.el6?distro=centos-6",
                   "version": "0.1.12-23.el6",
                 },
               },
@@ -2366,7 +2366,7 @@ Object {
                 "id": "libuser@0.56.13-8.el6_7",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.56.13-8.el6_7",
+                  "purl": "pkg:rpm/centos/libuser@0.56.13-8.el6_7?distro=centos-6",
                   "version": "0.56.13-8.el6_7",
                 },
               },
@@ -2374,7 +2374,7 @@ Object {
                 "id": "libutempter@1.1.5-4.1.el6",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.5-4.1.el6",
+                  "purl": "pkg:rpm/centos/libutempter@1.1.5-4.1.el6?distro=centos-6",
                   "version": "1.1.5-4.1.el6",
                 },
               },
@@ -2382,7 +2382,7 @@ Object {
                 "id": "libuuid@2.17.2-12.28.el6_9.2",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.17.2-12.28.el6_9.2",
+                  "purl": "pkg:rpm/centos/libuuid@2.17.2-12.28.el6_9.2?distro=centos-6",
                   "version": "2.17.2-12.28.el6_9.2",
                 },
               },
@@ -2390,7 +2390,7 @@ Object {
                 "id": "libxml2@2.7.6-21.el6_8.1",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.7.6-21.el6_8.1",
+                  "purl": "pkg:rpm/centos/libxml2@2.7.6-21.el6_8.1?distro=centos-6",
                   "version": "2.7.6-21.el6_8.1",
                 },
               },
@@ -2398,7 +2398,7 @@ Object {
                 "id": "logrotate@3.7.8-28.el6",
                 "info": Object {
                   "name": "logrotate",
-                  "purl": "pkg:rpm/logrotate@3.7.8-28.el6",
+                  "purl": "pkg:rpm/centos/logrotate@3.7.8-28.el6?distro=centos-6",
                   "version": "3.7.8-28.el6",
                 },
               },
@@ -2406,7 +2406,7 @@ Object {
                 "id": "lsof@4.82-5.el6",
                 "info": Object {
                   "name": "lsof",
-                  "purl": "pkg:rpm/lsof@4.82-5.el6",
+                  "purl": "pkg:rpm/centos/lsof@4.82-5.el6?distro=centos-6",
                   "version": "4.82-5.el6",
                 },
               },
@@ -2414,7 +2414,7 @@ Object {
                 "id": "lua@5.1.4-4.1.el6",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-4.1.el6",
+                  "purl": "pkg:rpm/centos/lua@5.1.4-4.1.el6?distro=centos-6",
                   "version": "5.1.4-4.1.el6",
                 },
               },
@@ -2422,7 +2422,7 @@ Object {
                 "id": "m4@1.4.13-5.el6",
                 "info": Object {
                   "name": "m4",
-                  "purl": "pkg:rpm/m4@1.4.13-5.el6",
+                  "purl": "pkg:rpm/centos/m4@1.4.13-5.el6?distro=centos-6",
                   "version": "1.4.13-5.el6",
                 },
               },
@@ -2430,7 +2430,7 @@ Object {
                 "id": "mailx@12.4-10.el6_10",
                 "info": Object {
                   "name": "mailx",
-                  "purl": "pkg:rpm/mailx@12.4-10.el6_10",
+                  "purl": "pkg:rpm/centos/mailx@12.4-10.el6_10?distro=centos-6",
                   "version": "12.4-10.el6_10",
                 },
               },
@@ -2438,7 +2438,7 @@ Object {
                 "id": "make@1:3.81-23.el6",
                 "info": Object {
                   "name": "make",
-                  "purl": "pkg:rpm/make@1:3.81-23.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/make@1:3.81-23.el6?distro=centos-6&epoch=1",
                   "version": "1:3.81-23.el6",
                 },
               },
@@ -2446,7 +2446,7 @@ Object {
                 "id": "man@1.6f-39.el6",
                 "info": Object {
                   "name": "man",
-                  "purl": "pkg:rpm/man@1.6f-39.el6",
+                  "purl": "pkg:rpm/centos/man@1.6f-39.el6?distro=centos-6",
                   "version": "1.6f-39.el6",
                 },
               },
@@ -2454,7 +2454,7 @@ Object {
                 "id": "mingetty@1.08-5.el6",
                 "info": Object {
                   "name": "mingetty",
-                  "purl": "pkg:rpm/mingetty@1.08-5.el6",
+                  "purl": "pkg:rpm/centos/mingetty@1.08-5.el6?distro=centos-6",
                   "version": "1.08-5.el6",
                 },
               },
@@ -2462,7 +2462,7 @@ Object {
                 "id": "module-init-tools@3.9-26.el6",
                 "info": Object {
                   "name": "module-init-tools",
-                  "purl": "pkg:rpm/module-init-tools@3.9-26.el6",
+                  "purl": "pkg:rpm/centos/module-init-tools@3.9-26.el6?distro=centos-6",
                   "version": "3.9-26.el6",
                 },
               },
@@ -2470,7 +2470,7 @@ Object {
                 "id": "mysql-libs@5.1.73-8.el6_8",
                 "info": Object {
                   "name": "mysql-libs",
-                  "purl": "pkg:rpm/mysql-libs@5.1.73-8.el6_8",
+                  "purl": "pkg:rpm/centos/mysql-libs@5.1.73-8.el6_8?distro=centos-6",
                   "version": "5.1.73-8.el6_8",
                 },
               },
@@ -2478,7 +2478,7 @@ Object {
                 "id": "nc@1.84-24.el6",
                 "info": Object {
                   "name": "nc",
-                  "purl": "pkg:rpm/nc@1.84-24.el6",
+                  "purl": "pkg:rpm/centos/nc@1.84-24.el6?distro=centos-6",
                   "version": "1.84-24.el6",
                 },
               },
@@ -2486,7 +2486,7 @@ Object {
                 "id": "ncurses@5.7-4.20090207.el6",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@5.7-4.20090207.el6",
+                  "purl": "pkg:rpm/centos/ncurses@5.7-4.20090207.el6?distro=centos-6",
                   "version": "5.7-4.20090207.el6",
                 },
               },
@@ -2494,7 +2494,7 @@ Object {
                 "id": "ncurses-base@5.7-4.20090207.el6",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@5.7-4.20090207.el6",
+                  "purl": "pkg:rpm/centos/ncurses-base@5.7-4.20090207.el6?distro=centos-6",
                   "version": "5.7-4.20090207.el6",
                 },
               },
@@ -2502,7 +2502,7 @@ Object {
                 "id": "ncurses-libs@5.7-4.20090207.el6",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@5.7-4.20090207.el6",
+                  "purl": "pkg:rpm/centos/ncurses-libs@5.7-4.20090207.el6?distro=centos-6",
                   "version": "5.7-4.20090207.el6",
                 },
               },
@@ -2510,7 +2510,7 @@ Object {
                 "id": "net-tools@1.60-114.el6",
                 "info": Object {
                   "name": "net-tools",
-                  "purl": "pkg:rpm/net-tools@1.60-114.el6",
+                  "purl": "pkg:rpm/centos/net-tools@1.60-114.el6?distro=centos-6",
                   "version": "1.60-114.el6",
                 },
               },
@@ -2518,7 +2518,7 @@ Object {
                 "id": "nmap@2:5.51-6.el6",
                 "info": Object {
                   "name": "nmap",
-                  "purl": "pkg:rpm/nmap@2:5.51-6.el6?epoch=2",
+                  "purl": "pkg:rpm/centos/nmap@2:5.51-6.el6?distro=centos-6&epoch=2",
                   "version": "2:5.51-6.el6",
                 },
               },
@@ -2526,7 +2526,7 @@ Object {
                 "id": "nspr@4.19.0-1.el6",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.19.0-1.el6",
+                  "purl": "pkg:rpm/centos/nspr@4.19.0-1.el6?distro=centos-6",
                   "version": "4.19.0-1.el6",
                 },
               },
@@ -2534,7 +2534,7 @@ Object {
                 "id": "nss@3.36.0-8.el6",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.36.0-8.el6",
+                  "purl": "pkg:rpm/centos/nss@3.36.0-8.el6?distro=centos-6",
                   "version": "3.36.0-8.el6",
                 },
               },
@@ -2542,7 +2542,7 @@ Object {
                 "id": "nss-softokn@3.14.3-23.3.el6_8",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.14.3-23.3.el6_8",
+                  "purl": "pkg:rpm/centos/nss-softokn@3.14.3-23.3.el6_8?distro=centos-6",
                   "version": "3.14.3-23.3.el6_8",
                 },
               },
@@ -2550,7 +2550,7 @@ Object {
                 "id": "nss-softokn-freebl@3.14.3-23.3.el6_8",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.14.3-23.3.el6_8",
+                  "purl": "pkg:rpm/centos/nss-softokn-freebl@3.14.3-23.3.el6_8?distro=centos-6",
                   "version": "3.14.3-23.3.el6_8",
                 },
               },
@@ -2558,7 +2558,7 @@ Object {
                 "id": "nss-sysinit@3.36.0-8.el6",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.36.0-8.el6",
+                  "purl": "pkg:rpm/centos/nss-sysinit@3.36.0-8.el6?distro=centos-6",
                   "version": "3.36.0-8.el6",
                 },
               },
@@ -2566,7 +2566,7 @@ Object {
                 "id": "nss-tools@3.36.0-8.el6",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.36.0-8.el6",
+                  "purl": "pkg:rpm/centos/nss-tools@3.36.0-8.el6?distro=centos-6",
                   "version": "3.36.0-8.el6",
                 },
               },
@@ -2574,7 +2574,7 @@ Object {
                 "id": "nss-util@3.36.0-1.el6",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.36.0-1.el6",
+                  "purl": "pkg:rpm/centos/nss-util@3.36.0-1.el6?distro=centos-6",
                   "version": "3.36.0-1.el6",
                 },
               },
@@ -2582,7 +2582,7 @@ Object {
                 "id": "openldap@2.4.40-16.el6",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.40-16.el6",
+                  "purl": "pkg:rpm/centos/openldap@2.4.40-16.el6?distro=centos-6",
                   "version": "2.4.40-16.el6",
                 },
               },
@@ -2590,7 +2590,7 @@ Object {
                 "id": "openssl@1.0.1e-58.el6_10",
                 "info": Object {
                   "name": "openssl",
-                  "purl": "pkg:rpm/openssl@1.0.1e-58.el6_10",
+                  "purl": "pkg:rpm/centos/openssl@1.0.1e-58.el6_10?distro=centos-6",
                   "version": "1.0.1e-58.el6_10",
                 },
               },
@@ -2598,7 +2598,7 @@ Object {
                 "id": "p11-kit@0.18.5-2.el6_5.2",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.18.5-2.el6_5.2",
+                  "purl": "pkg:rpm/centos/p11-kit@0.18.5-2.el6_5.2?distro=centos-6",
                   "version": "0.18.5-2.el6_5.2",
                 },
               },
@@ -2606,7 +2606,7 @@ Object {
                 "id": "p11-kit-trust@0.18.5-2.el6_5.2",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.18.5-2.el6_5.2",
+                  "purl": "pkg:rpm/centos/p11-kit-trust@0.18.5-2.el6_5.2?distro=centos-6",
                   "version": "0.18.5-2.el6_5.2",
                 },
               },
@@ -2614,7 +2614,7 @@ Object {
                 "id": "pam@1.1.1-24.el6",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.1.1-24.el6",
+                  "purl": "pkg:rpm/centos/pam@1.1.1-24.el6?distro=centos-6",
                   "version": "1.1.1-24.el6",
                 },
               },
@@ -2622,7 +2622,7 @@ Object {
                 "id": "passwd@0.77-7.el6",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.77-7.el6",
+                  "purl": "pkg:rpm/centos/passwd@0.77-7.el6?distro=centos-6",
                   "version": "0.77-7.el6",
                 },
               },
@@ -2630,7 +2630,7 @@ Object {
                 "id": "patch@2.6-8.el6_9",
                 "info": Object {
                   "name": "patch",
-                  "purl": "pkg:rpm/patch@2.6-8.el6_9",
+                  "purl": "pkg:rpm/centos/patch@2.6-8.el6_9?distro=centos-6",
                   "version": "2.6-8.el6_9",
                 },
               },
@@ -2638,7 +2638,7 @@ Object {
                 "id": "pax@3.4-10.1.el6",
                 "info": Object {
                   "name": "pax",
-                  "purl": "pkg:rpm/pax@3.4-10.1.el6",
+                  "purl": "pkg:rpm/centos/pax@3.4-10.1.el6?distro=centos-6",
                   "version": "3.4-10.1.el6",
                 },
               },
@@ -2646,7 +2646,7 @@ Object {
                 "id": "pcre@7.8-7.el6",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@7.8-7.el6",
+                  "purl": "pkg:rpm/centos/pcre@7.8-7.el6?distro=centos-6",
                   "version": "7.8-7.el6",
                 },
               },
@@ -2654,7 +2654,7 @@ Object {
                 "id": "perl@4:5.10.1-144.el6",
                 "info": Object {
                   "name": "perl",
-                  "purl": "pkg:rpm/perl@4:5.10.1-144.el6?epoch=4",
+                  "purl": "pkg:rpm/centos/perl@4:5.10.1-144.el6?distro=centos-6&epoch=4",
                   "version": "4:5.10.1-144.el6",
                 },
               },
@@ -2662,7 +2662,7 @@ Object {
                 "id": "perl-CGI@3.51-144.el6",
                 "info": Object {
                   "name": "perl-CGI",
-                  "purl": "pkg:rpm/perl-CGI@3.51-144.el6",
+                  "purl": "pkg:rpm/centos/perl-CGI@3.51-144.el6?distro=centos-6",
                   "version": "3.51-144.el6",
                 },
               },
@@ -2670,7 +2670,7 @@ Object {
                 "id": "perl-ExtUtils-MakeMaker@6.55-144.el6",
                 "info": Object {
                   "name": "perl-ExtUtils-MakeMaker",
-                  "purl": "pkg:rpm/perl-ExtUtils-MakeMaker@6.55-144.el6",
+                  "purl": "pkg:rpm/centos/perl-ExtUtils-MakeMaker@6.55-144.el6?distro=centos-6",
                   "version": "6.55-144.el6",
                 },
               },
@@ -2678,7 +2678,7 @@ Object {
                 "id": "perl-ExtUtils-ParseXS@1:2.2003.0-144.el6",
                 "info": Object {
                   "name": "perl-ExtUtils-ParseXS",
-                  "purl": "pkg:rpm/perl-ExtUtils-ParseXS@1:2.2003.0-144.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/perl-ExtUtils-ParseXS@1:2.2003.0-144.el6?distro=centos-6&epoch=1",
                   "version": "1:2.2003.0-144.el6",
                 },
               },
@@ -2686,7 +2686,7 @@ Object {
                 "id": "perl-Module-Pluggable@1:3.90-144.el6",
                 "info": Object {
                   "name": "perl-Module-Pluggable",
-                  "purl": "pkg:rpm/perl-Module-Pluggable@1:3.90-144.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/perl-Module-Pluggable@1:3.90-144.el6?distro=centos-6&epoch=1",
                   "version": "1:3.90-144.el6",
                 },
               },
@@ -2694,7 +2694,7 @@ Object {
                 "id": "perl-Pod-Escapes@1:1.04-144.el6",
                 "info": Object {
                   "name": "perl-Pod-Escapes",
-                  "purl": "pkg:rpm/perl-Pod-Escapes@1:1.04-144.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/perl-Pod-Escapes@1:1.04-144.el6?distro=centos-6&epoch=1",
                   "version": "1:1.04-144.el6",
                 },
               },
@@ -2702,7 +2702,7 @@ Object {
                 "id": "perl-Pod-Simple@1:3.13-144.el6",
                 "info": Object {
                   "name": "perl-Pod-Simple",
-                  "purl": "pkg:rpm/perl-Pod-Simple@1:3.13-144.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/perl-Pod-Simple@1:3.13-144.el6?distro=centos-6&epoch=1",
                   "version": "1:3.13-144.el6",
                 },
               },
@@ -2710,7 +2710,7 @@ Object {
                 "id": "perl-Test-Harness@3.17-144.el6",
                 "info": Object {
                   "name": "perl-Test-Harness",
-                  "purl": "pkg:rpm/perl-Test-Harness@3.17-144.el6",
+                  "purl": "pkg:rpm/centos/perl-Test-Harness@3.17-144.el6?distro=centos-6",
                   "version": "3.17-144.el6",
                 },
               },
@@ -2718,7 +2718,7 @@ Object {
                 "id": "perl-Test-Simple@0.92-144.el6",
                 "info": Object {
                   "name": "perl-Test-Simple",
-                  "purl": "pkg:rpm/perl-Test-Simple@0.92-144.el6",
+                  "purl": "pkg:rpm/centos/perl-Test-Simple@0.92-144.el6?distro=centos-6",
                   "version": "0.92-144.el6",
                 },
               },
@@ -2726,7 +2726,7 @@ Object {
                 "id": "perl-devel@4:5.10.1-144.el6",
                 "info": Object {
                   "name": "perl-devel",
-                  "purl": "pkg:rpm/perl-devel@4:5.10.1-144.el6?epoch=4",
+                  "purl": "pkg:rpm/centos/perl-devel@4:5.10.1-144.el6?distro=centos-6&epoch=4",
                   "version": "4:5.10.1-144.el6",
                 },
               },
@@ -2734,7 +2734,7 @@ Object {
                 "id": "perl-libs@4:5.10.1-144.el6",
                 "info": Object {
                   "name": "perl-libs",
-                  "purl": "pkg:rpm/perl-libs@4:5.10.1-144.el6?epoch=4",
+                  "purl": "pkg:rpm/centos/perl-libs@4:5.10.1-144.el6?distro=centos-6&epoch=4",
                   "version": "4:5.10.1-144.el6",
                 },
               },
@@ -2742,7 +2742,7 @@ Object {
                 "id": "perl-version@3:0.77-144.el6",
                 "info": Object {
                   "name": "perl-version",
-                  "purl": "pkg:rpm/perl-version@3:0.77-144.el6?epoch=3",
+                  "purl": "pkg:rpm/centos/perl-version@3:0.77-144.el6?distro=centos-6&epoch=3",
                   "version": "3:0.77-144.el6",
                 },
               },
@@ -2750,7 +2750,7 @@ Object {
                 "id": "pinentry@0.7.6-8.el6",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.7.6-8.el6",
+                  "purl": "pkg:rpm/centos/pinentry@0.7.6-8.el6?distro=centos-6",
                   "version": "0.7.6-8.el6",
                 },
               },
@@ -2758,7 +2758,7 @@ Object {
                 "id": "pkgconfig@1:0.23-9.1.el6",
                 "info": Object {
                   "name": "pkgconfig",
-                  "purl": "pkg:rpm/pkgconfig@1:0.23-9.1.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/pkgconfig@1:0.23-9.1.el6?distro=centos-6&epoch=1",
                   "version": "1:0.23-9.1.el6",
                 },
               },
@@ -2766,7 +2766,7 @@ Object {
                 "id": "plymouth@0.8.3-29.el6.centos",
                 "info": Object {
                   "name": "plymouth",
-                  "purl": "pkg:rpm/plymouth@0.8.3-29.el6.centos",
+                  "purl": "pkg:rpm/centos/plymouth@0.8.3-29.el6.centos?distro=centos-6",
                   "version": "0.8.3-29.el6.centos",
                 },
               },
@@ -2774,7 +2774,7 @@ Object {
                 "id": "plymouth-core-libs@0.8.3-29.el6.centos",
                 "info": Object {
                   "name": "plymouth-core-libs",
-                  "purl": "pkg:rpm/plymouth-core-libs@0.8.3-29.el6.centos",
+                  "purl": "pkg:rpm/centos/plymouth-core-libs@0.8.3-29.el6.centos?distro=centos-6",
                   "version": "0.8.3-29.el6.centos",
                 },
               },
@@ -2782,7 +2782,7 @@ Object {
                 "id": "plymouth-scripts@0.8.3-29.el6.centos",
                 "info": Object {
                   "name": "plymouth-scripts",
-                  "purl": "pkg:rpm/plymouth-scripts@0.8.3-29.el6.centos",
+                  "purl": "pkg:rpm/centos/plymouth-scripts@0.8.3-29.el6.centos?distro=centos-6",
                   "version": "0.8.3-29.el6.centos",
                 },
               },
@@ -2790,7 +2790,7 @@ Object {
                 "id": "policycoreutils@2.0.83-30.1.el6_8",
                 "info": Object {
                   "name": "policycoreutils",
-                  "purl": "pkg:rpm/policycoreutils@2.0.83-30.1.el6_8",
+                  "purl": "pkg:rpm/centos/policycoreutils@2.0.83-30.1.el6_8?distro=centos-6",
                   "version": "2.0.83-30.1.el6_8",
                 },
               },
@@ -2798,7 +2798,7 @@ Object {
                 "id": "popt@1.13-7.el6",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-7.el6",
+                  "purl": "pkg:rpm/centos/popt@1.13-7.el6?distro=centos-6",
                   "version": "1.13-7.el6",
                 },
               },
@@ -2806,7 +2806,7 @@ Object {
                 "id": "postfix@2:2.6.6-8.el6",
                 "info": Object {
                   "name": "postfix",
-                  "purl": "pkg:rpm/postfix@2:2.6.6-8.el6?epoch=2",
+                  "purl": "pkg:rpm/centos/postfix@2:2.6.6-8.el6?distro=centos-6&epoch=2",
                   "version": "2:2.6.6-8.el6",
                 },
               },
@@ -2814,7 +2814,7 @@ Object {
                 "id": "procps@3.2.8-45.el6_9.3",
                 "info": Object {
                   "name": "procps",
-                  "purl": "pkg:rpm/procps@3.2.8-45.el6_9.3",
+                  "purl": "pkg:rpm/centos/procps@3.2.8-45.el6_9.3?distro=centos-6",
                   "version": "3.2.8-45.el6_9.3",
                 },
               },
@@ -2822,7 +2822,7 @@ Object {
                 "id": "psmisc@22.6-24.el6",
                 "info": Object {
                   "name": "psmisc",
-                  "purl": "pkg:rpm/psmisc@22.6-24.el6",
+                  "purl": "pkg:rpm/centos/psmisc@22.6-24.el6?distro=centos-6",
                   "version": "22.6-24.el6",
                 },
               },
@@ -2830,7 +2830,7 @@ Object {
                 "id": "pth@2.0.7-9.3.el6",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-9.3.el6",
+                  "purl": "pkg:rpm/centos/pth@2.0.7-9.3.el6?distro=centos-6",
                   "version": "2.0.7-9.3.el6",
                 },
               },
@@ -2838,7 +2838,7 @@ Object {
                 "id": "pygpgme@0.1-18.20090824bzr68.el6",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.1-18.20090824bzr68.el6",
+                  "purl": "pkg:rpm/centos/pygpgme@0.1-18.20090824bzr68.el6?distro=centos-6",
                   "version": "0.1-18.20090824bzr68.el6",
                 },
               },
@@ -2846,7 +2846,7 @@ Object {
                 "id": "python@2.6.6-66.el6_8",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.6.6-66.el6_8",
+                  "purl": "pkg:rpm/centos/python@2.6.6-66.el6_8?distro=centos-6",
                   "version": "2.6.6-66.el6_8",
                 },
               },
@@ -2854,7 +2854,7 @@ Object {
                 "id": "python-iniparse@0.3.1-2.1.el6",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.3.1-2.1.el6",
+                  "purl": "pkg:rpm/centos/python-iniparse@0.3.1-2.1.el6?distro=centos-6",
                   "version": "0.3.1-2.1.el6",
                 },
               },
@@ -2862,7 +2862,7 @@ Object {
                 "id": "python-libs@2.6.6-66.el6_8",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.6.6-66.el6_8",
+                  "purl": "pkg:rpm/centos/python-libs@2.6.6-66.el6_8?distro=centos-6",
                   "version": "2.6.6-66.el6_8",
                 },
               },
@@ -2870,7 +2870,7 @@ Object {
                 "id": "python-pycurl@7.19.0-9.el6",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-9.el6",
+                  "purl": "pkg:rpm/centos/python-pycurl@7.19.0-9.el6?distro=centos-6",
                   "version": "7.19.0-9.el6",
                 },
               },
@@ -2878,7 +2878,7 @@ Object {
                 "id": "python-urlgrabber@3.9.1-11.el6",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.9.1-11.el6",
+                  "purl": "pkg:rpm/centos/python-urlgrabber@3.9.1-11.el6?distro=centos-6",
                   "version": "3.9.1-11.el6",
                 },
               },
@@ -2886,7 +2886,7 @@ Object {
                 "id": "readline@6.0-4.el6",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.0-4.el6",
+                  "purl": "pkg:rpm/centos/readline@6.0-4.el6?distro=centos-6",
                   "version": "6.0-4.el6",
                 },
               },
@@ -2894,7 +2894,7 @@ Object {
                 "id": "redhat-logos@60.0.14-12.el6.centos",
                 "info": Object {
                   "name": "redhat-logos",
-                  "purl": "pkg:rpm/redhat-logos@60.0.14-12.el6.centos",
+                  "purl": "pkg:rpm/centos/redhat-logos@60.0.14-12.el6.centos?distro=centos-6",
                   "version": "60.0.14-12.el6.centos",
                 },
               },
@@ -2902,7 +2902,7 @@ Object {
                 "id": "redhat-lsb-core@4.0-7.el6.centos",
                 "info": Object {
                   "name": "redhat-lsb-core",
-                  "purl": "pkg:rpm/redhat-lsb-core@4.0-7.el6.centos",
+                  "purl": "pkg:rpm/centos/redhat-lsb-core@4.0-7.el6.centos?distro=centos-6",
                   "version": "4.0-7.el6.centos",
                 },
               },
@@ -2910,7 +2910,7 @@ Object {
                 "id": "rootfiles@8.1-6.1.el6",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-6.1.el6",
+                  "purl": "pkg:rpm/centos/rootfiles@8.1-6.1.el6?distro=centos-6",
                   "version": "8.1-6.1.el6",
                 },
               },
@@ -2918,7 +2918,7 @@ Object {
                 "id": "rpm@4.8.0-59.el6",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.8.0-59.el6",
+                  "purl": "pkg:rpm/centos/rpm@4.8.0-59.el6?distro=centos-6",
                   "version": "4.8.0-59.el6",
                 },
               },
@@ -2926,7 +2926,7 @@ Object {
                 "id": "rpm-libs@4.8.0-59.el6",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.8.0-59.el6",
+                  "purl": "pkg:rpm/centos/rpm-libs@4.8.0-59.el6?distro=centos-6",
                   "version": "4.8.0-59.el6",
                 },
               },
@@ -2934,7 +2934,7 @@ Object {
                 "id": "rpm-python@4.8.0-59.el6",
                 "info": Object {
                   "name": "rpm-python",
-                  "purl": "pkg:rpm/rpm-python@4.8.0-59.el6",
+                  "purl": "pkg:rpm/centos/rpm-python@4.8.0-59.el6?distro=centos-6",
                   "version": "4.8.0-59.el6",
                 },
               },
@@ -2942,7 +2942,7 @@ Object {
                 "id": "rsyslog@5.8.10-12.el6",
                 "info": Object {
                   "name": "rsyslog",
-                  "purl": "pkg:rpm/rsyslog@5.8.10-12.el6",
+                  "purl": "pkg:rpm/centos/rsyslog@5.8.10-12.el6?distro=centos-6",
                   "version": "5.8.10-12.el6",
                 },
               },
@@ -2950,7 +2950,7 @@ Object {
                 "id": "sed@4.2.1-10.el6",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.1-10.el6",
+                  "purl": "pkg:rpm/centos/sed@4.2.1-10.el6?distro=centos-6",
                   "version": "4.2.1-10.el6",
                 },
               },
@@ -2958,7 +2958,7 @@ Object {
                 "id": "setup@2.8.14-23.el6",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.14-23.el6",
+                  "purl": "pkg:rpm/centos/setup@2.8.14-23.el6?distro=centos-6",
                   "version": "2.8.14-23.el6",
                 },
               },
@@ -2966,7 +2966,7 @@ Object {
                 "id": "shadow-utils@2:4.1.5.1-5.el6",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.1.5.1-5.el6?epoch=2",
+                  "purl": "pkg:rpm/centos/shadow-utils@2:4.1.5.1-5.el6?distro=centos-6&epoch=2",
                   "version": "2:4.1.5.1-5.el6",
                 },
               },
@@ -2974,7 +2974,7 @@ Object {
                 "id": "shared-mime-info@0.70-6.el6",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@0.70-6.el6",
+                  "purl": "pkg:rpm/centos/shared-mime-info@0.70-6.el6?distro=centos-6",
                   "version": "0.70-6.el6",
                 },
               },
@@ -2982,7 +2982,7 @@ Object {
                 "id": "sqlite@3.6.20-1.el6_7.2",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.6.20-1.el6_7.2",
+                  "purl": "pkg:rpm/centos/sqlite@3.6.20-1.el6_7.2?distro=centos-6",
                   "version": "3.6.20-1.el6_7.2",
                 },
               },
@@ -2990,7 +2990,7 @@ Object {
                 "id": "strace@4.8-11.el6",
                 "info": Object {
                   "name": "strace",
-                  "purl": "pkg:rpm/strace@4.8-11.el6",
+                  "purl": "pkg:rpm/centos/strace@4.8-11.el6?distro=centos-6",
                   "version": "4.8-11.el6",
                 },
               },
@@ -2998,7 +2998,7 @@ Object {
                 "id": "sudo@1.8.6p3-29.el6_10.3",
                 "info": Object {
                   "name": "sudo",
-                  "purl": "pkg:rpm/sudo@1.8.6p3-29.el6_10.3",
+                  "purl": "pkg:rpm/centos/sudo@1.8.6p3-29.el6_10.3?distro=centos-6",
                   "version": "1.8.6p3-29.el6_10.3",
                 },
               },
@@ -3006,7 +3006,7 @@ Object {
                 "id": "sysvinit-tools@2.87-6.dsf.el6",
                 "info": Object {
                   "name": "sysvinit-tools",
-                  "purl": "pkg:rpm/sysvinit-tools@2.87-6.dsf.el6",
+                  "purl": "pkg:rpm/centos/sysvinit-tools@2.87-6.dsf.el6?distro=centos-6",
                   "version": "2.87-6.dsf.el6",
                 },
               },
@@ -3014,7 +3014,7 @@ Object {
                 "id": "tar@2:1.23-15.el6_8",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.23-15.el6_8?epoch=2",
+                  "purl": "pkg:rpm/centos/tar@2:1.23-15.el6_8?distro=centos-6&epoch=2",
                   "version": "2:1.23-15.el6_8",
                 },
               },
@@ -3022,7 +3022,7 @@ Object {
                 "id": "tcpdump@14:4.0.0-11.20090921gitdf3cb4.2.el6",
                 "info": Object {
                   "name": "tcpdump",
-                  "purl": "pkg:rpm/tcpdump@14:4.0.0-11.20090921gitdf3cb4.2.el6?epoch=14",
+                  "purl": "pkg:rpm/centos/tcpdump@14:4.0.0-11.20090921gitdf3cb4.2.el6?distro=centos-6&epoch=14",
                   "version": "14:4.0.0-11.20090921gitdf3cb4.2.el6",
                 },
               },
@@ -3030,7 +3030,7 @@ Object {
                 "id": "telnet@1:0.17-49.el6_10",
                 "info": Object {
                   "name": "telnet",
-                  "purl": "pkg:rpm/telnet@1:0.17-49.el6_10?epoch=1",
+                  "purl": "pkg:rpm/centos/telnet@1:0.17-49.el6_10?distro=centos-6&epoch=1",
                   "version": "1:0.17-49.el6_10",
                 },
               },
@@ -3038,7 +3038,7 @@ Object {
                 "id": "time@1.7-38.el6",
                 "info": Object {
                   "name": "time",
-                  "purl": "pkg:rpm/time@1.7-38.el6",
+                  "purl": "pkg:rpm/centos/time@1.7-38.el6?distro=centos-6",
                   "version": "1.7-38.el6",
                 },
               },
@@ -3046,7 +3046,7 @@ Object {
                 "id": "tzdata@2018e-3.el6",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2018e-3.el6",
+                  "purl": "pkg:rpm/centos/tzdata@2018e-3.el6?distro=centos-6",
                   "version": "2018e-3.el6",
                 },
               },
@@ -3054,7 +3054,7 @@ Object {
                 "id": "udev@147-2.74.el6_10",
                 "info": Object {
                   "name": "udev",
-                  "purl": "pkg:rpm/udev@147-2.74.el6_10",
+                  "purl": "pkg:rpm/centos/udev@147-2.74.el6_10?distro=centos-6",
                   "version": "147-2.74.el6_10",
                 },
               },
@@ -3062,7 +3062,7 @@ Object {
                 "id": "upstart@0.6.5-17.el6",
                 "info": Object {
                   "name": "upstart",
-                  "purl": "pkg:rpm/upstart@0.6.5-17.el6",
+                  "purl": "pkg:rpm/centos/upstart@0.6.5-17.el6?distro=centos-6",
                   "version": "0.6.5-17.el6",
                 },
               },
@@ -3070,7 +3070,7 @@ Object {
                 "id": "ustr@1.0.4-9.1.el6",
                 "info": Object {
                   "name": "ustr",
-                  "purl": "pkg:rpm/ustr@1.0.4-9.1.el6",
+                  "purl": "pkg:rpm/centos/ustr@1.0.4-9.1.el6?distro=centos-6",
                   "version": "1.0.4-9.1.el6",
                 },
               },
@@ -3078,7 +3078,7 @@ Object {
                 "id": "util-linux-ng@2.17.2-12.28.el6_9.2",
                 "info": Object {
                   "name": "util-linux-ng",
-                  "purl": "pkg:rpm/util-linux-ng@2.17.2-12.28.el6_9.2",
+                  "purl": "pkg:rpm/centos/util-linux-ng@2.17.2-12.28.el6_9.2?distro=centos-6",
                   "version": "2.17.2-12.28.el6_9.2",
                 },
               },
@@ -3086,7 +3086,7 @@ Object {
                 "id": "vim-minimal@2:7.4.629-5.el6_10.2",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:7.4.629-5.el6_10.2?epoch=2",
+                  "purl": "pkg:rpm/centos/vim-minimal@2:7.4.629-5.el6_10.2?distro=centos-6&epoch=2",
                   "version": "2:7.4.629-5.el6_10.2",
                 },
               },
@@ -3094,7 +3094,7 @@ Object {
                 "id": "wget@1.12-10.el6",
                 "info": Object {
                   "name": "wget",
-                  "purl": "pkg:rpm/wget@1.12-10.el6",
+                  "purl": "pkg:rpm/centos/wget@1.12-10.el6?distro=centos-6",
                   "version": "1.12-10.el6",
                 },
               },
@@ -3102,7 +3102,7 @@ Object {
                 "id": "which@2.19-6.el6",
                 "info": Object {
                   "name": "which",
-                  "purl": "pkg:rpm/which@2.19-6.el6",
+                  "purl": "pkg:rpm/centos/which@2.19-6.el6?distro=centos-6",
                   "version": "2.19-6.el6",
                 },
               },
@@ -3110,7 +3110,7 @@ Object {
                 "id": "xz@4.999.9-0.5.beta.20091007git.el6",
                 "info": Object {
                   "name": "xz",
-                  "purl": "pkg:rpm/xz@4.999.9-0.5.beta.20091007git.el6",
+                  "purl": "pkg:rpm/centos/xz@4.999.9-0.5.beta.20091007git.el6?distro=centos-6",
                   "version": "4.999.9-0.5.beta.20091007git.el6",
                 },
               },
@@ -3118,7 +3118,7 @@ Object {
                 "id": "xz-libs@4.999.9-0.5.beta.20091007git.el6",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@4.999.9-0.5.beta.20091007git.el6",
+                  "purl": "pkg:rpm/centos/xz-libs@4.999.9-0.5.beta.20091007git.el6?distro=centos-6",
                   "version": "4.999.9-0.5.beta.20091007git.el6",
                 },
               },
@@ -3126,7 +3126,7 @@ Object {
                 "id": "xz-lzma-compat@4.999.9-0.5.beta.20091007git.el6",
                 "info": Object {
                   "name": "xz-lzma-compat",
-                  "purl": "pkg:rpm/xz-lzma-compat@4.999.9-0.5.beta.20091007git.el6",
+                  "purl": "pkg:rpm/centos/xz-lzma-compat@4.999.9-0.5.beta.20091007git.el6?distro=centos-6",
                   "version": "4.999.9-0.5.beta.20091007git.el6",
                 },
               },
@@ -3134,7 +3134,7 @@ Object {
                 "id": "yum@3.2.29-81.el6.centos",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.2.29-81.el6.centos",
+                  "purl": "pkg:rpm/centos/yum@3.2.29-81.el6.centos?distro=centos-6",
                   "version": "3.2.29-81.el6.centos",
                 },
               },
@@ -3142,7 +3142,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.2-16.el6",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.2-16.el6",
+                  "purl": "pkg:rpm/centos/yum-metadata-parser@1.1.2-16.el6?distro=centos-6",
                   "version": "1.1.2-16.el6",
                 },
               },
@@ -3150,7 +3150,7 @@ Object {
                 "id": "yum-plugin-fastestmirror@1.1.30-42.el6_10",
                 "info": Object {
                   "name": "yum-plugin-fastestmirror",
-                  "purl": "pkg:rpm/yum-plugin-fastestmirror@1.1.30-42.el6_10",
+                  "purl": "pkg:rpm/centos/yum-plugin-fastestmirror@1.1.30-42.el6_10?distro=centos-6",
                   "version": "1.1.30-42.el6_10",
                 },
               },
@@ -3158,7 +3158,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.30-42.el6_10",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.30-42.el6_10",
+                  "purl": "pkg:rpm/centos/yum-plugin-ovl@1.1.30-42.el6_10?distro=centos-6",
                   "version": "1.1.30-42.el6_10",
                 },
               },
@@ -3166,7 +3166,7 @@ Object {
                 "id": "zlib@1.2.3-29.el6",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.3-29.el6",
+                  "purl": "pkg:rpm/centos/zlib@1.2.3-29.el6?distro=centos-6",
                   "version": "1.2.3-29.el6",
                 },
               },
@@ -4846,7 +4846,7 @@ Object {
                 "id": "MAKEDEV@3.24-6.el6",
                 "info": Object {
                   "name": "MAKEDEV",
-                  "purl": "pkg:rpm/MAKEDEV@3.24-6.el6",
+                  "purl": "pkg:rpm/centos/MAKEDEV@3.24-6.el6?distro=centos-6",
                   "version": "3.24-6.el6",
                 },
               },
@@ -4854,7 +4854,7 @@ Object {
                 "id": "at@3.1.10-49.el6",
                 "info": Object {
                   "name": "at",
-                  "purl": "pkg:rpm/at@3.1.10-49.el6",
+                  "purl": "pkg:rpm/centos/at@3.1.10-49.el6?distro=centos-6",
                   "version": "3.1.10-49.el6",
                 },
               },
@@ -4862,7 +4862,7 @@ Object {
                 "id": "audit-libs@2.4.5-6.el6",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@2.4.5-6.el6",
+                  "purl": "pkg:rpm/centos/audit-libs@2.4.5-6.el6?distro=centos-6",
                   "version": "2.4.5-6.el6",
                 },
               },
@@ -4870,7 +4870,7 @@ Object {
                 "id": "basesystem@10.0-4.el6",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-4.el6",
+                  "purl": "pkg:rpm/centos/basesystem@10.0-4.el6?distro=centos-6",
                   "version": "10.0-4.el6",
                 },
               },
@@ -4878,7 +4878,7 @@ Object {
                 "id": "bash@4.1.2-48.el6",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.1.2-48.el6",
+                  "purl": "pkg:rpm/centos/bash@4.1.2-48.el6?distro=centos-6",
                   "version": "4.1.2-48.el6",
                 },
               },
@@ -4886,7 +4886,7 @@ Object {
                 "id": "bc@1.06.95-1.el6",
                 "info": Object {
                   "name": "bc",
-                  "purl": "pkg:rpm/bc@1.06.95-1.el6",
+                  "purl": "pkg:rpm/centos/bc@1.06.95-1.el6?distro=centos-6",
                   "version": "1.06.95-1.el6",
                 },
               },
@@ -4894,7 +4894,7 @@ Object {
                 "id": "bind-libs@32:9.8.2-0.68.rc1.el6_10.1",
                 "info": Object {
                   "name": "bind-libs",
-                  "purl": "pkg:rpm/bind-libs@32:9.8.2-0.68.rc1.el6_10.1?epoch=32",
+                  "purl": "pkg:rpm/centos/bind-libs@32:9.8.2-0.68.rc1.el6_10.1?distro=centos-6&epoch=32",
                   "version": "32:9.8.2-0.68.rc1.el6_10.1",
                 },
               },
@@ -4902,7 +4902,7 @@ Object {
                 "id": "bind-utils@32:9.8.2-0.68.rc1.el6_10.1",
                 "info": Object {
                   "name": "bind-utils",
-                  "purl": "pkg:rpm/bind-utils@32:9.8.2-0.68.rc1.el6_10.1?epoch=32",
+                  "purl": "pkg:rpm/centos/bind-utils@32:9.8.2-0.68.rc1.el6_10.1?distro=centos-6&epoch=32",
                   "version": "32:9.8.2-0.68.rc1.el6_10.1",
                 },
               },
@@ -4910,7 +4910,7 @@ Object {
                 "id": "binutils@2.20.51.0.2-5.48.el6",
                 "info": Object {
                   "name": "binutils",
-                  "purl": "pkg:rpm/binutils@2.20.51.0.2-5.48.el6",
+                  "purl": "pkg:rpm/centos/binutils@2.20.51.0.2-5.48.el6?distro=centos-6",
                   "version": "2.20.51.0.2-5.48.el6",
                 },
               },
@@ -4918,7 +4918,7 @@ Object {
                 "id": "bzip2@1.0.5-7.el6_0",
                 "info": Object {
                   "name": "bzip2",
-                  "purl": "pkg:rpm/bzip2@1.0.5-7.el6_0",
+                  "purl": "pkg:rpm/centos/bzip2@1.0.5-7.el6_0?distro=centos-6",
                   "version": "1.0.5-7.el6_0",
                 },
               },
@@ -4926,7 +4926,7 @@ Object {
                 "id": "bzip2-libs@1.0.5-7.el6_0",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.5-7.el6_0",
+                  "purl": "pkg:rpm/centos/bzip2-libs@1.0.5-7.el6_0?distro=centos-6",
                   "version": "1.0.5-7.el6_0",
                 },
               },
@@ -4934,7 +4934,7 @@ Object {
                 "id": "ca-certificates@2020.2.41-65.1.el6_10",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2020.2.41-65.1.el6_10",
+                  "purl": "pkg:rpm/centos/ca-certificates@2020.2.41-65.1.el6_10?distro=centos-6",
                   "version": "2020.2.41-65.1.el6_10",
                 },
               },
@@ -4942,7 +4942,7 @@ Object {
                 "id": "centos-release@6-10.el6.centos.12.3",
                 "info": Object {
                   "name": "centos-release",
-                  "purl": "pkg:rpm/centos-release@6-10.el6.centos.12.3",
+                  "purl": "pkg:rpm/centos/centos-release@6-10.el6.centos.12.3?distro=centos-6",
                   "version": "6-10.el6.centos.12.3",
                 },
               },
@@ -4950,7 +4950,7 @@ Object {
                 "id": "checkpolicy@2.0.22-1.el6",
                 "info": Object {
                   "name": "checkpolicy",
-                  "purl": "pkg:rpm/checkpolicy@2.0.22-1.el6",
+                  "purl": "pkg:rpm/centos/checkpolicy@2.0.22-1.el6?distro=centos-6",
                   "version": "2.0.22-1.el6",
                 },
               },
@@ -4958,7 +4958,7 @@ Object {
                 "id": "chkconfig@1.3.49.5-1.el6",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.3.49.5-1.el6",
+                  "purl": "pkg:rpm/centos/chkconfig@1.3.49.5-1.el6?distro=centos-6",
                   "version": "1.3.49.5-1.el6",
                 },
               },
@@ -4966,7 +4966,7 @@ Object {
                 "id": "coreutils@8.4-47.el6",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.4-47.el6",
+                  "purl": "pkg:rpm/centos/coreutils@8.4-47.el6?distro=centos-6",
                   "version": "8.4-47.el6",
                 },
               },
@@ -4974,7 +4974,7 @@ Object {
                 "id": "coreutils-libs@8.4-47.el6",
                 "info": Object {
                   "name": "coreutils-libs",
-                  "purl": "pkg:rpm/coreutils-libs@8.4-47.el6",
+                  "purl": "pkg:rpm/centos/coreutils-libs@8.4-47.el6?distro=centos-6",
                   "version": "8.4-47.el6",
                 },
               },
@@ -4982,7 +4982,7 @@ Object {
                 "id": "cpio@2.10-13.el6",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.10-13.el6",
+                  "purl": "pkg:rpm/centos/cpio@2.10-13.el6?distro=centos-6",
                   "version": "2.10-13.el6",
                 },
               },
@@ -4990,7 +4990,7 @@ Object {
                 "id": "cracklib@2.8.16-4.el6",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.8.16-4.el6",
+                  "purl": "pkg:rpm/centos/cracklib@2.8.16-4.el6?distro=centos-6",
                   "version": "2.8.16-4.el6",
                 },
               },
@@ -4998,7 +4998,7 @@ Object {
                 "id": "cracklib-dicts@2.8.16-4.el6",
                 "info": Object {
                   "name": "cracklib-dicts",
-                  "purl": "pkg:rpm/cracklib-dicts@2.8.16-4.el6",
+                  "purl": "pkg:rpm/centos/cracklib-dicts@2.8.16-4.el6?distro=centos-6",
                   "version": "2.8.16-4.el6",
                 },
               },
@@ -5006,7 +5006,7 @@ Object {
                 "id": "cronie@1.4.4-16.el6_8.2",
                 "info": Object {
                   "name": "cronie",
-                  "purl": "pkg:rpm/cronie@1.4.4-16.el6_8.2",
+                  "purl": "pkg:rpm/centos/cronie@1.4.4-16.el6_8.2?distro=centos-6",
                   "version": "1.4.4-16.el6_8.2",
                 },
               },
@@ -5014,7 +5014,7 @@ Object {
                 "id": "cronie-anacron@1.4.4-16.el6_8.2",
                 "info": Object {
                   "name": "cronie-anacron",
-                  "purl": "pkg:rpm/cronie-anacron@1.4.4-16.el6_8.2",
+                  "purl": "pkg:rpm/centos/cronie-anacron@1.4.4-16.el6_8.2?distro=centos-6",
                   "version": "1.4.4-16.el6_8.2",
                 },
               },
@@ -5022,7 +5022,7 @@ Object {
                 "id": "crontabs@1.10-33.el6",
                 "info": Object {
                   "name": "crontabs",
-                  "purl": "pkg:rpm/crontabs@1.10-33.el6",
+                  "purl": "pkg:rpm/centos/crontabs@1.10-33.el6?distro=centos-6",
                   "version": "1.10-33.el6",
                 },
               },
@@ -5030,7 +5030,7 @@ Object {
                 "id": "curl@7.19.7-54.el6_10",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.19.7-54.el6_10",
+                  "purl": "pkg:rpm/centos/curl@7.19.7-54.el6_10?distro=centos-6",
                   "version": "7.19.7-54.el6_10",
                 },
               },
@@ -5038,7 +5038,7 @@ Object {
                 "id": "cvs@1.11.23-16.el6",
                 "info": Object {
                   "name": "cvs",
-                  "purl": "pkg:rpm/cvs@1.11.23-16.el6",
+                  "purl": "pkg:rpm/centos/cvs@1.11.23-16.el6?distro=centos-6",
                   "version": "1.11.23-16.el6",
                 },
               },
@@ -5046,7 +5046,7 @@ Object {
                 "id": "cyrus-sasl@2.1.23-15.el6_6.2",
                 "info": Object {
                   "name": "cyrus-sasl",
-                  "purl": "pkg:rpm/cyrus-sasl@2.1.23-15.el6_6.2",
+                  "purl": "pkg:rpm/centos/cyrus-sasl@2.1.23-15.el6_6.2?distro=centos-6",
                   "version": "2.1.23-15.el6_6.2",
                 },
               },
@@ -5054,7 +5054,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.23-15.el6_6.2",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.23-15.el6_6.2",
+                  "purl": "pkg:rpm/centos/cyrus-sasl-lib@2.1.23-15.el6_6.2?distro=centos-6",
                   "version": "2.1.23-15.el6_6.2",
                 },
               },
@@ -5062,7 +5062,7 @@ Object {
                 "id": "dash@0.5.5.1-4.el6",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:rpm/dash@0.5.5.1-4.el6",
+                  "purl": "pkg:rpm/centos/dash@0.5.5.1-4.el6?distro=centos-6",
                   "version": "0.5.5.1-4.el6",
                 },
               },
@@ -5070,7 +5070,7 @@ Object {
                 "id": "db4@4.7.25-22.el6",
                 "info": Object {
                   "name": "db4",
-                  "purl": "pkg:rpm/db4@4.7.25-22.el6",
+                  "purl": "pkg:rpm/centos/db4@4.7.25-22.el6?distro=centos-6",
                   "version": "4.7.25-22.el6",
                 },
               },
@@ -5078,7 +5078,7 @@ Object {
                 "id": "db4-cxx@4.7.25-22.el6",
                 "info": Object {
                   "name": "db4-cxx",
-                  "purl": "pkg:rpm/db4-cxx@4.7.25-22.el6",
+                  "purl": "pkg:rpm/centos/db4-cxx@4.7.25-22.el6?distro=centos-6",
                   "version": "4.7.25-22.el6",
                 },
               },
@@ -5086,7 +5086,7 @@ Object {
                 "id": "db4-devel@4.7.25-22.el6",
                 "info": Object {
                   "name": "db4-devel",
-                  "purl": "pkg:rpm/db4-devel@4.7.25-22.el6",
+                  "purl": "pkg:rpm/centos/db4-devel@4.7.25-22.el6?distro=centos-6",
                   "version": "4.7.25-22.el6",
                 },
               },
@@ -5094,7 +5094,7 @@ Object {
                 "id": "db4-utils@4.7.25-22.el6",
                 "info": Object {
                   "name": "db4-utils",
-                  "purl": "pkg:rpm/db4-utils@4.7.25-22.el6",
+                  "purl": "pkg:rpm/centos/db4-utils@4.7.25-22.el6?distro=centos-6",
                   "version": "4.7.25-22.el6",
                 },
               },
@@ -5102,7 +5102,7 @@ Object {
                 "id": "dbus-glib@0.86-6.el6",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.86-6.el6",
+                  "purl": "pkg:rpm/centos/dbus-glib@0.86-6.el6?distro=centos-6",
                   "version": "0.86-6.el6",
                 },
               },
@@ -5110,7 +5110,7 @@ Object {
                 "id": "dbus-libs@1:1.2.24-9.el6",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.2.24-9.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/dbus-libs@1:1.2.24-9.el6?distro=centos-6&epoch=1",
                   "version": "1:1.2.24-9.el6",
                 },
               },
@@ -5118,7 +5118,7 @@ Object {
                 "id": "diffutils@2.8.1-28.el6",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@2.8.1-28.el6",
+                  "purl": "pkg:rpm/centos/diffutils@2.8.1-28.el6?distro=centos-6",
                   "version": "2.8.1-28.el6",
                 },
               },
@@ -5126,7 +5126,7 @@ Object {
                 "id": "dmidecode@1:2.12-7.el6",
                 "info": Object {
                   "name": "dmidecode",
-                  "purl": "pkg:rpm/dmidecode@1:2.12-7.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/dmidecode@1:2.12-7.el6?distro=centos-6&epoch=1",
                   "version": "1:2.12-7.el6",
                 },
               },
@@ -5134,7 +5134,7 @@ Object {
                 "id": "ed@1.1-3.3.el6",
                 "info": Object {
                   "name": "ed",
-                  "purl": "pkg:rpm/ed@1.1-3.3.el6",
+                  "purl": "pkg:rpm/centos/ed@1.1-3.3.el6?distro=centos-6",
                   "version": "1.1-3.3.el6",
                 },
               },
@@ -5142,7 +5142,7 @@ Object {
                 "id": "elfutils-libelf@0.164-2.el6",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.164-2.el6",
+                  "purl": "pkg:rpm/centos/elfutils-libelf@0.164-2.el6?distro=centos-6",
                   "version": "0.164-2.el6",
                 },
               },
@@ -5150,7 +5150,7 @@ Object {
                 "id": "ethtool@2:3.5-6.el6",
                 "info": Object {
                   "name": "ethtool",
-                  "purl": "pkg:rpm/ethtool@2:3.5-6.el6?epoch=2",
+                  "purl": "pkg:rpm/centos/ethtool@2:3.5-6.el6?distro=centos-6&epoch=2",
                   "version": "2:3.5-6.el6",
                 },
               },
@@ -5158,7 +5158,7 @@ Object {
                 "id": "expat@2.0.1-13.el6_8",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.0.1-13.el6_8",
+                  "purl": "pkg:rpm/centos/expat@2.0.1-13.el6_8?distro=centos-6",
                   "version": "2.0.1-13.el6_8",
                 },
               },
@@ -5166,7 +5166,7 @@ Object {
                 "id": "file@5.04-30.el6",
                 "info": Object {
                   "name": "file",
-                  "purl": "pkg:rpm/file@5.04-30.el6",
+                  "purl": "pkg:rpm/centos/file@5.04-30.el6?distro=centos-6",
                   "version": "5.04-30.el6",
                 },
               },
@@ -5174,7 +5174,7 @@ Object {
                 "id": "file-libs@5.04-30.el6",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.04-30.el6",
+                  "purl": "pkg:rpm/centos/file-libs@5.04-30.el6?distro=centos-6",
                   "version": "5.04-30.el6",
                 },
               },
@@ -5182,7 +5182,7 @@ Object {
                 "id": "filesystem@2.4.30-3.el6",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@2.4.30-3.el6",
+                  "purl": "pkg:rpm/centos/filesystem@2.4.30-3.el6?distro=centos-6",
                   "version": "2.4.30-3.el6",
                 },
               },
@@ -5190,7 +5190,7 @@ Object {
                 "id": "findutils@1:4.4.2-9.el6",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.4.2-9.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/findutils@1:4.4.2-9.el6?distro=centos-6&epoch=1",
                   "version": "1:4.4.2-9.el6",
                 },
               },
@@ -5198,7 +5198,7 @@ Object {
                 "id": "gamin@0.1.10-9.el6",
                 "info": Object {
                   "name": "gamin",
-                  "purl": "pkg:rpm/gamin@0.1.10-9.el6",
+                  "purl": "pkg:rpm/centos/gamin@0.1.10-9.el6?distro=centos-6",
                   "version": "0.1.10-9.el6",
                 },
               },
@@ -5206,7 +5206,7 @@ Object {
                 "id": "gawk@3.1.7-10.el6_7.3",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@3.1.7-10.el6_7.3",
+                  "purl": "pkg:rpm/centos/gawk@3.1.7-10.el6_7.3?distro=centos-6",
                   "version": "3.1.7-10.el6_7.3",
                 },
               },
@@ -5214,7 +5214,7 @@ Object {
                 "id": "gdbm@1.8.0-39.el6",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1.8.0-39.el6",
+                  "purl": "pkg:rpm/centos/gdbm@1.8.0-39.el6?distro=centos-6",
                   "version": "1.8.0-39.el6",
                 },
               },
@@ -5222,7 +5222,7 @@ Object {
                 "id": "gdbm-devel@1.8.0-39.el6",
                 "info": Object {
                   "name": "gdbm-devel",
-                  "purl": "pkg:rpm/gdbm-devel@1.8.0-39.el6",
+                  "purl": "pkg:rpm/centos/gdbm-devel@1.8.0-39.el6?distro=centos-6",
                   "version": "1.8.0-39.el6",
                 },
               },
@@ -5230,7 +5230,7 @@ Object {
                 "id": "gettext@0.17-18.el6",
                 "info": Object {
                   "name": "gettext",
-                  "purl": "pkg:rpm/gettext@0.17-18.el6",
+                  "purl": "pkg:rpm/centos/gettext@0.17-18.el6?distro=centos-6",
                   "version": "0.17-18.el6",
                 },
               },
@@ -5238,7 +5238,7 @@ Object {
                 "id": "glib2@2.28.8-10.el6",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.28.8-10.el6",
+                  "purl": "pkg:rpm/centos/glib2@2.28.8-10.el6?distro=centos-6",
                   "version": "2.28.8-10.el6",
                 },
               },
@@ -5246,7 +5246,7 @@ Object {
                 "id": "glibc@2.12-1.212.el6_10.3",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.12-1.212.el6_10.3",
+                  "purl": "pkg:rpm/centos/glibc@2.12-1.212.el6_10.3?distro=centos-6",
                   "version": "2.12-1.212.el6_10.3",
                 },
               },
@@ -5254,7 +5254,7 @@ Object {
                 "id": "glibc-common@2.12-1.212.el6_10.3",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.12-1.212.el6_10.3",
+                  "purl": "pkg:rpm/centos/glibc-common@2.12-1.212.el6_10.3?distro=centos-6",
                   "version": "2.12-1.212.el6_10.3",
                 },
               },
@@ -5262,7 +5262,7 @@ Object {
                 "id": "glibc-devel@2.12-1.212.el6_10.3",
                 "info": Object {
                   "name": "glibc-devel",
-                  "purl": "pkg:rpm/glibc-devel@2.12-1.212.el6_10.3",
+                  "purl": "pkg:rpm/centos/glibc-devel@2.12-1.212.el6_10.3?distro=centos-6",
                   "version": "2.12-1.212.el6_10.3",
                 },
               },
@@ -5270,7 +5270,7 @@ Object {
                 "id": "glibc-headers@2.12-1.212.el6_10.3",
                 "info": Object {
                   "name": "glibc-headers",
-                  "purl": "pkg:rpm/glibc-headers@2.12-1.212.el6_10.3",
+                  "purl": "pkg:rpm/centos/glibc-headers@2.12-1.212.el6_10.3?distro=centos-6",
                   "version": "2.12-1.212.el6_10.3",
                 },
               },
@@ -5278,7 +5278,7 @@ Object {
                 "id": "gmp@4.3.1-13.el6",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@4.3.1-13.el6",
+                  "purl": "pkg:rpm/centos/gmp@4.3.1-13.el6?distro=centos-6",
                   "version": "4.3.1-13.el6",
                 },
               },
@@ -5286,7 +5286,7 @@ Object {
                 "id": "gnupg2@2.0.14-9.el6_10",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.14-9.el6_10",
+                  "purl": "pkg:rpm/centos/gnupg2@2.0.14-9.el6_10?distro=centos-6",
                   "version": "2.0.14-9.el6_10",
                 },
               },
@@ -5294,7 +5294,7 @@ Object {
                 "id": "gpg-pubkey@c105b9de-4e0fd3a3",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@c105b9de-4e0fd3a3",
+                  "purl": "pkg:rpm/centos/gpg-pubkey@c105b9de-4e0fd3a3?distro=centos-6",
                   "version": "c105b9de-4e0fd3a3",
                 },
               },
@@ -5302,7 +5302,7 @@ Object {
                 "id": "gpgme@1.1.8-3.el6",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.1.8-3.el6",
+                  "purl": "pkg:rpm/centos/gpgme@1.1.8-3.el6?distro=centos-6",
                   "version": "1.1.8-3.el6",
                 },
               },
@@ -5310,7 +5310,7 @@ Object {
                 "id": "grep@2.20-6.el6",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-6.el6",
+                  "purl": "pkg:rpm/centos/grep@2.20-6.el6?distro=centos-6",
                   "version": "2.20-6.el6",
                 },
               },
@@ -5318,7 +5318,7 @@ Object {
                 "id": "groff@1.18.1.4-21.el6",
                 "info": Object {
                   "name": "groff",
-                  "purl": "pkg:rpm/groff@1.18.1.4-21.el6",
+                  "purl": "pkg:rpm/centos/groff@1.18.1.4-21.el6?distro=centos-6",
                   "version": "1.18.1.4-21.el6",
                 },
               },
@@ -5326,7 +5326,7 @@ Object {
                 "id": "gzip@1.3.12-24.el6",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.3.12-24.el6",
+                  "purl": "pkg:rpm/centos/gzip@1.3.12-24.el6?distro=centos-6",
                   "version": "1.3.12-24.el6",
                 },
               },
@@ -5334,7 +5334,7 @@ Object {
                 "id": "hwdata@0.233-20.1.el6",
                 "info": Object {
                   "name": "hwdata",
-                  "purl": "pkg:rpm/hwdata@0.233-20.1.el6",
+                  "purl": "pkg:rpm/centos/hwdata@0.233-20.1.el6?distro=centos-6",
                   "version": "0.233-20.1.el6",
                 },
               },
@@ -5342,7 +5342,7 @@ Object {
                 "id": "info@4.13a-8.el6",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@4.13a-8.el6",
+                  "purl": "pkg:rpm/centos/info@4.13a-8.el6?distro=centos-6",
                   "version": "4.13a-8.el6",
                 },
               },
@@ -5350,7 +5350,7 @@ Object {
                 "id": "initscripts@9.03.61-1.el6.centos",
                 "info": Object {
                   "name": "initscripts",
-                  "purl": "pkg:rpm/initscripts@9.03.61-1.el6.centos",
+                  "purl": "pkg:rpm/centos/initscripts@9.03.61-1.el6.centos?distro=centos-6",
                   "version": "9.03.61-1.el6.centos",
                 },
               },
@@ -5358,7 +5358,7 @@ Object {
                 "id": "iproute@2.6.32-57.el6",
                 "info": Object {
                   "name": "iproute",
-                  "purl": "pkg:rpm/iproute@2.6.32-57.el6",
+                  "purl": "pkg:rpm/centos/iproute@2.6.32-57.el6?distro=centos-6",
                   "version": "2.6.32-57.el6",
                 },
               },
@@ -5366,7 +5366,7 @@ Object {
                 "id": "iptables@1.4.7-19.el6",
                 "info": Object {
                   "name": "iptables",
-                  "purl": "pkg:rpm/iptables@1.4.7-19.el6",
+                  "purl": "pkg:rpm/centos/iptables@1.4.7-19.el6?distro=centos-6",
                   "version": "1.4.7-19.el6",
                 },
               },
@@ -5374,7 +5374,7 @@ Object {
                 "id": "iputils@20071127-24.el6",
                 "info": Object {
                   "name": "iputils",
-                  "purl": "pkg:rpm/iputils@20071127-24.el6",
+                  "purl": "pkg:rpm/centos/iputils@20071127-24.el6?distro=centos-6",
                   "version": "20071127-24.el6",
                 },
               },
@@ -5382,7 +5382,7 @@ Object {
                 "id": "kernel-headers@2.6.32-754.35.1.el6",
                 "info": Object {
                   "name": "kernel-headers",
-                  "purl": "pkg:rpm/kernel-headers@2.6.32-754.35.1.el6",
+                  "purl": "pkg:rpm/centos/kernel-headers@2.6.32-754.35.1.el6?distro=centos-6",
                   "version": "2.6.32-754.35.1.el6",
                 },
               },
@@ -5390,7 +5390,7 @@ Object {
                 "id": "keyutils-libs@1.4-5.el6",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.4-5.el6",
+                  "purl": "pkg:rpm/centos/keyutils-libs@1.4-5.el6?distro=centos-6",
                   "version": "1.4-5.el6",
                 },
               },
@@ -5398,7 +5398,7 @@ Object {
                 "id": "krb5-libs@1.10.3-65.el6",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.10.3-65.el6",
+                  "purl": "pkg:rpm/centos/krb5-libs@1.10.3-65.el6?distro=centos-6",
                   "version": "1.10.3-65.el6",
                 },
               },
@@ -5406,7 +5406,7 @@ Object {
                 "id": "less@436-13.el6",
                 "info": Object {
                   "name": "less",
-                  "purl": "pkg:rpm/less@436-13.el6",
+                  "purl": "pkg:rpm/centos/less@436-13.el6?distro=centos-6",
                   "version": "436-13.el6",
                 },
               },
@@ -5414,7 +5414,7 @@ Object {
                 "id": "libacl@2.2.49-7.el6_9.1",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.49-7.el6_9.1",
+                  "purl": "pkg:rpm/centos/libacl@2.2.49-7.el6_9.1?distro=centos-6",
                   "version": "2.2.49-7.el6_9.1",
                 },
               },
@@ -5422,7 +5422,7 @@ Object {
                 "id": "libattr@2.4.44-7.el6",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.44-7.el6",
+                  "purl": "pkg:rpm/centos/libattr@2.4.44-7.el6?distro=centos-6",
                   "version": "2.4.44-7.el6",
                 },
               },
@@ -5430,7 +5430,7 @@ Object {
                 "id": "libblkid@2.17.2-12.28.el6_9.2",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.17.2-12.28.el6_9.2",
+                  "purl": "pkg:rpm/centos/libblkid@2.17.2-12.28.el6_9.2?distro=centos-6",
                   "version": "2.17.2-12.28.el6_9.2",
                 },
               },
@@ -5438,7 +5438,7 @@ Object {
                 "id": "libcap@2.16-5.5.el6",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.16-5.5.el6",
+                  "purl": "pkg:rpm/centos/libcap@2.16-5.5.el6?distro=centos-6",
                   "version": "2.16-5.5.el6",
                 },
               },
@@ -5446,7 +5446,7 @@ Object {
                 "id": "libcom_err@1.41.12-24.el6",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.41.12-24.el6",
+                  "purl": "pkg:rpm/centos/libcom_err@1.41.12-24.el6?distro=centos-6",
                   "version": "1.41.12-24.el6",
                 },
               },
@@ -5454,7 +5454,7 @@ Object {
                 "id": "libcurl@7.19.7-54.el6_10",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.19.7-54.el6_10",
+                  "purl": "pkg:rpm/centos/libcurl@7.19.7-54.el6_10?distro=centos-6",
                   "version": "7.19.7-54.el6_10",
                 },
               },
@@ -5462,7 +5462,7 @@ Object {
                 "id": "libdrm@2.4.65-2.el6",
                 "info": Object {
                   "name": "libdrm",
-                  "purl": "pkg:rpm/libdrm@2.4.65-2.el6",
+                  "purl": "pkg:rpm/centos/libdrm@2.4.65-2.el6?distro=centos-6",
                   "version": "2.4.65-2.el6",
                 },
               },
@@ -5470,7 +5470,7 @@ Object {
                 "id": "libffi@3.0.5-3.2.el6",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.5-3.2.el6",
+                  "purl": "pkg:rpm/centos/libffi@3.0.5-3.2.el6?distro=centos-6",
                   "version": "3.0.5-3.2.el6",
                 },
               },
@@ -5478,7 +5478,7 @@ Object {
                 "id": "libgcc@4.4.7-23.el6",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@4.4.7-23.el6",
+                  "purl": "pkg:rpm/centos/libgcc@4.4.7-23.el6?distro=centos-6",
                   "version": "4.4.7-23.el6",
                 },
               },
@@ -5486,7 +5486,7 @@ Object {
                 "id": "libgcrypt@1.4.5-12.el6_8",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.4.5-12.el6_8",
+                  "purl": "pkg:rpm/centos/libgcrypt@1.4.5-12.el6_8?distro=centos-6",
                   "version": "1.4.5-12.el6_8",
                 },
               },
@@ -5494,7 +5494,7 @@ Object {
                 "id": "libgomp@4.4.7-23.el6",
                 "info": Object {
                   "name": "libgomp",
-                  "purl": "pkg:rpm/libgomp@4.4.7-23.el6",
+                  "purl": "pkg:rpm/centos/libgomp@4.4.7-23.el6?distro=centos-6",
                   "version": "4.4.7-23.el6",
                 },
               },
@@ -5502,7 +5502,7 @@ Object {
                 "id": "libgpg-error@1.7-4.el6",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.7-4.el6",
+                  "purl": "pkg:rpm/centos/libgpg-error@1.7-4.el6?distro=centos-6",
                   "version": "1.7-4.el6",
                 },
               },
@@ -5510,7 +5510,7 @@ Object {
                 "id": "libidn@1.18-2.el6",
                 "info": Object {
                   "name": "libidn",
-                  "purl": "pkg:rpm/libidn@1.18-2.el6",
+                  "purl": "pkg:rpm/centos/libidn@1.18-2.el6?distro=centos-6",
                   "version": "1.18-2.el6",
                 },
               },
@@ -5518,7 +5518,7 @@ Object {
                 "id": "libnih@1.0.1-8.el6",
                 "info": Object {
                   "name": "libnih",
-                  "purl": "pkg:rpm/libnih@1.0.1-8.el6",
+                  "purl": "pkg:rpm/centos/libnih@1.0.1-8.el6?distro=centos-6",
                   "version": "1.0.1-8.el6",
                 },
               },
@@ -5526,7 +5526,7 @@ Object {
                 "id": "libpcap@14:1.4.0-4.20130826git2dbcaa1.el6",
                 "info": Object {
                   "name": "libpcap",
-                  "purl": "pkg:rpm/libpcap@14:1.4.0-4.20130826git2dbcaa1.el6?epoch=14",
+                  "purl": "pkg:rpm/centos/libpcap@14:1.4.0-4.20130826git2dbcaa1.el6?distro=centos-6&epoch=14",
                   "version": "14:1.4.0-4.20130826git2dbcaa1.el6",
                 },
               },
@@ -5534,7 +5534,7 @@ Object {
                 "id": "libpciaccess@0.13.4-1.el6",
                 "info": Object {
                   "name": "libpciaccess",
-                  "purl": "pkg:rpm/libpciaccess@0.13.4-1.el6",
+                  "purl": "pkg:rpm/centos/libpciaccess@0.13.4-1.el6?distro=centos-6",
                   "version": "0.13.4-1.el6",
                 },
               },
@@ -5542,7 +5542,7 @@ Object {
                 "id": "libselinux@2.0.94-7.el6",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.0.94-7.el6",
+                  "purl": "pkg:rpm/centos/libselinux@2.0.94-7.el6?distro=centos-6",
                   "version": "2.0.94-7.el6",
                 },
               },
@@ -5550,7 +5550,7 @@ Object {
                 "id": "libselinux-utils@2.0.94-7.el6",
                 "info": Object {
                   "name": "libselinux-utils",
-                  "purl": "pkg:rpm/libselinux-utils@2.0.94-7.el6",
+                  "purl": "pkg:rpm/centos/libselinux-utils@2.0.94-7.el6?distro=centos-6",
                   "version": "2.0.94-7.el6",
                 },
               },
@@ -5558,7 +5558,7 @@ Object {
                 "id": "libsemanage@2.0.43-5.1.el6",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.0.43-5.1.el6",
+                  "purl": "pkg:rpm/centos/libsemanage@2.0.43-5.1.el6?distro=centos-6",
                   "version": "2.0.43-5.1.el6",
                 },
               },
@@ -5566,7 +5566,7 @@ Object {
                 "id": "libsepol@2.0.41-4.el6",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.0.41-4.el6",
+                  "purl": "pkg:rpm/centos/libsepol@2.0.41-4.el6?distro=centos-6",
                   "version": "2.0.41-4.el6",
                 },
               },
@@ -5574,7 +5574,7 @@ Object {
                 "id": "libssh2@1.4.2-2.el6_7.1",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.4.2-2.el6_7.1",
+                  "purl": "pkg:rpm/centos/libssh2@1.4.2-2.el6_7.1?distro=centos-6",
                   "version": "1.4.2-2.el6_7.1",
                 },
               },
@@ -5582,7 +5582,7 @@ Object {
                 "id": "libstdc++@4.4.7-23.el6",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@4.4.7-23.el6",
+                  "purl": "pkg:rpm/centos/libstdc%2B%2B@4.4.7-23.el6?distro=centos-6",
                   "version": "4.4.7-23.el6",
                 },
               },
@@ -5590,7 +5590,7 @@ Object {
                 "id": "libtasn1@2.3-6.el6_5",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@2.3-6.el6_5",
+                  "purl": "pkg:rpm/centos/libtasn1@2.3-6.el6_5?distro=centos-6",
                   "version": "2.3-6.el6_5",
                 },
               },
@@ -5598,7 +5598,7 @@ Object {
                 "id": "libusb@0.1.12-23.el6",
                 "info": Object {
                   "name": "libusb",
-                  "purl": "pkg:rpm/libusb@0.1.12-23.el6",
+                  "purl": "pkg:rpm/centos/libusb@0.1.12-23.el6?distro=centos-6",
                   "version": "0.1.12-23.el6",
                 },
               },
@@ -5606,7 +5606,7 @@ Object {
                 "id": "libuser@0.56.13-8.el6_7",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.56.13-8.el6_7",
+                  "purl": "pkg:rpm/centos/libuser@0.56.13-8.el6_7?distro=centos-6",
                   "version": "0.56.13-8.el6_7",
                 },
               },
@@ -5614,7 +5614,7 @@ Object {
                 "id": "libutempter@1.1.5-4.1.el6",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.5-4.1.el6",
+                  "purl": "pkg:rpm/centos/libutempter@1.1.5-4.1.el6?distro=centos-6",
                   "version": "1.1.5-4.1.el6",
                 },
               },
@@ -5622,7 +5622,7 @@ Object {
                 "id": "libuuid@2.17.2-12.28.el6_9.2",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.17.2-12.28.el6_9.2",
+                  "purl": "pkg:rpm/centos/libuuid@2.17.2-12.28.el6_9.2?distro=centos-6",
                   "version": "2.17.2-12.28.el6_9.2",
                 },
               },
@@ -5630,7 +5630,7 @@ Object {
                 "id": "libxml2@2.7.6-21.el6_8.1",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.7.6-21.el6_8.1",
+                  "purl": "pkg:rpm/centos/libxml2@2.7.6-21.el6_8.1?distro=centos-6",
                   "version": "2.7.6-21.el6_8.1",
                 },
               },
@@ -5638,7 +5638,7 @@ Object {
                 "id": "logrotate@3.7.8-28.el6",
                 "info": Object {
                   "name": "logrotate",
-                  "purl": "pkg:rpm/logrotate@3.7.8-28.el6",
+                  "purl": "pkg:rpm/centos/logrotate@3.7.8-28.el6?distro=centos-6",
                   "version": "3.7.8-28.el6",
                 },
               },
@@ -5646,7 +5646,7 @@ Object {
                 "id": "lsof@4.82-5.el6",
                 "info": Object {
                   "name": "lsof",
-                  "purl": "pkg:rpm/lsof@4.82-5.el6",
+                  "purl": "pkg:rpm/centos/lsof@4.82-5.el6?distro=centos-6",
                   "version": "4.82-5.el6",
                 },
               },
@@ -5654,7 +5654,7 @@ Object {
                 "id": "lua@5.1.4-4.1.el6",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-4.1.el6",
+                  "purl": "pkg:rpm/centos/lua@5.1.4-4.1.el6?distro=centos-6",
                   "version": "5.1.4-4.1.el6",
                 },
               },
@@ -5662,7 +5662,7 @@ Object {
                 "id": "m4@1.4.13-5.el6",
                 "info": Object {
                   "name": "m4",
-                  "purl": "pkg:rpm/m4@1.4.13-5.el6",
+                  "purl": "pkg:rpm/centos/m4@1.4.13-5.el6?distro=centos-6",
                   "version": "1.4.13-5.el6",
                 },
               },
@@ -5670,7 +5670,7 @@ Object {
                 "id": "mailx@12.4-10.el6_10",
                 "info": Object {
                   "name": "mailx",
-                  "purl": "pkg:rpm/mailx@12.4-10.el6_10",
+                  "purl": "pkg:rpm/centos/mailx@12.4-10.el6_10?distro=centos-6",
                   "version": "12.4-10.el6_10",
                 },
               },
@@ -5678,7 +5678,7 @@ Object {
                 "id": "make@1:3.81-23.el6",
                 "info": Object {
                   "name": "make",
-                  "purl": "pkg:rpm/make@1:3.81-23.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/make@1:3.81-23.el6?distro=centos-6&epoch=1",
                   "version": "1:3.81-23.el6",
                 },
               },
@@ -5686,7 +5686,7 @@ Object {
                 "id": "man@1.6f-39.el6",
                 "info": Object {
                   "name": "man",
-                  "purl": "pkg:rpm/man@1.6f-39.el6",
+                  "purl": "pkg:rpm/centos/man@1.6f-39.el6?distro=centos-6",
                   "version": "1.6f-39.el6",
                 },
               },
@@ -5694,7 +5694,7 @@ Object {
                 "id": "mingetty@1.08-5.el6",
                 "info": Object {
                   "name": "mingetty",
-                  "purl": "pkg:rpm/mingetty@1.08-5.el6",
+                  "purl": "pkg:rpm/centos/mingetty@1.08-5.el6?distro=centos-6",
                   "version": "1.08-5.el6",
                 },
               },
@@ -5702,7 +5702,7 @@ Object {
                 "id": "module-init-tools@3.9-26.el6",
                 "info": Object {
                   "name": "module-init-tools",
-                  "purl": "pkg:rpm/module-init-tools@3.9-26.el6",
+                  "purl": "pkg:rpm/centos/module-init-tools@3.9-26.el6?distro=centos-6",
                   "version": "3.9-26.el6",
                 },
               },
@@ -5710,7 +5710,7 @@ Object {
                 "id": "mysql-libs@5.1.73-8.el6_8",
                 "info": Object {
                   "name": "mysql-libs",
-                  "purl": "pkg:rpm/mysql-libs@5.1.73-8.el6_8",
+                  "purl": "pkg:rpm/centos/mysql-libs@5.1.73-8.el6_8?distro=centos-6",
                   "version": "5.1.73-8.el6_8",
                 },
               },
@@ -5718,7 +5718,7 @@ Object {
                 "id": "nc@1.84-24.el6",
                 "info": Object {
                   "name": "nc",
-                  "purl": "pkg:rpm/nc@1.84-24.el6",
+                  "purl": "pkg:rpm/centos/nc@1.84-24.el6?distro=centos-6",
                   "version": "1.84-24.el6",
                 },
               },
@@ -5726,7 +5726,7 @@ Object {
                 "id": "ncurses@5.7-4.20090207.el6",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@5.7-4.20090207.el6",
+                  "purl": "pkg:rpm/centos/ncurses@5.7-4.20090207.el6?distro=centos-6",
                   "version": "5.7-4.20090207.el6",
                 },
               },
@@ -5734,7 +5734,7 @@ Object {
                 "id": "ncurses-base@5.7-4.20090207.el6",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@5.7-4.20090207.el6",
+                  "purl": "pkg:rpm/centos/ncurses-base@5.7-4.20090207.el6?distro=centos-6",
                   "version": "5.7-4.20090207.el6",
                 },
               },
@@ -5742,7 +5742,7 @@ Object {
                 "id": "ncurses-libs@5.7-4.20090207.el6",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@5.7-4.20090207.el6",
+                  "purl": "pkg:rpm/centos/ncurses-libs@5.7-4.20090207.el6?distro=centos-6",
                   "version": "5.7-4.20090207.el6",
                 },
               },
@@ -5750,7 +5750,7 @@ Object {
                 "id": "net-tools@1.60-114.el6",
                 "info": Object {
                   "name": "net-tools",
-                  "purl": "pkg:rpm/net-tools@1.60-114.el6",
+                  "purl": "pkg:rpm/centos/net-tools@1.60-114.el6?distro=centos-6",
                   "version": "1.60-114.el6",
                 },
               },
@@ -5758,7 +5758,7 @@ Object {
                 "id": "nmap@2:5.51-6.el6",
                 "info": Object {
                   "name": "nmap",
-                  "purl": "pkg:rpm/nmap@2:5.51-6.el6?epoch=2",
+                  "purl": "pkg:rpm/centos/nmap@2:5.51-6.el6?distro=centos-6&epoch=2",
                   "version": "2:5.51-6.el6",
                 },
               },
@@ -5766,7 +5766,7 @@ Object {
                 "id": "nspr@4.19.0-1.el6",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.19.0-1.el6",
+                  "purl": "pkg:rpm/centos/nspr@4.19.0-1.el6?distro=centos-6",
                   "version": "4.19.0-1.el6",
                 },
               },
@@ -5774,7 +5774,7 @@ Object {
                 "id": "nss@3.36.0-8.el6",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.36.0-8.el6",
+                  "purl": "pkg:rpm/centos/nss@3.36.0-8.el6?distro=centos-6",
                   "version": "3.36.0-8.el6",
                 },
               },
@@ -5782,7 +5782,7 @@ Object {
                 "id": "nss-softokn@3.14.3-23.3.el6_8",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.14.3-23.3.el6_8",
+                  "purl": "pkg:rpm/centos/nss-softokn@3.14.3-23.3.el6_8?distro=centos-6",
                   "version": "3.14.3-23.3.el6_8",
                 },
               },
@@ -5790,7 +5790,7 @@ Object {
                 "id": "nss-softokn-freebl@3.14.3-23.3.el6_8",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.14.3-23.3.el6_8",
+                  "purl": "pkg:rpm/centos/nss-softokn-freebl@3.14.3-23.3.el6_8?distro=centos-6",
                   "version": "3.14.3-23.3.el6_8",
                 },
               },
@@ -5798,7 +5798,7 @@ Object {
                 "id": "nss-sysinit@3.36.0-8.el6",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.36.0-8.el6",
+                  "purl": "pkg:rpm/centos/nss-sysinit@3.36.0-8.el6?distro=centos-6",
                   "version": "3.36.0-8.el6",
                 },
               },
@@ -5806,7 +5806,7 @@ Object {
                 "id": "nss-tools@3.36.0-8.el6",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.36.0-8.el6",
+                  "purl": "pkg:rpm/centos/nss-tools@3.36.0-8.el6?distro=centos-6",
                   "version": "3.36.0-8.el6",
                 },
               },
@@ -5814,7 +5814,7 @@ Object {
                 "id": "nss-util@3.36.0-1.el6",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.36.0-1.el6",
+                  "purl": "pkg:rpm/centos/nss-util@3.36.0-1.el6?distro=centos-6",
                   "version": "3.36.0-1.el6",
                 },
               },
@@ -5822,7 +5822,7 @@ Object {
                 "id": "openldap@2.4.40-16.el6",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.40-16.el6",
+                  "purl": "pkg:rpm/centos/openldap@2.4.40-16.el6?distro=centos-6",
                   "version": "2.4.40-16.el6",
                 },
               },
@@ -5830,7 +5830,7 @@ Object {
                 "id": "openssl@1.0.1e-58.el6_10",
                 "info": Object {
                   "name": "openssl",
-                  "purl": "pkg:rpm/openssl@1.0.1e-58.el6_10",
+                  "purl": "pkg:rpm/centos/openssl@1.0.1e-58.el6_10?distro=centos-6",
                   "version": "1.0.1e-58.el6_10",
                 },
               },
@@ -5838,7 +5838,7 @@ Object {
                 "id": "p11-kit@0.18.5-2.el6_5.2",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.18.5-2.el6_5.2",
+                  "purl": "pkg:rpm/centos/p11-kit@0.18.5-2.el6_5.2?distro=centos-6",
                   "version": "0.18.5-2.el6_5.2",
                 },
               },
@@ -5846,7 +5846,7 @@ Object {
                 "id": "p11-kit-trust@0.18.5-2.el6_5.2",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.18.5-2.el6_5.2",
+                  "purl": "pkg:rpm/centos/p11-kit-trust@0.18.5-2.el6_5.2?distro=centos-6",
                   "version": "0.18.5-2.el6_5.2",
                 },
               },
@@ -5854,7 +5854,7 @@ Object {
                 "id": "pam@1.1.1-24.el6",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.1.1-24.el6",
+                  "purl": "pkg:rpm/centos/pam@1.1.1-24.el6?distro=centos-6",
                   "version": "1.1.1-24.el6",
                 },
               },
@@ -5862,7 +5862,7 @@ Object {
                 "id": "passwd@0.77-7.el6",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.77-7.el6",
+                  "purl": "pkg:rpm/centos/passwd@0.77-7.el6?distro=centos-6",
                   "version": "0.77-7.el6",
                 },
               },
@@ -5870,7 +5870,7 @@ Object {
                 "id": "patch@2.6-8.el6_9",
                 "info": Object {
                   "name": "patch",
-                  "purl": "pkg:rpm/patch@2.6-8.el6_9",
+                  "purl": "pkg:rpm/centos/patch@2.6-8.el6_9?distro=centos-6",
                   "version": "2.6-8.el6_9",
                 },
               },
@@ -5878,7 +5878,7 @@ Object {
                 "id": "pax@3.4-10.1.el6",
                 "info": Object {
                   "name": "pax",
-                  "purl": "pkg:rpm/pax@3.4-10.1.el6",
+                  "purl": "pkg:rpm/centos/pax@3.4-10.1.el6?distro=centos-6",
                   "version": "3.4-10.1.el6",
                 },
               },
@@ -5886,7 +5886,7 @@ Object {
                 "id": "pcre@7.8-7.el6",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@7.8-7.el6",
+                  "purl": "pkg:rpm/centos/pcre@7.8-7.el6?distro=centos-6",
                   "version": "7.8-7.el6",
                 },
               },
@@ -5894,7 +5894,7 @@ Object {
                 "id": "perl@4:5.10.1-144.el6",
                 "info": Object {
                   "name": "perl",
-                  "purl": "pkg:rpm/perl@4:5.10.1-144.el6?epoch=4",
+                  "purl": "pkg:rpm/centos/perl@4:5.10.1-144.el6?distro=centos-6&epoch=4",
                   "version": "4:5.10.1-144.el6",
                 },
               },
@@ -5902,7 +5902,7 @@ Object {
                 "id": "perl-CGI@3.51-144.el6",
                 "info": Object {
                   "name": "perl-CGI",
-                  "purl": "pkg:rpm/perl-CGI@3.51-144.el6",
+                  "purl": "pkg:rpm/centos/perl-CGI@3.51-144.el6?distro=centos-6",
                   "version": "3.51-144.el6",
                 },
               },
@@ -5910,7 +5910,7 @@ Object {
                 "id": "perl-ExtUtils-MakeMaker@6.55-144.el6",
                 "info": Object {
                   "name": "perl-ExtUtils-MakeMaker",
-                  "purl": "pkg:rpm/perl-ExtUtils-MakeMaker@6.55-144.el6",
+                  "purl": "pkg:rpm/centos/perl-ExtUtils-MakeMaker@6.55-144.el6?distro=centos-6",
                   "version": "6.55-144.el6",
                 },
               },
@@ -5918,7 +5918,7 @@ Object {
                 "id": "perl-ExtUtils-ParseXS@1:2.2003.0-144.el6",
                 "info": Object {
                   "name": "perl-ExtUtils-ParseXS",
-                  "purl": "pkg:rpm/perl-ExtUtils-ParseXS@1:2.2003.0-144.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/perl-ExtUtils-ParseXS@1:2.2003.0-144.el6?distro=centos-6&epoch=1",
                   "version": "1:2.2003.0-144.el6",
                 },
               },
@@ -5926,7 +5926,7 @@ Object {
                 "id": "perl-Module-Pluggable@1:3.90-144.el6",
                 "info": Object {
                   "name": "perl-Module-Pluggable",
-                  "purl": "pkg:rpm/perl-Module-Pluggable@1:3.90-144.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/perl-Module-Pluggable@1:3.90-144.el6?distro=centos-6&epoch=1",
                   "version": "1:3.90-144.el6",
                 },
               },
@@ -5934,7 +5934,7 @@ Object {
                 "id": "perl-Pod-Escapes@1:1.04-144.el6",
                 "info": Object {
                   "name": "perl-Pod-Escapes",
-                  "purl": "pkg:rpm/perl-Pod-Escapes@1:1.04-144.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/perl-Pod-Escapes@1:1.04-144.el6?distro=centos-6&epoch=1",
                   "version": "1:1.04-144.el6",
                 },
               },
@@ -5942,7 +5942,7 @@ Object {
                 "id": "perl-Pod-Simple@1:3.13-144.el6",
                 "info": Object {
                   "name": "perl-Pod-Simple",
-                  "purl": "pkg:rpm/perl-Pod-Simple@1:3.13-144.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/perl-Pod-Simple@1:3.13-144.el6?distro=centos-6&epoch=1",
                   "version": "1:3.13-144.el6",
                 },
               },
@@ -5950,7 +5950,7 @@ Object {
                 "id": "perl-Test-Harness@3.17-144.el6",
                 "info": Object {
                   "name": "perl-Test-Harness",
-                  "purl": "pkg:rpm/perl-Test-Harness@3.17-144.el6",
+                  "purl": "pkg:rpm/centos/perl-Test-Harness@3.17-144.el6?distro=centos-6",
                   "version": "3.17-144.el6",
                 },
               },
@@ -5958,7 +5958,7 @@ Object {
                 "id": "perl-Test-Simple@0.92-144.el6",
                 "info": Object {
                   "name": "perl-Test-Simple",
-                  "purl": "pkg:rpm/perl-Test-Simple@0.92-144.el6",
+                  "purl": "pkg:rpm/centos/perl-Test-Simple@0.92-144.el6?distro=centos-6",
                   "version": "0.92-144.el6",
                 },
               },
@@ -5966,7 +5966,7 @@ Object {
                 "id": "perl-devel@4:5.10.1-144.el6",
                 "info": Object {
                   "name": "perl-devel",
-                  "purl": "pkg:rpm/perl-devel@4:5.10.1-144.el6?epoch=4",
+                  "purl": "pkg:rpm/centos/perl-devel@4:5.10.1-144.el6?distro=centos-6&epoch=4",
                   "version": "4:5.10.1-144.el6",
                 },
               },
@@ -5974,7 +5974,7 @@ Object {
                 "id": "perl-libs@4:5.10.1-144.el6",
                 "info": Object {
                   "name": "perl-libs",
-                  "purl": "pkg:rpm/perl-libs@4:5.10.1-144.el6?epoch=4",
+                  "purl": "pkg:rpm/centos/perl-libs@4:5.10.1-144.el6?distro=centos-6&epoch=4",
                   "version": "4:5.10.1-144.el6",
                 },
               },
@@ -5982,7 +5982,7 @@ Object {
                 "id": "perl-version@3:0.77-144.el6",
                 "info": Object {
                   "name": "perl-version",
-                  "purl": "pkg:rpm/perl-version@3:0.77-144.el6?epoch=3",
+                  "purl": "pkg:rpm/centos/perl-version@3:0.77-144.el6?distro=centos-6&epoch=3",
                   "version": "3:0.77-144.el6",
                 },
               },
@@ -5990,7 +5990,7 @@ Object {
                 "id": "pinentry@0.7.6-8.el6",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.7.6-8.el6",
+                  "purl": "pkg:rpm/centos/pinentry@0.7.6-8.el6?distro=centos-6",
                   "version": "0.7.6-8.el6",
                 },
               },
@@ -5998,7 +5998,7 @@ Object {
                 "id": "pkgconfig@1:0.23-9.1.el6",
                 "info": Object {
                   "name": "pkgconfig",
-                  "purl": "pkg:rpm/pkgconfig@1:0.23-9.1.el6?epoch=1",
+                  "purl": "pkg:rpm/centos/pkgconfig@1:0.23-9.1.el6?distro=centos-6&epoch=1",
                   "version": "1:0.23-9.1.el6",
                 },
               },
@@ -6006,7 +6006,7 @@ Object {
                 "id": "plymouth@0.8.3-29.el6.centos",
                 "info": Object {
                   "name": "plymouth",
-                  "purl": "pkg:rpm/plymouth@0.8.3-29.el6.centos",
+                  "purl": "pkg:rpm/centos/plymouth@0.8.3-29.el6.centos?distro=centos-6",
                   "version": "0.8.3-29.el6.centos",
                 },
               },
@@ -6014,7 +6014,7 @@ Object {
                 "id": "plymouth-core-libs@0.8.3-29.el6.centos",
                 "info": Object {
                   "name": "plymouth-core-libs",
-                  "purl": "pkg:rpm/plymouth-core-libs@0.8.3-29.el6.centos",
+                  "purl": "pkg:rpm/centos/plymouth-core-libs@0.8.3-29.el6.centos?distro=centos-6",
                   "version": "0.8.3-29.el6.centos",
                 },
               },
@@ -6022,7 +6022,7 @@ Object {
                 "id": "plymouth-scripts@0.8.3-29.el6.centos",
                 "info": Object {
                   "name": "plymouth-scripts",
-                  "purl": "pkg:rpm/plymouth-scripts@0.8.3-29.el6.centos",
+                  "purl": "pkg:rpm/centos/plymouth-scripts@0.8.3-29.el6.centos?distro=centos-6",
                   "version": "0.8.3-29.el6.centos",
                 },
               },
@@ -6030,7 +6030,7 @@ Object {
                 "id": "policycoreutils@2.0.83-30.1.el6_8",
                 "info": Object {
                   "name": "policycoreutils",
-                  "purl": "pkg:rpm/policycoreutils@2.0.83-30.1.el6_8",
+                  "purl": "pkg:rpm/centos/policycoreutils@2.0.83-30.1.el6_8?distro=centos-6",
                   "version": "2.0.83-30.1.el6_8",
                 },
               },
@@ -6038,7 +6038,7 @@ Object {
                 "id": "popt@1.13-7.el6",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-7.el6",
+                  "purl": "pkg:rpm/centos/popt@1.13-7.el6?distro=centos-6",
                   "version": "1.13-7.el6",
                 },
               },
@@ -6046,7 +6046,7 @@ Object {
                 "id": "postfix@2:2.6.6-8.el6",
                 "info": Object {
                   "name": "postfix",
-                  "purl": "pkg:rpm/postfix@2:2.6.6-8.el6?epoch=2",
+                  "purl": "pkg:rpm/centos/postfix@2:2.6.6-8.el6?distro=centos-6&epoch=2",
                   "version": "2:2.6.6-8.el6",
                 },
               },
@@ -6054,7 +6054,7 @@ Object {
                 "id": "procps@3.2.8-45.el6_9.3",
                 "info": Object {
                   "name": "procps",
-                  "purl": "pkg:rpm/procps@3.2.8-45.el6_9.3",
+                  "purl": "pkg:rpm/centos/procps@3.2.8-45.el6_9.3?distro=centos-6",
                   "version": "3.2.8-45.el6_9.3",
                 },
               },
@@ -6062,7 +6062,7 @@ Object {
                 "id": "psmisc@22.6-24.el6",
                 "info": Object {
                   "name": "psmisc",
-                  "purl": "pkg:rpm/psmisc@22.6-24.el6",
+                  "purl": "pkg:rpm/centos/psmisc@22.6-24.el6?distro=centos-6",
                   "version": "22.6-24.el6",
                 },
               },
@@ -6070,7 +6070,7 @@ Object {
                 "id": "pth@2.0.7-9.3.el6",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-9.3.el6",
+                  "purl": "pkg:rpm/centos/pth@2.0.7-9.3.el6?distro=centos-6",
                   "version": "2.0.7-9.3.el6",
                 },
               },
@@ -6078,7 +6078,7 @@ Object {
                 "id": "pygpgme@0.1-18.20090824bzr68.el6",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.1-18.20090824bzr68.el6",
+                  "purl": "pkg:rpm/centos/pygpgme@0.1-18.20090824bzr68.el6?distro=centos-6",
                   "version": "0.1-18.20090824bzr68.el6",
                 },
               },
@@ -6086,7 +6086,7 @@ Object {
                 "id": "python@2.6.6-66.el6_8",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.6.6-66.el6_8",
+                  "purl": "pkg:rpm/centos/python@2.6.6-66.el6_8?distro=centos-6",
                   "version": "2.6.6-66.el6_8",
                 },
               },
@@ -6094,7 +6094,7 @@ Object {
                 "id": "python-iniparse@0.3.1-2.1.el6",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.3.1-2.1.el6",
+                  "purl": "pkg:rpm/centos/python-iniparse@0.3.1-2.1.el6?distro=centos-6",
                   "version": "0.3.1-2.1.el6",
                 },
               },
@@ -6102,7 +6102,7 @@ Object {
                 "id": "python-libs@2.6.6-66.el6_8",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.6.6-66.el6_8",
+                  "purl": "pkg:rpm/centos/python-libs@2.6.6-66.el6_8?distro=centos-6",
                   "version": "2.6.6-66.el6_8",
                 },
               },
@@ -6110,7 +6110,7 @@ Object {
                 "id": "python-pycurl@7.19.0-9.el6",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-9.el6",
+                  "purl": "pkg:rpm/centos/python-pycurl@7.19.0-9.el6?distro=centos-6",
                   "version": "7.19.0-9.el6",
                 },
               },
@@ -6118,7 +6118,7 @@ Object {
                 "id": "python-urlgrabber@3.9.1-11.el6",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.9.1-11.el6",
+                  "purl": "pkg:rpm/centos/python-urlgrabber@3.9.1-11.el6?distro=centos-6",
                   "version": "3.9.1-11.el6",
                 },
               },
@@ -6126,7 +6126,7 @@ Object {
                 "id": "readline@6.0-4.el6",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.0-4.el6",
+                  "purl": "pkg:rpm/centos/readline@6.0-4.el6?distro=centos-6",
                   "version": "6.0-4.el6",
                 },
               },
@@ -6134,7 +6134,7 @@ Object {
                 "id": "redhat-logos@60.0.14-12.el6.centos",
                 "info": Object {
                   "name": "redhat-logos",
-                  "purl": "pkg:rpm/redhat-logos@60.0.14-12.el6.centos",
+                  "purl": "pkg:rpm/centos/redhat-logos@60.0.14-12.el6.centos?distro=centos-6",
                   "version": "60.0.14-12.el6.centos",
                 },
               },
@@ -6142,7 +6142,7 @@ Object {
                 "id": "redhat-lsb-core@4.0-7.el6.centos",
                 "info": Object {
                   "name": "redhat-lsb-core",
-                  "purl": "pkg:rpm/redhat-lsb-core@4.0-7.el6.centos",
+                  "purl": "pkg:rpm/centos/redhat-lsb-core@4.0-7.el6.centos?distro=centos-6",
                   "version": "4.0-7.el6.centos",
                 },
               },
@@ -6150,7 +6150,7 @@ Object {
                 "id": "rootfiles@8.1-6.1.el6",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-6.1.el6",
+                  "purl": "pkg:rpm/centos/rootfiles@8.1-6.1.el6?distro=centos-6",
                   "version": "8.1-6.1.el6",
                 },
               },
@@ -6158,7 +6158,7 @@ Object {
                 "id": "rpm@4.8.0-59.el6",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.8.0-59.el6",
+                  "purl": "pkg:rpm/centos/rpm@4.8.0-59.el6?distro=centos-6",
                   "version": "4.8.0-59.el6",
                 },
               },
@@ -6166,7 +6166,7 @@ Object {
                 "id": "rpm-libs@4.8.0-59.el6",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.8.0-59.el6",
+                  "purl": "pkg:rpm/centos/rpm-libs@4.8.0-59.el6?distro=centos-6",
                   "version": "4.8.0-59.el6",
                 },
               },
@@ -6174,7 +6174,7 @@ Object {
                 "id": "rpm-python@4.8.0-59.el6",
                 "info": Object {
                   "name": "rpm-python",
-                  "purl": "pkg:rpm/rpm-python@4.8.0-59.el6",
+                  "purl": "pkg:rpm/centos/rpm-python@4.8.0-59.el6?distro=centos-6",
                   "version": "4.8.0-59.el6",
                 },
               },
@@ -6182,7 +6182,7 @@ Object {
                 "id": "rsyslog@5.8.10-12.el6",
                 "info": Object {
                   "name": "rsyslog",
-                  "purl": "pkg:rpm/rsyslog@5.8.10-12.el6",
+                  "purl": "pkg:rpm/centos/rsyslog@5.8.10-12.el6?distro=centos-6",
                   "version": "5.8.10-12.el6",
                 },
               },
@@ -6190,7 +6190,7 @@ Object {
                 "id": "sed@4.2.1-10.el6",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.1-10.el6",
+                  "purl": "pkg:rpm/centos/sed@4.2.1-10.el6?distro=centos-6",
                   "version": "4.2.1-10.el6",
                 },
               },
@@ -6198,7 +6198,7 @@ Object {
                 "id": "setup@2.8.14-23.el6",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.14-23.el6",
+                  "purl": "pkg:rpm/centos/setup@2.8.14-23.el6?distro=centos-6",
                   "version": "2.8.14-23.el6",
                 },
               },
@@ -6206,7 +6206,7 @@ Object {
                 "id": "shadow-utils@2:4.1.5.1-5.el6",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.1.5.1-5.el6?epoch=2",
+                  "purl": "pkg:rpm/centos/shadow-utils@2:4.1.5.1-5.el6?distro=centos-6&epoch=2",
                   "version": "2:4.1.5.1-5.el6",
                 },
               },
@@ -6214,7 +6214,7 @@ Object {
                 "id": "shared-mime-info@0.70-6.el6",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@0.70-6.el6",
+                  "purl": "pkg:rpm/centos/shared-mime-info@0.70-6.el6?distro=centos-6",
                   "version": "0.70-6.el6",
                 },
               },
@@ -6222,7 +6222,7 @@ Object {
                 "id": "sqlite@3.6.20-1.el6_7.2",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.6.20-1.el6_7.2",
+                  "purl": "pkg:rpm/centos/sqlite@3.6.20-1.el6_7.2?distro=centos-6",
                   "version": "3.6.20-1.el6_7.2",
                 },
               },
@@ -6230,7 +6230,7 @@ Object {
                 "id": "strace@4.8-11.el6",
                 "info": Object {
                   "name": "strace",
-                  "purl": "pkg:rpm/strace@4.8-11.el6",
+                  "purl": "pkg:rpm/centos/strace@4.8-11.el6?distro=centos-6",
                   "version": "4.8-11.el6",
                 },
               },
@@ -6238,7 +6238,7 @@ Object {
                 "id": "sudo@1.8.6p3-29.el6_10.3",
                 "info": Object {
                   "name": "sudo",
-                  "purl": "pkg:rpm/sudo@1.8.6p3-29.el6_10.3",
+                  "purl": "pkg:rpm/centos/sudo@1.8.6p3-29.el6_10.3?distro=centos-6",
                   "version": "1.8.6p3-29.el6_10.3",
                 },
               },
@@ -6246,7 +6246,7 @@ Object {
                 "id": "sysvinit-tools@2.87-6.dsf.el6",
                 "info": Object {
                   "name": "sysvinit-tools",
-                  "purl": "pkg:rpm/sysvinit-tools@2.87-6.dsf.el6",
+                  "purl": "pkg:rpm/centos/sysvinit-tools@2.87-6.dsf.el6?distro=centos-6",
                   "version": "2.87-6.dsf.el6",
                 },
               },
@@ -6254,7 +6254,7 @@ Object {
                 "id": "tar@2:1.23-15.el6_8",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.23-15.el6_8?epoch=2",
+                  "purl": "pkg:rpm/centos/tar@2:1.23-15.el6_8?distro=centos-6&epoch=2",
                   "version": "2:1.23-15.el6_8",
                 },
               },
@@ -6262,7 +6262,7 @@ Object {
                 "id": "tcpdump@14:4.0.0-11.20090921gitdf3cb4.2.el6",
                 "info": Object {
                   "name": "tcpdump",
-                  "purl": "pkg:rpm/tcpdump@14:4.0.0-11.20090921gitdf3cb4.2.el6?epoch=14",
+                  "purl": "pkg:rpm/centos/tcpdump@14:4.0.0-11.20090921gitdf3cb4.2.el6?distro=centos-6&epoch=14",
                   "version": "14:4.0.0-11.20090921gitdf3cb4.2.el6",
                 },
               },
@@ -6270,7 +6270,7 @@ Object {
                 "id": "telnet@1:0.17-49.el6_10",
                 "info": Object {
                   "name": "telnet",
-                  "purl": "pkg:rpm/telnet@1:0.17-49.el6_10?epoch=1",
+                  "purl": "pkg:rpm/centos/telnet@1:0.17-49.el6_10?distro=centos-6&epoch=1",
                   "version": "1:0.17-49.el6_10",
                 },
               },
@@ -6278,7 +6278,7 @@ Object {
                 "id": "time@1.7-38.el6",
                 "info": Object {
                   "name": "time",
-                  "purl": "pkg:rpm/time@1.7-38.el6",
+                  "purl": "pkg:rpm/centos/time@1.7-38.el6?distro=centos-6",
                   "version": "1.7-38.el6",
                 },
               },
@@ -6286,7 +6286,7 @@ Object {
                 "id": "tzdata@2018e-3.el6",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2018e-3.el6",
+                  "purl": "pkg:rpm/centos/tzdata@2018e-3.el6?distro=centos-6",
                   "version": "2018e-3.el6",
                 },
               },
@@ -6294,7 +6294,7 @@ Object {
                 "id": "udev@147-2.74.el6_10",
                 "info": Object {
                   "name": "udev",
-                  "purl": "pkg:rpm/udev@147-2.74.el6_10",
+                  "purl": "pkg:rpm/centos/udev@147-2.74.el6_10?distro=centos-6",
                   "version": "147-2.74.el6_10",
                 },
               },
@@ -6302,7 +6302,7 @@ Object {
                 "id": "upstart@0.6.5-17.el6",
                 "info": Object {
                   "name": "upstart",
-                  "purl": "pkg:rpm/upstart@0.6.5-17.el6",
+                  "purl": "pkg:rpm/centos/upstart@0.6.5-17.el6?distro=centos-6",
                   "version": "0.6.5-17.el6",
                 },
               },
@@ -6310,7 +6310,7 @@ Object {
                 "id": "ustr@1.0.4-9.1.el6",
                 "info": Object {
                   "name": "ustr",
-                  "purl": "pkg:rpm/ustr@1.0.4-9.1.el6",
+                  "purl": "pkg:rpm/centos/ustr@1.0.4-9.1.el6?distro=centos-6",
                   "version": "1.0.4-9.1.el6",
                 },
               },
@@ -6318,7 +6318,7 @@ Object {
                 "id": "util-linux-ng@2.17.2-12.28.el6_9.2",
                 "info": Object {
                   "name": "util-linux-ng",
-                  "purl": "pkg:rpm/util-linux-ng@2.17.2-12.28.el6_9.2",
+                  "purl": "pkg:rpm/centos/util-linux-ng@2.17.2-12.28.el6_9.2?distro=centos-6",
                   "version": "2.17.2-12.28.el6_9.2",
                 },
               },
@@ -6326,7 +6326,7 @@ Object {
                 "id": "vim-minimal@2:7.4.629-5.el6_10.2",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:7.4.629-5.el6_10.2?epoch=2",
+                  "purl": "pkg:rpm/centos/vim-minimal@2:7.4.629-5.el6_10.2?distro=centos-6&epoch=2",
                   "version": "2:7.4.629-5.el6_10.2",
                 },
               },
@@ -6334,7 +6334,7 @@ Object {
                 "id": "wget@1.12-10.el6",
                 "info": Object {
                   "name": "wget",
-                  "purl": "pkg:rpm/wget@1.12-10.el6",
+                  "purl": "pkg:rpm/centos/wget@1.12-10.el6?distro=centos-6",
                   "version": "1.12-10.el6",
                 },
               },
@@ -6342,7 +6342,7 @@ Object {
                 "id": "which@2.19-6.el6",
                 "info": Object {
                   "name": "which",
-                  "purl": "pkg:rpm/which@2.19-6.el6",
+                  "purl": "pkg:rpm/centos/which@2.19-6.el6?distro=centos-6",
                   "version": "2.19-6.el6",
                 },
               },
@@ -6350,7 +6350,7 @@ Object {
                 "id": "xz@4.999.9-0.5.beta.20091007git.el6",
                 "info": Object {
                   "name": "xz",
-                  "purl": "pkg:rpm/xz@4.999.9-0.5.beta.20091007git.el6",
+                  "purl": "pkg:rpm/centos/xz@4.999.9-0.5.beta.20091007git.el6?distro=centos-6",
                   "version": "4.999.9-0.5.beta.20091007git.el6",
                 },
               },
@@ -6358,7 +6358,7 @@ Object {
                 "id": "xz-libs@4.999.9-0.5.beta.20091007git.el6",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@4.999.9-0.5.beta.20091007git.el6",
+                  "purl": "pkg:rpm/centos/xz-libs@4.999.9-0.5.beta.20091007git.el6?distro=centos-6",
                   "version": "4.999.9-0.5.beta.20091007git.el6",
                 },
               },
@@ -6366,7 +6366,7 @@ Object {
                 "id": "xz-lzma-compat@4.999.9-0.5.beta.20091007git.el6",
                 "info": Object {
                   "name": "xz-lzma-compat",
-                  "purl": "pkg:rpm/xz-lzma-compat@4.999.9-0.5.beta.20091007git.el6",
+                  "purl": "pkg:rpm/centos/xz-lzma-compat@4.999.9-0.5.beta.20091007git.el6?distro=centos-6",
                   "version": "4.999.9-0.5.beta.20091007git.el6",
                 },
               },
@@ -6374,7 +6374,7 @@ Object {
                 "id": "yum@3.2.29-81.el6.centos",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.2.29-81.el6.centos",
+                  "purl": "pkg:rpm/centos/yum@3.2.29-81.el6.centos?distro=centos-6",
                   "version": "3.2.29-81.el6.centos",
                 },
               },
@@ -6382,7 +6382,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.2-16.el6",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.2-16.el6",
+                  "purl": "pkg:rpm/centos/yum-metadata-parser@1.1.2-16.el6?distro=centos-6",
                   "version": "1.1.2-16.el6",
                 },
               },
@@ -6390,7 +6390,7 @@ Object {
                 "id": "yum-plugin-fastestmirror@1.1.30-42.el6_10",
                 "info": Object {
                   "name": "yum-plugin-fastestmirror",
-                  "purl": "pkg:rpm/yum-plugin-fastestmirror@1.1.30-42.el6_10",
+                  "purl": "pkg:rpm/centos/yum-plugin-fastestmirror@1.1.30-42.el6_10?distro=centos-6",
                   "version": "1.1.30-42.el6_10",
                 },
               },
@@ -6398,7 +6398,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.30-42.el6_10",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.30-42.el6_10",
+                  "purl": "pkg:rpm/centos/yum-plugin-ovl@1.1.30-42.el6_10?distro=centos-6",
                   "version": "1.1.30-42.el6_10",
                 },
               },
@@ -6406,7 +6406,7 @@ Object {
                 "id": "zlib@1.2.3-29.el6",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.3-29.el6",
+                  "purl": "pkg:rpm/centos/zlib@1.2.3-29.el6?distro=centos-6",
                   "version": "1.2.3-29.el6",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/centos7.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/centos7.spec.ts.snap
@@ -1214,7 +1214,7 @@ Object {
                 "id": "acl@2.2.51-15.el7",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:rpm/acl@2.2.51-15.el7",
+                  "purl": "pkg:rpm/centos/acl@2.2.51-15.el7?distro=centos-7",
                   "version": "2.2.51-15.el7",
                 },
               },
@@ -1222,7 +1222,7 @@ Object {
                 "id": "audit-libs@2.8.5-4.el7",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@2.8.5-4.el7",
+                  "purl": "pkg:rpm/centos/audit-libs@2.8.5-4.el7?distro=centos-7",
                   "version": "2.8.5-4.el7",
                 },
               },
@@ -1230,7 +1230,7 @@ Object {
                 "id": "basesystem@10.0-7.el7.centos",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.el7.centos",
+                  "purl": "pkg:rpm/centos/basesystem@10.0-7.el7.centos?distro=centos-7",
                   "version": "10.0-7.el7.centos",
                 },
               },
@@ -1238,7 +1238,7 @@ Object {
                 "id": "bash@4.2.46-34.el7",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-34.el7",
+                  "purl": "pkg:rpm/centos/bash@4.2.46-34.el7?distro=centos-7",
                   "version": "4.2.46-34.el7",
                 },
               },
@@ -1246,7 +1246,7 @@ Object {
                 "id": "bind-license@32:9.11.4-16.P2.el7",
                 "info": Object {
                   "name": "bind-license",
-                  "purl": "pkg:rpm/bind-license@32:9.11.4-16.P2.el7?epoch=32",
+                  "purl": "pkg:rpm/centos/bind-license@32:9.11.4-16.P2.el7?distro=centos-7&epoch=32",
                   "version": "32:9.11.4-16.P2.el7",
                 },
               },
@@ -1254,7 +1254,7 @@ Object {
                 "id": "binutils@2.27-43.base.el7",
                 "info": Object {
                   "name": "binutils",
-                  "purl": "pkg:rpm/binutils@2.27-43.base.el7",
+                  "purl": "pkg:rpm/centos/binutils@2.27-43.base.el7?distro=centos-7",
                   "version": "2.27-43.base.el7",
                 },
               },
@@ -1262,7 +1262,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.el7",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.el7",
+                  "purl": "pkg:rpm/centos/bzip2-libs@1.0.6-13.el7?distro=centos-7",
                   "version": "1.0.6-13.el7",
                 },
               },
@@ -1270,7 +1270,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.el7_7",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.el7_7",
+                  "purl": "pkg:rpm/centos/ca-certificates@2019.2.32-76.el7_7?distro=centos-7",
                   "version": "2019.2.32-76.el7_7",
                 },
               },
@@ -1278,7 +1278,7 @@ Object {
                 "id": "centos-release@7-8.2003.0.el7.centos",
                 "info": Object {
                   "name": "centos-release",
-                  "purl": "pkg:rpm/centos-release@7-8.2003.0.el7.centos",
+                  "purl": "pkg:rpm/centos/centos-release@7-8.2003.0.el7.centos?distro=centos-7",
                   "version": "7-8.2003.0.el7.centos",
                 },
               },
@@ -1286,7 +1286,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.el7",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.el7",
+                  "purl": "pkg:rpm/centos/chkconfig@1.7.4-1.el7?distro=centos-7",
                   "version": "1.7.4-1.el7",
                 },
               },
@@ -1294,7 +1294,7 @@ Object {
                 "id": "coreutils@8.22-24.el7",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.el7",
+                  "purl": "pkg:rpm/centos/coreutils@8.22-24.el7?distro=centos-7",
                   "version": "8.22-24.el7",
                 },
               },
@@ -1302,7 +1302,7 @@ Object {
                 "id": "cpio@2.11-27.el7",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.el7",
+                  "purl": "pkg:rpm/centos/cpio@2.11-27.el7?distro=centos-7",
                   "version": "2.11-27.el7",
                 },
               },
@@ -1310,7 +1310,7 @@ Object {
                 "id": "cracklib@2.9.0-11.el7",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.0-11.el7",
+                  "purl": "pkg:rpm/centos/cracklib@2.9.0-11.el7?distro=centos-7",
                   "version": "2.9.0-11.el7",
                 },
               },
@@ -1318,7 +1318,7 @@ Object {
                 "id": "cracklib-dicts@2.9.0-11.el7",
                 "info": Object {
                   "name": "cracklib-dicts",
-                  "purl": "pkg:rpm/cracklib-dicts@2.9.0-11.el7",
+                  "purl": "pkg:rpm/centos/cracklib-dicts@2.9.0-11.el7?distro=centos-7",
                   "version": "2.9.0-11.el7",
                 },
               },
@@ -1326,7 +1326,7 @@ Object {
                 "id": "cryptsetup-libs@2.0.3-6.el7",
                 "info": Object {
                   "name": "cryptsetup-libs",
-                  "purl": "pkg:rpm/cryptsetup-libs@2.0.3-6.el7",
+                  "purl": "pkg:rpm/centos/cryptsetup-libs@2.0.3-6.el7?distro=centos-7",
                   "version": "2.0.3-6.el7",
                 },
               },
@@ -1334,7 +1334,7 @@ Object {
                 "id": "curl@7.29.0-57.el7",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.29.0-57.el7",
+                  "purl": "pkg:rpm/centos/curl@7.29.0-57.el7?distro=centos-7",
                   "version": "7.29.0-57.el7",
                 },
               },
@@ -1342,7 +1342,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.el7",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.el7",
+                  "purl": "pkg:rpm/centos/cyrus-sasl-lib@2.1.26-23.el7?distro=centos-7",
                   "version": "2.1.26-23.el7",
                 },
               },
@@ -1350,7 +1350,7 @@ Object {
                 "id": "dbus@1:1.10.24-13.el7_6",
                 "info": Object {
                   "name": "dbus",
-                  "purl": "pkg:rpm/dbus@1:1.10.24-13.el7_6?epoch=1",
+                  "purl": "pkg:rpm/centos/dbus@1:1.10.24-13.el7_6?distro=centos-7&epoch=1",
                   "version": "1:1.10.24-13.el7_6",
                 },
               },
@@ -1358,7 +1358,7 @@ Object {
                 "id": "dbus-glib@0.100-7.el7",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.100-7.el7",
+                  "purl": "pkg:rpm/centos/dbus-glib@0.100-7.el7?distro=centos-7",
                   "version": "0.100-7.el7",
                 },
               },
@@ -1366,7 +1366,7 @@ Object {
                 "id": "dbus-libs@1:1.10.24-13.el7_6",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.10.24-13.el7_6?epoch=1",
+                  "purl": "pkg:rpm/centos/dbus-libs@1:1.10.24-13.el7_6?distro=centos-7&epoch=1",
                   "version": "1:1.10.24-13.el7_6",
                 },
               },
@@ -1374,7 +1374,7 @@ Object {
                 "id": "dbus-python@1.1.1-9.el7",
                 "info": Object {
                   "name": "dbus-python",
-                  "purl": "pkg:rpm/dbus-python@1.1.1-9.el7",
+                  "purl": "pkg:rpm/centos/dbus-python@1.1.1-9.el7?distro=centos-7",
                   "version": "1.1.1-9.el7",
                 },
               },
@@ -1382,7 +1382,7 @@ Object {
                 "id": "device-mapper@7:1.02.164-7.el7",
                 "info": Object {
                   "name": "device-mapper",
-                  "purl": "pkg:rpm/device-mapper@7:1.02.164-7.el7?epoch=7",
+                  "purl": "pkg:rpm/centos/device-mapper@7:1.02.164-7.el7?distro=centos-7&epoch=7",
                   "version": "7:1.02.164-7.el7",
                 },
               },
@@ -1390,7 +1390,7 @@ Object {
                 "id": "device-mapper-libs@7:1.02.164-7.el7",
                 "info": Object {
                   "name": "device-mapper-libs",
-                  "purl": "pkg:rpm/device-mapper-libs@7:1.02.164-7.el7?epoch=7",
+                  "purl": "pkg:rpm/centos/device-mapper-libs@7:1.02.164-7.el7?distro=centos-7&epoch=7",
                   "version": "7:1.02.164-7.el7",
                 },
               },
@@ -1398,7 +1398,7 @@ Object {
                 "id": "diffutils@3.3-5.el7",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.el7",
+                  "purl": "pkg:rpm/centos/diffutils@3.3-5.el7?distro=centos-7",
                   "version": "3.3-5.el7",
                 },
               },
@@ -1406,7 +1406,7 @@ Object {
                 "id": "dracut@033-568.el7",
                 "info": Object {
                   "name": "dracut",
-                  "purl": "pkg:rpm/dracut@033-568.el7",
+                  "purl": "pkg:rpm/centos/dracut@033-568.el7?distro=centos-7",
                   "version": "033-568.el7",
                 },
               },
@@ -1414,7 +1414,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-default-yama-scope@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -1422,7 +1422,7 @@ Object {
                 "id": "elfutils-libelf@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-libelf@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -1430,7 +1430,7 @@ Object {
                 "id": "elfutils-libs@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-libs@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -1438,7 +1438,7 @@ Object {
                 "id": "expat@2.1.0-11.el7",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-11.el7",
+                  "purl": "pkg:rpm/centos/expat@2.1.0-11.el7?distro=centos-7",
                   "version": "2.1.0-11.el7",
                 },
               },
@@ -1446,7 +1446,7 @@ Object {
                 "id": "file-libs@5.11-36.el7",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-36.el7",
+                  "purl": "pkg:rpm/centos/file-libs@5.11-36.el7?distro=centos-7",
                   "version": "5.11-36.el7",
                 },
               },
@@ -1454,7 +1454,7 @@ Object {
                 "id": "filesystem@3.2-25.el7",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.el7",
+                  "purl": "pkg:rpm/centos/filesystem@3.2-25.el7?distro=centos-7",
                   "version": "3.2-25.el7",
                 },
               },
@@ -1462,7 +1462,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.el7",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/findutils@1:4.5.11-6.el7?distro=centos-7&epoch=1",
                   "version": "1:4.5.11-6.el7",
                 },
               },
@@ -1470,7 +1470,7 @@ Object {
                 "id": "gawk@4.0.2-4.el7_3.1",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.el7_3.1",
+                  "purl": "pkg:rpm/centos/gawk@4.0.2-4.el7_3.1?distro=centos-7",
                   "version": "4.0.2-4.el7_3.1",
                 },
               },
@@ -1478,7 +1478,7 @@ Object {
                 "id": "gdbm@1.10-8.el7",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1.10-8.el7",
+                  "purl": "pkg:rpm/centos/gdbm@1.10-8.el7?distro=centos-7",
                   "version": "1.10-8.el7",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "geoipupdate@2.5.0-1.el7",
                 "info": Object {
                   "name": "geoipupdate",
-                  "purl": "pkg:rpm/geoipupdate@2.5.0-1.el7",
+                  "purl": "pkg:rpm/centos/geoipupdate@2.5.0-1.el7?distro=centos-7",
                   "version": "2.5.0-1.el7",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "glib2@2.56.1-5.el7",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-5.el7",
+                  "purl": "pkg:rpm/centos/glib2@2.56.1-5.el7?distro=centos-7",
                   "version": "2.56.1-5.el7",
                 },
               },
@@ -1502,7 +1502,7 @@ Object {
                 "id": "glibc@2.17-307.el7.1",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.17-307.el7.1",
+                  "purl": "pkg:rpm/centos/glibc@2.17-307.el7.1?distro=centos-7",
                   "version": "2.17-307.el7.1",
                 },
               },
@@ -1510,7 +1510,7 @@ Object {
                 "id": "glibc-common@2.17-307.el7.1",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.17-307.el7.1",
+                  "purl": "pkg:rpm/centos/glibc-common@2.17-307.el7.1?distro=centos-7",
                   "version": "2.17-307.el7.1",
                 },
               },
@@ -1518,7 +1518,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.el7",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/gmp@1:6.0.0-15.el7?distro=centos-7&epoch=1",
                   "version": "1:6.0.0-15.el7",
                 },
               },
@@ -1526,7 +1526,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.el7_5",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.el7_5",
+                  "purl": "pkg:rpm/centos/gnupg2@2.0.22-5.el7_5?distro=centos-7",
                   "version": "2.0.22-5.el7_5",
                 },
               },
@@ -1534,7 +1534,7 @@ Object {
                 "id": "gobject-introspection@1.56.1-1.el7",
                 "info": Object {
                   "name": "gobject-introspection",
-                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el7",
+                  "purl": "pkg:rpm/centos/gobject-introspection@1.56.1-1.el7?distro=centos-7",
                   "version": "1.56.1-1.el7",
                 },
               },
@@ -1542,7 +1542,7 @@ Object {
                 "id": "gpgme@1.3.2-5.el7",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.el7",
+                  "purl": "pkg:rpm/centos/gpgme@1.3.2-5.el7?distro=centos-7",
                   "version": "1.3.2-5.el7",
                 },
               },
@@ -1550,7 +1550,7 @@ Object {
                 "id": "grep@2.20-3.el7",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.el7",
+                  "purl": "pkg:rpm/centos/grep@2.20-3.el7?distro=centos-7",
                   "version": "2.20-3.el7",
                 },
               },
@@ -1558,7 +1558,7 @@ Object {
                 "id": "gzip@1.5-10.el7",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.5-10.el7",
+                  "purl": "pkg:rpm/centos/gzip@1.5-10.el7?distro=centos-7",
                   "version": "1.5-10.el7",
                 },
               },
@@ -1566,7 +1566,7 @@ Object {
                 "id": "hardlink@1:1.0-19.el7",
                 "info": Object {
                   "name": "hardlink",
-                  "purl": "pkg:rpm/hardlink@1:1.0-19.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/hardlink@1:1.0-19.el7?distro=centos-7&epoch=1",
                   "version": "1:1.0-19.el7",
                 },
               },
@@ -1574,7 +1574,7 @@ Object {
                 "id": "hostname@3.13-3.el7_7.1",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:rpm/hostname@3.13-3.el7_7.1",
+                  "purl": "pkg:rpm/centos/hostname@3.13-3.el7_7.1?distro=centos-7",
                   "version": "3.13-3.el7_7.1",
                 },
               },
@@ -1582,7 +1582,7 @@ Object {
                 "id": "info@5.1-5.el7",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.el7",
+                  "purl": "pkg:rpm/centos/info@5.1-5.el7?distro=centos-7",
                   "version": "5.1-5.el7",
                 },
               },
@@ -1590,7 +1590,7 @@ Object {
                 "id": "iputils@20160308-10.el7",
                 "info": Object {
                   "name": "iputils",
-                  "purl": "pkg:rpm/iputils@20160308-10.el7",
+                  "purl": "pkg:rpm/centos/iputils@20160308-10.el7?distro=centos-7",
                   "version": "20160308-10.el7",
                 },
               },
@@ -1598,7 +1598,7 @@ Object {
                 "id": "json-c@0.11-4.el7_0",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.11-4.el7_0",
+                  "purl": "pkg:rpm/centos/json-c@0.11-4.el7_0?distro=centos-7",
                   "version": "0.11-4.el7_0",
                 },
               },
@@ -1606,7 +1606,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.el7",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.el7",
+                  "purl": "pkg:rpm/centos/keyutils-libs@1.5.8-3.el7?distro=centos-7",
                   "version": "1.5.8-3.el7",
                 },
               },
@@ -1614,7 +1614,7 @@ Object {
                 "id": "kmod@20-28.el7",
                 "info": Object {
                   "name": "kmod",
-                  "purl": "pkg:rpm/kmod@20-28.el7",
+                  "purl": "pkg:rpm/centos/kmod@20-28.el7?distro=centos-7",
                   "version": "20-28.el7",
                 },
               },
@@ -1622,7 +1622,7 @@ Object {
                 "id": "kmod-libs@20-28.el7",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/kmod-libs@20-28.el7",
+                  "purl": "pkg:rpm/centos/kmod-libs@20-28.el7?distro=centos-7",
                   "version": "20-28.el7",
                 },
               },
@@ -1630,7 +1630,7 @@ Object {
                 "id": "kpartx@0.4.9-131.el7",
                 "info": Object {
                   "name": "kpartx",
-                  "purl": "pkg:rpm/kpartx@0.4.9-131.el7",
+                  "purl": "pkg:rpm/centos/kpartx@0.4.9-131.el7?distro=centos-7",
                   "version": "0.4.9-131.el7",
                 },
               },
@@ -1638,7 +1638,7 @@ Object {
                 "id": "krb5-libs@1.15.1-46.el7",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-46.el7",
+                  "purl": "pkg:rpm/centos/krb5-libs@1.15.1-46.el7?distro=centos-7",
                   "version": "1.15.1-46.el7",
                 },
               },
@@ -1646,7 +1646,7 @@ Object {
                 "id": "libacl@2.2.51-15.el7",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-15.el7",
+                  "purl": "pkg:rpm/centos/libacl@2.2.51-15.el7?distro=centos-7",
                   "version": "2.2.51-15.el7",
                 },
               },
@@ -1654,7 +1654,7 @@ Object {
                 "id": "libassuan@2.1.0-3.el7",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.el7",
+                  "purl": "pkg:rpm/centos/libassuan@2.1.0-3.el7?distro=centos-7",
                   "version": "2.1.0-3.el7",
                 },
               },
@@ -1662,7 +1662,7 @@ Object {
                 "id": "libattr@2.4.46-13.el7",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-13.el7",
+                  "purl": "pkg:rpm/centos/libattr@2.4.46-13.el7?distro=centos-7",
                   "version": "2.4.46-13.el7",
                 },
               },
@@ -1670,7 +1670,7 @@ Object {
                 "id": "libblkid@2.23.2-63.el7",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libblkid@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -1678,7 +1678,7 @@ Object {
                 "id": "libcap@2.22-11.el7",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-11.el7",
+                  "purl": "pkg:rpm/centos/libcap@2.22-11.el7?distro=centos-7",
                   "version": "2.22-11.el7",
                 },
               },
@@ -1686,7 +1686,7 @@ Object {
                 "id": "libcap-ng@0.7.5-4.el7",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.7.5-4.el7",
+                  "purl": "pkg:rpm/centos/libcap-ng@0.7.5-4.el7?distro=centos-7",
                   "version": "0.7.5-4.el7",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "libcom_err@1.42.9-17.el7",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-17.el7",
+                  "purl": "pkg:rpm/centos/libcom_err@1.42.9-17.el7?distro=centos-7",
                   "version": "1.42.9-17.el7",
                 },
               },
@@ -1702,7 +1702,7 @@ Object {
                 "id": "libcurl@7.29.0-57.el7",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.29.0-57.el7",
+                  "purl": "pkg:rpm/centos/libcurl@7.29.0-57.el7?distro=centos-7",
                   "version": "7.29.0-57.el7",
                 },
               },
@@ -1710,7 +1710,7 @@ Object {
                 "id": "libdb@5.3.21-25.el7",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-25.el7",
+                  "purl": "pkg:rpm/centos/libdb@5.3.21-25.el7?distro=centos-7",
                   "version": "5.3.21-25.el7",
                 },
               },
@@ -1718,7 +1718,7 @@ Object {
                 "id": "libdb-utils@5.3.21-25.el7",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-25.el7",
+                  "purl": "pkg:rpm/centos/libdb-utils@5.3.21-25.el7?distro=centos-7",
                   "version": "5.3.21-25.el7",
                 },
               },
@@ -1726,7 +1726,7 @@ Object {
                 "id": "libffi@3.0.13-19.el7",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-19.el7",
+                  "purl": "pkg:rpm/centos/libffi@3.0.13-19.el7?distro=centos-7",
                   "version": "3.0.13-19.el7",
                 },
               },
@@ -1734,7 +1734,7 @@ Object {
                 "id": "libgcc@4.8.5-39.el7",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/libgcc@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -1742,7 +1742,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.el7",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.el7",
+                  "purl": "pkg:rpm/centos/libgcrypt@1.5.3-14.el7?distro=centos-7",
                   "version": "1.5.3-14.el7",
                 },
               },
@@ -1750,7 +1750,7 @@ Object {
                 "id": "libgpg-error@1.12-3.el7",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.el7",
+                  "purl": "pkg:rpm/centos/libgpg-error@1.12-3.el7?distro=centos-7",
                   "version": "1.12-3.el7",
                 },
               },
@@ -1758,7 +1758,7 @@ Object {
                 "id": "libidn@1.28-4.el7",
                 "info": Object {
                   "name": "libidn",
-                  "purl": "pkg:rpm/libidn@1.28-4.el7",
+                  "purl": "pkg:rpm/centos/libidn@1.28-4.el7?distro=centos-7",
                   "version": "1.28-4.el7",
                 },
               },
@@ -1766,7 +1766,7 @@ Object {
                 "id": "libmount@2.23.2-63.el7",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libmount@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -1774,7 +1774,7 @@ Object {
                 "id": "libpwquality@1.2.3-5.el7",
                 "info": Object {
                   "name": "libpwquality",
-                  "purl": "pkg:rpm/libpwquality@1.2.3-5.el7",
+                  "purl": "pkg:rpm/centos/libpwquality@1.2.3-5.el7?distro=centos-7",
                   "version": "1.2.3-5.el7",
                 },
               },
@@ -1782,7 +1782,7 @@ Object {
                 "id": "libselinux@2.5-15.el7",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-15.el7",
+                  "purl": "pkg:rpm/centos/libselinux@2.5-15.el7?distro=centos-7",
                   "version": "2.5-15.el7",
                 },
               },
@@ -1790,7 +1790,7 @@ Object {
                 "id": "libsemanage@2.5-14.el7",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.5-14.el7",
+                  "purl": "pkg:rpm/centos/libsemanage@2.5-14.el7?distro=centos-7",
                   "version": "2.5-14.el7",
                 },
               },
@@ -1798,7 +1798,7 @@ Object {
                 "id": "libsepol@2.5-10.el7",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-10.el7",
+                  "purl": "pkg:rpm/centos/libsepol@2.5-10.el7?distro=centos-7",
                   "version": "2.5-10.el7",
                 },
               },
@@ -1806,7 +1806,7 @@ Object {
                 "id": "libsmartcols@2.23.2-63.el7",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libsmartcols@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -1814,7 +1814,7 @@ Object {
                 "id": "libssh2@1.8.0-3.el7",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.8.0-3.el7",
+                  "purl": "pkg:rpm/centos/libssh2@1.8.0-3.el7?distro=centos-7",
                   "version": "1.8.0-3.el7",
                 },
               },
@@ -1822,7 +1822,7 @@ Object {
                 "id": "libstdc++@4.8.5-39.el7",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/libstdc%2B%2B@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -1830,7 +1830,7 @@ Object {
                 "id": "libtasn1@4.10-1.el7",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.el7",
+                  "purl": "pkg:rpm/centos/libtasn1@4.10-1.el7?distro=centos-7",
                   "version": "4.10-1.el7",
                 },
               },
@@ -1838,7 +1838,7 @@ Object {
                 "id": "libuser@0.60-9.el7",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.60-9.el7",
+                  "purl": "pkg:rpm/centos/libuser@0.60-9.el7?distro=centos-7",
                   "version": "0.60-9.el7",
                 },
               },
@@ -1846,7 +1846,7 @@ Object {
                 "id": "libutempter@1.1.6-4.el7",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.6-4.el7",
+                  "purl": "pkg:rpm/centos/libutempter@1.1.6-4.el7?distro=centos-7",
                   "version": "1.1.6-4.el7",
                 },
               },
@@ -1854,7 +1854,7 @@ Object {
                 "id": "libuuid@2.23.2-63.el7",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libuuid@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -1862,7 +1862,7 @@ Object {
                 "id": "libverto@0.2.5-4.el7",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.el7",
+                  "purl": "pkg:rpm/centos/libverto@0.2.5-4.el7?distro=centos-7",
                   "version": "0.2.5-4.el7",
                 },
               },
@@ -1870,7 +1870,7 @@ Object {
                 "id": "libxml2@2.9.1-6.el7.4",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.el7.4",
+                  "purl": "pkg:rpm/centos/libxml2@2.9.1-6.el7.4?distro=centos-7",
                   "version": "2.9.1-6.el7.4",
                 },
               },
@@ -1878,7 +1878,7 @@ Object {
                 "id": "libxml2-python@2.9.1-6.el7.4",
                 "info": Object {
                   "name": "libxml2-python",
-                  "purl": "pkg:rpm/libxml2-python@2.9.1-6.el7.4",
+                  "purl": "pkg:rpm/centos/libxml2-python@2.9.1-6.el7.4?distro=centos-7",
                   "version": "2.9.1-6.el7.4",
                 },
               },
@@ -1886,7 +1886,7 @@ Object {
                 "id": "lua@5.1.4-15.el7",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.el7",
+                  "purl": "pkg:rpm/centos/lua@5.1.4-15.el7?distro=centos-7",
                   "version": "5.1.4-15.el7",
                 },
               },
@@ -1894,7 +1894,7 @@ Object {
                 "id": "lz4@1.7.5-3.el7",
                 "info": Object {
                   "name": "lz4",
-                  "purl": "pkg:rpm/lz4@1.7.5-3.el7",
+                  "purl": "pkg:rpm/centos/lz4@1.7.5-3.el7?distro=centos-7",
                   "version": "1.7.5-3.el7",
                 },
               },
@@ -1902,7 +1902,7 @@ Object {
                 "id": "ncurses@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -1910,7 +1910,7 @@ Object {
                 "id": "ncurses-base@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses-base@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -1918,7 +1918,7 @@ Object {
                 "id": "ncurses-libs@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses-libs@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -1926,7 +1926,7 @@ Object {
                 "id": "nspr@4.21.0-1.el7",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.el7",
+                  "purl": "pkg:rpm/centos/nspr@4.21.0-1.el7?distro=centos-7",
                   "version": "4.21.0-1.el7",
                 },
               },
@@ -1934,7 +1934,7 @@ Object {
                 "id": "nss@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -1942,7 +1942,7 @@ Object {
                 "id": "nss-pem@1.0.3-7.el7",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-7.el7",
+                  "purl": "pkg:rpm/centos/nss-pem@1.0.3-7.el7?distro=centos-7",
                   "version": "1.0.3-7.el7",
                 },
               },
@@ -1950,7 +1950,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.el7_7",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.el7_7",
+                  "purl": "pkg:rpm/centos/nss-softokn@3.44.0-8.el7_7?distro=centos-7",
                   "version": "3.44.0-8.el7_7",
                 },
               },
@@ -1958,7 +1958,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.el7_7",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.el7_7",
+                  "purl": "pkg:rpm/centos/nss-softokn-freebl@3.44.0-8.el7_7?distro=centos-7",
                   "version": "3.44.0-8.el7_7",
                 },
               },
@@ -1966,7 +1966,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss-sysinit@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -1974,7 +1974,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss-tools@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -1982,7 +1982,7 @@ Object {
                 "id": "nss-util@3.44.0-4.el7_7",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.el7_7",
+                  "purl": "pkg:rpm/centos/nss-util@3.44.0-4.el7_7?distro=centos-7",
                   "version": "3.44.0-4.el7_7",
                 },
               },
@@ -1990,7 +1990,7 @@ Object {
                 "id": "openldap@2.4.44-21.el7_6",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-21.el7_6",
+                  "purl": "pkg:rpm/centos/openldap@2.4.44-21.el7_6?distro=centos-7",
                   "version": "2.4.44-21.el7_6",
                 },
               },
@@ -1998,7 +1998,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.el7",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/openssl-libs@1:1.0.2k-19.el7?distro=centos-7&epoch=1",
                   "version": "1:1.0.2k-19.el7",
                 },
               },
@@ -2006,7 +2006,7 @@ Object {
                 "id": "p11-kit@0.23.5-3.el7",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.5-3.el7",
+                  "purl": "pkg:rpm/centos/p11-kit@0.23.5-3.el7?distro=centos-7",
                   "version": "0.23.5-3.el7",
                 },
               },
@@ -2014,7 +2014,7 @@ Object {
                 "id": "p11-kit-trust@0.23.5-3.el7",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.5-3.el7",
+                  "purl": "pkg:rpm/centos/p11-kit-trust@0.23.5-3.el7?distro=centos-7",
                   "version": "0.23.5-3.el7",
                 },
               },
@@ -2022,7 +2022,7 @@ Object {
                 "id": "pam@1.1.8-23.el7",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.1.8-23.el7",
+                  "purl": "pkg:rpm/centos/pam@1.1.8-23.el7?distro=centos-7",
                   "version": "1.1.8-23.el7",
                 },
               },
@@ -2030,7 +2030,7 @@ Object {
                 "id": "passwd@0.79-6.el7",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.79-6.el7",
+                  "purl": "pkg:rpm/centos/passwd@0.79-6.el7?distro=centos-7",
                   "version": "0.79-6.el7",
                 },
               },
@@ -2038,7 +2038,7 @@ Object {
                 "id": "pcre@8.32-17.el7",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.el7",
+                  "purl": "pkg:rpm/centos/pcre@8.32-17.el7?distro=centos-7",
                   "version": "8.32-17.el7",
                 },
               },
@@ -2046,7 +2046,7 @@ Object {
                 "id": "pinentry@0.8.1-17.el7",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.el7",
+                  "purl": "pkg:rpm/centos/pinentry@0.8.1-17.el7?distro=centos-7",
                   "version": "0.8.1-17.el7",
                 },
               },
@@ -2054,7 +2054,7 @@ Object {
                 "id": "pkgconfig@1:0.27.1-4.el7",
                 "info": Object {
                   "name": "pkgconfig",
-                  "purl": "pkg:rpm/pkgconfig@1:0.27.1-4.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/pkgconfig@1:0.27.1-4.el7?distro=centos-7&epoch=1",
                   "version": "1:0.27.1-4.el7",
                 },
               },
@@ -2062,7 +2062,7 @@ Object {
                 "id": "popt@1.13-16.el7",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.el7",
+                  "purl": "pkg:rpm/centos/popt@1.13-16.el7?distro=centos-7",
                   "version": "1.13-16.el7",
                 },
               },
@@ -2070,7 +2070,7 @@ Object {
                 "id": "procps-ng@3.3.10-27.el7",
                 "info": Object {
                   "name": "procps-ng",
-                  "purl": "pkg:rpm/procps-ng@3.3.10-27.el7",
+                  "purl": "pkg:rpm/centos/procps-ng@3.3.10-27.el7?distro=centos-7",
                   "version": "3.3.10-27.el7",
                 },
               },
@@ -2078,7 +2078,7 @@ Object {
                 "id": "pth@2.0.7-23.el7",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.el7",
+                  "purl": "pkg:rpm/centos/pth@2.0.7-23.el7?distro=centos-7",
                   "version": "2.0.7-23.el7",
                 },
               },
@@ -2086,7 +2086,7 @@ Object {
                 "id": "pygpgme@0.3-9.el7",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.el7",
+                  "purl": "pkg:rpm/centos/pygpgme@0.3-9.el7?distro=centos-7",
                   "version": "0.3-9.el7",
                 },
               },
@@ -2094,7 +2094,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.el7",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.el7",
+                  "purl": "pkg:rpm/centos/pyliblzma@0.5.3-11.el7?distro=centos-7",
                   "version": "0.5.3-11.el7",
                 },
               },
@@ -2102,7 +2102,7 @@ Object {
                 "id": "python@2.7.5-88.el7",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.5-88.el7",
+                  "purl": "pkg:rpm/centos/python@2.7.5-88.el7?distro=centos-7",
                   "version": "2.7.5-88.el7",
                 },
               },
@@ -2110,7 +2110,7 @@ Object {
                 "id": "python-chardet@2.2.1-3.el7",
                 "info": Object {
                   "name": "python-chardet",
-                  "purl": "pkg:rpm/python-chardet@2.2.1-3.el7",
+                  "purl": "pkg:rpm/centos/python-chardet@2.2.1-3.el7?distro=centos-7",
                   "version": "2.2.1-3.el7",
                 },
               },
@@ -2118,7 +2118,7 @@ Object {
                 "id": "python-gobject-base@3.22.0-1.el7_4.1",
                 "info": Object {
                   "name": "python-gobject-base",
-                  "purl": "pkg:rpm/python-gobject-base@3.22.0-1.el7_4.1",
+                  "purl": "pkg:rpm/centos/python-gobject-base@3.22.0-1.el7_4.1?distro=centos-7",
                   "version": "3.22.0-1.el7_4.1",
                 },
               },
@@ -2126,7 +2126,7 @@ Object {
                 "id": "python-iniparse@0.4-9.el7",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.el7",
+                  "purl": "pkg:rpm/centos/python-iniparse@0.4-9.el7?distro=centos-7",
                   "version": "0.4-9.el7",
                 },
               },
@@ -2134,7 +2134,7 @@ Object {
                 "id": "python-kitchen@1.1.1-5.el7",
                 "info": Object {
                   "name": "python-kitchen",
-                  "purl": "pkg:rpm/python-kitchen@1.1.1-5.el7",
+                  "purl": "pkg:rpm/centos/python-kitchen@1.1.1-5.el7?distro=centos-7",
                   "version": "1.1.1-5.el7",
                 },
               },
@@ -2142,7 +2142,7 @@ Object {
                 "id": "python-libs@2.7.5-88.el7",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.5-88.el7",
+                  "purl": "pkg:rpm/centos/python-libs@2.7.5-88.el7?distro=centos-7",
                   "version": "2.7.5-88.el7",
                 },
               },
@@ -2150,7 +2150,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.el7",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.el7",
+                  "purl": "pkg:rpm/centos/python-pycurl@7.19.0-19.el7?distro=centos-7",
                   "version": "7.19.0-19.el7",
                 },
               },
@@ -2158,7 +2158,7 @@ Object {
                 "id": "python-urlgrabber@3.10-10.el7",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-10.el7",
+                  "purl": "pkg:rpm/centos/python-urlgrabber@3.10-10.el7?distro=centos-7",
                   "version": "3.10-10.el7",
                 },
               },
@@ -2166,7 +2166,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.el7",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.el7",
+                  "purl": "pkg:rpm/centos/pyxattr@0.5.1-5.el7?distro=centos-7",
                   "version": "0.5.1-5.el7",
                 },
               },
@@ -2174,7 +2174,7 @@ Object {
                 "id": "qrencode-libs@3.4.1-3.el7",
                 "info": Object {
                   "name": "qrencode-libs",
-                  "purl": "pkg:rpm/qrencode-libs@3.4.1-3.el7",
+                  "purl": "pkg:rpm/centos/qrencode-libs@3.4.1-3.el7?distro=centos-7",
                   "version": "3.4.1-3.el7",
                 },
               },
@@ -2182,7 +2182,7 @@ Object {
                 "id": "readline@6.2-11.el7",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-11.el7",
+                  "purl": "pkg:rpm/centos/readline@6.2-11.el7?distro=centos-7",
                   "version": "6.2-11.el7",
                 },
               },
@@ -2190,7 +2190,7 @@ Object {
                 "id": "rootfiles@8.1-11.el7",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-11.el7",
+                  "purl": "pkg:rpm/centos/rootfiles@8.1-11.el7?distro=centos-7",
                   "version": "8.1-11.el7",
                 },
               },
@@ -2198,7 +2198,7 @@ Object {
                 "id": "rpm@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -2206,7 +2206,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-build-libs@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -2214,7 +2214,7 @@ Object {
                 "id": "rpm-libs@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-libs@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -2222,7 +2222,7 @@ Object {
                 "id": "rpm-python@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-python",
-                  "purl": "pkg:rpm/rpm-python@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-python@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -2230,7 +2230,7 @@ Object {
                 "id": "sed@4.2.2-6.el7",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-6.el7",
+                  "purl": "pkg:rpm/centos/sed@4.2.2-6.el7?distro=centos-7",
                   "version": "4.2.2-6.el7",
                 },
               },
@@ -2238,7 +2238,7 @@ Object {
                 "id": "setup@2.8.71-11.el7",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-11.el7",
+                  "purl": "pkg:rpm/centos/setup@2.8.71-11.el7?distro=centos-7",
                   "version": "2.8.71-11.el7",
                 },
               },
@@ -2246,7 +2246,7 @@ Object {
                 "id": "shadow-utils@2:4.6-5.el7",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.6-5.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/shadow-utils@2:4.6-5.el7?distro=centos-7&epoch=2",
                   "version": "2:4.6-5.el7",
                 },
               },
@@ -2254,7 +2254,7 @@ Object {
                 "id": "shared-mime-info@1.8-5.el7",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-5.el7",
+                  "purl": "pkg:rpm/centos/shared-mime-info@1.8-5.el7?distro=centos-7",
                   "version": "1.8-5.el7",
                 },
               },
@@ -2262,7 +2262,7 @@ Object {
                 "id": "sqlite@3.7.17-8.el7_7.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.el7_7.1",
+                  "purl": "pkg:rpm/centos/sqlite@3.7.17-8.el7_7.1?distro=centos-7",
                   "version": "3.7.17-8.el7_7.1",
                 },
               },
@@ -2270,7 +2270,7 @@ Object {
                 "id": "systemd@219-73.el7.1",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/systemd@219-73.el7.1",
+                  "purl": "pkg:rpm/centos/systemd@219-73.el7.1?distro=centos-7",
                   "version": "219-73.el7.1",
                 },
               },
@@ -2278,7 +2278,7 @@ Object {
                 "id": "systemd-libs@219-73.el7.1",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@219-73.el7.1",
+                  "purl": "pkg:rpm/centos/systemd-libs@219-73.el7.1?distro=centos-7",
                   "version": "219-73.el7.1",
                 },
               },
@@ -2286,7 +2286,7 @@ Object {
                 "id": "tar@2:1.26-35.el7",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.26-35.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/tar@2:1.26-35.el7?distro=centos-7&epoch=2",
                   "version": "2:1.26-35.el7",
                 },
               },
@@ -2294,7 +2294,7 @@ Object {
                 "id": "tzdata@2019c-1.el7",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2019c-1.el7",
+                  "purl": "pkg:rpm/centos/tzdata@2019c-1.el7?distro=centos-7",
                   "version": "2019c-1.el7",
                 },
               },
@@ -2302,7 +2302,7 @@ Object {
                 "id": "ustr@1.0.4-16.el7",
                 "info": Object {
                   "name": "ustr",
-                  "purl": "pkg:rpm/ustr@1.0.4-16.el7",
+                  "purl": "pkg:rpm/centos/ustr@1.0.4-16.el7?distro=centos-7",
                   "version": "1.0.4-16.el7",
                 },
               },
@@ -2310,7 +2310,7 @@ Object {
                 "id": "util-linux@2.23.2-63.el7",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/util-linux@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -2318,7 +2318,7 @@ Object {
                 "id": "vim-minimal@2:7.4.629-6.el7",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:7.4.629-6.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/vim-minimal@2:7.4.629-6.el7?distro=centos-7&epoch=2",
                   "version": "2:7.4.629-6.el7",
                 },
               },
@@ -2326,7 +2326,7 @@ Object {
                 "id": "xz@5.2.2-1.el7",
                 "info": Object {
                   "name": "xz",
-                  "purl": "pkg:rpm/xz@5.2.2-1.el7",
+                  "purl": "pkg:rpm/centos/xz@5.2.2-1.el7?distro=centos-7",
                   "version": "5.2.2-1.el7",
                 },
               },
@@ -2334,7 +2334,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.el7",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.el7",
+                  "purl": "pkg:rpm/centos/xz-libs@5.2.2-1.el7?distro=centos-7",
                   "version": "5.2.2-1.el7",
                 },
               },
@@ -2342,7 +2342,7 @@ Object {
                 "id": "yum@3.4.3-167.el7.centos",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-167.el7.centos",
+                  "purl": "pkg:rpm/centos/yum@3.4.3-167.el7.centos?distro=centos-7",
                   "version": "3.4.3-167.el7.centos",
                 },
               },
@@ -2350,7 +2350,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.el7",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.el7",
+                  "purl": "pkg:rpm/centos/yum-metadata-parser@1.1.4-10.el7?distro=centos-7",
                   "version": "1.1.4-10.el7",
                 },
               },
@@ -2358,7 +2358,7 @@ Object {
                 "id": "yum-plugin-fastestmirror@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-plugin-fastestmirror",
-                  "purl": "pkg:rpm/yum-plugin-fastestmirror@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-plugin-fastestmirror@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -2366,7 +2366,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-plugin-ovl@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -2374,7 +2374,7 @@ Object {
                 "id": "yum-utils@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-utils",
-                  "purl": "pkg:rpm/yum-utils@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-utils@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -2382,7 +2382,7 @@ Object {
                 "id": "zlib@1.2.7-18.el7",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.el7",
+                  "purl": "pkg:rpm/centos/zlib@1.2.7-18.el7?distro=centos-7",
                   "version": "1.2.7-18.el7",
                 },
               },
@@ -3666,7 +3666,7 @@ Object {
                 "id": "acl@2.2.51-15.el7",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:rpm/acl@2.2.51-15.el7",
+                  "purl": "pkg:rpm/centos/acl@2.2.51-15.el7?distro=centos-7",
                   "version": "2.2.51-15.el7",
                 },
               },
@@ -3674,7 +3674,7 @@ Object {
                 "id": "audit-libs@2.8.5-4.el7",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@2.8.5-4.el7",
+                  "purl": "pkg:rpm/centos/audit-libs@2.8.5-4.el7?distro=centos-7",
                   "version": "2.8.5-4.el7",
                 },
               },
@@ -3682,7 +3682,7 @@ Object {
                 "id": "basesystem@10.0-7.el7.centos",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.el7.centos",
+                  "purl": "pkg:rpm/centos/basesystem@10.0-7.el7.centos?distro=centos-7",
                   "version": "10.0-7.el7.centos",
                 },
               },
@@ -3690,7 +3690,7 @@ Object {
                 "id": "bash@4.2.46-34.el7",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-34.el7",
+                  "purl": "pkg:rpm/centos/bash@4.2.46-34.el7?distro=centos-7",
                   "version": "4.2.46-34.el7",
                 },
               },
@@ -3698,7 +3698,7 @@ Object {
                 "id": "bind-license@32:9.11.4-16.P2.el7",
                 "info": Object {
                   "name": "bind-license",
-                  "purl": "pkg:rpm/bind-license@32:9.11.4-16.P2.el7?epoch=32",
+                  "purl": "pkg:rpm/centos/bind-license@32:9.11.4-16.P2.el7?distro=centos-7&epoch=32",
                   "version": "32:9.11.4-16.P2.el7",
                 },
               },
@@ -3706,7 +3706,7 @@ Object {
                 "id": "binutils@2.27-43.base.el7",
                 "info": Object {
                   "name": "binutils",
-                  "purl": "pkg:rpm/binutils@2.27-43.base.el7",
+                  "purl": "pkg:rpm/centos/binutils@2.27-43.base.el7?distro=centos-7",
                   "version": "2.27-43.base.el7",
                 },
               },
@@ -3714,7 +3714,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.el7",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.el7",
+                  "purl": "pkg:rpm/centos/bzip2-libs@1.0.6-13.el7?distro=centos-7",
                   "version": "1.0.6-13.el7",
                 },
               },
@@ -3722,7 +3722,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.el7_7",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.el7_7",
+                  "purl": "pkg:rpm/centos/ca-certificates@2019.2.32-76.el7_7?distro=centos-7",
                   "version": "2019.2.32-76.el7_7",
                 },
               },
@@ -3730,7 +3730,7 @@ Object {
                 "id": "centos-release@7-8.2003.0.el7.centos",
                 "info": Object {
                   "name": "centos-release",
-                  "purl": "pkg:rpm/centos-release@7-8.2003.0.el7.centos",
+                  "purl": "pkg:rpm/centos/centos-release@7-8.2003.0.el7.centos?distro=centos-7",
                   "version": "7-8.2003.0.el7.centos",
                 },
               },
@@ -3738,7 +3738,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.el7",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.el7",
+                  "purl": "pkg:rpm/centos/chkconfig@1.7.4-1.el7?distro=centos-7",
                   "version": "1.7.4-1.el7",
                 },
               },
@@ -3746,7 +3746,7 @@ Object {
                 "id": "coreutils@8.22-24.el7",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.el7",
+                  "purl": "pkg:rpm/centos/coreutils@8.22-24.el7?distro=centos-7",
                   "version": "8.22-24.el7",
                 },
               },
@@ -3754,7 +3754,7 @@ Object {
                 "id": "cpio@2.11-27.el7",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.el7",
+                  "purl": "pkg:rpm/centos/cpio@2.11-27.el7?distro=centos-7",
                   "version": "2.11-27.el7",
                 },
               },
@@ -3762,7 +3762,7 @@ Object {
                 "id": "cracklib@2.9.0-11.el7",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.0-11.el7",
+                  "purl": "pkg:rpm/centos/cracklib@2.9.0-11.el7?distro=centos-7",
                   "version": "2.9.0-11.el7",
                 },
               },
@@ -3770,7 +3770,7 @@ Object {
                 "id": "cracklib-dicts@2.9.0-11.el7",
                 "info": Object {
                   "name": "cracklib-dicts",
-                  "purl": "pkg:rpm/cracklib-dicts@2.9.0-11.el7",
+                  "purl": "pkg:rpm/centos/cracklib-dicts@2.9.0-11.el7?distro=centos-7",
                   "version": "2.9.0-11.el7",
                 },
               },
@@ -3778,7 +3778,7 @@ Object {
                 "id": "cryptsetup-libs@2.0.3-6.el7",
                 "info": Object {
                   "name": "cryptsetup-libs",
-                  "purl": "pkg:rpm/cryptsetup-libs@2.0.3-6.el7",
+                  "purl": "pkg:rpm/centos/cryptsetup-libs@2.0.3-6.el7?distro=centos-7",
                   "version": "2.0.3-6.el7",
                 },
               },
@@ -3786,7 +3786,7 @@ Object {
                 "id": "curl@7.29.0-57.el7",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.29.0-57.el7",
+                  "purl": "pkg:rpm/centos/curl@7.29.0-57.el7?distro=centos-7",
                   "version": "7.29.0-57.el7",
                 },
               },
@@ -3794,7 +3794,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.el7",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.el7",
+                  "purl": "pkg:rpm/centos/cyrus-sasl-lib@2.1.26-23.el7?distro=centos-7",
                   "version": "2.1.26-23.el7",
                 },
               },
@@ -3802,7 +3802,7 @@ Object {
                 "id": "dbus@1:1.10.24-13.el7_6",
                 "info": Object {
                   "name": "dbus",
-                  "purl": "pkg:rpm/dbus@1:1.10.24-13.el7_6?epoch=1",
+                  "purl": "pkg:rpm/centos/dbus@1:1.10.24-13.el7_6?distro=centos-7&epoch=1",
                   "version": "1:1.10.24-13.el7_6",
                 },
               },
@@ -3810,7 +3810,7 @@ Object {
                 "id": "dbus-glib@0.100-7.el7",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.100-7.el7",
+                  "purl": "pkg:rpm/centos/dbus-glib@0.100-7.el7?distro=centos-7",
                   "version": "0.100-7.el7",
                 },
               },
@@ -3818,7 +3818,7 @@ Object {
                 "id": "dbus-libs@1:1.10.24-13.el7_6",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.10.24-13.el7_6?epoch=1",
+                  "purl": "pkg:rpm/centos/dbus-libs@1:1.10.24-13.el7_6?distro=centos-7&epoch=1",
                   "version": "1:1.10.24-13.el7_6",
                 },
               },
@@ -3826,7 +3826,7 @@ Object {
                 "id": "dbus-python@1.1.1-9.el7",
                 "info": Object {
                   "name": "dbus-python",
-                  "purl": "pkg:rpm/dbus-python@1.1.1-9.el7",
+                  "purl": "pkg:rpm/centos/dbus-python@1.1.1-9.el7?distro=centos-7",
                   "version": "1.1.1-9.el7",
                 },
               },
@@ -3834,7 +3834,7 @@ Object {
                 "id": "device-mapper@7:1.02.164-7.el7",
                 "info": Object {
                   "name": "device-mapper",
-                  "purl": "pkg:rpm/device-mapper@7:1.02.164-7.el7?epoch=7",
+                  "purl": "pkg:rpm/centos/device-mapper@7:1.02.164-7.el7?distro=centos-7&epoch=7",
                   "version": "7:1.02.164-7.el7",
                 },
               },
@@ -3842,7 +3842,7 @@ Object {
                 "id": "device-mapper-libs@7:1.02.164-7.el7",
                 "info": Object {
                   "name": "device-mapper-libs",
-                  "purl": "pkg:rpm/device-mapper-libs@7:1.02.164-7.el7?epoch=7",
+                  "purl": "pkg:rpm/centos/device-mapper-libs@7:1.02.164-7.el7?distro=centos-7&epoch=7",
                   "version": "7:1.02.164-7.el7",
                 },
               },
@@ -3850,7 +3850,7 @@ Object {
                 "id": "diffutils@3.3-5.el7",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.el7",
+                  "purl": "pkg:rpm/centos/diffutils@3.3-5.el7?distro=centos-7",
                   "version": "3.3-5.el7",
                 },
               },
@@ -3858,7 +3858,7 @@ Object {
                 "id": "dracut@033-568.el7",
                 "info": Object {
                   "name": "dracut",
-                  "purl": "pkg:rpm/dracut@033-568.el7",
+                  "purl": "pkg:rpm/centos/dracut@033-568.el7?distro=centos-7",
                   "version": "033-568.el7",
                 },
               },
@@ -3866,7 +3866,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-default-yama-scope@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -3874,7 +3874,7 @@ Object {
                 "id": "elfutils-libelf@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-libelf@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -3882,7 +3882,7 @@ Object {
                 "id": "elfutils-libs@0.176-4.el7",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.176-4.el7",
+                  "purl": "pkg:rpm/centos/elfutils-libs@0.176-4.el7?distro=centos-7",
                   "version": "0.176-4.el7",
                 },
               },
@@ -3890,7 +3890,7 @@ Object {
                 "id": "expat@2.1.0-11.el7",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-11.el7",
+                  "purl": "pkg:rpm/centos/expat@2.1.0-11.el7?distro=centos-7",
                   "version": "2.1.0-11.el7",
                 },
               },
@@ -3898,7 +3898,7 @@ Object {
                 "id": "file-libs@5.11-36.el7",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-36.el7",
+                  "purl": "pkg:rpm/centos/file-libs@5.11-36.el7?distro=centos-7",
                   "version": "5.11-36.el7",
                 },
               },
@@ -3906,7 +3906,7 @@ Object {
                 "id": "filesystem@3.2-25.el7",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.el7",
+                  "purl": "pkg:rpm/centos/filesystem@3.2-25.el7?distro=centos-7",
                   "version": "3.2-25.el7",
                 },
               },
@@ -3914,7 +3914,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.el7",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/findutils@1:4.5.11-6.el7?distro=centos-7&epoch=1",
                   "version": "1:4.5.11-6.el7",
                 },
               },
@@ -3922,7 +3922,7 @@ Object {
                 "id": "gawk@4.0.2-4.el7_3.1",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.el7_3.1",
+                  "purl": "pkg:rpm/centos/gawk@4.0.2-4.el7_3.1?distro=centos-7",
                   "version": "4.0.2-4.el7_3.1",
                 },
               },
@@ -3930,7 +3930,7 @@ Object {
                 "id": "gdbm@1.10-8.el7",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1.10-8.el7",
+                  "purl": "pkg:rpm/centos/gdbm@1.10-8.el7?distro=centos-7",
                   "version": "1.10-8.el7",
                 },
               },
@@ -3938,7 +3938,7 @@ Object {
                 "id": "geoipupdate@2.5.0-1.el7",
                 "info": Object {
                   "name": "geoipupdate",
-                  "purl": "pkg:rpm/geoipupdate@2.5.0-1.el7",
+                  "purl": "pkg:rpm/centos/geoipupdate@2.5.0-1.el7?distro=centos-7",
                   "version": "2.5.0-1.el7",
                 },
               },
@@ -3946,7 +3946,7 @@ Object {
                 "id": "glib2@2.56.1-5.el7",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-5.el7",
+                  "purl": "pkg:rpm/centos/glib2@2.56.1-5.el7?distro=centos-7",
                   "version": "2.56.1-5.el7",
                 },
               },
@@ -3954,7 +3954,7 @@ Object {
                 "id": "glibc@2.17-307.el7.1",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.17-307.el7.1",
+                  "purl": "pkg:rpm/centos/glibc@2.17-307.el7.1?distro=centos-7",
                   "version": "2.17-307.el7.1",
                 },
               },
@@ -3962,7 +3962,7 @@ Object {
                 "id": "glibc-common@2.17-307.el7.1",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.17-307.el7.1",
+                  "purl": "pkg:rpm/centos/glibc-common@2.17-307.el7.1?distro=centos-7",
                   "version": "2.17-307.el7.1",
                 },
               },
@@ -3970,7 +3970,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.el7",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/gmp@1:6.0.0-15.el7?distro=centos-7&epoch=1",
                   "version": "1:6.0.0-15.el7",
                 },
               },
@@ -3978,7 +3978,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.el7_5",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.el7_5",
+                  "purl": "pkg:rpm/centos/gnupg2@2.0.22-5.el7_5?distro=centos-7",
                   "version": "2.0.22-5.el7_5",
                 },
               },
@@ -3986,7 +3986,7 @@ Object {
                 "id": "gobject-introspection@1.56.1-1.el7",
                 "info": Object {
                   "name": "gobject-introspection",
-                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el7",
+                  "purl": "pkg:rpm/centos/gobject-introspection@1.56.1-1.el7?distro=centos-7",
                   "version": "1.56.1-1.el7",
                 },
               },
@@ -3994,7 +3994,7 @@ Object {
                 "id": "gpgme@1.3.2-5.el7",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.el7",
+                  "purl": "pkg:rpm/centos/gpgme@1.3.2-5.el7?distro=centos-7",
                   "version": "1.3.2-5.el7",
                 },
               },
@@ -4002,7 +4002,7 @@ Object {
                 "id": "grep@2.20-3.el7",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.el7",
+                  "purl": "pkg:rpm/centos/grep@2.20-3.el7?distro=centos-7",
                   "version": "2.20-3.el7",
                 },
               },
@@ -4010,7 +4010,7 @@ Object {
                 "id": "gzip@1.5-10.el7",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.5-10.el7",
+                  "purl": "pkg:rpm/centos/gzip@1.5-10.el7?distro=centos-7",
                   "version": "1.5-10.el7",
                 },
               },
@@ -4018,7 +4018,7 @@ Object {
                 "id": "hardlink@1:1.0-19.el7",
                 "info": Object {
                   "name": "hardlink",
-                  "purl": "pkg:rpm/hardlink@1:1.0-19.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/hardlink@1:1.0-19.el7?distro=centos-7&epoch=1",
                   "version": "1:1.0-19.el7",
                 },
               },
@@ -4026,7 +4026,7 @@ Object {
                 "id": "hostname@3.13-3.el7_7.1",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:rpm/hostname@3.13-3.el7_7.1",
+                  "purl": "pkg:rpm/centos/hostname@3.13-3.el7_7.1?distro=centos-7",
                   "version": "3.13-3.el7_7.1",
                 },
               },
@@ -4034,7 +4034,7 @@ Object {
                 "id": "info@5.1-5.el7",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.el7",
+                  "purl": "pkg:rpm/centos/info@5.1-5.el7?distro=centos-7",
                   "version": "5.1-5.el7",
                 },
               },
@@ -4042,7 +4042,7 @@ Object {
                 "id": "iputils@20160308-10.el7",
                 "info": Object {
                   "name": "iputils",
-                  "purl": "pkg:rpm/iputils@20160308-10.el7",
+                  "purl": "pkg:rpm/centos/iputils@20160308-10.el7?distro=centos-7",
                   "version": "20160308-10.el7",
                 },
               },
@@ -4050,7 +4050,7 @@ Object {
                 "id": "json-c@0.11-4.el7_0",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.11-4.el7_0",
+                  "purl": "pkg:rpm/centos/json-c@0.11-4.el7_0?distro=centos-7",
                   "version": "0.11-4.el7_0",
                 },
               },
@@ -4058,7 +4058,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.el7",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.el7",
+                  "purl": "pkg:rpm/centos/keyutils-libs@1.5.8-3.el7?distro=centos-7",
                   "version": "1.5.8-3.el7",
                 },
               },
@@ -4066,7 +4066,7 @@ Object {
                 "id": "kmod@20-28.el7",
                 "info": Object {
                   "name": "kmod",
-                  "purl": "pkg:rpm/kmod@20-28.el7",
+                  "purl": "pkg:rpm/centos/kmod@20-28.el7?distro=centos-7",
                   "version": "20-28.el7",
                 },
               },
@@ -4074,7 +4074,7 @@ Object {
                 "id": "kmod-libs@20-28.el7",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/kmod-libs@20-28.el7",
+                  "purl": "pkg:rpm/centos/kmod-libs@20-28.el7?distro=centos-7",
                   "version": "20-28.el7",
                 },
               },
@@ -4082,7 +4082,7 @@ Object {
                 "id": "kpartx@0.4.9-131.el7",
                 "info": Object {
                   "name": "kpartx",
-                  "purl": "pkg:rpm/kpartx@0.4.9-131.el7",
+                  "purl": "pkg:rpm/centos/kpartx@0.4.9-131.el7?distro=centos-7",
                   "version": "0.4.9-131.el7",
                 },
               },
@@ -4090,7 +4090,7 @@ Object {
                 "id": "krb5-libs@1.15.1-46.el7",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-46.el7",
+                  "purl": "pkg:rpm/centos/krb5-libs@1.15.1-46.el7?distro=centos-7",
                   "version": "1.15.1-46.el7",
                 },
               },
@@ -4098,7 +4098,7 @@ Object {
                 "id": "libacl@2.2.51-15.el7",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-15.el7",
+                  "purl": "pkg:rpm/centos/libacl@2.2.51-15.el7?distro=centos-7",
                   "version": "2.2.51-15.el7",
                 },
               },
@@ -4106,7 +4106,7 @@ Object {
                 "id": "libassuan@2.1.0-3.el7",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.el7",
+                  "purl": "pkg:rpm/centos/libassuan@2.1.0-3.el7?distro=centos-7",
                   "version": "2.1.0-3.el7",
                 },
               },
@@ -4114,7 +4114,7 @@ Object {
                 "id": "libattr@2.4.46-13.el7",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-13.el7",
+                  "purl": "pkg:rpm/centos/libattr@2.4.46-13.el7?distro=centos-7",
                   "version": "2.4.46-13.el7",
                 },
               },
@@ -4122,7 +4122,7 @@ Object {
                 "id": "libblkid@2.23.2-63.el7",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libblkid@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -4130,7 +4130,7 @@ Object {
                 "id": "libcap@2.22-11.el7",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-11.el7",
+                  "purl": "pkg:rpm/centos/libcap@2.22-11.el7?distro=centos-7",
                   "version": "2.22-11.el7",
                 },
               },
@@ -4138,7 +4138,7 @@ Object {
                 "id": "libcap-ng@0.7.5-4.el7",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.7.5-4.el7",
+                  "purl": "pkg:rpm/centos/libcap-ng@0.7.5-4.el7?distro=centos-7",
                   "version": "0.7.5-4.el7",
                 },
               },
@@ -4146,7 +4146,7 @@ Object {
                 "id": "libcom_err@1.42.9-17.el7",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-17.el7",
+                  "purl": "pkg:rpm/centos/libcom_err@1.42.9-17.el7?distro=centos-7",
                   "version": "1.42.9-17.el7",
                 },
               },
@@ -4154,7 +4154,7 @@ Object {
                 "id": "libcurl@7.29.0-57.el7",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.29.0-57.el7",
+                  "purl": "pkg:rpm/centos/libcurl@7.29.0-57.el7?distro=centos-7",
                   "version": "7.29.0-57.el7",
                 },
               },
@@ -4162,7 +4162,7 @@ Object {
                 "id": "libdb@5.3.21-25.el7",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-25.el7",
+                  "purl": "pkg:rpm/centos/libdb@5.3.21-25.el7?distro=centos-7",
                   "version": "5.3.21-25.el7",
                 },
               },
@@ -4170,7 +4170,7 @@ Object {
                 "id": "libdb-utils@5.3.21-25.el7",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-25.el7",
+                  "purl": "pkg:rpm/centos/libdb-utils@5.3.21-25.el7?distro=centos-7",
                   "version": "5.3.21-25.el7",
                 },
               },
@@ -4178,7 +4178,7 @@ Object {
                 "id": "libffi@3.0.13-19.el7",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-19.el7",
+                  "purl": "pkg:rpm/centos/libffi@3.0.13-19.el7?distro=centos-7",
                   "version": "3.0.13-19.el7",
                 },
               },
@@ -4186,7 +4186,7 @@ Object {
                 "id": "libgcc@4.8.5-39.el7",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/libgcc@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -4194,7 +4194,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.el7",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.el7",
+                  "purl": "pkg:rpm/centos/libgcrypt@1.5.3-14.el7?distro=centos-7",
                   "version": "1.5.3-14.el7",
                 },
               },
@@ -4202,7 +4202,7 @@ Object {
                 "id": "libgpg-error@1.12-3.el7",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.el7",
+                  "purl": "pkg:rpm/centos/libgpg-error@1.12-3.el7?distro=centos-7",
                   "version": "1.12-3.el7",
                 },
               },
@@ -4210,7 +4210,7 @@ Object {
                 "id": "libidn@1.28-4.el7",
                 "info": Object {
                   "name": "libidn",
-                  "purl": "pkg:rpm/libidn@1.28-4.el7",
+                  "purl": "pkg:rpm/centos/libidn@1.28-4.el7?distro=centos-7",
                   "version": "1.28-4.el7",
                 },
               },
@@ -4218,7 +4218,7 @@ Object {
                 "id": "libmount@2.23.2-63.el7",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libmount@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -4226,7 +4226,7 @@ Object {
                 "id": "libpwquality@1.2.3-5.el7",
                 "info": Object {
                   "name": "libpwquality",
-                  "purl": "pkg:rpm/libpwquality@1.2.3-5.el7",
+                  "purl": "pkg:rpm/centos/libpwquality@1.2.3-5.el7?distro=centos-7",
                   "version": "1.2.3-5.el7",
                 },
               },
@@ -4234,7 +4234,7 @@ Object {
                 "id": "libselinux@2.5-15.el7",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-15.el7",
+                  "purl": "pkg:rpm/centos/libselinux@2.5-15.el7?distro=centos-7",
                   "version": "2.5-15.el7",
                 },
               },
@@ -4242,7 +4242,7 @@ Object {
                 "id": "libsemanage@2.5-14.el7",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.5-14.el7",
+                  "purl": "pkg:rpm/centos/libsemanage@2.5-14.el7?distro=centos-7",
                   "version": "2.5-14.el7",
                 },
               },
@@ -4250,7 +4250,7 @@ Object {
                 "id": "libsepol@2.5-10.el7",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-10.el7",
+                  "purl": "pkg:rpm/centos/libsepol@2.5-10.el7?distro=centos-7",
                   "version": "2.5-10.el7",
                 },
               },
@@ -4258,7 +4258,7 @@ Object {
                 "id": "libsmartcols@2.23.2-63.el7",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libsmartcols@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -4266,7 +4266,7 @@ Object {
                 "id": "libssh2@1.8.0-3.el7",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.8.0-3.el7",
+                  "purl": "pkg:rpm/centos/libssh2@1.8.0-3.el7?distro=centos-7",
                   "version": "1.8.0-3.el7",
                 },
               },
@@ -4274,7 +4274,7 @@ Object {
                 "id": "libstdc++@4.8.5-39.el7",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@4.8.5-39.el7",
+                  "purl": "pkg:rpm/centos/libstdc%2B%2B@4.8.5-39.el7?distro=centos-7",
                   "version": "4.8.5-39.el7",
                 },
               },
@@ -4282,7 +4282,7 @@ Object {
                 "id": "libtasn1@4.10-1.el7",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.el7",
+                  "purl": "pkg:rpm/centos/libtasn1@4.10-1.el7?distro=centos-7",
                   "version": "4.10-1.el7",
                 },
               },
@@ -4290,7 +4290,7 @@ Object {
                 "id": "libuser@0.60-9.el7",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.60-9.el7",
+                  "purl": "pkg:rpm/centos/libuser@0.60-9.el7?distro=centos-7",
                   "version": "0.60-9.el7",
                 },
               },
@@ -4298,7 +4298,7 @@ Object {
                 "id": "libutempter@1.1.6-4.el7",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.6-4.el7",
+                  "purl": "pkg:rpm/centos/libutempter@1.1.6-4.el7?distro=centos-7",
                   "version": "1.1.6-4.el7",
                 },
               },
@@ -4306,7 +4306,7 @@ Object {
                 "id": "libuuid@2.23.2-63.el7",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/libuuid@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -4314,7 +4314,7 @@ Object {
                 "id": "libverto@0.2.5-4.el7",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.el7",
+                  "purl": "pkg:rpm/centos/libverto@0.2.5-4.el7?distro=centos-7",
                   "version": "0.2.5-4.el7",
                 },
               },
@@ -4322,7 +4322,7 @@ Object {
                 "id": "libxml2@2.9.1-6.el7.4",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.el7.4",
+                  "purl": "pkg:rpm/centos/libxml2@2.9.1-6.el7.4?distro=centos-7",
                   "version": "2.9.1-6.el7.4",
                 },
               },
@@ -4330,7 +4330,7 @@ Object {
                 "id": "libxml2-python@2.9.1-6.el7.4",
                 "info": Object {
                   "name": "libxml2-python",
-                  "purl": "pkg:rpm/libxml2-python@2.9.1-6.el7.4",
+                  "purl": "pkg:rpm/centos/libxml2-python@2.9.1-6.el7.4?distro=centos-7",
                   "version": "2.9.1-6.el7.4",
                 },
               },
@@ -4338,7 +4338,7 @@ Object {
                 "id": "lua@5.1.4-15.el7",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.el7",
+                  "purl": "pkg:rpm/centos/lua@5.1.4-15.el7?distro=centos-7",
                   "version": "5.1.4-15.el7",
                 },
               },
@@ -4346,7 +4346,7 @@ Object {
                 "id": "lz4@1.7.5-3.el7",
                 "info": Object {
                   "name": "lz4",
-                  "purl": "pkg:rpm/lz4@1.7.5-3.el7",
+                  "purl": "pkg:rpm/centos/lz4@1.7.5-3.el7?distro=centos-7",
                   "version": "1.7.5-3.el7",
                 },
               },
@@ -4354,7 +4354,7 @@ Object {
                 "id": "ncurses@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -4362,7 +4362,7 @@ Object {
                 "id": "ncurses-base@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses-base@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -4370,7 +4370,7 @@ Object {
                 "id": "ncurses-libs@5.9-14.20130511.el7_4",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@5.9-14.20130511.el7_4",
+                  "purl": "pkg:rpm/centos/ncurses-libs@5.9-14.20130511.el7_4?distro=centos-7",
                   "version": "5.9-14.20130511.el7_4",
                 },
               },
@@ -4378,7 +4378,7 @@ Object {
                 "id": "nspr@4.21.0-1.el7",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.el7",
+                  "purl": "pkg:rpm/centos/nspr@4.21.0-1.el7?distro=centos-7",
                   "version": "4.21.0-1.el7",
                 },
               },
@@ -4386,7 +4386,7 @@ Object {
                 "id": "nss@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -4394,7 +4394,7 @@ Object {
                 "id": "nss-pem@1.0.3-7.el7",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-7.el7",
+                  "purl": "pkg:rpm/centos/nss-pem@1.0.3-7.el7?distro=centos-7",
                   "version": "1.0.3-7.el7",
                 },
               },
@@ -4402,7 +4402,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.el7_7",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.el7_7",
+                  "purl": "pkg:rpm/centos/nss-softokn@3.44.0-8.el7_7?distro=centos-7",
                   "version": "3.44.0-8.el7_7",
                 },
               },
@@ -4410,7 +4410,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.el7_7",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.el7_7",
+                  "purl": "pkg:rpm/centos/nss-softokn-freebl@3.44.0-8.el7_7?distro=centos-7",
                   "version": "3.44.0-8.el7_7",
                 },
               },
@@ -4418,7 +4418,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss-sysinit@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -4426,7 +4426,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.el7_7",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.el7_7",
+                  "purl": "pkg:rpm/centos/nss-tools@3.44.0-7.el7_7?distro=centos-7",
                   "version": "3.44.0-7.el7_7",
                 },
               },
@@ -4434,7 +4434,7 @@ Object {
                 "id": "nss-util@3.44.0-4.el7_7",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.el7_7",
+                  "purl": "pkg:rpm/centos/nss-util@3.44.0-4.el7_7?distro=centos-7",
                   "version": "3.44.0-4.el7_7",
                 },
               },
@@ -4442,7 +4442,7 @@ Object {
                 "id": "openldap@2.4.44-21.el7_6",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-21.el7_6",
+                  "purl": "pkg:rpm/centos/openldap@2.4.44-21.el7_6?distro=centos-7",
                   "version": "2.4.44-21.el7_6",
                 },
               },
@@ -4450,7 +4450,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.el7",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/openssl-libs@1:1.0.2k-19.el7?distro=centos-7&epoch=1",
                   "version": "1:1.0.2k-19.el7",
                 },
               },
@@ -4458,7 +4458,7 @@ Object {
                 "id": "p11-kit@0.23.5-3.el7",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.5-3.el7",
+                  "purl": "pkg:rpm/centos/p11-kit@0.23.5-3.el7?distro=centos-7",
                   "version": "0.23.5-3.el7",
                 },
               },
@@ -4466,7 +4466,7 @@ Object {
                 "id": "p11-kit-trust@0.23.5-3.el7",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.5-3.el7",
+                  "purl": "pkg:rpm/centos/p11-kit-trust@0.23.5-3.el7?distro=centos-7",
                   "version": "0.23.5-3.el7",
                 },
               },
@@ -4474,7 +4474,7 @@ Object {
                 "id": "pam@1.1.8-23.el7",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.1.8-23.el7",
+                  "purl": "pkg:rpm/centos/pam@1.1.8-23.el7?distro=centos-7",
                   "version": "1.1.8-23.el7",
                 },
               },
@@ -4482,7 +4482,7 @@ Object {
                 "id": "passwd@0.79-6.el7",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.79-6.el7",
+                  "purl": "pkg:rpm/centos/passwd@0.79-6.el7?distro=centos-7",
                   "version": "0.79-6.el7",
                 },
               },
@@ -4490,7 +4490,7 @@ Object {
                 "id": "pcre@8.32-17.el7",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.el7",
+                  "purl": "pkg:rpm/centos/pcre@8.32-17.el7?distro=centos-7",
                   "version": "8.32-17.el7",
                 },
               },
@@ -4498,7 +4498,7 @@ Object {
                 "id": "pinentry@0.8.1-17.el7",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.el7",
+                  "purl": "pkg:rpm/centos/pinentry@0.8.1-17.el7?distro=centos-7",
                   "version": "0.8.1-17.el7",
                 },
               },
@@ -4506,7 +4506,7 @@ Object {
                 "id": "pkgconfig@1:0.27.1-4.el7",
                 "info": Object {
                   "name": "pkgconfig",
-                  "purl": "pkg:rpm/pkgconfig@1:0.27.1-4.el7?epoch=1",
+                  "purl": "pkg:rpm/centos/pkgconfig@1:0.27.1-4.el7?distro=centos-7&epoch=1",
                   "version": "1:0.27.1-4.el7",
                 },
               },
@@ -4514,7 +4514,7 @@ Object {
                 "id": "popt@1.13-16.el7",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.el7",
+                  "purl": "pkg:rpm/centos/popt@1.13-16.el7?distro=centos-7",
                   "version": "1.13-16.el7",
                 },
               },
@@ -4522,7 +4522,7 @@ Object {
                 "id": "procps-ng@3.3.10-27.el7",
                 "info": Object {
                   "name": "procps-ng",
-                  "purl": "pkg:rpm/procps-ng@3.3.10-27.el7",
+                  "purl": "pkg:rpm/centos/procps-ng@3.3.10-27.el7?distro=centos-7",
                   "version": "3.3.10-27.el7",
                 },
               },
@@ -4530,7 +4530,7 @@ Object {
                 "id": "pth@2.0.7-23.el7",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.el7",
+                  "purl": "pkg:rpm/centos/pth@2.0.7-23.el7?distro=centos-7",
                   "version": "2.0.7-23.el7",
                 },
               },
@@ -4538,7 +4538,7 @@ Object {
                 "id": "pygpgme@0.3-9.el7",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.el7",
+                  "purl": "pkg:rpm/centos/pygpgme@0.3-9.el7?distro=centos-7",
                   "version": "0.3-9.el7",
                 },
               },
@@ -4546,7 +4546,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.el7",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.el7",
+                  "purl": "pkg:rpm/centos/pyliblzma@0.5.3-11.el7?distro=centos-7",
                   "version": "0.5.3-11.el7",
                 },
               },
@@ -4554,7 +4554,7 @@ Object {
                 "id": "python@2.7.5-88.el7",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.5-88.el7",
+                  "purl": "pkg:rpm/centos/python@2.7.5-88.el7?distro=centos-7",
                   "version": "2.7.5-88.el7",
                 },
               },
@@ -4562,7 +4562,7 @@ Object {
                 "id": "python-chardet@2.2.1-3.el7",
                 "info": Object {
                   "name": "python-chardet",
-                  "purl": "pkg:rpm/python-chardet@2.2.1-3.el7",
+                  "purl": "pkg:rpm/centos/python-chardet@2.2.1-3.el7?distro=centos-7",
                   "version": "2.2.1-3.el7",
                 },
               },
@@ -4570,7 +4570,7 @@ Object {
                 "id": "python-gobject-base@3.22.0-1.el7_4.1",
                 "info": Object {
                   "name": "python-gobject-base",
-                  "purl": "pkg:rpm/python-gobject-base@3.22.0-1.el7_4.1",
+                  "purl": "pkg:rpm/centos/python-gobject-base@3.22.0-1.el7_4.1?distro=centos-7",
                   "version": "3.22.0-1.el7_4.1",
                 },
               },
@@ -4578,7 +4578,7 @@ Object {
                 "id": "python-iniparse@0.4-9.el7",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.el7",
+                  "purl": "pkg:rpm/centos/python-iniparse@0.4-9.el7?distro=centos-7",
                   "version": "0.4-9.el7",
                 },
               },
@@ -4586,7 +4586,7 @@ Object {
                 "id": "python-kitchen@1.1.1-5.el7",
                 "info": Object {
                   "name": "python-kitchen",
-                  "purl": "pkg:rpm/python-kitchen@1.1.1-5.el7",
+                  "purl": "pkg:rpm/centos/python-kitchen@1.1.1-5.el7?distro=centos-7",
                   "version": "1.1.1-5.el7",
                 },
               },
@@ -4594,7 +4594,7 @@ Object {
                 "id": "python-libs@2.7.5-88.el7",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.5-88.el7",
+                  "purl": "pkg:rpm/centos/python-libs@2.7.5-88.el7?distro=centos-7",
                   "version": "2.7.5-88.el7",
                 },
               },
@@ -4602,7 +4602,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.el7",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.el7",
+                  "purl": "pkg:rpm/centos/python-pycurl@7.19.0-19.el7?distro=centos-7",
                   "version": "7.19.0-19.el7",
                 },
               },
@@ -4610,7 +4610,7 @@ Object {
                 "id": "python-urlgrabber@3.10-10.el7",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-10.el7",
+                  "purl": "pkg:rpm/centos/python-urlgrabber@3.10-10.el7?distro=centos-7",
                   "version": "3.10-10.el7",
                 },
               },
@@ -4618,7 +4618,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.el7",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.el7",
+                  "purl": "pkg:rpm/centos/pyxattr@0.5.1-5.el7?distro=centos-7",
                   "version": "0.5.1-5.el7",
                 },
               },
@@ -4626,7 +4626,7 @@ Object {
                 "id": "qrencode-libs@3.4.1-3.el7",
                 "info": Object {
                   "name": "qrencode-libs",
-                  "purl": "pkg:rpm/qrencode-libs@3.4.1-3.el7",
+                  "purl": "pkg:rpm/centos/qrencode-libs@3.4.1-3.el7?distro=centos-7",
                   "version": "3.4.1-3.el7",
                 },
               },
@@ -4634,7 +4634,7 @@ Object {
                 "id": "readline@6.2-11.el7",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-11.el7",
+                  "purl": "pkg:rpm/centos/readline@6.2-11.el7?distro=centos-7",
                   "version": "6.2-11.el7",
                 },
               },
@@ -4642,7 +4642,7 @@ Object {
                 "id": "rootfiles@8.1-11.el7",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-11.el7",
+                  "purl": "pkg:rpm/centos/rootfiles@8.1-11.el7?distro=centos-7",
                   "version": "8.1-11.el7",
                 },
               },
@@ -4650,7 +4650,7 @@ Object {
                 "id": "rpm@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -4658,7 +4658,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-build-libs@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -4666,7 +4666,7 @@ Object {
                 "id": "rpm-libs@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-libs@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -4674,7 +4674,7 @@ Object {
                 "id": "rpm-python@4.11.3-43.el7",
                 "info": Object {
                   "name": "rpm-python",
-                  "purl": "pkg:rpm/rpm-python@4.11.3-43.el7",
+                  "purl": "pkg:rpm/centos/rpm-python@4.11.3-43.el7?distro=centos-7",
                   "version": "4.11.3-43.el7",
                 },
               },
@@ -4682,7 +4682,7 @@ Object {
                 "id": "sed@4.2.2-6.el7",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-6.el7",
+                  "purl": "pkg:rpm/centos/sed@4.2.2-6.el7?distro=centos-7",
                   "version": "4.2.2-6.el7",
                 },
               },
@@ -4690,7 +4690,7 @@ Object {
                 "id": "setup@2.8.71-11.el7",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-11.el7",
+                  "purl": "pkg:rpm/centos/setup@2.8.71-11.el7?distro=centos-7",
                   "version": "2.8.71-11.el7",
                 },
               },
@@ -4698,7 +4698,7 @@ Object {
                 "id": "shadow-utils@2:4.6-5.el7",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.6-5.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/shadow-utils@2:4.6-5.el7?distro=centos-7&epoch=2",
                   "version": "2:4.6-5.el7",
                 },
               },
@@ -4706,7 +4706,7 @@ Object {
                 "id": "shared-mime-info@1.8-5.el7",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-5.el7",
+                  "purl": "pkg:rpm/centos/shared-mime-info@1.8-5.el7?distro=centos-7",
                   "version": "1.8-5.el7",
                 },
               },
@@ -4714,7 +4714,7 @@ Object {
                 "id": "sqlite@3.7.17-8.el7_7.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.el7_7.1",
+                  "purl": "pkg:rpm/centos/sqlite@3.7.17-8.el7_7.1?distro=centos-7",
                   "version": "3.7.17-8.el7_7.1",
                 },
               },
@@ -4722,7 +4722,7 @@ Object {
                 "id": "systemd@219-73.el7.1",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/systemd@219-73.el7.1",
+                  "purl": "pkg:rpm/centos/systemd@219-73.el7.1?distro=centos-7",
                   "version": "219-73.el7.1",
                 },
               },
@@ -4730,7 +4730,7 @@ Object {
                 "id": "systemd-libs@219-73.el7.1",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@219-73.el7.1",
+                  "purl": "pkg:rpm/centos/systemd-libs@219-73.el7.1?distro=centos-7",
                   "version": "219-73.el7.1",
                 },
               },
@@ -4738,7 +4738,7 @@ Object {
                 "id": "tar@2:1.26-35.el7",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.26-35.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/tar@2:1.26-35.el7?distro=centos-7&epoch=2",
                   "version": "2:1.26-35.el7",
                 },
               },
@@ -4746,7 +4746,7 @@ Object {
                 "id": "tzdata@2019c-1.el7",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2019c-1.el7",
+                  "purl": "pkg:rpm/centos/tzdata@2019c-1.el7?distro=centos-7",
                   "version": "2019c-1.el7",
                 },
               },
@@ -4754,7 +4754,7 @@ Object {
                 "id": "ustr@1.0.4-16.el7",
                 "info": Object {
                   "name": "ustr",
-                  "purl": "pkg:rpm/ustr@1.0.4-16.el7",
+                  "purl": "pkg:rpm/centos/ustr@1.0.4-16.el7?distro=centos-7",
                   "version": "1.0.4-16.el7",
                 },
               },
@@ -4762,7 +4762,7 @@ Object {
                 "id": "util-linux@2.23.2-63.el7",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.23.2-63.el7",
+                  "purl": "pkg:rpm/centos/util-linux@2.23.2-63.el7?distro=centos-7",
                   "version": "2.23.2-63.el7",
                 },
               },
@@ -4770,7 +4770,7 @@ Object {
                 "id": "vim-minimal@2:7.4.629-6.el7",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:7.4.629-6.el7?epoch=2",
+                  "purl": "pkg:rpm/centos/vim-minimal@2:7.4.629-6.el7?distro=centos-7&epoch=2",
                   "version": "2:7.4.629-6.el7",
                 },
               },
@@ -4778,7 +4778,7 @@ Object {
                 "id": "xz@5.2.2-1.el7",
                 "info": Object {
                   "name": "xz",
-                  "purl": "pkg:rpm/xz@5.2.2-1.el7",
+                  "purl": "pkg:rpm/centos/xz@5.2.2-1.el7?distro=centos-7",
                   "version": "5.2.2-1.el7",
                 },
               },
@@ -4786,7 +4786,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.el7",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.el7",
+                  "purl": "pkg:rpm/centos/xz-libs@5.2.2-1.el7?distro=centos-7",
                   "version": "5.2.2-1.el7",
                 },
               },
@@ -4794,7 +4794,7 @@ Object {
                 "id": "yum@3.4.3-167.el7.centos",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-167.el7.centos",
+                  "purl": "pkg:rpm/centos/yum@3.4.3-167.el7.centos?distro=centos-7",
                   "version": "3.4.3-167.el7.centos",
                 },
               },
@@ -4802,7 +4802,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.el7",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.el7",
+                  "purl": "pkg:rpm/centos/yum-metadata-parser@1.1.4-10.el7?distro=centos-7",
                   "version": "1.1.4-10.el7",
                 },
               },
@@ -4810,7 +4810,7 @@ Object {
                 "id": "yum-plugin-fastestmirror@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-plugin-fastestmirror",
-                  "purl": "pkg:rpm/yum-plugin-fastestmirror@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-plugin-fastestmirror@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -4818,7 +4818,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-plugin-ovl@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -4826,7 +4826,7 @@ Object {
                 "id": "yum-utils@1.1.31-53.el7",
                 "info": Object {
                   "name": "yum-utils",
-                  "purl": "pkg:rpm/yum-utils@1.1.31-53.el7",
+                  "purl": "pkg:rpm/centos/yum-utils@1.1.31-53.el7?distro=centos-7",
                   "version": "1.1.31-53.el7",
                 },
               },
@@ -4834,7 +4834,7 @@ Object {
                 "id": "zlib@1.2.7-18.el7",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.el7",
+                  "purl": "pkg:rpm/centos/zlib@1.2.7-18.el7?distro=centos-7",
                   "version": "1.2.7-18.el7",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/debian9.spec.ts.snap
@@ -1050,7 +1050,7 @@ Object {
                 "id": "adduser@3.115",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.115",
+                  "purl": "pkg:deb/debian/adduser@3.115?distro=debian-stretch",
                   "version": "3.115",
                 },
               },
@@ -1058,7 +1058,7 @@ Object {
                 "id": "shadow/passwd@1:4.4-4.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.4-4.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/passwd@1:4.4-4.1?distro=debian-stretch&upstream=shadow",
                   "version": "1:4.4-4.1",
                 },
               },
@@ -1066,7 +1066,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.4.10",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.4.10?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg5.0@1.4.10?distro=debian-stretch&upstream=apt",
                   "version": "1.4.10",
                 },
               },
@@ -1074,7 +1074,7 @@ Object {
                 "id": "debian-archive-keyring@2017.5+deb9u1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2017.5%2Bdeb9u1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2017.5%2Bdeb9u1?distro=debian-stretch",
                   "version": "2017.5+deb9u1",
                 },
               },
@@ -1082,7 +1082,7 @@ Object {
                 "id": "gcc-6/libstdc++6@6.3.0-18+deb9u1",
                 "info": Object {
                   "name": "gcc-6/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@6.3.0-18%2Bdeb9u1?upstream=gcc-6",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B6@6.3.0-18%2Bdeb9u1?distro=debian-stretch&upstream=gcc-6",
                   "version": "6.3.0-18+deb9u1",
                 },
               },
@@ -1090,7 +1090,7 @@ Object {
                 "id": "gnupg2/gpgv@2.1.18-8~deb9u4",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.1.18-8~deb9u4?upstream=gnupg2",
+                  "purl": "pkg:deb/debian/gpgv@2.1.18-8~deb9u4?distro=debian-stretch&upstream=gnupg2",
                   "version": "2.1.18-8~deb9u4",
                 },
               },
@@ -1098,7 +1098,7 @@ Object {
                 "id": "init-system-helpers@1.48",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.48",
+                  "purl": "pkg:deb/debian/init-system-helpers@1.48?distro=debian-stretch",
                   "version": "1.48",
                 },
               },
@@ -1106,7 +1106,7 @@ Object {
                 "id": "apt@1.4.10",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.4.10",
+                  "purl": "pkg:deb/debian/apt@1.4.10?distro=debian-stretch",
                   "version": "1.4.10",
                 },
               },
@@ -1114,7 +1114,7 @@ Object {
                 "id": "lz4/liblz4-1@0.0~r131-2+b1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@0.0~r131-2%2Bb1?upstream=lz4%400.0~r131-2",
+                  "purl": "pkg:deb/debian/liblz4-1@0.0~r131-2%2Bb1?distro=debian-stretch&upstream=lz4%400.0~r131-2",
                   "version": "0.0~r131-2+b1",
                 },
               },
@@ -1143,7 +1143,7 @@ Object {
                 "id": "base-files@9.9+deb9u13",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@9.9%2Bdeb9u13",
+                  "purl": "pkg:deb/debian/base-files@9.9%2Bdeb9u13?distro=debian-stretch",
                   "version": "9.9+deb9u13",
                 },
               },
@@ -1151,7 +1151,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.227",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.227?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.227?distro=debian-stretch&upstream=cdebconf",
                   "version": "0.227",
                 },
               },
@@ -1159,7 +1159,7 @@ Object {
                 "id": "base-passwd@3.5.43",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.43",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.43?distro=debian-stretch",
                   "version": "3.5.43",
                 },
               },
@@ -1167,7 +1167,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?distro=debian-stretch&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1175,7 +1175,7 @@ Object {
                 "id": "debianutils@4.8.1.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.1.1",
+                  "purl": "pkg:deb/debian/debianutils@4.8.1.1?distro=debian-stretch",
                   "version": "4.8.1.1",
                 },
               },
@@ -1183,7 +1183,7 @@ Object {
                 "id": "dash@0.5.8-2.4",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.8-2.4",
+                  "purl": "pkg:deb/debian/dash@0.5.8-2.4?distro=debian-stretch",
                   "version": "0.5.8-2.4",
                 },
               },
@@ -1191,7 +1191,7 @@ Object {
                 "id": "ncurses/libtinfo5@6.0+20161126-1+deb9u2",
                 "info": Object {
                   "name": "ncurses/libtinfo5",
-                  "purl": "pkg:deb/libtinfo5@6.0%2B20161126-1%2Bdeb9u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo5@6.0%2B20161126-1%2Bdeb9u2?distro=debian-stretch&upstream=ncurses",
                   "version": "6.0+20161126-1+deb9u2",
                 },
               },
@@ -1199,7 +1199,7 @@ Object {
                 "id": "bash@4.4-5",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@4.4-5",
+                  "purl": "pkg:deb/debian/bash@4.4-5?distro=debian-stretch",
                   "version": "4.4-5",
                 },
               },
@@ -1214,7 +1214,7 @@ Object {
                 "id": "coreutils@8.26-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.26-3",
+                  "purl": "pkg:deb/debian/coreutils@8.26-3?distro=debian-stretch",
                   "version": "8.26-3",
                 },
               },
@@ -1229,7 +1229,7 @@ Object {
                 "id": "sensible-utils@0.0.9+deb9u1",
                 "info": Object {
                   "name": "sensible-utils",
-                  "purl": "pkg:deb/sensible-utils@0.0.9%2Bdeb9u1",
+                  "purl": "pkg:deb/debian/sensible-utils@0.0.9%2Bdeb9u1?distro=debian-stretch",
                   "version": "0.0.9+deb9u1",
                 },
               },
@@ -1237,7 +1237,7 @@ Object {
                 "id": "diffutils@1:3.5-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.5-3",
+                  "purl": "pkg:deb/debian/diffutils@1:3.5-3?distro=debian-stretch",
                   "version": "1:3.5-3",
                 },
               },
@@ -1252,7 +1252,7 @@ Object {
                 "id": "e2fsprogs/e2fslibs@1.43.4-2+deb9u2",
                 "info": Object {
                   "name": "e2fsprogs/e2fslibs",
-                  "purl": "pkg:deb/e2fslibs@1.43.4-2%2Bdeb9u2?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/e2fslibs@1.43.4-2%2Bdeb9u2?distro=debian-stretch&upstream=e2fsprogs",
                   "version": "1.43.4-2+deb9u2",
                 },
               },
@@ -1260,7 +1260,7 @@ Object {
                 "id": "e2fsprogs/libcomerr2@1.43.4-2+deb9u2",
                 "info": Object {
                   "name": "e2fsprogs/libcomerr2",
-                  "purl": "pkg:deb/libcomerr2@1.43.4-2%2Bdeb9u2?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libcomerr2@1.43.4-2%2Bdeb9u2?distro=debian-stretch&upstream=e2fsprogs",
                   "version": "1.43.4-2+deb9u2",
                 },
               },
@@ -1268,7 +1268,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.43.4-2+deb9u2",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.43.4-2%2Bdeb9u2?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libss2@1.43.4-2%2Bdeb9u2?distro=debian-stretch&upstream=e2fsprogs",
                   "version": "1.43.4-2+deb9u2",
                 },
               },
@@ -1276,7 +1276,7 @@ Object {
                 "id": "ncurses/libncursesw5@6.0+20161126-1+deb9u2",
                 "info": Object {
                   "name": "ncurses/libncursesw5",
-                  "purl": "pkg:deb/libncursesw5@6.0%2B20161126-1%2Bdeb9u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw5@6.0%2B20161126-1%2Bdeb9u2?distro=debian-stretch&upstream=ncurses",
                   "version": "6.0+20161126-1+deb9u2",
                 },
               },
@@ -1284,7 +1284,7 @@ Object {
                 "id": "pam/libpam0g@1.1.8-3.6",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.1.8-3.6?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam0g@1.1.8-3.6?distro=debian-stretch&upstream=pam",
                   "version": "1.1.8-3.6",
                 },
               },
@@ -1292,7 +1292,7 @@ Object {
                 "id": "systemd/libsystemd0@232-25+deb9u12",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@232-25%2Bdeb9u12?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@232-25%2Bdeb9u12?distro=debian-stretch&upstream=systemd",
                   "version": "232-25+deb9u12",
                 },
               },
@@ -1300,7 +1300,7 @@ Object {
                 "id": "systemd/libudev1@232-25+deb9u12",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@232-25%2Bdeb9u12?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@232-25%2Bdeb9u12?distro=debian-stretch&upstream=systemd",
                   "version": "232-25+deb9u12",
                 },
               },
@@ -1308,7 +1308,7 @@ Object {
                 "id": "util-linux/libblkid1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.29.2-1%2Bdeb9u1?distro=debian-stretch&upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1316,7 +1316,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libfdisk1@2.29.2-1%2Bdeb9u1?distro=debian-stretch&upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1324,7 +1324,7 @@ Object {
                 "id": "util-linux/libmount1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.29.2-1%2Bdeb9u1?distro=debian-stretch&upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1332,7 +1332,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.29.2-1%2Bdeb9u1?distro=debian-stretch&upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1340,7 +1340,7 @@ Object {
                 "id": "util-linux/libuuid1@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.29.2-1%2Bdeb9u1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libuuid1@2.29.2-1%2Bdeb9u1?distro=debian-stretch&upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1348,7 +1348,7 @@ Object {
                 "id": "util-linux@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.29.2-1%2Bdeb9u1",
+                  "purl": "pkg:deb/debian/util-linux@2.29.2-1%2Bdeb9u1?distro=debian-stretch",
                   "version": "2.29.2-1+deb9u1",
                 },
               },
@@ -1356,7 +1356,7 @@ Object {
                 "id": "e2fsprogs@1.43.4-2+deb9u2",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.43.4-2%2Bdeb9u2",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.43.4-2%2Bdeb9u2?distro=debian-stretch",
                   "version": "1.43.4-2+deb9u2",
                 },
               },
@@ -1364,7 +1364,7 @@ Object {
                 "id": "findutils@4.6.0+git+20161106-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20161106-2",
+                  "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20161106-2?distro=debian-stretch",
                   "version": "4.6.0+git+20161106-2",
                 },
               },
@@ -1386,7 +1386,7 @@ Object {
                 "id": "glibc/libc-bin@2.24-11+deb9u4",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.24-11%2Bdeb9u4?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.24-11%2Bdeb9u4?distro=debian-stretch&upstream=glibc",
                   "version": "2.24-11+deb9u4",
                 },
               },
@@ -1408,7 +1408,7 @@ Object {
                 "id": "libgcrypt20@1.7.6-2+deb9u3",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.7.6-2%2Bdeb9u3",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.7.6-2%2Bdeb9u3?distro=debian-stretch",
                   "version": "1.7.6-2+deb9u3",
                 },
               },
@@ -1416,7 +1416,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.26-2",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.26-2?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.26-2?distro=debian-stretch&upstream=libgpg-error",
                   "version": "1.26-2",
                 },
               },
@@ -1424,7 +1424,7 @@ Object {
                 "id": "grep@2.27-2",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@2.27-2",
+                  "purl": "pkg:deb/debian/grep@2.27-2?distro=debian-stretch",
                   "version": "2.27-2",
                 },
               },
@@ -1432,7 +1432,7 @@ Object {
                 "id": "gzip/gzip@1.6-5+b1",
                 "info": Object {
                   "name": "gzip/gzip",
-                  "purl": "pkg:deb/gzip@1.6-5%2Bb1?upstream=gzip%401.6-5",
+                  "purl": "pkg:deb/debian/gzip@1.6-5%2Bb1?distro=debian-stretch&upstream=gzip%401.6-5",
                   "version": "1.6-5+b1",
                 },
               },
@@ -1440,7 +1440,7 @@ Object {
                 "id": "hostname/hostname@3.18+b1",
                 "info": Object {
                   "name": "hostname/hostname",
-                  "purl": "pkg:deb/hostname@3.18%2Bb1?upstream=hostname%403.18",
+                  "purl": "pkg:deb/debian/hostname@3.18%2Bb1?distro=debian-stretch&upstream=hostname%403.18",
                   "version": "3.18+b1",
                 },
               },
@@ -1448,7 +1448,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28-12+deb9u1",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28-12%2Bdeb9u1?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3@5.3.28-12%2Bdeb9u1?distro=debian-stretch&upstream=db5.3",
                   "version": "5.3.28-12+deb9u1",
                 },
               },
@@ -1456,7 +1456,7 @@ Object {
                 "id": "elfutils/libelf1@0.168-1",
                 "info": Object {
                   "name": "elfutils/libelf1",
-                  "purl": "pkg:deb/libelf1@0.168-1?upstream=elfutils",
+                  "purl": "pkg:deb/debian/libelf1@0.168-1?distro=debian-stretch&upstream=elfutils",
                   "version": "0.168-1",
                 },
               },
@@ -1464,7 +1464,7 @@ Object {
                 "id": "libmnl/libmnl0@1.0.4-2",
                 "info": Object {
                   "name": "libmnl/libmnl0",
-                  "purl": "pkg:deb/libmnl0@1.0.4-2?upstream=libmnl",
+                  "purl": "pkg:deb/debian/libmnl0@1.0.4-2?distro=debian-stretch&upstream=libmnl",
                   "version": "1.0.4-2",
                 },
               },
@@ -1472,7 +1472,7 @@ Object {
                 "id": "iproute2@4.9.0-1+deb9u1",
                 "info": Object {
                   "name": "iproute2",
-                  "purl": "pkg:deb/iproute2@4.9.0-1%2Bdeb9u1",
+                  "purl": "pkg:deb/debian/iproute2@4.9.0-1%2Bdeb9u1?distro=debian-stretch",
                   "version": "4.9.0-1+deb9u1",
                 },
               },
@@ -1480,7 +1480,7 @@ Object {
                 "id": "libcap2@1:2.25-1",
                 "info": Object {
                   "name": "libcap2",
-                  "purl": "pkg:deb/libcap2@1:2.25-1",
+                  "purl": "pkg:deb/debian/libcap2@1:2.25-1?distro=debian-stretch",
                   "version": "1:2.25-1",
                 },
               },
@@ -1488,7 +1488,7 @@ Object {
                 "id": "libidn/libidn11@1.33-1+deb9u1",
                 "info": Object {
                   "name": "libidn/libidn11",
-                  "purl": "pkg:deb/libidn11@1.33-1%2Bdeb9u1?upstream=libidn",
+                  "purl": "pkg:deb/debian/libidn11@1.33-1%2Bdeb9u1?distro=debian-stretch&upstream=libidn",
                   "version": "1.33-1+deb9u1",
                 },
               },
@@ -1496,7 +1496,7 @@ Object {
                 "id": "nettle/libnettle6@3.3-1+b2",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.3-1%2Bb2?upstream=nettle%403.3-1",
+                  "purl": "pkg:deb/debian/libnettle6@3.3-1%2Bb2?distro=debian-stretch&upstream=nettle%403.3-1",
                   "version": "3.3-1+b2",
                 },
               },
@@ -1504,7 +1504,7 @@ Object {
                 "id": "iputils/iputils-ping@3:20161105-1",
                 "info": Object {
                   "name": "iputils/iputils-ping",
-                  "purl": "pkg:deb/iputils-ping@3:20161105-1?upstream=iputils",
+                  "purl": "pkg:deb/debian/iputils-ping@3:20161105-1?distro=debian-stretch&upstream=iputils",
                   "version": "3:20161105-1",
                 },
               },
@@ -1526,7 +1526,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.6-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.6-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage-common@2.6-2?distro=debian-stretch&upstream=libsemanage",
                   "version": "2.6-2",
                 },
               },
@@ -1534,7 +1534,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.6-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.6-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage1@2.6-2?distro=debian-stretch&upstream=libsemanage",
                   "version": "2.6-2",
                 },
               },
@@ -1542,7 +1542,7 @@ Object {
                 "id": "libsepol/libsepol1@2.6-2",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.6-2?upstream=libsepol",
+                  "purl": "pkg:deb/debian/libsepol1@2.6-2?distro=debian-stretch&upstream=libsepol",
                   "version": "2.6-2",
                 },
               },
@@ -1550,7 +1550,7 @@ Object {
                 "id": "lsb/lsb-base@9.20161125",
                 "info": Object {
                   "name": "lsb/lsb-base",
-                  "purl": "pkg:deb/lsb-base@9.20161125?upstream=lsb",
+                  "purl": "pkg:deb/debian/lsb-base@9.20161125?distro=debian-stretch&upstream=lsb",
                   "version": "9.20161125",
                 },
               },
@@ -1558,7 +1558,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.0+20161126-1+deb9u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.0%2B20161126-1%2Bdeb9u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@6.0%2B20161126-1%2Bdeb9u2?distro=debian-stretch&upstream=ncurses",
                   "version": "6.0+20161126-1+deb9u2",
                 },
               },
@@ -1566,7 +1566,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.0+20161126-1+deb9u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.0%2B20161126-1%2Bdeb9u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@6.0%2B20161126-1%2Bdeb9u2?distro=debian-stretch&upstream=ncurses",
                   "version": "6.0+20161126-1+deb9u2",
                 },
               },
@@ -1574,7 +1574,7 @@ Object {
                 "id": "pam/libpam-modules@1.1.8-3.6",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.1.8-3.6?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules@1.1.8-3.6?distro=debian-stretch&upstream=pam",
                   "version": "1.1.8-3.6",
                 },
               },
@@ -1582,7 +1582,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.1.8-3.6",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.1.8-3.6?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules-bin@1.1.8-3.6?distro=debian-stretch&upstream=pam",
                   "version": "1.1.8-3.6",
                 },
               },
@@ -1590,7 +1590,7 @@ Object {
                 "id": "pam/libpam-runtime@1.1.8-3.6",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.1.8-3.6?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.1.8-3.6?distro=debian-stretch&upstream=pam",
                   "version": "1.1.8-3.6",
                 },
               },
@@ -1612,7 +1612,7 @@ Object {
                 "id": "sed@4.4-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.4-1",
+                  "purl": "pkg:deb/debian/sed@4.4-1?distro=debian-stretch",
                   "version": "4.4-1",
                 },
               },
@@ -1620,7 +1620,7 @@ Object {
                 "id": "shadow/login@1:4.4-4.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.4-4.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.4-4.1?distro=debian-stretch&upstream=shadow",
                   "version": "1:4.4-4.1",
                 },
               },
@@ -1628,7 +1628,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.88dsf-59.9",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.88dsf-59.9?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.88dsf-59.9?distro=debian-stretch&upstream=sysvinit",
                   "version": "2.88dsf-59.9",
                 },
               },
@@ -1643,7 +1643,7 @@ Object {
                 "id": "tzdata@2020a-0+deb9u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb9u1",
+                  "purl": "pkg:deb/debian/tzdata@2020a-0%2Bdeb9u1?distro=debian-stretch",
                   "version": "2020a-0+deb9u1",
                 },
               },
@@ -1651,7 +1651,7 @@ Object {
                 "id": "ustr/libustr-1.0-1@1.0.4-6",
                 "info": Object {
                   "name": "ustr/libustr-1.0-1",
-                  "purl": "pkg:deb/libustr-1.0-1@1.0.4-6?upstream=ustr",
+                  "purl": "pkg:deb/debian/libustr-1.0-1@1.0.4-6?distro=debian-stretch&upstream=ustr",
                   "version": "1.0.4-6",
                 },
               },
@@ -1659,7 +1659,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.29.2-1%2Bdeb9u1?upstream=util-linux%402.29.2-1%2Bdeb9u1",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.29.2-1%2Bdeb9u1?distro=debian-stretch&upstream=util-linux%402.29.2-1%2Bdeb9u1",
                   "version": "1:2.29.2-1+deb9u1",
                 },
               },
@@ -1667,7 +1667,7 @@ Object {
                 "id": "util-linux/mount@2.29.2-1+deb9u1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.29.2-1%2Bdeb9u1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.29.2-1%2Bdeb9u1?distro=debian-stretch&upstream=util-linux",
                   "version": "2.29.2-1+deb9u1",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/distroless.spec.ts.snap
@@ -102,7 +102,7 @@ Object {
                 "id": "base-files@10.3+deb10u5",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u5",
+                  "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u5?distro=debian-buster",
                   "version": "10.3+deb10u5",
                 },
               },
@@ -110,7 +110,7 @@ Object {
                 "id": "glibc/libc6@2.28-10",
                 "info": Object {
                   "name": "glibc/libc6",
-                  "purl": "pkg:deb/libc6@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc6@2.28-10?distro=debian-buster&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -118,7 +118,7 @@ Object {
                 "id": "netbase@5.6",
                 "info": Object {
                   "name": "netbase",
-                  "purl": "pkg:deb/netbase@5.6",
+                  "purl": "pkg:deb/debian/netbase@5.6?distro=debian-buster",
                   "version": "5.6",
                 },
               },
@@ -126,7 +126,7 @@ Object {
                 "id": "openssl/libssl1.1@1.1.1d-0+deb10u3",
                 "info": Object {
                   "name": "openssl/libssl1.1",
-                  "purl": "pkg:deb/libssl1.1@1.1.1d-0%2Bdeb10u3?upstream=openssl",
+                  "purl": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u3?distro=debian-buster&upstream=openssl",
                   "version": "1.1.1d-0+deb10u3",
                 },
               },
@@ -134,7 +134,7 @@ Object {
                 "id": "openssl@1.1.1d-0+deb10u3",
                 "info": Object {
                   "name": "openssl",
-                  "purl": "pkg:deb/openssl@1.1.1d-0%2Bdeb10u3",
+                  "purl": "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u3?distro=debian-buster",
                   "version": "1.1.1d-0+deb10u3",
                 },
               },
@@ -142,7 +142,7 @@ Object {
                 "id": "tzdata@2020a-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/tzdata@2020a-0%2Bdeb10u1?distro=debian-buster",
                   "version": "2020a-0+deb10u1",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/oraclelinux8.2.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/oraclelinux8.2.spec.ts.snap
@@ -1494,7 +1494,7 @@ Object {
                 "id": "acl@2.2.53-1.el8",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:rpm/acl@2.2.53-1.el8",
+                  "purl": "pkg:rpm/oracle/acl@2.2.53-1.el8?distro=oracle-8",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -1502,7 +1502,7 @@ Object {
                 "id": "audit-libs@3.0-0.17.20191104git1c2f876.el8",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@3.0-0.17.20191104git1c2f876.el8",
+                  "purl": "pkg:rpm/oracle/audit-libs@3.0-0.17.20191104git1c2f876.el8?distro=oracle-8",
                   "version": "3.0-0.17.20191104git1c2f876.el8",
                 },
               },
@@ -1510,7 +1510,7 @@ Object {
                 "id": "basesystem@11-5.el8",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@11-5.el8",
+                  "purl": "pkg:rpm/oracle/basesystem@11-5.el8?distro=oracle-8",
                   "version": "11-5.el8",
                 },
               },
@@ -1518,7 +1518,7 @@ Object {
                 "id": "bash@4.4.19-10.el8",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.4.19-10.el8",
+                  "purl": "pkg:rpm/oracle/bash@4.4.19-10.el8?distro=oracle-8",
                   "version": "4.4.19-10.el8",
                 },
               },
@@ -1526,7 +1526,7 @@ Object {
                 "id": "bind-export-libs@32:9.11.13-6.el8_2.1",
                 "info": Object {
                   "name": "bind-export-libs",
-                  "purl": "pkg:rpm/bind-export-libs@32:9.11.13-6.el8_2.1?epoch=32",
+                  "purl": "pkg:rpm/oracle/bind-export-libs@32:9.11.13-6.el8_2.1?distro=oracle-8&epoch=32",
                   "version": "32:9.11.13-6.el8_2.1",
                 },
               },
@@ -1534,7 +1534,7 @@ Object {
                 "id": "brotli@1.0.6-1.el8",
                 "info": Object {
                   "name": "brotli",
-                  "purl": "pkg:rpm/brotli@1.0.6-1.el8",
+                  "purl": "pkg:rpm/oracle/brotli@1.0.6-1.el8?distro=oracle-8",
                   "version": "1.0.6-1.el8",
                 },
               },
@@ -1542,7 +1542,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-26.el8",
+                  "purl": "pkg:rpm/oracle/bzip2-libs@1.0.6-26.el8?distro=oracle-8",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -1550,7 +1550,7 @@ Object {
                 "id": "ca-certificates@2020.2.41-80.0.el8_2",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2020.2.41-80.0.el8_2",
+                  "purl": "pkg:rpm/oracle/ca-certificates@2020.2.41-80.0.el8_2?distro=oracle-8",
                   "version": "2020.2.41-80.0.el8_2",
                 },
               },
@@ -1558,7 +1558,7 @@ Object {
                 "id": "chkconfig@1.11-1.el8",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.11-1.el8",
+                  "purl": "pkg:rpm/oracle/chkconfig@1.11-1.el8?distro=oracle-8",
                   "version": "1.11-1.el8",
                 },
               },
@@ -1566,7 +1566,7 @@ Object {
                 "id": "coreutils@8.30-7.0.1.el8_2.1",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.30-7.0.1.el8_2.1",
+                  "purl": "pkg:rpm/oracle/coreutils@8.30-7.0.1.el8_2.1?distro=oracle-8",
                   "version": "8.30-7.0.1.el8_2.1",
                 },
               },
@@ -1574,7 +1574,7 @@ Object {
                 "id": "coreutils-common@8.30-7.0.1.el8_2.1",
                 "info": Object {
                   "name": "coreutils-common",
-                  "purl": "pkg:rpm/coreutils-common@8.30-7.0.1.el8_2.1",
+                  "purl": "pkg:rpm/oracle/coreutils-common@8.30-7.0.1.el8_2.1?distro=oracle-8",
                   "version": "8.30-7.0.1.el8_2.1",
                 },
               },
@@ -1582,7 +1582,7 @@ Object {
                 "id": "cracklib@2.9.6-15.el8",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.6-15.el8",
+                  "purl": "pkg:rpm/oracle/cracklib@2.9.6-15.el8?distro=oracle-8",
                   "version": "2.9.6-15.el8",
                 },
               },
@@ -1590,7 +1590,7 @@ Object {
                 "id": "crypto-policies@20191128-2.git23e1bf1.el8",
                 "info": Object {
                   "name": "crypto-policies",
-                  "purl": "pkg:rpm/crypto-policies@20191128-2.git23e1bf1.el8",
+                  "purl": "pkg:rpm/oracle/crypto-policies@20191128-2.git23e1bf1.el8?distro=oracle-8",
                   "version": "20191128-2.git23e1bf1.el8",
                 },
               },
@@ -1598,7 +1598,7 @@ Object {
                 "id": "cryptsetup-libs@2.2.2-1.el8",
                 "info": Object {
                   "name": "cryptsetup-libs",
-                  "purl": "pkg:rpm/cryptsetup-libs@2.2.2-1.el8",
+                  "purl": "pkg:rpm/oracle/cryptsetup-libs@2.2.2-1.el8?distro=oracle-8",
                   "version": "2.2.2-1.el8",
                 },
               },
@@ -1606,7 +1606,7 @@ Object {
                 "id": "curl@7.61.1-12.el8",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.el8",
+                  "purl": "pkg:rpm/oracle/curl@7.61.1-12.el8?distro=oracle-8",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -1614,7 +1614,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.27-1.el8",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.27-1.el8",
+                  "purl": "pkg:rpm/oracle/cyrus-sasl-lib@2.1.27-1.el8?distro=oracle-8",
                   "version": "2.1.27-1.el8",
                 },
               },
@@ -1622,7 +1622,7 @@ Object {
                 "id": "dbus@1:1.12.8-10.0.1.el8_2",
                 "info": Object {
                   "name": "dbus",
-                  "purl": "pkg:rpm/dbus@1:1.12.8-10.0.1.el8_2?epoch=1",
+                  "purl": "pkg:rpm/oracle/dbus@1:1.12.8-10.0.1.el8_2?distro=oracle-8&epoch=1",
                   "version": "1:1.12.8-10.0.1.el8_2",
                 },
               },
@@ -1630,7 +1630,7 @@ Object {
                 "id": "dbus-common@1:1.12.8-10.0.1.el8_2",
                 "info": Object {
                   "name": "dbus-common",
-                  "purl": "pkg:rpm/dbus-common@1:1.12.8-10.0.1.el8_2?epoch=1",
+                  "purl": "pkg:rpm/oracle/dbus-common@1:1.12.8-10.0.1.el8_2?distro=oracle-8&epoch=1",
                   "version": "1:1.12.8-10.0.1.el8_2",
                 },
               },
@@ -1638,7 +1638,7 @@ Object {
                 "id": "dbus-daemon@1:1.12.8-10.0.1.el8_2",
                 "info": Object {
                   "name": "dbus-daemon",
-                  "purl": "pkg:rpm/dbus-daemon@1:1.12.8-10.0.1.el8_2?epoch=1",
+                  "purl": "pkg:rpm/oracle/dbus-daemon@1:1.12.8-10.0.1.el8_2?distro=oracle-8&epoch=1",
                   "version": "1:1.12.8-10.0.1.el8_2",
                 },
               },
@@ -1646,7 +1646,7 @@ Object {
                 "id": "dbus-libs@1:1.12.8-10.0.1.el8_2",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.12.8-10.0.1.el8_2?epoch=1",
+                  "purl": "pkg:rpm/oracle/dbus-libs@1:1.12.8-10.0.1.el8_2?distro=oracle-8&epoch=1",
                   "version": "1:1.12.8-10.0.1.el8_2",
                 },
               },
@@ -1654,7 +1654,7 @@ Object {
                 "id": "dbus-tools@1:1.12.8-10.0.1.el8_2",
                 "info": Object {
                   "name": "dbus-tools",
-                  "purl": "pkg:rpm/dbus-tools@1:1.12.8-10.0.1.el8_2?epoch=1",
+                  "purl": "pkg:rpm/oracle/dbus-tools@1:1.12.8-10.0.1.el8_2?distro=oracle-8&epoch=1",
                   "version": "1:1.12.8-10.0.1.el8_2",
                 },
               },
@@ -1662,7 +1662,7 @@ Object {
                 "id": "device-mapper@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper",
-                  "purl": "pkg:rpm/device-mapper@8:1.02.169-3.el8?epoch=8",
+                  "purl": "pkg:rpm/oracle/device-mapper@8:1.02.169-3.el8?distro=oracle-8&epoch=8",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -1670,7 +1670,7 @@ Object {
                 "id": "device-mapper-libs@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper-libs",
-                  "purl": "pkg:rpm/device-mapper-libs@8:1.02.169-3.el8?epoch=8",
+                  "purl": "pkg:rpm/oracle/device-mapper-libs@8:1.02.169-3.el8?distro=oracle-8&epoch=8",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -1678,7 +1678,7 @@ Object {
                 "id": "dhcp-client@12:4.3.6-40.el8",
                 "info": Object {
                   "name": "dhcp-client",
-                  "purl": "pkg:rpm/dhcp-client@12:4.3.6-40.el8?epoch=12",
+                  "purl": "pkg:rpm/oracle/dhcp-client@12:4.3.6-40.el8?distro=oracle-8&epoch=12",
                   "version": "12:4.3.6-40.el8",
                 },
               },
@@ -1686,7 +1686,7 @@ Object {
                 "id": "dhcp-common@12:4.3.6-40.el8",
                 "info": Object {
                   "name": "dhcp-common",
-                  "purl": "pkg:rpm/dhcp-common@12:4.3.6-40.el8?epoch=12",
+                  "purl": "pkg:rpm/oracle/dhcp-common@12:4.3.6-40.el8?distro=oracle-8&epoch=12",
                   "version": "12:4.3.6-40.el8",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "dhcp-libs@12:4.3.6-40.el8",
                 "info": Object {
                   "name": "dhcp-libs",
-                  "purl": "pkg:rpm/dhcp-libs@12:4.3.6-40.el8?epoch=12",
+                  "purl": "pkg:rpm/oracle/dhcp-libs@12:4.3.6-40.el8?distro=oracle-8&epoch=12",
                   "version": "12:4.3.6-40.el8",
                 },
               },
@@ -1702,7 +1702,7 @@ Object {
                 "id": "diffutils@3.6-6.el8",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.6-6.el8",
+                  "purl": "pkg:rpm/oracle/diffutils@3.6-6.el8?distro=oracle-8",
                   "version": "3.6-6.el8",
                 },
               },
@@ -1710,7 +1710,7 @@ Object {
                 "id": "dnf@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "dnf",
-                  "purl": "pkg:rpm/dnf@4.2.17-7.el8_2",
+                  "purl": "pkg:rpm/oracle/dnf@4.2.17-7.el8_2?distro=oracle-8",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -1718,7 +1718,7 @@ Object {
                 "id": "dnf-data@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "dnf-data",
-                  "purl": "pkg:rpm/dnf-data@4.2.17-7.el8_2",
+                  "purl": "pkg:rpm/oracle/dnf-data@4.2.17-7.el8_2?distro=oracle-8",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -1726,7 +1726,7 @@ Object {
                 "id": "dnf-plugins-core@4.0.12-4.el8_2",
                 "info": Object {
                   "name": "dnf-plugins-core",
-                  "purl": "pkg:rpm/dnf-plugins-core@4.0.12-4.el8_2",
+                  "purl": "pkg:rpm/oracle/dnf-plugins-core@4.0.12-4.el8_2?distro=oracle-8",
                   "version": "4.0.12-4.el8_2",
                 },
               },
@@ -1734,7 +1734,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.178-7.el8",
+                  "purl": "pkg:rpm/oracle/elfutils-default-yama-scope@0.178-7.el8?distro=oracle-8",
                   "version": "0.178-7.el8",
                 },
               },
@@ -1742,7 +1742,7 @@ Object {
                 "id": "elfutils-libelf@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.178-7.el8",
+                  "purl": "pkg:rpm/oracle/elfutils-libelf@0.178-7.el8?distro=oracle-8",
                   "version": "0.178-7.el8",
                 },
               },
@@ -1750,7 +1750,7 @@ Object {
                 "id": "elfutils-libs@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.178-7.el8",
+                  "purl": "pkg:rpm/oracle/elfutils-libs@0.178-7.el8?distro=oracle-8",
                   "version": "0.178-7.el8",
                 },
               },
@@ -1758,7 +1758,7 @@ Object {
                 "id": "expat@2.2.5-3.el8",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.2.5-3.el8",
+                  "purl": "pkg:rpm/oracle/expat@2.2.5-3.el8?distro=oracle-8",
                   "version": "2.2.5-3.el8",
                 },
               },
@@ -1766,7 +1766,7 @@ Object {
                 "id": "file-libs@5.33-13.el8",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.33-13.el8",
+                  "purl": "pkg:rpm/oracle/file-libs@5.33-13.el8?distro=oracle-8",
                   "version": "5.33-13.el8",
                 },
               },
@@ -1774,7 +1774,7 @@ Object {
                 "id": "filesystem@3.8-2.el8",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.8-2.el8",
+                  "purl": "pkg:rpm/oracle/filesystem@3.8-2.el8?distro=oracle-8",
                   "version": "3.8-2.el8",
                 },
               },
@@ -1782,7 +1782,7 @@ Object {
                 "id": "findutils@1:4.6.0-20.el8",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.6.0-20.el8?epoch=1",
+                  "purl": "pkg:rpm/oracle/findutils@1:4.6.0-20.el8?distro=oracle-8&epoch=1",
                   "version": "1:4.6.0-20.el8",
                 },
               },
@@ -1790,7 +1790,7 @@ Object {
                 "id": "fipscheck@1.5.0-4.el8",
                 "info": Object {
                   "name": "fipscheck",
-                  "purl": "pkg:rpm/fipscheck@1.5.0-4.el8",
+                  "purl": "pkg:rpm/oracle/fipscheck@1.5.0-4.el8?distro=oracle-8",
                   "version": "1.5.0-4.el8",
                 },
               },
@@ -1798,7 +1798,7 @@ Object {
                 "id": "fipscheck-lib@1.5.0-4.el8",
                 "info": Object {
                   "name": "fipscheck-lib",
-                  "purl": "pkg:rpm/fipscheck-lib@1.5.0-4.el8",
+                  "purl": "pkg:rpm/oracle/fipscheck-lib@1.5.0-4.el8?distro=oracle-8",
                   "version": "1.5.0-4.el8",
                 },
               },
@@ -1806,7 +1806,7 @@ Object {
                 "id": "gawk@4.2.1-1.el8",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.2.1-1.el8",
+                  "purl": "pkg:rpm/oracle/gawk@4.2.1-1.el8?distro=oracle-8",
                   "version": "4.2.1-1.el8",
                 },
               },
@@ -1814,7 +1814,7 @@ Object {
                 "id": "gdbm@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.18-1.el8?epoch=1",
+                  "purl": "pkg:rpm/oracle/gdbm@1:1.18-1.el8?distro=oracle-8&epoch=1",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -1822,7 +1822,7 @@ Object {
                 "id": "gdbm-libs@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm-libs",
-                  "purl": "pkg:rpm/gdbm-libs@1:1.18-1.el8?epoch=1",
+                  "purl": "pkg:rpm/oracle/gdbm-libs@1:1.18-1.el8?distro=oracle-8&epoch=1",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -1830,7 +1830,7 @@ Object {
                 "id": "glib2@2.56.4-8.el8",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.4-8.el8",
+                  "purl": "pkg:rpm/oracle/glib2@2.56.4-8.el8?distro=oracle-8",
                   "version": "2.56.4-8.el8",
                 },
               },
@@ -1838,7 +1838,7 @@ Object {
                 "id": "glibc@2.28-101.0.1.el8",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.28-101.0.1.el8",
+                  "purl": "pkg:rpm/oracle/glibc@2.28-101.0.1.el8?distro=oracle-8",
                   "version": "2.28-101.0.1.el8",
                 },
               },
@@ -1846,7 +1846,7 @@ Object {
                 "id": "glibc-all-langpacks@2.28-101.0.1.el8",
                 "info": Object {
                   "name": "glibc-all-langpacks",
-                  "purl": "pkg:rpm/glibc-all-langpacks@2.28-101.0.1.el8",
+                  "purl": "pkg:rpm/oracle/glibc-all-langpacks@2.28-101.0.1.el8?distro=oracle-8",
                   "version": "2.28-101.0.1.el8",
                 },
               },
@@ -1854,7 +1854,7 @@ Object {
                 "id": "glibc-common@2.28-101.0.1.el8",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.28-101.0.1.el8",
+                  "purl": "pkg:rpm/oracle/glibc-common@2.28-101.0.1.el8?distro=oracle-8",
                   "version": "2.28-101.0.1.el8",
                 },
               },
@@ -1862,7 +1862,7 @@ Object {
                 "id": "gmp@1:6.1.2-10.el8",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.1.2-10.el8?epoch=1",
+                  "purl": "pkg:rpm/oracle/gmp@1:6.1.2-10.el8?distro=oracle-8&epoch=1",
                   "version": "1:6.1.2-10.el8",
                 },
               },
@@ -1870,7 +1870,7 @@ Object {
                 "id": "gnupg2@2.2.9-1.el8",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.2.9-1.el8",
+                  "purl": "pkg:rpm/oracle/gnupg2@2.2.9-1.el8?distro=oracle-8",
                   "version": "2.2.9-1.el8",
                 },
               },
@@ -1878,7 +1878,7 @@ Object {
                 "id": "gnutls@3.6.8-11.el8_2",
                 "info": Object {
                   "name": "gnutls",
-                  "purl": "pkg:rpm/gnutls@3.6.8-11.el8_2",
+                  "purl": "pkg:rpm/oracle/gnutls@3.6.8-11.el8_2?distro=oracle-8",
                   "version": "3.6.8-11.el8_2",
                 },
               },
@@ -1886,7 +1886,7 @@ Object {
                 "id": "gpg-pubkey@ad986da3-5cabf60d",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@ad986da3-5cabf60d",
+                  "purl": "pkg:rpm/oracle/gpg-pubkey@ad986da3-5cabf60d?distro=oracle-8",
                   "version": "ad986da3-5cabf60d",
                 },
               },
@@ -1894,7 +1894,7 @@ Object {
                 "id": "gpgme@1.10.0-6.0.1.el8",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.10.0-6.0.1.el8",
+                  "purl": "pkg:rpm/oracle/gpgme@1.10.0-6.0.1.el8?distro=oracle-8",
                   "version": "1.10.0-6.0.1.el8",
                 },
               },
@@ -1902,7 +1902,7 @@ Object {
                 "id": "grep@3.1-6.el8",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@3.1-6.el8",
+                  "purl": "pkg:rpm/oracle/grep@3.1-6.el8?distro=oracle-8",
                   "version": "3.1-6.el8",
                 },
               },
@@ -1910,7 +1910,7 @@ Object {
                 "id": "gzip@1.9-9.el8",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.9-9.el8",
+                  "purl": "pkg:rpm/oracle/gzip@1.9-9.el8?distro=oracle-8",
                   "version": "1.9-9.el8",
                 },
               },
@@ -1918,7 +1918,7 @@ Object {
                 "id": "ima-evm-utils@1.1-5.el8",
                 "info": Object {
                   "name": "ima-evm-utils",
-                  "purl": "pkg:rpm/ima-evm-utils@1.1-5.el8",
+                  "purl": "pkg:rpm/oracle/ima-evm-utils@1.1-5.el8?distro=oracle-8",
                   "version": "1.1-5.el8",
                 },
               },
@@ -1926,7 +1926,7 @@ Object {
                 "id": "info@6.5-6.el8",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@6.5-6.el8",
+                  "purl": "pkg:rpm/oracle/info@6.5-6.el8?distro=oracle-8",
                   "version": "6.5-6.el8",
                 },
               },
@@ -1934,7 +1934,7 @@ Object {
                 "id": "initscripts@10.00.6-1.0.1.el8_2.2",
                 "info": Object {
                   "name": "initscripts",
-                  "purl": "pkg:rpm/initscripts@10.00.6-1.0.1.el8_2.2",
+                  "purl": "pkg:rpm/oracle/initscripts@10.00.6-1.0.1.el8_2.2?distro=oracle-8",
                   "version": "10.00.6-1.0.1.el8_2.2",
                 },
               },
@@ -1942,7 +1942,7 @@ Object {
                 "id": "ipcalc@0.2.4-4.el8",
                 "info": Object {
                   "name": "ipcalc",
-                  "purl": "pkg:rpm/ipcalc@0.2.4-4.el8",
+                  "purl": "pkg:rpm/oracle/ipcalc@0.2.4-4.el8?distro=oracle-8",
                   "version": "0.2.4-4.el8",
                 },
               },
@@ -1950,7 +1950,7 @@ Object {
                 "id": "iproute@5.3.0-1.el8",
                 "info": Object {
                   "name": "iproute",
-                  "purl": "pkg:rpm/iproute@5.3.0-1.el8",
+                  "purl": "pkg:rpm/oracle/iproute@5.3.0-1.el8?distro=oracle-8",
                   "version": "5.3.0-1.el8",
                 },
               },
@@ -1958,7 +1958,7 @@ Object {
                 "id": "iptables-libs@1.8.4-10.el8_2.1",
                 "info": Object {
                   "name": "iptables-libs",
-                  "purl": "pkg:rpm/iptables-libs@1.8.4-10.el8_2.1",
+                  "purl": "pkg:rpm/oracle/iptables-libs@1.8.4-10.el8_2.1?distro=oracle-8",
                   "version": "1.8.4-10.el8_2.1",
                 },
               },
@@ -1966,7 +1966,7 @@ Object {
                 "id": "iputils@20180629-2.el8",
                 "info": Object {
                   "name": "iputils",
-                  "purl": "pkg:rpm/iputils@20180629-2.el8",
+                  "purl": "pkg:rpm/oracle/iputils@20180629-2.el8?distro=oracle-8",
                   "version": "20180629-2.el8",
                 },
               },
@@ -1974,7 +1974,7 @@ Object {
                 "id": "json-c@0.13.1-0.2.el8",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.13.1-0.2.el8",
+                  "purl": "pkg:rpm/oracle/json-c@0.13.1-0.2.el8?distro=oracle-8",
                   "version": "0.13.1-0.2.el8",
                 },
               },
@@ -1982,7 +1982,7 @@ Object {
                 "id": "keyutils-libs@1.5.10-6.el8",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.10-6.el8",
+                  "purl": "pkg:rpm/oracle/keyutils-libs@1.5.10-6.el8?distro=oracle-8",
                   "version": "1.5.10-6.el8",
                 },
               },
@@ -1990,7 +1990,7 @@ Object {
                 "id": "kmod-libs@25-16.0.1.el8",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/kmod-libs@25-16.0.1.el8",
+                  "purl": "pkg:rpm/oracle/kmod-libs@25-16.0.1.el8?distro=oracle-8",
                   "version": "25-16.0.1.el8",
                 },
               },
@@ -1998,7 +1998,7 @@ Object {
                 "id": "krb5-libs@1.17-18.el8",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.17-18.el8",
+                  "purl": "pkg:rpm/oracle/krb5-libs@1.17-18.el8?distro=oracle-8",
                   "version": "1.17-18.el8",
                 },
               },
@@ -2006,7 +2006,7 @@ Object {
                 "id": "libacl@2.2.53-1.el8",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.53-1.el8",
+                  "purl": "pkg:rpm/oracle/libacl@2.2.53-1.el8?distro=oracle-8",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -2014,7 +2014,7 @@ Object {
                 "id": "libarchive@3.3.2-8.el8_1",
                 "info": Object {
                   "name": "libarchive",
-                  "purl": "pkg:rpm/libarchive@3.3.2-8.el8_1",
+                  "purl": "pkg:rpm/oracle/libarchive@3.3.2-8.el8_1?distro=oracle-8",
                   "version": "3.3.2-8.el8_1",
                 },
               },
@@ -2022,7 +2022,7 @@ Object {
                 "id": "libassuan@2.5.1-3.el8",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.5.1-3.el8",
+                  "purl": "pkg:rpm/oracle/libassuan@2.5.1-3.el8?distro=oracle-8",
                   "version": "2.5.1-3.el8",
                 },
               },
@@ -2030,7 +2030,7 @@ Object {
                 "id": "libattr@2.4.48-3.el8",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.48-3.el8",
+                  "purl": "pkg:rpm/oracle/libattr@2.4.48-3.el8?distro=oracle-8",
                   "version": "2.4.48-3.el8",
                 },
               },
@@ -2038,7 +2038,7 @@ Object {
                 "id": "libblkid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.32.1-22.el8",
+                  "purl": "pkg:rpm/oracle/libblkid@2.32.1-22.el8?distro=oracle-8",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -2046,7 +2046,7 @@ Object {
                 "id": "libcap@2.26-3.el8",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.26-3.el8",
+                  "purl": "pkg:rpm/oracle/libcap@2.26-3.el8?distro=oracle-8",
                   "version": "2.26-3.el8",
                 },
               },
@@ -2054,7 +2054,7 @@ Object {
                 "id": "libcap-ng@0.7.9-5.el8",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.7.9-5.el8",
+                  "purl": "pkg:rpm/oracle/libcap-ng@0.7.9-5.el8?distro=oracle-8",
                   "version": "0.7.9-5.el8",
                 },
               },
@@ -2062,7 +2062,7 @@ Object {
                 "id": "libcom_err@1.45.4-3.el8",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.45.4-3.el8",
+                  "purl": "pkg:rpm/oracle/libcom_err@1.45.4-3.el8?distro=oracle-8",
                   "version": "1.45.4-3.el8",
                 },
               },
@@ -2070,7 +2070,7 @@ Object {
                 "id": "libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "libcomps",
-                  "purl": "pkg:rpm/libcomps@0.1.11-4.el8",
+                  "purl": "pkg:rpm/oracle/libcomps@0.1.11-4.el8?distro=oracle-8",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -2078,7 +2078,7 @@ Object {
                 "id": "libcurl@7.61.1-12.el8",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.el8",
+                  "purl": "pkg:rpm/oracle/libcurl@7.61.1-12.el8?distro=oracle-8",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -2086,7 +2086,7 @@ Object {
                 "id": "libdb@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.28-37.el8",
+                  "purl": "pkg:rpm/oracle/libdb@5.3.28-37.el8?distro=oracle-8",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -2094,7 +2094,7 @@ Object {
                 "id": "libdb-utils@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.28-37.el8",
+                  "purl": "pkg:rpm/oracle/libdb-utils@5.3.28-37.el8?distro=oracle-8",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -2102,7 +2102,7 @@ Object {
                 "id": "libdnf@0.39.1-6.0.1.el8_2",
                 "info": Object {
                   "name": "libdnf",
-                  "purl": "pkg:rpm/libdnf@0.39.1-6.0.1.el8_2",
+                  "purl": "pkg:rpm/oracle/libdnf@0.39.1-6.0.1.el8_2?distro=oracle-8",
                   "version": "0.39.1-6.0.1.el8_2",
                 },
               },
@@ -2110,7 +2110,7 @@ Object {
                 "id": "libedit@3.1-23.20170329cvs.el8",
                 "info": Object {
                   "name": "libedit",
-                  "purl": "pkg:rpm/libedit@3.1-23.20170329cvs.el8",
+                  "purl": "pkg:rpm/oracle/libedit@3.1-23.20170329cvs.el8?distro=oracle-8",
                   "version": "3.1-23.20170329cvs.el8",
                 },
               },
@@ -2118,7 +2118,7 @@ Object {
                 "id": "libestr@0.1.10-1.el8",
                 "info": Object {
                   "name": "libestr",
-                  "purl": "pkg:rpm/libestr@0.1.10-1.el8",
+                  "purl": "pkg:rpm/oracle/libestr@0.1.10-1.el8?distro=oracle-8",
                   "version": "0.1.10-1.el8",
                 },
               },
@@ -2126,7 +2126,7 @@ Object {
                 "id": "libfastjson@0.99.8-2.el8",
                 "info": Object {
                   "name": "libfastjson",
-                  "purl": "pkg:rpm/libfastjson@0.99.8-2.el8",
+                  "purl": "pkg:rpm/oracle/libfastjson@0.99.8-2.el8?distro=oracle-8",
                   "version": "0.99.8-2.el8",
                 },
               },
@@ -2134,7 +2134,7 @@ Object {
                 "id": "libfdisk@2.32.1-22.el8",
                 "info": Object {
                   "name": "libfdisk",
-                  "purl": "pkg:rpm/libfdisk@2.32.1-22.el8",
+                  "purl": "pkg:rpm/oracle/libfdisk@2.32.1-22.el8?distro=oracle-8",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -2142,7 +2142,7 @@ Object {
                 "id": "libffi@3.1-21.el8",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.1-21.el8",
+                  "purl": "pkg:rpm/oracle/libffi@3.1-21.el8?distro=oracle-8",
                   "version": "3.1-21.el8",
                 },
               },
@@ -2150,7 +2150,7 @@ Object {
                 "id": "libgcc@8.3.1-5.0.3.el8",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@8.3.1-5.0.3.el8",
+                  "purl": "pkg:rpm/oracle/libgcc@8.3.1-5.0.3.el8?distro=oracle-8",
                   "version": "8.3.1-5.0.3.el8",
                 },
               },
@@ -2158,7 +2158,7 @@ Object {
                 "id": "libgcrypt@1.8.3-4.el8",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.8.3-4.el8",
+                  "purl": "pkg:rpm/oracle/libgcrypt@1.8.3-4.el8?distro=oracle-8",
                   "version": "1.8.3-4.el8",
                 },
               },
@@ -2166,7 +2166,7 @@ Object {
                 "id": "libgpg-error@1.31-1.el8",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.31-1.el8",
+                  "purl": "pkg:rpm/oracle/libgpg-error@1.31-1.el8?distro=oracle-8",
                   "version": "1.31-1.el8",
                 },
               },
@@ -2174,7 +2174,7 @@ Object {
                 "id": "libidn2@2.2.0-1.el8",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.2.0-1.el8",
+                  "purl": "pkg:rpm/oracle/libidn2@2.2.0-1.el8?distro=oracle-8",
                   "version": "2.2.0-1.el8",
                 },
               },
@@ -2182,7 +2182,7 @@ Object {
                 "id": "libksba@1.3.5-7.el8",
                 "info": Object {
                   "name": "libksba",
-                  "purl": "pkg:rpm/libksba@1.3.5-7.el8",
+                  "purl": "pkg:rpm/oracle/libksba@1.3.5-7.el8?distro=oracle-8",
                   "version": "1.3.5-7.el8",
                 },
               },
@@ -2190,7 +2190,7 @@ Object {
                 "id": "libmetalink@0.1.3-7.el8",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.3-7.el8",
+                  "purl": "pkg:rpm/oracle/libmetalink@0.1.3-7.el8?distro=oracle-8",
                   "version": "0.1.3-7.el8",
                 },
               },
@@ -2198,7 +2198,7 @@ Object {
                 "id": "libmnl@1.0.4-6.el8",
                 "info": Object {
                   "name": "libmnl",
-                  "purl": "pkg:rpm/libmnl@1.0.4-6.el8",
+                  "purl": "pkg:rpm/oracle/libmnl@1.0.4-6.el8?distro=oracle-8",
                   "version": "1.0.4-6.el8",
                 },
               },
@@ -2206,7 +2206,7 @@ Object {
                 "id": "libmodulemd1@1.8.16-0.2.8.2.1",
                 "info": Object {
                   "name": "libmodulemd1",
-                  "purl": "pkg:rpm/libmodulemd1@1.8.16-0.2.8.2.1",
+                  "purl": "pkg:rpm/oracle/libmodulemd1@1.8.16-0.2.8.2.1?distro=oracle-8",
                   "version": "1.8.16-0.2.8.2.1",
                 },
               },
@@ -2214,7 +2214,7 @@ Object {
                 "id": "libmount@2.32.1-22.el8",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.32.1-22.el8",
+                  "purl": "pkg:rpm/oracle/libmount@2.32.1-22.el8?distro=oracle-8",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -2222,7 +2222,7 @@ Object {
                 "id": "libnghttp2@1.33.0-3.el8_2.1",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.33.0-3.el8_2.1",
+                  "purl": "pkg:rpm/oracle/libnghttp2@1.33.0-3.el8_2.1?distro=oracle-8",
                   "version": "1.33.0-3.el8_2.1",
                 },
               },
@@ -2230,7 +2230,7 @@ Object {
                 "id": "libnsl2@1.2.0-2.20180605git4a062cf.el8",
                 "info": Object {
                   "name": "libnsl2",
-                  "purl": "pkg:rpm/libnsl2@1.2.0-2.20180605git4a062cf.el8",
+                  "purl": "pkg:rpm/oracle/libnsl2@1.2.0-2.20180605git4a062cf.el8?distro=oracle-8",
                   "version": "1.2.0-2.20180605git4a062cf.el8",
                 },
               },
@@ -2238,7 +2238,7 @@ Object {
                 "id": "libpcap@14:1.9.0-3.el8",
                 "info": Object {
                   "name": "libpcap",
-                  "purl": "pkg:rpm/libpcap@14:1.9.0-3.el8?epoch=14",
+                  "purl": "pkg:rpm/oracle/libpcap@14:1.9.0-3.el8?distro=oracle-8&epoch=14",
                   "version": "14:1.9.0-3.el8",
                 },
               },
@@ -2246,7 +2246,7 @@ Object {
                 "id": "libpsl@0.20.2-5.el8",
                 "info": Object {
                   "name": "libpsl",
-                  "purl": "pkg:rpm/libpsl@0.20.2-5.el8",
+                  "purl": "pkg:rpm/oracle/libpsl@0.20.2-5.el8?distro=oracle-8",
                   "version": "0.20.2-5.el8",
                 },
               },
@@ -2254,7 +2254,7 @@ Object {
                 "id": "libpwquality@1.4.0-9.el8",
                 "info": Object {
                   "name": "libpwquality",
-                  "purl": "pkg:rpm/libpwquality@1.4.0-9.el8",
+                  "purl": "pkg:rpm/oracle/libpwquality@1.4.0-9.el8?distro=oracle-8",
                   "version": "1.4.0-9.el8",
                 },
               },
@@ -2262,7 +2262,7 @@ Object {
                 "id": "librepo@1.11.0-3.el8_2",
                 "info": Object {
                   "name": "librepo",
-                  "purl": "pkg:rpm/librepo@1.11.0-3.el8_2",
+                  "purl": "pkg:rpm/oracle/librepo@1.11.0-3.el8_2?distro=oracle-8",
                   "version": "1.11.0-3.el8_2",
                 },
               },
@@ -2270,7 +2270,7 @@ Object {
                 "id": "libreport-filesystem@2.9.5-10.0.1.el8",
                 "info": Object {
                   "name": "libreport-filesystem",
-                  "purl": "pkg:rpm/libreport-filesystem@2.9.5-10.0.1.el8",
+                  "purl": "pkg:rpm/oracle/libreport-filesystem@2.9.5-10.0.1.el8?distro=oracle-8",
                   "version": "2.9.5-10.0.1.el8",
                 },
               },
@@ -2278,7 +2278,7 @@ Object {
                 "id": "libseccomp@2.4.1-1.el8",
                 "info": Object {
                   "name": "libseccomp",
-                  "purl": "pkg:rpm/libseccomp@2.4.1-1.el8",
+                  "purl": "pkg:rpm/oracle/libseccomp@2.4.1-1.el8?distro=oracle-8",
                   "version": "2.4.1-1.el8",
                 },
               },
@@ -2286,7 +2286,7 @@ Object {
                 "id": "libselinux@2.9-3.el8",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.9-3.el8",
+                  "purl": "pkg:rpm/oracle/libselinux@2.9-3.el8?distro=oracle-8",
                   "version": "2.9-3.el8",
                 },
               },
@@ -2294,7 +2294,7 @@ Object {
                 "id": "libselinux-utils@2.9-3.el8",
                 "info": Object {
                   "name": "libselinux-utils",
-                  "purl": "pkg:rpm/libselinux-utils@2.9-3.el8",
+                  "purl": "pkg:rpm/oracle/libselinux-utils@2.9-3.el8?distro=oracle-8",
                   "version": "2.9-3.el8",
                 },
               },
@@ -2302,7 +2302,7 @@ Object {
                 "id": "libsemanage@2.9-2.el8",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.9-2.el8",
+                  "purl": "pkg:rpm/oracle/libsemanage@2.9-2.el8?distro=oracle-8",
                   "version": "2.9-2.el8",
                 },
               },
@@ -2310,7 +2310,7 @@ Object {
                 "id": "libsepol@2.9-1.el8",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.9-1.el8",
+                  "purl": "pkg:rpm/oracle/libsepol@2.9-1.el8?distro=oracle-8",
                   "version": "2.9-1.el8",
                 },
               },
@@ -2318,7 +2318,7 @@ Object {
                 "id": "libsigsegv@2.11-5.el8",
                 "info": Object {
                   "name": "libsigsegv",
-                  "purl": "pkg:rpm/libsigsegv@2.11-5.el8",
+                  "purl": "pkg:rpm/oracle/libsigsegv@2.11-5.el8?distro=oracle-8",
                   "version": "2.11-5.el8",
                 },
               },
@@ -2326,7 +2326,7 @@ Object {
                 "id": "libsmartcols@2.32.1-22.el8",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.32.1-22.el8",
+                  "purl": "pkg:rpm/oracle/libsmartcols@2.32.1-22.el8?distro=oracle-8",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -2334,7 +2334,7 @@ Object {
                 "id": "libsolv@0.7.7-1.el8",
                 "info": Object {
                   "name": "libsolv",
-                  "purl": "pkg:rpm/libsolv@0.7.7-1.el8",
+                  "purl": "pkg:rpm/oracle/libsolv@0.7.7-1.el8?distro=oracle-8",
                   "version": "0.7.7-1.el8",
                 },
               },
@@ -2342,7 +2342,7 @@ Object {
                 "id": "libssh@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh",
-                  "purl": "pkg:rpm/libssh@0.9.0-4.el8",
+                  "purl": "pkg:rpm/oracle/libssh@0.9.0-4.el8?distro=oracle-8",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -2350,7 +2350,7 @@ Object {
                 "id": "libssh-config@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh-config",
-                  "purl": "pkg:rpm/libssh-config@0.9.0-4.el8",
+                  "purl": "pkg:rpm/oracle/libssh-config@0.9.0-4.el8?distro=oracle-8",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -2358,7 +2358,7 @@ Object {
                 "id": "libstdc++@8.3.1-5.0.3.el8",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@8.3.1-5.0.3.el8",
+                  "purl": "pkg:rpm/oracle/libstdc%2B%2B@8.3.1-5.0.3.el8?distro=oracle-8",
                   "version": "8.3.1-5.0.3.el8",
                 },
               },
@@ -2366,7 +2366,7 @@ Object {
                 "id": "libtasn1@4.13-3.el8",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.13-3.el8",
+                  "purl": "pkg:rpm/oracle/libtasn1@4.13-3.el8?distro=oracle-8",
                   "version": "4.13-3.el8",
                 },
               },
@@ -2374,7 +2374,7 @@ Object {
                 "id": "libtirpc@1.1.4-4.el8",
                 "info": Object {
                   "name": "libtirpc",
-                  "purl": "pkg:rpm/libtirpc@1.1.4-4.el8",
+                  "purl": "pkg:rpm/oracle/libtirpc@1.1.4-4.el8?distro=oracle-8",
                   "version": "1.1.4-4.el8",
                 },
               },
@@ -2382,7 +2382,7 @@ Object {
                 "id": "libunistring@0.9.9-3.el8",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.9-3.el8",
+                  "purl": "pkg:rpm/oracle/libunistring@0.9.9-3.el8?distro=oracle-8",
                   "version": "0.9.9-3.el8",
                 },
               },
@@ -2390,7 +2390,7 @@ Object {
                 "id": "libusbx@1.0.22-1.el8",
                 "info": Object {
                   "name": "libusbx",
-                  "purl": "pkg:rpm/libusbx@1.0.22-1.el8",
+                  "purl": "pkg:rpm/oracle/libusbx@1.0.22-1.el8?distro=oracle-8",
                   "version": "1.0.22-1.el8",
                 },
               },
@@ -2398,7 +2398,7 @@ Object {
                 "id": "libuser@0.62-23.el8",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.62-23.el8",
+                  "purl": "pkg:rpm/oracle/libuser@0.62-23.el8?distro=oracle-8",
                   "version": "0.62-23.el8",
                 },
               },
@@ -2406,7 +2406,7 @@ Object {
                 "id": "libutempter@1.1.6-14.el8",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.6-14.el8",
+                  "purl": "pkg:rpm/oracle/libutempter@1.1.6-14.el8?distro=oracle-8",
                   "version": "1.1.6-14.el8",
                 },
               },
@@ -2414,7 +2414,7 @@ Object {
                 "id": "libuuid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.32.1-22.el8",
+                  "purl": "pkg:rpm/oracle/libuuid@2.32.1-22.el8?distro=oracle-8",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -2422,7 +2422,7 @@ Object {
                 "id": "libverto@0.3.0-5.el8",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.3.0-5.el8",
+                  "purl": "pkg:rpm/oracle/libverto@0.3.0-5.el8?distro=oracle-8",
                   "version": "0.3.0-5.el8",
                 },
               },
@@ -2430,7 +2430,7 @@ Object {
                 "id": "libxcrypt@4.1.1-4.el8",
                 "info": Object {
                   "name": "libxcrypt",
-                  "purl": "pkg:rpm/libxcrypt@4.1.1-4.el8",
+                  "purl": "pkg:rpm/oracle/libxcrypt@4.1.1-4.el8?distro=oracle-8",
                   "version": "4.1.1-4.el8",
                 },
               },
@@ -2438,7 +2438,7 @@ Object {
                 "id": "libxml2@2.9.7-7.0.1.el8",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.7-7.0.1.el8",
+                  "purl": "pkg:rpm/oracle/libxml2@2.9.7-7.0.1.el8?distro=oracle-8",
                   "version": "2.9.7-7.0.1.el8",
                 },
               },
@@ -2446,7 +2446,7 @@ Object {
                 "id": "libyaml@0.1.7-5.el8",
                 "info": Object {
                   "name": "libyaml",
-                  "purl": "pkg:rpm/libyaml@0.1.7-5.el8",
+                  "purl": "pkg:rpm/oracle/libyaml@0.1.7-5.el8?distro=oracle-8",
                   "version": "0.1.7-5.el8",
                 },
               },
@@ -2454,7 +2454,7 @@ Object {
                 "id": "libzstd@1.4.2-2.el8",
                 "info": Object {
                   "name": "libzstd",
-                  "purl": "pkg:rpm/libzstd@1.4.2-2.el8",
+                  "purl": "pkg:rpm/oracle/libzstd@1.4.2-2.el8?distro=oracle-8",
                   "version": "1.4.2-2.el8",
                 },
               },
@@ -2462,7 +2462,7 @@ Object {
                 "id": "logrotate@3.14.0-3.el8",
                 "info": Object {
                   "name": "logrotate",
-                  "purl": "pkg:rpm/logrotate@3.14.0-3.el8",
+                  "purl": "pkg:rpm/oracle/logrotate@3.14.0-3.el8?distro=oracle-8",
                   "version": "3.14.0-3.el8",
                 },
               },
@@ -2470,7 +2470,7 @@ Object {
                 "id": "lua-libs@5.3.4-11.el8",
                 "info": Object {
                   "name": "lua-libs",
-                  "purl": "pkg:rpm/lua-libs@5.3.4-11.el8",
+                  "purl": "pkg:rpm/oracle/lua-libs@5.3.4-11.el8?distro=oracle-8",
                   "version": "5.3.4-11.el8",
                 },
               },
@@ -2478,7 +2478,7 @@ Object {
                 "id": "lz4-libs@1.8.1.2-4.el8",
                 "info": Object {
                   "name": "lz4-libs",
-                  "purl": "pkg:rpm/lz4-libs@1.8.1.2-4.el8",
+                  "purl": "pkg:rpm/oracle/lz4-libs@1.8.1.2-4.el8?distro=oracle-8",
                   "version": "1.8.1.2-4.el8",
                 },
               },
@@ -2486,7 +2486,7 @@ Object {
                 "id": "mpfr@3.1.6-1.el8",
                 "info": Object {
                   "name": "mpfr",
-                  "purl": "pkg:rpm/mpfr@3.1.6-1.el8",
+                  "purl": "pkg:rpm/oracle/mpfr@3.1.6-1.el8?distro=oracle-8",
                   "version": "3.1.6-1.el8",
                 },
               },
@@ -2494,7 +2494,7 @@ Object {
                 "id": "ncurses@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.1-7.20180224.el8",
+                  "purl": "pkg:rpm/oracle/ncurses@6.1-7.20180224.el8?distro=oracle-8",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -2502,7 +2502,7 @@ Object {
                 "id": "ncurses-base@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.1-7.20180224.el8",
+                  "purl": "pkg:rpm/oracle/ncurses-base@6.1-7.20180224.el8?distro=oracle-8",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -2510,7 +2510,7 @@ Object {
                 "id": "ncurses-libs@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.1-7.20180224.el8",
+                  "purl": "pkg:rpm/oracle/ncurses-libs@6.1-7.20180224.el8?distro=oracle-8",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -2518,7 +2518,7 @@ Object {
                 "id": "nettle@3.4.1-1.el8",
                 "info": Object {
                   "name": "nettle",
-                  "purl": "pkg:rpm/nettle@3.4.1-1.el8",
+                  "purl": "pkg:rpm/oracle/nettle@3.4.1-1.el8?distro=oracle-8",
                   "version": "3.4.1-1.el8",
                 },
               },
@@ -2526,7 +2526,7 @@ Object {
                 "id": "npth@1.5-4.el8",
                 "info": Object {
                   "name": "npth",
-                  "purl": "pkg:rpm/npth@1.5-4.el8",
+                  "purl": "pkg:rpm/oracle/npth@1.5-4.el8?distro=oracle-8",
                   "version": "1.5-4.el8",
                 },
               },
@@ -2534,7 +2534,7 @@ Object {
                 "id": "openldap@2.4.46-11.el8_1",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.46-11.el8_1",
+                  "purl": "pkg:rpm/oracle/openldap@2.4.46-11.el8_1?distro=oracle-8",
                   "version": "2.4.46-11.el8_1",
                 },
               },
@@ -2542,7 +2542,7 @@ Object {
                 "id": "openssh@8.0p1-4.el8_1",
                 "info": Object {
                   "name": "openssh",
-                  "purl": "pkg:rpm/openssh@8.0p1-4.el8_1",
+                  "purl": "pkg:rpm/oracle/openssh@8.0p1-4.el8_1?distro=oracle-8",
                   "version": "8.0p1-4.el8_1",
                 },
               },
@@ -2550,7 +2550,7 @@ Object {
                 "id": "openssh-clients@8.0p1-4.el8_1",
                 "info": Object {
                   "name": "openssh-clients",
-                  "purl": "pkg:rpm/openssh-clients@8.0p1-4.el8_1",
+                  "purl": "pkg:rpm/oracle/openssh-clients@8.0p1-4.el8_1?distro=oracle-8",
                   "version": "8.0p1-4.el8_1",
                 },
               },
@@ -2558,7 +2558,7 @@ Object {
                 "id": "openssh-server@8.0p1-4.el8_1",
                 "info": Object {
                   "name": "openssh-server",
-                  "purl": "pkg:rpm/openssh-server@8.0p1-4.el8_1",
+                  "purl": "pkg:rpm/oracle/openssh-server@8.0p1-4.el8_1?distro=oracle-8",
                   "version": "8.0p1-4.el8_1",
                 },
               },
@@ -2566,7 +2566,7 @@ Object {
                 "id": "openssl-libs@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.1.1c-15.el8?epoch=1",
+                  "purl": "pkg:rpm/oracle/openssl-libs@1:1.1.1c-15.el8?distro=oracle-8&epoch=1",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -2574,7 +2574,7 @@ Object {
                 "id": "oraclelinux-release@8:8.2-1.0.8.el8",
                 "info": Object {
                   "name": "oraclelinux-release",
-                  "purl": "pkg:rpm/oraclelinux-release@8:8.2-1.0.8.el8?epoch=8",
+                  "purl": "pkg:rpm/oracle/oraclelinux-release@8:8.2-1.0.8.el8?distro=oracle-8&epoch=8",
                   "version": "8:8.2-1.0.8.el8",
                 },
               },
@@ -2582,7 +2582,7 @@ Object {
                 "id": "oraclelinux-release-el8@1.0-12.el8",
                 "info": Object {
                   "name": "oraclelinux-release-el8",
-                  "purl": "pkg:rpm/oraclelinux-release-el8@1.0-12.el8",
+                  "purl": "pkg:rpm/oracle/oraclelinux-release-el8@1.0-12.el8?distro=oracle-8",
                   "version": "1.0-12.el8",
                 },
               },
@@ -2590,7 +2590,7 @@ Object {
                 "id": "p11-kit@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.14-5.el8_0",
+                  "purl": "pkg:rpm/oracle/p11-kit@0.23.14-5.el8_0?distro=oracle-8",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -2598,7 +2598,7 @@ Object {
                 "id": "p11-kit-trust@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.14-5.el8_0",
+                  "purl": "pkg:rpm/oracle/p11-kit-trust@0.23.14-5.el8_0?distro=oracle-8",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -2606,7 +2606,7 @@ Object {
                 "id": "pam@1.3.1-8.el8",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.3.1-8.el8",
+                  "purl": "pkg:rpm/oracle/pam@1.3.1-8.el8?distro=oracle-8",
                   "version": "1.3.1-8.el8",
                 },
               },
@@ -2614,7 +2614,7 @@ Object {
                 "id": "passwd@0.80-3.el8",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.80-3.el8",
+                  "purl": "pkg:rpm/oracle/passwd@0.80-3.el8?distro=oracle-8",
                   "version": "0.80-3.el8",
                 },
               },
@@ -2622,7 +2622,7 @@ Object {
                 "id": "pcre@8.42-4.el8",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.42-4.el8",
+                  "purl": "pkg:rpm/oracle/pcre@8.42-4.el8?distro=oracle-8",
                   "version": "8.42-4.el8",
                 },
               },
@@ -2630,7 +2630,7 @@ Object {
                 "id": "pcre2@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2",
-                  "purl": "pkg:rpm/pcre2@10.32-1.el8",
+                  "purl": "pkg:rpm/oracle/pcre2@10.32-1.el8?distro=oracle-8",
                   "version": "10.32-1.el8",
                 },
               },
@@ -2638,7 +2638,7 @@ Object {
                 "id": "platform-python@3.6.8-23.0.1.el8",
                 "info": Object {
                   "name": "platform-python",
-                  "purl": "pkg:rpm/platform-python@3.6.8-23.0.1.el8",
+                  "purl": "pkg:rpm/oracle/platform-python@3.6.8-23.0.1.el8?distro=oracle-8",
                   "version": "3.6.8-23.0.1.el8",
                 },
               },
@@ -2646,7 +2646,7 @@ Object {
                 "id": "platform-python-setuptools@39.2.0-5.el8",
                 "info": Object {
                   "name": "platform-python-setuptools",
-                  "purl": "pkg:rpm/platform-python-setuptools@39.2.0-5.el8",
+                  "purl": "pkg:rpm/oracle/platform-python-setuptools@39.2.0-5.el8?distro=oracle-8",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -2654,7 +2654,7 @@ Object {
                 "id": "policycoreutils@2.9-9.0.1.el8",
                 "info": Object {
                   "name": "policycoreutils",
-                  "purl": "pkg:rpm/policycoreutils@2.9-9.0.1.el8",
+                  "purl": "pkg:rpm/oracle/policycoreutils@2.9-9.0.1.el8?distro=oracle-8",
                   "version": "2.9-9.0.1.el8",
                 },
               },
@@ -2662,7 +2662,7 @@ Object {
                 "id": "popt@1.16-14.el8",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.16-14.el8",
+                  "purl": "pkg:rpm/oracle/popt@1.16-14.el8?distro=oracle-8",
                   "version": "1.16-14.el8",
                 },
               },
@@ -2670,7 +2670,7 @@ Object {
                 "id": "procps-ng@3.3.15-1.el8",
                 "info": Object {
                   "name": "procps-ng",
-                  "purl": "pkg:rpm/procps-ng@3.3.15-1.el8",
+                  "purl": "pkg:rpm/oracle/procps-ng@3.3.15-1.el8?distro=oracle-8",
                   "version": "3.3.15-1.el8",
                 },
               },
@@ -2678,7 +2678,7 @@ Object {
                 "id": "publicsuffix-list-dafsa@20180723-1.el8",
                 "info": Object {
                   "name": "publicsuffix-list-dafsa",
-                  "purl": "pkg:rpm/publicsuffix-list-dafsa@20180723-1.el8",
+                  "purl": "pkg:rpm/oracle/publicsuffix-list-dafsa@20180723-1.el8?distro=oracle-8",
                   "version": "20180723-1.el8",
                 },
               },
@@ -2686,7 +2686,7 @@ Object {
                 "id": "python3-dateutil@1:2.6.1-6.el8",
                 "info": Object {
                   "name": "python3-dateutil",
-                  "purl": "pkg:rpm/python3-dateutil@1:2.6.1-6.el8?epoch=1",
+                  "purl": "pkg:rpm/oracle/python3-dateutil@1:2.6.1-6.el8?distro=oracle-8&epoch=1",
                   "version": "1:2.6.1-6.el8",
                 },
               },
@@ -2694,7 +2694,7 @@ Object {
                 "id": "python3-dnf@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "python3-dnf",
-                  "purl": "pkg:rpm/python3-dnf@4.2.17-7.el8_2",
+                  "purl": "pkg:rpm/oracle/python3-dnf@4.2.17-7.el8_2?distro=oracle-8",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -2702,7 +2702,7 @@ Object {
                 "id": "python3-dnf-plugins-core@4.0.12-4.el8_2",
                 "info": Object {
                   "name": "python3-dnf-plugins-core",
-                  "purl": "pkg:rpm/python3-dnf-plugins-core@4.0.12-4.el8_2",
+                  "purl": "pkg:rpm/oracle/python3-dnf-plugins-core@4.0.12-4.el8_2?distro=oracle-8",
                   "version": "4.0.12-4.el8_2",
                 },
               },
@@ -2710,7 +2710,7 @@ Object {
                 "id": "python3-gpg@1.10.0-6.0.1.el8",
                 "info": Object {
                   "name": "python3-gpg",
-                  "purl": "pkg:rpm/python3-gpg@1.10.0-6.0.1.el8",
+                  "purl": "pkg:rpm/oracle/python3-gpg@1.10.0-6.0.1.el8?distro=oracle-8",
                   "version": "1.10.0-6.0.1.el8",
                 },
               },
@@ -2718,7 +2718,7 @@ Object {
                 "id": "python3-hawkey@0.39.1-6.0.1.el8_2",
                 "info": Object {
                   "name": "python3-hawkey",
-                  "purl": "pkg:rpm/python3-hawkey@0.39.1-6.0.1.el8_2",
+                  "purl": "pkg:rpm/oracle/python3-hawkey@0.39.1-6.0.1.el8_2?distro=oracle-8",
                   "version": "0.39.1-6.0.1.el8_2",
                 },
               },
@@ -2726,7 +2726,7 @@ Object {
                 "id": "python3-libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "python3-libcomps",
-                  "purl": "pkg:rpm/python3-libcomps@0.1.11-4.el8",
+                  "purl": "pkg:rpm/oracle/python3-libcomps@0.1.11-4.el8?distro=oracle-8",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -2734,7 +2734,7 @@ Object {
                 "id": "python3-libdnf@0.39.1-6.0.1.el8_2",
                 "info": Object {
                   "name": "python3-libdnf",
-                  "purl": "pkg:rpm/python3-libdnf@0.39.1-6.0.1.el8_2",
+                  "purl": "pkg:rpm/oracle/python3-libdnf@0.39.1-6.0.1.el8_2?distro=oracle-8",
                   "version": "0.39.1-6.0.1.el8_2",
                 },
               },
@@ -2742,7 +2742,7 @@ Object {
                 "id": "python3-libs@3.6.8-23.0.1.el8",
                 "info": Object {
                   "name": "python3-libs",
-                  "purl": "pkg:rpm/python3-libs@3.6.8-23.0.1.el8",
+                  "purl": "pkg:rpm/oracle/python3-libs@3.6.8-23.0.1.el8?distro=oracle-8",
                   "version": "3.6.8-23.0.1.el8",
                 },
               },
@@ -2750,7 +2750,7 @@ Object {
                 "id": "python3-pip-wheel@9.0.3-16.el8",
                 "info": Object {
                   "name": "python3-pip-wheel",
-                  "purl": "pkg:rpm/python3-pip-wheel@9.0.3-16.el8",
+                  "purl": "pkg:rpm/oracle/python3-pip-wheel@9.0.3-16.el8?distro=oracle-8",
                   "version": "9.0.3-16.el8",
                 },
               },
@@ -2758,7 +2758,7 @@ Object {
                 "id": "python3-rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "python3-rpm",
-                  "purl": "pkg:rpm/python3-rpm@4.14.2-37.el8",
+                  "purl": "pkg:rpm/oracle/python3-rpm@4.14.2-37.el8?distro=oracle-8",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -2766,7 +2766,7 @@ Object {
                 "id": "python3-setuptools-wheel@39.2.0-5.el8",
                 "info": Object {
                   "name": "python3-setuptools-wheel",
-                  "purl": "pkg:rpm/python3-setuptools-wheel@39.2.0-5.el8",
+                  "purl": "pkg:rpm/oracle/python3-setuptools-wheel@39.2.0-5.el8?distro=oracle-8",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -2774,7 +2774,7 @@ Object {
                 "id": "python3-six@1.11.0-8.el8",
                 "info": Object {
                   "name": "python3-six",
-                  "purl": "pkg:rpm/python3-six@1.11.0-8.el8",
+                  "purl": "pkg:rpm/oracle/python3-six@1.11.0-8.el8?distro=oracle-8",
                   "version": "1.11.0-8.el8",
                 },
               },
@@ -2782,7 +2782,7 @@ Object {
                 "id": "readline@7.0-10.el8",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@7.0-10.el8",
+                  "purl": "pkg:rpm/oracle/readline@7.0-10.el8?distro=oracle-8",
                   "version": "7.0-10.el8",
                 },
               },
@@ -2790,7 +2790,7 @@ Object {
                 "id": "redhat-release@2:8.2-1.0.0.1.el8",
                 "info": Object {
                   "name": "redhat-release",
-                  "purl": "pkg:rpm/redhat-release@2:8.2-1.0.0.1.el8?epoch=2",
+                  "purl": "pkg:rpm/oracle/redhat-release@2:8.2-1.0.0.1.el8?distro=oracle-8&epoch=2",
                   "version": "2:8.2-1.0.0.1.el8",
                 },
               },
@@ -2798,7 +2798,7 @@ Object {
                 "id": "rootfiles@8.1-22.el8",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-22.el8",
+                  "purl": "pkg:rpm/oracle/rootfiles@8.1-22.el8?distro=oracle-8",
                   "version": "8.1-22.el8",
                 },
               },
@@ -2806,7 +2806,7 @@ Object {
                 "id": "rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.14.2-37.el8",
+                  "purl": "pkg:rpm/oracle/rpm@4.14.2-37.el8?distro=oracle-8",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -2814,7 +2814,7 @@ Object {
                 "id": "rpm-build-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.14.2-37.el8",
+                  "purl": "pkg:rpm/oracle/rpm-build-libs@4.14.2-37.el8?distro=oracle-8",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -2822,7 +2822,7 @@ Object {
                 "id": "rpm-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.14.2-37.el8",
+                  "purl": "pkg:rpm/oracle/rpm-libs@4.14.2-37.el8?distro=oracle-8",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -2830,7 +2830,7 @@ Object {
                 "id": "rsyslog@8.1911.0-3.el8",
                 "info": Object {
                   "name": "rsyslog",
-                  "purl": "pkg:rpm/rsyslog@8.1911.0-3.el8",
+                  "purl": "pkg:rpm/oracle/rsyslog@8.1911.0-3.el8?distro=oracle-8",
                   "version": "8.1911.0-3.el8",
                 },
               },
@@ -2838,7 +2838,7 @@ Object {
                 "id": "sed@4.5-1.el8",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.5-1.el8",
+                  "purl": "pkg:rpm/oracle/sed@4.5-1.el8?distro=oracle-8",
                   "version": "4.5-1.el8",
                 },
               },
@@ -2846,7 +2846,7 @@ Object {
                 "id": "setup@2.12.2-5.el8",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.12.2-5.el8",
+                  "purl": "pkg:rpm/oracle/setup@2.12.2-5.el8?distro=oracle-8",
                   "version": "2.12.2-5.el8",
                 },
               },
@@ -2854,7 +2854,7 @@ Object {
                 "id": "shadow-utils@2:4.6-8.el8",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.6-8.el8?epoch=2",
+                  "purl": "pkg:rpm/oracle/shadow-utils@2:4.6-8.el8?distro=oracle-8&epoch=2",
                   "version": "2:4.6-8.el8",
                 },
               },
@@ -2862,7 +2862,7 @@ Object {
                 "id": "sqlite-libs@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite-libs",
-                  "purl": "pkg:rpm/sqlite-libs@3.26.0-6.el8",
+                  "purl": "pkg:rpm/oracle/sqlite-libs@3.26.0-6.el8?distro=oracle-8",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -2870,7 +2870,7 @@ Object {
                 "id": "systemd@239-31.0.1.el8_2.2",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/systemd@239-31.0.1.el8_2.2",
+                  "purl": "pkg:rpm/oracle/systemd@239-31.0.1.el8_2.2?distro=oracle-8",
                   "version": "239-31.0.1.el8_2.2",
                 },
               },
@@ -2878,7 +2878,7 @@ Object {
                 "id": "systemd-libs@239-31.0.1.el8_2.2",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@239-31.0.1.el8_2.2",
+                  "purl": "pkg:rpm/oracle/systemd-libs@239-31.0.1.el8_2.2?distro=oracle-8",
                   "version": "239-31.0.1.el8_2.2",
                 },
               },
@@ -2886,7 +2886,7 @@ Object {
                 "id": "systemd-pam@239-31.0.1.el8_2.2",
                 "info": Object {
                   "name": "systemd-pam",
-                  "purl": "pkg:rpm/systemd-pam@239-31.0.1.el8_2.2",
+                  "purl": "pkg:rpm/oracle/systemd-pam@239-31.0.1.el8_2.2?distro=oracle-8",
                   "version": "239-31.0.1.el8_2.2",
                 },
               },
@@ -2894,7 +2894,7 @@ Object {
                 "id": "tzdata@2020a-1.el8",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2020a-1.el8",
+                  "purl": "pkg:rpm/oracle/tzdata@2020a-1.el8?distro=oracle-8",
                   "version": "2020a-1.el8",
                 },
               },
@@ -2902,7 +2902,7 @@ Object {
                 "id": "util-linux@2.32.1-22.el8",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.32.1-22.el8",
+                  "purl": "pkg:rpm/oracle/util-linux@2.32.1-22.el8?distro=oracle-8",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -2910,7 +2910,7 @@ Object {
                 "id": "vim-minimal@2:8.0.1763-13.0.1.el8",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.0.1763-13.0.1.el8?epoch=2",
+                  "purl": "pkg:rpm/oracle/vim-minimal@2:8.0.1763-13.0.1.el8?distro=oracle-8&epoch=2",
                   "version": "2:8.0.1763-13.0.1.el8",
                 },
               },
@@ -2918,7 +2918,7 @@ Object {
                 "id": "xz-libs@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.4-3.el8",
+                  "purl": "pkg:rpm/oracle/xz-libs@5.2.4-3.el8?distro=oracle-8",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -2926,7 +2926,7 @@ Object {
                 "id": "yum@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@4.2.17-7.el8_2",
+                  "purl": "pkg:rpm/oracle/yum@4.2.17-7.el8_2?distro=oracle-8",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -2934,7 +2934,7 @@ Object {
                 "id": "yum-utils@4.0.12-4.el8_2",
                 "info": Object {
                   "name": "yum-utils",
-                  "purl": "pkg:rpm/yum-utils@4.0.12-4.el8_2",
+                  "purl": "pkg:rpm/oracle/yum-utils@4.0.12-4.el8_2?distro=oracle-8",
                   "version": "4.0.12-4.el8_2",
                 },
               },
@@ -2942,7 +2942,7 @@ Object {
                 "id": "zlib@1.2.11-16.el8_2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.11-16.el8_2",
+                  "purl": "pkg:rpm/oracle/zlib@1.2.11-16.el8_2?distro=oracle-8",
                   "version": "1.2.11-16.el8_2",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
@@ -1006,7 +1006,7 @@ Object {
                 "id": "aaa_base@84.87+git20180409.04c9dae-3.39.1",
                 "info": Object {
                   "name": "aaa_base",
-                  "purl": "pkg:rpm/aaa_base@84.87%2Bgit20180409.04c9dae-3.39.1",
+                  "purl": "pkg:rpm/sles/aaa_base@84.87%2Bgit20180409.04c9dae-3.39.1?distro=sles-15.2",
                   "version": "84.87+git20180409.04c9dae-3.39.1",
                 },
               },
@@ -1014,7 +1014,7 @@ Object {
                 "id": "bash@4.4-9.10.1",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.4-9.10.1",
+                  "purl": "pkg:rpm/sles/bash@4.4-9.10.1?distro=sles-15.2",
                   "version": "4.4-9.10.1",
                 },
               },
@@ -1022,7 +1022,7 @@ Object {
                 "id": "boost-license1_66_0@1.66.0-10.1",
                 "info": Object {
                   "name": "boost-license1_66_0",
-                  "purl": "pkg:rpm/boost-license1_66_0@1.66.0-10.1",
+                  "purl": "pkg:rpm/sles/boost-license1_66_0@1.66.0-10.1?distro=sles-15.2",
                   "version": "1.66.0-10.1",
                 },
               },
@@ -1030,7 +1030,7 @@ Object {
                 "id": "ca-certificates@2+git20170807.10b2785-7.3.3",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2%2Bgit20170807.10b2785-7.3.3",
+                  "purl": "pkg:rpm/sles/ca-certificates@2%2Bgit20170807.10b2785-7.3.3?distro=sles-15.2",
                   "version": "2+git20170807.10b2785-7.3.3",
                 },
               },
@@ -1038,7 +1038,7 @@ Object {
                 "id": "ca-certificates-mozilla@2.42-9.3.1",
                 "info": Object {
                   "name": "ca-certificates-mozilla",
-                  "purl": "pkg:rpm/ca-certificates-mozilla@2.42-9.3.1",
+                  "purl": "pkg:rpm/sles/ca-certificates-mozilla@2.42-9.3.1?distro=sles-15.2",
                   "version": "2.42-9.3.1",
                 },
               },
@@ -1046,7 +1046,7 @@ Object {
                 "id": "container-suseconnect@2.3.0-4.15.2",
                 "info": Object {
                   "name": "container-suseconnect",
-                  "purl": "pkg:rpm/container-suseconnect@2.3.0-4.15.2",
+                  "purl": "pkg:rpm/sles/container-suseconnect@2.3.0-4.15.2?distro=sles-15.2",
                   "version": "2.3.0-4.15.2",
                 },
               },
@@ -1054,7 +1054,7 @@ Object {
                 "id": "coreutils@8.29-2.12",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.29-2.12",
+                  "purl": "pkg:rpm/sles/coreutils@8.29-2.12?distro=sles-15.2",
                   "version": "8.29-2.12",
                 },
               },
@@ -1062,7 +1062,7 @@ Object {
                 "id": "cpio@2.12-3.3.1",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.12-3.3.1",
+                  "purl": "pkg:rpm/sles/cpio@2.12-3.3.1?distro=sles-15.2",
                   "version": "2.12-3.3.1",
                 },
               },
@@ -1070,7 +1070,7 @@ Object {
                 "id": "cracklib@2.9.7-11.3.1",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.7-11.3.1",
+                  "purl": "pkg:rpm/sles/cracklib@2.9.7-11.3.1?distro=sles-15.2",
                   "version": "2.9.7-11.3.1",
                 },
               },
@@ -1078,7 +1078,7 @@ Object {
                 "id": "cracklib-dict-small@2.9.7-11.3.1",
                 "info": Object {
                   "name": "cracklib-dict-small",
-                  "purl": "pkg:rpm/cracklib-dict-small@2.9.7-11.3.1",
+                  "purl": "pkg:rpm/sles/cracklib-dict-small@2.9.7-11.3.1?distro=sles-15.2",
                   "version": "2.9.7-11.3.1",
                 },
               },
@@ -1086,7 +1086,7 @@ Object {
                 "id": "diffutils@3.6-4.3.1",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.6-4.3.1",
+                  "purl": "pkg:rpm/sles/diffutils@3.6-4.3.1?distro=sles-15.2",
                   "version": "3.6-4.3.1",
                 },
               },
@@ -1094,7 +1094,7 @@ Object {
                 "id": "file-magic@5.32-7.8.1",
                 "info": Object {
                   "name": "file-magic",
-                  "purl": "pkg:rpm/file-magic@5.32-7.8.1",
+                  "purl": "pkg:rpm/sles/file-magic@5.32-7.8.1?distro=sles-15.2",
                   "version": "5.32-7.8.1",
                 },
               },
@@ -1102,7 +1102,7 @@ Object {
                 "id": "filesystem@15.0-9.2",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@15.0-9.2",
+                  "purl": "pkg:rpm/sles/filesystem@15.0-9.2?distro=sles-15.2",
                   "version": "15.0-9.2",
                 },
               },
@@ -1110,7 +1110,7 @@ Object {
                 "id": "fillup@1.42-2.18",
                 "info": Object {
                   "name": "fillup",
-                  "purl": "pkg:rpm/fillup@1.42-2.18",
+                  "purl": "pkg:rpm/sles/fillup@1.42-2.18?distro=sles-15.2",
                   "version": "1.42-2.18",
                 },
               },
@@ -1118,7 +1118,7 @@ Object {
                 "id": "findutils@4.6.0-2.21",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@4.6.0-2.21",
+                  "purl": "pkg:rpm/sles/findutils@4.6.0-2.21?distro=sles-15.2",
                   "version": "4.6.0-2.21",
                 },
               },
@@ -1126,7 +1126,7 @@ Object {
                 "id": "glibc@2.26-13.51.1",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.26-13.51.1",
+                  "purl": "pkg:rpm/sles/glibc@2.26-13.51.1?distro=sles-15.2",
                   "version": "2.26-13.51.1",
                 },
               },
@@ -1134,7 +1134,7 @@ Object {
                 "id": "gpg-pubkey@50a3dd1c-50f35137",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@50a3dd1c-50f35137",
+                  "purl": "pkg:rpm/sles/gpg-pubkey@50a3dd1c-50f35137?distro=sles-15.2",
                   "version": "50a3dd1c-50f35137",
                 },
               },
@@ -1142,7 +1142,7 @@ Object {
                 "id": "gpg2@2.2.5-4.14.4",
                 "info": Object {
                   "name": "gpg2",
-                  "purl": "pkg:rpm/gpg2@2.2.5-4.14.4",
+                  "purl": "pkg:rpm/sles/gpg2@2.2.5-4.14.4?distro=sles-15.2",
                   "version": "2.2.5-4.14.4",
                 },
               },
@@ -1150,7 +1150,7 @@ Object {
                 "id": "grep@3.1-4.3.12",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@3.1-4.3.12",
+                  "purl": "pkg:rpm/sles/grep@3.1-4.3.12?distro=sles-15.2",
                   "version": "3.1-4.3.12",
                 },
               },
@@ -1158,7 +1158,7 @@ Object {
                 "id": "info@6.5-4.17",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@6.5-4.17",
+                  "purl": "pkg:rpm/sles/info@6.5-4.17?distro=sles-15.2",
                   "version": "6.5-4.17",
                 },
               },
@@ -1166,7 +1166,7 @@ Object {
                 "id": "krb5@1.16.3-3.12.2",
                 "info": Object {
                   "name": "krb5",
-                  "purl": "pkg:rpm/krb5@1.16.3-3.12.2",
+                  "purl": "pkg:rpm/sles/krb5@1.16.3-3.12.2?distro=sles-15.2",
                   "version": "1.16.3-3.12.2",
                 },
               },
@@ -1174,7 +1174,7 @@ Object {
                 "id": "kubic-locale-archive@2.26-2.15",
                 "info": Object {
                   "name": "kubic-locale-archive",
-                  "purl": "pkg:rpm/kubic-locale-archive@2.26-2.15",
+                  "purl": "pkg:rpm/sles/kubic-locale-archive@2.26-2.15?distro=sles-15.2",
                   "version": "2.26-2.15",
                 },
               },
@@ -1182,7 +1182,7 @@ Object {
                 "id": "libacl1@2.2.52-4.3.1",
                 "info": Object {
                   "name": "libacl1",
-                  "purl": "pkg:rpm/libacl1@2.2.52-4.3.1",
+                  "purl": "pkg:rpm/sles/libacl1@2.2.52-4.3.1?distro=sles-15.2",
                   "version": "2.2.52-4.3.1",
                 },
               },
@@ -1190,7 +1190,7 @@ Object {
                 "id": "libassuan0@2.5.1-2.14",
                 "info": Object {
                   "name": "libassuan0",
-                  "purl": "pkg:rpm/libassuan0@2.5.1-2.14",
+                  "purl": "pkg:rpm/sles/libassuan0@2.5.1-2.14?distro=sles-15.2",
                   "version": "2.5.1-2.14",
                 },
               },
@@ -1198,7 +1198,7 @@ Object {
                 "id": "libattr1@2.4.47-2.19",
                 "info": Object {
                   "name": "libattr1",
-                  "purl": "pkg:rpm/libattr1@2.4.47-2.19",
+                  "purl": "pkg:rpm/sles/libattr1@2.4.47-2.19?distro=sles-15.2",
                   "version": "2.4.47-2.19",
                 },
               },
@@ -1206,7 +1206,7 @@ Object {
                 "id": "libaudit1@2.8.1-10.7",
                 "info": Object {
                   "name": "libaudit1",
-                  "purl": "pkg:rpm/libaudit1@2.8.1-10.7",
+                  "purl": "pkg:rpm/sles/libaudit1@2.8.1-10.7?distro=sles-15.2",
                   "version": "2.8.1-10.7",
                 },
               },
@@ -1214,7 +1214,7 @@ Object {
                 "id": "libaugeas0@1.10.1-1.11",
                 "info": Object {
                   "name": "libaugeas0",
-                  "purl": "pkg:rpm/libaugeas0@1.10.1-1.11",
+                  "purl": "pkg:rpm/sles/libaugeas0@1.10.1-1.11?distro=sles-15.2",
                   "version": "1.10.1-1.11",
                 },
               },
@@ -1222,7 +1222,7 @@ Object {
                 "id": "libblkid1@2.33.1-4.8.1",
                 "info": Object {
                   "name": "libblkid1",
-                  "purl": "pkg:rpm/libblkid1@2.33.1-4.8.1",
+                  "purl": "pkg:rpm/sles/libblkid1@2.33.1-4.8.1?distro=sles-15.2",
                   "version": "2.33.1-4.8.1",
                 },
               },
@@ -1230,7 +1230,7 @@ Object {
                 "id": "libboost_system1_66_0@1.66.0-10.1",
                 "info": Object {
                   "name": "libboost_system1_66_0",
-                  "purl": "pkg:rpm/libboost_system1_66_0@1.66.0-10.1",
+                  "purl": "pkg:rpm/sles/libboost_system1_66_0@1.66.0-10.1?distro=sles-15.2",
                   "version": "1.66.0-10.1",
                 },
               },
@@ -1238,7 +1238,7 @@ Object {
                 "id": "libboost_thread1_66_0@1.66.0-10.1",
                 "info": Object {
                   "name": "libboost_thread1_66_0",
-                  "purl": "pkg:rpm/libboost_thread1_66_0@1.66.0-10.1",
+                  "purl": "pkg:rpm/sles/libboost_thread1_66_0@1.66.0-10.1?distro=sles-15.2",
                   "version": "1.66.0-10.1",
                 },
               },
@@ -1246,7 +1246,7 @@ Object {
                 "id": "libbz2-1@1.0.6-5.9.1",
                 "info": Object {
                   "name": "libbz2-1",
-                  "purl": "pkg:rpm/libbz2-1@1.0.6-5.9.1",
+                  "purl": "pkg:rpm/sles/libbz2-1@1.0.6-5.9.1?distro=sles-15.2",
                   "version": "1.0.6-5.9.1",
                 },
               },
@@ -1254,7 +1254,7 @@ Object {
                 "id": "libcap-ng0@0.7.9-4.37",
                 "info": Object {
                   "name": "libcap-ng0",
-                  "purl": "pkg:rpm/libcap-ng0@0.7.9-4.37",
+                  "purl": "pkg:rpm/sles/libcap-ng0@0.7.9-4.37?distro=sles-15.2",
                   "version": "0.7.9-4.37",
                 },
               },
@@ -1262,7 +1262,7 @@ Object {
                 "id": "libcap2@2.25-2.41",
                 "info": Object {
                   "name": "libcap2",
-                  "purl": "pkg:rpm/libcap2@2.25-2.41",
+                  "purl": "pkg:rpm/sles/libcap2@2.25-2.41?distro=sles-15.2",
                   "version": "2.25-2.41",
                 },
               },
@@ -1270,7 +1270,7 @@ Object {
                 "id": "libcom_err2@1.43.8-4.23.1",
                 "info": Object {
                   "name": "libcom_err2",
-                  "purl": "pkg:rpm/libcom_err2@1.43.8-4.23.1",
+                  "purl": "pkg:rpm/sles/libcom_err2@1.43.8-4.23.1?distro=sles-15.2",
                   "version": "1.43.8-4.23.1",
                 },
               },
@@ -1278,7 +1278,7 @@ Object {
                 "id": "libcrack2@2.9.7-11.3.1",
                 "info": Object {
                   "name": "libcrack2",
-                  "purl": "pkg:rpm/libcrack2@2.9.7-11.3.1",
+                  "purl": "pkg:rpm/sles/libcrack2@2.9.7-11.3.1?distro=sles-15.2",
                   "version": "2.9.7-11.3.1",
                 },
               },
@@ -1286,7 +1286,7 @@ Object {
                 "id": "libcurl4@7.66.0-4.6.1",
                 "info": Object {
                   "name": "libcurl4",
-                  "purl": "pkg:rpm/libcurl4@7.66.0-4.6.1",
+                  "purl": "pkg:rpm/sles/libcurl4@7.66.0-4.6.1?distro=sles-15.2",
                   "version": "7.66.0-4.6.1",
                 },
               },
@@ -1294,7 +1294,7 @@ Object {
                 "id": "libdw1@0.168-4.5.3",
                 "info": Object {
                   "name": "libdw1",
-                  "purl": "pkg:rpm/libdw1@0.168-4.5.3",
+                  "purl": "pkg:rpm/sles/libdw1@0.168-4.5.3?distro=sles-15.2",
                   "version": "0.168-4.5.3",
                 },
               },
@@ -1302,7 +1302,7 @@ Object {
                 "id": "libebl-plugins@0.168-4.5.3",
                 "info": Object {
                   "name": "libebl-plugins",
-                  "purl": "pkg:rpm/libebl-plugins@0.168-4.5.3",
+                  "purl": "pkg:rpm/sles/libebl-plugins@0.168-4.5.3?distro=sles-15.2",
                   "version": "0.168-4.5.3",
                 },
               },
@@ -1310,7 +1310,7 @@ Object {
                 "id": "libelf1@0.168-4.5.3",
                 "info": Object {
                   "name": "libelf1",
-                  "purl": "pkg:rpm/libelf1@0.168-4.5.3",
+                  "purl": "pkg:rpm/sles/libelf1@0.168-4.5.3?distro=sles-15.2",
                   "version": "0.168-4.5.3",
                 },
               },
@@ -1318,7 +1318,7 @@ Object {
                 "id": "libfdisk1@2.33.1-4.8.1",
                 "info": Object {
                   "name": "libfdisk1",
-                  "purl": "pkg:rpm/libfdisk1@2.33.1-4.8.1",
+                  "purl": "pkg:rpm/sles/libfdisk1@2.33.1-4.8.1?distro=sles-15.2",
                   "version": "2.33.1-4.8.1",
                 },
               },
@@ -1326,7 +1326,7 @@ Object {
                 "id": "libffi7@3.2.1.git259-10.8",
                 "info": Object {
                   "name": "libffi7",
-                  "purl": "pkg:rpm/libffi7@3.2.1.git259-10.8",
+                  "purl": "pkg:rpm/sles/libffi7@3.2.1.git259-10.8?distro=sles-15.2",
                   "version": "3.2.1.git259-10.8",
                 },
               },
@@ -1334,7 +1334,7 @@ Object {
                 "id": "libgcc_s1@9.3.1+git1296-1.6.1",
                 "info": Object {
                   "name": "libgcc_s1",
-                  "purl": "pkg:rpm/libgcc_s1@9.3.1%2Bgit1296-1.6.1",
+                  "purl": "pkg:rpm/sles/libgcc_s1@9.3.1%2Bgit1296-1.6.1?distro=sles-15.2",
                   "version": "9.3.1+git1296-1.6.1",
                 },
               },
@@ -1342,7 +1342,7 @@ Object {
                 "id": "libgcrypt20@1.8.2-8.36.1",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:rpm/libgcrypt20@1.8.2-8.36.1",
+                  "purl": "pkg:rpm/sles/libgcrypt20@1.8.2-8.36.1?distro=sles-15.2",
                   "version": "1.8.2-8.36.1",
                 },
               },
@@ -1350,7 +1350,7 @@ Object {
                 "id": "libglib-2_0-0@2.62.5-1.26",
                 "info": Object {
                   "name": "libglib-2_0-0",
-                  "purl": "pkg:rpm/libglib-2_0-0@2.62.5-1.26",
+                  "purl": "pkg:rpm/sles/libglib-2_0-0@2.62.5-1.26?distro=sles-15.2",
                   "version": "2.62.5-1.26",
                 },
               },
@@ -1358,7 +1358,7 @@ Object {
                 "id": "libgmp10@6.1.2-4.3.1",
                 "info": Object {
                   "name": "libgmp10",
-                  "purl": "pkg:rpm/libgmp10@6.1.2-4.3.1",
+                  "purl": "pkg:rpm/sles/libgmp10@6.1.2-4.3.1?distro=sles-15.2",
                   "version": "6.1.2-4.3.1",
                 },
               },
@@ -1366,7 +1366,7 @@ Object {
                 "id": "libgnutls30@3.6.7-12.1",
                 "info": Object {
                   "name": "libgnutls30",
-                  "purl": "pkg:rpm/libgnutls30@3.6.7-12.1",
+                  "purl": "pkg:rpm/sles/libgnutls30@3.6.7-12.1?distro=sles-15.2",
                   "version": "3.6.7-12.1",
                 },
               },
@@ -1374,7 +1374,7 @@ Object {
                 "id": "libgpg-error0@1.29-1.8",
                 "info": Object {
                   "name": "libgpg-error0",
-                  "purl": "pkg:rpm/libgpg-error0@1.29-1.8",
+                  "purl": "pkg:rpm/sles/libgpg-error0@1.29-1.8?distro=sles-15.2",
                   "version": "1.29-1.8",
                 },
               },
@@ -1382,7 +1382,7 @@ Object {
                 "id": "libgpgme11@1.13.1-2.57",
                 "info": Object {
                   "name": "libgpgme11",
-                  "purl": "pkg:rpm/libgpgme11@1.13.1-2.57",
+                  "purl": "pkg:rpm/sles/libgpgme11@1.13.1-2.57?distro=sles-15.2",
                   "version": "1.13.1-2.57",
                 },
               },
@@ -1390,7 +1390,7 @@ Object {
                 "id": "libhogweed4@3.4.1-4.12.1",
                 "info": Object {
                   "name": "libhogweed4",
-                  "purl": "pkg:rpm/libhogweed4@3.4.1-4.12.1",
+                  "purl": "pkg:rpm/sles/libhogweed4@3.4.1-4.12.1?distro=sles-15.2",
                   "version": "3.4.1-4.12.1",
                 },
               },
@@ -1398,7 +1398,7 @@ Object {
                 "id": "libidn2-0@2.2.0-3.3.1",
                 "info": Object {
                   "name": "libidn2-0",
-                  "purl": "pkg:rpm/libidn2-0@2.2.0-3.3.1",
+                  "purl": "pkg:rpm/sles/libidn2-0@2.2.0-3.3.1?distro=sles-15.2",
                   "version": "2.2.0-3.3.1",
                 },
               },
@@ -1406,7 +1406,7 @@ Object {
                 "id": "libkeyutils1@1.5.10-3.42",
                 "info": Object {
                   "name": "libkeyutils1",
-                  "purl": "pkg:rpm/libkeyutils1@1.5.10-3.42",
+                  "purl": "pkg:rpm/sles/libkeyutils1@1.5.10-3.42?distro=sles-15.2",
                   "version": "1.5.10-3.42",
                 },
               },
@@ -1414,7 +1414,7 @@ Object {
                 "id": "libksba8@1.3.5-2.14",
                 "info": Object {
                   "name": "libksba8",
-                  "purl": "pkg:rpm/libksba8@1.3.5-2.14",
+                  "purl": "pkg:rpm/sles/libksba8@1.3.5-2.14?distro=sles-15.2",
                   "version": "1.3.5-2.14",
                 },
               },
@@ -1422,7 +1422,7 @@ Object {
                 "id": "libldap-2_4-2@2.4.46-9.37.1",
                 "info": Object {
                   "name": "libldap-2_4-2",
-                  "purl": "pkg:rpm/libldap-2_4-2@2.4.46-9.37.1",
+                  "purl": "pkg:rpm/sles/libldap-2_4-2@2.4.46-9.37.1?distro=sles-15.2",
                   "version": "2.4.46-9.37.1",
                 },
               },
@@ -1430,7 +1430,7 @@ Object {
                 "id": "libldap-data@2.4.46-9.37.1",
                 "info": Object {
                   "name": "libldap-data",
-                  "purl": "pkg:rpm/libldap-data@2.4.46-9.37.1",
+                  "purl": "pkg:rpm/sles/libldap-data@2.4.46-9.37.1?distro=sles-15.2",
                   "version": "2.4.46-9.37.1",
                 },
               },
@@ -1438,7 +1438,7 @@ Object {
                 "id": "liblua5_3-5@5.3.4-3.3.2",
                 "info": Object {
                   "name": "liblua5_3-5",
-                  "purl": "pkg:rpm/liblua5_3-5@5.3.4-3.3.2",
+                  "purl": "pkg:rpm/sles/liblua5_3-5@5.3.4-3.3.2?distro=sles-15.2",
                   "version": "5.3.4-3.3.2",
                 },
               },
@@ -1446,7 +1446,7 @@ Object {
                 "id": "liblz4-1@1.8.0-3.5.1",
                 "info": Object {
                   "name": "liblz4-1",
-                  "purl": "pkg:rpm/liblz4-1@1.8.0-3.5.1",
+                  "purl": "pkg:rpm/sles/liblz4-1@1.8.0-3.5.1?distro=sles-15.2",
                   "version": "1.8.0-3.5.1",
                 },
               },
@@ -1454,7 +1454,7 @@ Object {
                 "id": "liblzma5@5.2.3-4.3.1",
                 "info": Object {
                   "name": "liblzma5",
-                  "purl": "pkg:rpm/liblzma5@5.2.3-4.3.1",
+                  "purl": "pkg:rpm/sles/liblzma5@5.2.3-4.3.1?distro=sles-15.2",
                   "version": "5.2.3-4.3.1",
                 },
               },
@@ -1462,7 +1462,7 @@ Object {
                 "id": "libmagic1@5.32-7.8.1",
                 "info": Object {
                   "name": "libmagic1",
-                  "purl": "pkg:rpm/libmagic1@5.32-7.8.1",
+                  "purl": "pkg:rpm/sles/libmagic1@5.32-7.8.1?distro=sles-15.2",
                   "version": "5.32-7.8.1",
                 },
               },
@@ -1470,7 +1470,7 @@ Object {
                 "id": "libmodman1@2.0.1-1.27",
                 "info": Object {
                   "name": "libmodman1",
-                  "purl": "pkg:rpm/libmodman1@2.0.1-1.27",
+                  "purl": "pkg:rpm/sles/libmodman1@2.0.1-1.27?distro=sles-15.2",
                   "version": "2.0.1-1.27",
                 },
               },
@@ -1478,7 +1478,7 @@ Object {
                 "id": "libmount1@2.33.1-4.8.1",
                 "info": Object {
                   "name": "libmount1",
-                  "purl": "pkg:rpm/libmount1@2.33.1-4.8.1",
+                  "purl": "pkg:rpm/sles/libmount1@2.33.1-4.8.1?distro=sles-15.2",
                   "version": "2.33.1-4.8.1",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "libncurses6@6.1-5.6.2",
                 "info": Object {
                   "name": "libncurses6",
-                  "purl": "pkg:rpm/libncurses6@6.1-5.6.2",
+                  "purl": "pkg:rpm/sles/libncurses6@6.1-5.6.2?distro=sles-15.2",
                   "version": "6.1-5.6.2",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "libnettle6@3.4.1-4.12.1",
                 "info": Object {
                   "name": "libnettle6",
-                  "purl": "pkg:rpm/libnettle6@3.4.1-4.12.1",
+                  "purl": "pkg:rpm/sles/libnettle6@3.4.1-4.12.1?distro=sles-15.2",
                   "version": "3.4.1-4.12.1",
                 },
               },
@@ -1502,7 +1502,7 @@ Object {
                 "id": "libnghttp2-14@1.40.0-1.15",
                 "info": Object {
                   "name": "libnghttp2-14",
-                  "purl": "pkg:rpm/libnghttp2-14@1.40.0-1.15",
+                  "purl": "pkg:rpm/sles/libnghttp2-14@1.40.0-1.15?distro=sles-15.2",
                   "version": "1.40.0-1.15",
                 },
               },
@@ -1510,7 +1510,7 @@ Object {
                 "id": "libnpth0@1.5-2.11",
                 "info": Object {
                   "name": "libnpth0",
-                  "purl": "pkg:rpm/libnpth0@1.5-2.11",
+                  "purl": "pkg:rpm/sles/libnpth0@1.5-2.11?distro=sles-15.2",
                   "version": "1.5-2.11",
                 },
               },
@@ -1518,7 +1518,7 @@ Object {
                 "id": "libnsl2@1.2.0-2.44",
                 "info": Object {
                   "name": "libnsl2",
-                  "purl": "pkg:rpm/libnsl2@1.2.0-2.44",
+                  "purl": "pkg:rpm/sles/libnsl2@1.2.0-2.44?distro=sles-15.2",
                   "version": "1.2.0-2.44",
                 },
               },
@@ -1526,7 +1526,7 @@ Object {
                 "id": "libopenssl1_1@1.1.1d-9.9",
                 "info": Object {
                   "name": "libopenssl1_1",
-                  "purl": "pkg:rpm/libopenssl1_1@1.1.1d-9.9",
+                  "purl": "pkg:rpm/sles/libopenssl1_1@1.1.1d-9.9?distro=sles-15.2",
                   "version": "1.1.1d-9.9",
                 },
               },
@@ -1534,7 +1534,7 @@ Object {
                 "id": "libp11-kit0@0.23.2-4.8.3",
                 "info": Object {
                   "name": "libp11-kit0",
-                  "purl": "pkg:rpm/libp11-kit0@0.23.2-4.8.3",
+                  "purl": "pkg:rpm/sles/libp11-kit0@0.23.2-4.8.3?distro=sles-15.2",
                   "version": "0.23.2-4.8.3",
                 },
               },
@@ -1542,7 +1542,7 @@ Object {
                 "id": "libpcre1@8.41-4.20",
                 "info": Object {
                   "name": "libpcre1",
-                  "purl": "pkg:rpm/libpcre1@8.41-4.20",
+                  "purl": "pkg:rpm/sles/libpcre1@8.41-4.20?distro=sles-15.2",
                   "version": "8.41-4.20",
                 },
               },
@@ -1550,7 +1550,7 @@ Object {
                 "id": "libpopt0@1.16-3.22",
                 "info": Object {
                   "name": "libpopt0",
-                  "purl": "pkg:rpm/libpopt0@1.16-3.22",
+                  "purl": "pkg:rpm/sles/libpopt0@1.16-3.22?distro=sles-15.2",
                   "version": "1.16-3.22",
                 },
               },
@@ -1558,7 +1558,7 @@ Object {
                 "id": "libprocps7@3.3.15-7.10.2",
                 "info": Object {
                   "name": "libprocps7",
-                  "purl": "pkg:rpm/libprocps7@3.3.15-7.10.2",
+                  "purl": "pkg:rpm/sles/libprocps7@3.3.15-7.10.2?distro=sles-15.2",
                   "version": "3.3.15-7.10.2",
                 },
               },
@@ -1566,7 +1566,7 @@ Object {
                 "id": "libproxy1@0.4.15-2.15",
                 "info": Object {
                   "name": "libproxy1",
-                  "purl": "pkg:rpm/libproxy1@0.4.15-2.15",
+                  "purl": "pkg:rpm/sles/libproxy1@0.4.15-2.15?distro=sles-15.2",
                   "version": "0.4.15-2.15",
                 },
               },
@@ -1574,7 +1574,7 @@ Object {
                 "id": "libpsl5@0.20.1-1.20",
                 "info": Object {
                   "name": "libpsl5",
-                  "purl": "pkg:rpm/libpsl5@0.20.1-1.20",
+                  "purl": "pkg:rpm/sles/libpsl5@0.20.1-1.20?distro=sles-15.2",
                   "version": "0.20.1-1.20",
                 },
               },
@@ -1582,7 +1582,7 @@ Object {
                 "id": "libreadline7@7.0-9.10.1",
                 "info": Object {
                   "name": "libreadline7",
-                  "purl": "pkg:rpm/libreadline7@7.0-9.10.1",
+                  "purl": "pkg:rpm/sles/libreadline7@7.0-9.10.1?distro=sles-15.2",
                   "version": "7.0-9.10.1",
                 },
               },
@@ -1590,7 +1590,7 @@ Object {
                 "id": "libsasl2-3@2.1.26-5.7.1",
                 "info": Object {
                   "name": "libsasl2-3",
-                  "purl": "pkg:rpm/libsasl2-3@2.1.26-5.7.1",
+                  "purl": "pkg:rpm/sles/libsasl2-3@2.1.26-5.7.1?distro=sles-15.2",
                   "version": "2.1.26-5.7.1",
                 },
               },
@@ -1598,7 +1598,7 @@ Object {
                 "id": "libselinux1@3.0-1.31",
                 "info": Object {
                   "name": "libselinux1",
-                  "purl": "pkg:rpm/libselinux1@3.0-1.31",
+                  "purl": "pkg:rpm/sles/libselinux1@3.0-1.31?distro=sles-15.2",
                   "version": "3.0-1.31",
                 },
               },
@@ -1606,7 +1606,7 @@ Object {
                 "id": "libsemanage1@3.0-1.27",
                 "info": Object {
                   "name": "libsemanage1",
-                  "purl": "pkg:rpm/libsemanage1@3.0-1.27",
+                  "purl": "pkg:rpm/sles/libsemanage1@3.0-1.27?distro=sles-15.2",
                   "version": "3.0-1.27",
                 },
               },
@@ -1614,7 +1614,7 @@ Object {
                 "id": "libsepol1@3.0-1.31",
                 "info": Object {
                   "name": "libsepol1",
-                  "purl": "pkg:rpm/libsepol1@3.0-1.31",
+                  "purl": "pkg:rpm/sles/libsepol1@3.0-1.31?distro=sles-15.2",
                   "version": "3.0-1.31",
                 },
               },
@@ -1622,7 +1622,7 @@ Object {
                 "id": "libsigc-2_0-0@2.10.2-1.18",
                 "info": Object {
                   "name": "libsigc-2_0-0",
-                  "purl": "pkg:rpm/libsigc-2_0-0@2.10.2-1.18",
+                  "purl": "pkg:rpm/sles/libsigc-2_0-0@2.10.2-1.18?distro=sles-15.2",
                   "version": "2.10.2-1.18",
                 },
               },
@@ -1630,7 +1630,7 @@ Object {
                 "id": "libsmartcols1@2.33.1-4.8.1",
                 "info": Object {
                   "name": "libsmartcols1",
-                  "purl": "pkg:rpm/libsmartcols1@2.33.1-4.8.1",
+                  "purl": "pkg:rpm/sles/libsmartcols1@2.33.1-4.8.1?distro=sles-15.2",
                   "version": "2.33.1-4.8.1",
                 },
               },
@@ -1638,7 +1638,7 @@ Object {
                 "id": "libsolv-tools@0.7.14-3.5.1",
                 "info": Object {
                   "name": "libsolv-tools",
-                  "purl": "pkg:rpm/libsolv-tools@0.7.14-3.5.1",
+                  "purl": "pkg:rpm/sles/libsolv-tools@0.7.14-3.5.1?distro=sles-15.2",
                   "version": "0.7.14-3.5.1",
                 },
               },
@@ -1646,7 +1646,7 @@ Object {
                 "id": "libsqlite3-0@3.28.0-3.9.2",
                 "info": Object {
                   "name": "libsqlite3-0",
-                  "purl": "pkg:rpm/libsqlite3-0@3.28.0-3.9.2",
+                  "purl": "pkg:rpm/sles/libsqlite3-0@3.28.0-3.9.2?distro=sles-15.2",
                   "version": "3.28.0-3.9.2",
                 },
               },
@@ -1654,7 +1654,7 @@ Object {
                 "id": "libssh4@0.8.7-10.12.1",
                 "info": Object {
                   "name": "libssh4",
-                  "purl": "pkg:rpm/libssh4@0.8.7-10.12.1",
+                  "purl": "pkg:rpm/sles/libssh4@0.8.7-10.12.1?distro=sles-15.2",
                   "version": "0.8.7-10.12.1",
                 },
               },
@@ -1662,7 +1662,7 @@ Object {
                 "id": "libstdc++6@9.3.1+git1296-1.6.1",
                 "info": Object {
                   "name": "libstdc++6",
-                  "purl": "pkg:rpm/libstdc%2B%2B6@9.3.1%2Bgit1296-1.6.1",
+                  "purl": "pkg:rpm/sles/libstdc%2B%2B6@9.3.1%2Bgit1296-1.6.1?distro=sles-15.2",
                   "version": "9.3.1+git1296-1.6.1",
                 },
               },
@@ -1670,7 +1670,7 @@ Object {
                 "id": "libsystemd0@234-24.58.1",
                 "info": Object {
                   "name": "libsystemd0",
-                  "purl": "pkg:rpm/libsystemd0@234-24.58.1",
+                  "purl": "pkg:rpm/sles/libsystemd0@234-24.58.1?distro=sles-15.2",
                   "version": "234-24.58.1",
                 },
               },
@@ -1678,7 +1678,7 @@ Object {
                 "id": "libtasn1@4.13-4.5.1",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.13-4.5.1",
+                  "purl": "pkg:rpm/sles/libtasn1@4.13-4.5.1?distro=sles-15.2",
                   "version": "4.13-4.5.1",
                 },
               },
@@ -1686,7 +1686,7 @@ Object {
                 "id": "libtasn1-6@4.13-4.5.1",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:rpm/libtasn1-6@4.13-4.5.1",
+                  "purl": "pkg:rpm/sles/libtasn1-6@4.13-4.5.1?distro=sles-15.2",
                   "version": "4.13-4.5.1",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "libtirpc-netconfig@1.0.2-3.8.1",
                 "info": Object {
                   "name": "libtirpc-netconfig",
-                  "purl": "pkg:rpm/libtirpc-netconfig@1.0.2-3.8.1",
+                  "purl": "pkg:rpm/sles/libtirpc-netconfig@1.0.2-3.8.1?distro=sles-15.2",
                   "version": "1.0.2-3.8.1",
                 },
               },
@@ -1702,7 +1702,7 @@ Object {
                 "id": "libtirpc3@1.0.2-3.8.1",
                 "info": Object {
                   "name": "libtirpc3",
-                  "purl": "pkg:rpm/libtirpc3@1.0.2-3.8.1",
+                  "purl": "pkg:rpm/sles/libtirpc3@1.0.2-3.8.1?distro=sles-15.2",
                   "version": "1.0.2-3.8.1",
                 },
               },
@@ -1710,7 +1710,7 @@ Object {
                 "id": "libudev1@234-24.58.1",
                 "info": Object {
                   "name": "libudev1",
-                  "purl": "pkg:rpm/libudev1@234-24.58.1",
+                  "purl": "pkg:rpm/sles/libudev1@234-24.58.1?distro=sles-15.2",
                   "version": "234-24.58.1",
                 },
               },
@@ -1718,7 +1718,7 @@ Object {
                 "id": "libunistring2@0.9.9-1.15",
                 "info": Object {
                   "name": "libunistring2",
-                  "purl": "pkg:rpm/libunistring2@0.9.9-1.15",
+                  "purl": "pkg:rpm/sles/libunistring2@0.9.9-1.15?distro=sles-15.2",
                   "version": "0.9.9-1.15",
                 },
               },
@@ -1726,7 +1726,7 @@ Object {
                 "id": "libusb-1_0-0@1.0.21-1.29",
                 "info": Object {
                   "name": "libusb-1_0-0",
-                  "purl": "pkg:rpm/libusb-1_0-0@1.0.21-1.29",
+                  "purl": "pkg:rpm/sles/libusb-1_0-0@1.0.21-1.29?distro=sles-15.2",
                   "version": "1.0.21-1.29",
                 },
               },
@@ -1734,7 +1734,7 @@ Object {
                 "id": "libutempter0@1.1.6-3.42",
                 "info": Object {
                   "name": "libutempter0",
-                  "purl": "pkg:rpm/libutempter0@1.1.6-3.42",
+                  "purl": "pkg:rpm/sles/libutempter0@1.1.6-3.42?distro=sles-15.2",
                   "version": "1.1.6-3.42",
                 },
               },
@@ -1742,7 +1742,7 @@ Object {
                 "id": "libuuid1@2.33.1-4.8.1",
                 "info": Object {
                   "name": "libuuid1",
-                  "purl": "pkg:rpm/libuuid1@2.33.1-4.8.1",
+                  "purl": "pkg:rpm/sles/libuuid1@2.33.1-4.8.1?distro=sles-15.2",
                   "version": "2.33.1-4.8.1",
                 },
               },
@@ -1750,7 +1750,7 @@ Object {
                 "id": "libverto1@0.2.6-3.20",
                 "info": Object {
                   "name": "libverto1",
-                  "purl": "pkg:rpm/libverto1@0.2.6-3.20",
+                  "purl": "pkg:rpm/sles/libverto1@0.2.6-3.20?distro=sles-15.2",
                   "version": "0.2.6-3.20",
                 },
               },
@@ -1758,7 +1758,7 @@ Object {
                 "id": "libxml2-2@2.9.7-3.25.1",
                 "info": Object {
                   "name": "libxml2-2",
-                  "purl": "pkg:rpm/libxml2-2@2.9.7-3.25.1",
+                  "purl": "pkg:rpm/sles/libxml2-2@2.9.7-3.25.1?distro=sles-15.2",
                   "version": "2.9.7-3.25.1",
                 },
               },
@@ -1766,7 +1766,7 @@ Object {
                 "id": "libz1@1.2.11-3.18.1",
                 "info": Object {
                   "name": "libz1",
-                  "purl": "pkg:rpm/libz1@1.2.11-3.18.1",
+                  "purl": "pkg:rpm/sles/libz1@1.2.11-3.18.1?distro=sles-15.2",
                   "version": "1.2.11-3.18.1",
                 },
               },
@@ -1774,7 +1774,7 @@ Object {
                 "id": "libzio1@1.06-2.20",
                 "info": Object {
                   "name": "libzio1",
-                  "purl": "pkg:rpm/libzio1@1.06-2.20",
+                  "purl": "pkg:rpm/sles/libzio1@1.06-2.20?distro=sles-15.2",
                   "version": "1.06-2.20",
                 },
               },
@@ -1782,7 +1782,7 @@ Object {
                 "id": "libzstd1@1.4.4-1.3.1",
                 "info": Object {
                   "name": "libzstd1",
-                  "purl": "pkg:rpm/libzstd1@1.4.4-1.3.1",
+                  "purl": "pkg:rpm/sles/libzstd1@1.4.4-1.3.1?distro=sles-15.2",
                   "version": "1.4.4-1.3.1",
                 },
               },
@@ -1790,7 +1790,7 @@ Object {
                 "id": "libzypp@17.24.1-3.11.1",
                 "info": Object {
                   "name": "libzypp",
-                  "purl": "pkg:rpm/libzypp@17.24.1-3.11.1",
+                  "purl": "pkg:rpm/sles/libzypp@17.24.1-3.11.1?distro=sles-15.2",
                   "version": "17.24.1-3.11.1",
                 },
               },
@@ -1798,7 +1798,7 @@ Object {
                 "id": "ncurses-utils@6.1-5.6.2",
                 "info": Object {
                   "name": "ncurses-utils",
-                  "purl": "pkg:rpm/ncurses-utils@6.1-5.6.2",
+                  "purl": "pkg:rpm/sles/ncurses-utils@6.1-5.6.2?distro=sles-15.2",
                   "version": "6.1-5.6.2",
                 },
               },
@@ -1806,7 +1806,7 @@ Object {
                 "id": "netcfg@11.6-1.11",
                 "info": Object {
                   "name": "netcfg",
-                  "purl": "pkg:rpm/netcfg@11.6-1.11",
+                  "purl": "pkg:rpm/sles/netcfg@11.6-1.11?distro=sles-15.2",
                   "version": "11.6-1.11",
                 },
               },
@@ -1814,7 +1814,7 @@ Object {
                 "id": "openssl@1.1.1d-1.46",
                 "info": Object {
                   "name": "openssl",
-                  "purl": "pkg:rpm/openssl@1.1.1d-1.46",
+                  "purl": "pkg:rpm/sles/openssl@1.1.1d-1.46?distro=sles-15.2",
                   "version": "1.1.1d-1.46",
                 },
               },
@@ -1822,7 +1822,7 @@ Object {
                 "id": "openssl-1_1@1.1.1d-9.9",
                 "info": Object {
                   "name": "openssl-1_1",
-                  "purl": "pkg:rpm/openssl-1_1@1.1.1d-9.9",
+                  "purl": "pkg:rpm/sles/openssl-1_1@1.1.1d-9.9?distro=sles-15.2",
                   "version": "1.1.1d-9.9",
                 },
               },
@@ -1830,7 +1830,7 @@ Object {
                 "id": "p11-kit@0.23.2-4.8.3",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.2-4.8.3",
+                  "purl": "pkg:rpm/sles/p11-kit@0.23.2-4.8.3?distro=sles-15.2",
                   "version": "0.23.2-4.8.3",
                 },
               },
@@ -1838,7 +1838,7 @@ Object {
                 "id": "p11-kit-tools@0.23.2-4.8.3",
                 "info": Object {
                   "name": "p11-kit-tools",
-                  "purl": "pkg:rpm/p11-kit-tools@0.23.2-4.8.3",
+                  "purl": "pkg:rpm/sles/p11-kit-tools@0.23.2-4.8.3?distro=sles-15.2",
                   "version": "0.23.2-4.8.3",
                 },
               },
@@ -1846,7 +1846,7 @@ Object {
                 "id": "pam@1.3.0-6.16.1",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.3.0-6.16.1",
+                  "purl": "pkg:rpm/sles/pam@1.3.0-6.16.1?distro=sles-15.2",
                   "version": "1.3.0-6.16.1",
                 },
               },
@@ -1854,7 +1854,7 @@ Object {
                 "id": "perl-base@5.26.1-7.12.1",
                 "info": Object {
                   "name": "perl-base",
-                  "purl": "pkg:rpm/perl-base@5.26.1-7.12.1",
+                  "purl": "pkg:rpm/sles/perl-base@5.26.1-7.12.1?distro=sles-15.2",
                   "version": "5.26.1-7.12.1",
                 },
               },
@@ -1862,7 +1862,7 @@ Object {
                 "id": "permissions@20181224-21.1",
                 "info": Object {
                   "name": "permissions",
-                  "purl": "pkg:rpm/permissions@20181224-21.1",
+                  "purl": "pkg:rpm/sles/permissions@20181224-21.1?distro=sles-15.2",
                   "version": "20181224-21.1",
                 },
               },
@@ -1870,7 +1870,7 @@ Object {
                 "id": "pinentry@1.1.0-4.3.1",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@1.1.0-4.3.1",
+                  "purl": "pkg:rpm/sles/pinentry@1.1.0-4.3.1?distro=sles-15.2",
                   "version": "1.1.0-4.3.1",
                 },
               },
@@ -1878,7 +1878,7 @@ Object {
                 "id": "procps@3.3.15-7.10.2",
                 "info": Object {
                   "name": "procps",
-                  "purl": "pkg:rpm/procps@3.3.15-7.10.2",
+                  "purl": "pkg:rpm/sles/procps@3.3.15-7.10.2?distro=sles-15.2",
                   "version": "3.3.15-7.10.2",
                 },
               },
@@ -1886,7 +1886,7 @@ Object {
                 "id": "rpm@4.14.1-20.3",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.14.1-20.3",
+                  "purl": "pkg:rpm/sles/rpm@4.14.1-20.3?distro=sles-15.2",
                   "version": "4.14.1-20.3",
                 },
               },
@@ -1894,7 +1894,7 @@ Object {
                 "id": "sed@4.4-2.11",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.4-2.11",
+                  "purl": "pkg:rpm/sles/sed@4.4-2.11?distro=sles-15.2",
                   "version": "4.4-2.11",
                 },
               },
@@ -1902,7 +1902,7 @@ Object {
                 "id": "shadow@4.6-3.5.6",
                 "info": Object {
                   "name": "shadow",
-                  "purl": "pkg:rpm/shadow@4.6-3.5.6",
+                  "purl": "pkg:rpm/sles/shadow@4.6-3.5.6?distro=sles-15.2",
                   "version": "4.6-3.5.6",
                 },
               },
@@ -1910,7 +1910,7 @@ Object {
                 "id": "sles-release@15.2-49.1",
                 "info": Object {
                   "name": "sles-release",
-                  "purl": "pkg:rpm/sles-release@15.2-49.1",
+                  "purl": "pkg:rpm/sles/sles-release@15.2-49.1?distro=sles-15.2",
                   "version": "15.2-49.1",
                 },
               },
@@ -1918,7 +1918,7 @@ Object {
                 "id": "suse-build-key@12.0-8.9.1",
                 "info": Object {
                   "name": "suse-build-key",
-                  "purl": "pkg:rpm/suse-build-key@12.0-8.9.1",
+                  "purl": "pkg:rpm/sles/suse-build-key@12.0-8.9.1?distro=sles-15.2",
                   "version": "12.0-8.9.1",
                 },
               },
@@ -1926,7 +1926,7 @@ Object {
                 "id": "system-group-hardware@20170617-4.155",
                 "info": Object {
                   "name": "system-group-hardware",
-                  "purl": "pkg:rpm/system-group-hardware@20170617-4.155",
+                  "purl": "pkg:rpm/sles/system-group-hardware@20170617-4.155?distro=sles-15.2",
                   "version": "20170617-4.155",
                 },
               },
@@ -1934,7 +1934,7 @@ Object {
                 "id": "system-user-root@20190513-3.3.1",
                 "info": Object {
                   "name": "system-user-root",
-                  "purl": "pkg:rpm/system-user-root@20190513-3.3.1",
+                  "purl": "pkg:rpm/sles/system-user-root@20190513-3.3.1?distro=sles-15.2",
                   "version": "20190513-3.3.1",
                 },
               },
@@ -1942,7 +1942,7 @@ Object {
                 "id": "sysuser-shadow@2.0-2.151",
                 "info": Object {
                   "name": "sysuser-shadow",
-                  "purl": "pkg:rpm/sysuser-shadow@2.0-2.151",
+                  "purl": "pkg:rpm/sles/sysuser-shadow@2.0-2.151?distro=sles-15.2",
                   "version": "2.0-2.151",
                 },
               },
@@ -1950,7 +1950,7 @@ Object {
                 "id": "terminfo-base@6.1-5.6.2",
                 "info": Object {
                   "name": "terminfo-base",
-                  "purl": "pkg:rpm/terminfo-base@6.1-5.6.2",
+                  "purl": "pkg:rpm/sles/terminfo-base@6.1-5.6.2?distro=sles-15.2",
                   "version": "6.1-5.6.2",
                 },
               },
@@ -1958,7 +1958,7 @@ Object {
                 "id": "util-linux@2.33.1-4.8.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.33.1-4.8.1",
+                  "purl": "pkg:rpm/sles/util-linux@2.33.1-4.8.1?distro=sles-15.2",
                   "version": "2.33.1-4.8.1",
                 },
               },
@@ -1966,7 +1966,7 @@ Object {
                 "id": "zypper@1.14.37-3.3.3",
                 "info": Object {
                   "name": "zypper",
-                  "purl": "pkg:rpm/zypper@1.14.37-3.3.3",
+                  "purl": "pkg:rpm/sles/zypper@1.14.37-3.3.3?distro=sles-15.2",
                   "version": "1.14.37-3.3.3",
                 },
               },

--- a/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
@@ -3030,7 +3030,7 @@ Object {
                 "id": "acl@2.2.53-1.el8",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:rpm/acl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/acl@2.2.53-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -3038,7 +3038,7 @@ Object {
                 "id": "annobin@8.90-1.el8",
                 "info": Object {
                   "name": "annobin",
-                  "purl": "pkg:rpm/annobin@8.90-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/annobin@8.90-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.90-1.el8",
                 },
               },
@@ -3046,7 +3046,7 @@ Object {
                 "id": "audit-libs@3.0-0.17.20191104git1c2f876.el8",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@3.0-0.17.20191104git1c2f876.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/audit-libs@3.0-0.17.20191104git1c2f876.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0-0.17.20191104git1c2f876.el8",
                 },
               },
@@ -3054,7 +3054,7 @@ Object {
                 "id": "autoconf@2.69-27.el8",
                 "info": Object {
                   "name": "autoconf",
-                  "purl": "pkg:rpm/autoconf@2.69-27.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/autoconf@2.69-27.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.69-27.el8",
                 },
               },
@@ -3062,7 +3062,7 @@ Object {
                 "id": "automake@1.16.1-6.el8",
                 "info": Object {
                   "name": "automake",
-                  "purl": "pkg:rpm/automake@1.16.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/automake@1.16.1-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.16.1-6.el8",
                 },
               },
@@ -3070,7 +3070,7 @@ Object {
                 "id": "basesystem@11-5.el8",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/basesystem@11-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "11-5.el8",
                 },
               },
@@ -3078,7 +3078,7 @@ Object {
                 "id": "bash@4.4.19-10.el8",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.4.19-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/bash@4.4.19-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.4.19-10.el8",
                 },
               },
@@ -3086,7 +3086,7 @@ Object {
                 "id": "binutils@2.30-73.el8",
                 "info": Object {
                   "name": "binutils",
-                  "purl": "pkg:rpm/binutils@2.30-73.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/binutils@2.30-73.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.30-73.el8",
                 },
               },
@@ -3094,7 +3094,7 @@ Object {
                 "id": "brotli@1.0.6-1.el8",
                 "info": Object {
                   "name": "brotli",
-                  "purl": "pkg:rpm/brotli@1.0.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/brotli@1.0.6-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.6-1.el8",
                 },
               },
@@ -3102,7 +3102,7 @@ Object {
                 "id": "bsdtar@3.3.2-8.el8_1",
                 "info": Object {
                   "name": "bsdtar",
-                  "purl": "pkg:rpm/bsdtar@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/bsdtar@3.3.2-8.el8_1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.3.2-8.el8_1",
                 },
               },
@@ -3110,7 +3110,7 @@ Object {
                 "id": "bzip2@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2",
-                  "purl": "pkg:rpm/bzip2@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/bzip2@1.0.6-26.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -3118,7 +3118,7 @@ Object {
                 "id": "bzip2-devel@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2-devel",
-                  "purl": "pkg:rpm/bzip2-devel@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/bzip2-devel@1.0.6-26.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -3126,7 +3126,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/bzip2-libs@1.0.6-26.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -3134,7 +3134,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-80.0.el8_1",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-80.0.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/ca-certificates@2019.2.32-80.0.el8_1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2019.2.32-80.0.el8_1",
                 },
               },
@@ -3142,7 +3142,7 @@ Object {
                 "id": "chkconfig@1.11-1.el8",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/chkconfig@1.11-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.11-1.el8",
                 },
               },
@@ -3150,7 +3150,7 @@ Object {
                 "id": "cmake@3.11.4-7.el8",
                 "info": Object {
                   "name": "cmake",
-                  "purl": "pkg:rpm/cmake@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/cmake@3.11.4-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11.4-7.el8",
                 },
               },
@@ -3158,7 +3158,7 @@ Object {
                 "id": "cmake-data@3.11.4-7.el8",
                 "info": Object {
                   "name": "cmake-data",
-                  "purl": "pkg:rpm/cmake-data@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/cmake-data@3.11.4-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11.4-7.el8",
                 },
               },
@@ -3166,7 +3166,7 @@ Object {
                 "id": "cmake-filesystem@3.11.4-7.el8",
                 "info": Object {
                   "name": "cmake-filesystem",
-                  "purl": "pkg:rpm/cmake-filesystem@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/cmake-filesystem@3.11.4-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11.4-7.el8",
                 },
               },
@@ -3174,7 +3174,7 @@ Object {
                 "id": "cmake-rpm-macros@3.11.4-7.el8",
                 "info": Object {
                   "name": "cmake-rpm-macros",
-                  "purl": "pkg:rpm/cmake-rpm-macros@3.11.4-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/cmake-rpm-macros@3.11.4-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11.4-7.el8",
                 },
               },
@@ -3182,7 +3182,7 @@ Object {
                 "id": "coreutils-single@8.30-7.el8_2.1",
                 "info": Object {
                   "name": "coreutils-single",
-                  "purl": "pkg:rpm/coreutils-single@8.30-7.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/coreutils-single@8.30-7.el8_2.1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.30-7.el8_2.1",
                 },
               },
@@ -3190,7 +3190,7 @@ Object {
                 "id": "cpp@8.3.1-5.el8",
                 "info": Object {
                   "name": "cpp",
-                  "purl": "pkg:rpm/cpp@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/cpp@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -3198,7 +3198,7 @@ Object {
                 "id": "cracklib@2.9.6-15.el8",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.6-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/cracklib@2.9.6-15.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.6-15.el8",
                 },
               },
@@ -3206,7 +3206,7 @@ Object {
                 "id": "crypto-policies@20191128-2.git23e1bf1.el8",
                 "info": Object {
                   "name": "crypto-policies",
-                  "purl": "pkg:rpm/crypto-policies@20191128-2.git23e1bf1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/crypto-policies@20191128-2.git23e1bf1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "20191128-2.git23e1bf1.el8",
                 },
               },
@@ -3214,7 +3214,7 @@ Object {
                 "id": "cryptsetup-libs@2.2.2-1.el8",
                 "info": Object {
                   "name": "cryptsetup-libs",
-                  "purl": "pkg:rpm/cryptsetup-libs@2.2.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/cryptsetup-libs@2.2.2-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.2-1.el8",
                 },
               },
@@ -3222,7 +3222,7 @@ Object {
                 "id": "curl@7.61.1-12.el8",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/curl@7.61.1-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -3230,7 +3230,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.27-1.el8",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.27-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/cyrus-sasl-lib@2.1.27-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.1.27-1.el8",
                 },
               },
@@ -3238,7 +3238,7 @@ Object {
                 "id": "dbus@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus",
-                  "purl": "pkg:rpm/dbus@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dbus@1:1.12.8-9.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3246,7 +3246,7 @@ Object {
                 "id": "dbus-common@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus-common",
-                  "purl": "pkg:rpm/dbus-common@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-common@1:1.12.8-9.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3254,7 +3254,7 @@ Object {
                 "id": "dbus-daemon@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus-daemon",
-                  "purl": "pkg:rpm/dbus-daemon@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-daemon@1:1.12.8-9.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3262,7 +3262,7 @@ Object {
                 "id": "dbus-glib@0.110-2.el8",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.110-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-glib@0.110-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.110-2.el8",
                 },
               },
@@ -3270,7 +3270,7 @@ Object {
                 "id": "dbus-libs@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-libs@1:1.12.8-9.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3278,7 +3278,7 @@ Object {
                 "id": "dbus-tools@1:1.12.8-9.el8",
                 "info": Object {
                   "name": "dbus-tools",
-                  "purl": "pkg:rpm/dbus-tools@1:1.12.8-9.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-tools@1:1.12.8-9.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.12.8-9.el8",
                 },
               },
@@ -3286,7 +3286,7 @@ Object {
                 "id": "dejavu-fonts-common@2.35-6.el8",
                 "info": Object {
                   "name": "dejavu-fonts-common",
-                  "purl": "pkg:rpm/dejavu-fonts-common@2.35-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dejavu-fonts-common@2.35-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.35-6.el8",
                 },
               },
@@ -3294,7 +3294,7 @@ Object {
                 "id": "dejavu-sans-fonts@2.35-6.el8",
                 "info": Object {
                   "name": "dejavu-sans-fonts",
-                  "purl": "pkg:rpm/dejavu-sans-fonts@2.35-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dejavu-sans-fonts@2.35-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.35-6.el8",
                 },
               },
@@ -3302,7 +3302,7 @@ Object {
                 "id": "device-mapper@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper",
-                  "purl": "pkg:rpm/device-mapper@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/device-mapper@8:1.02.169-3.el8?distro=rhel-8.2&epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -3310,7 +3310,7 @@ Object {
                 "id": "device-mapper-libs@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper-libs",
-                  "purl": "pkg:rpm/device-mapper-libs@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/device-mapper-libs@8:1.02.169-3.el8?distro=rhel-8.2&epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -3318,7 +3318,7 @@ Object {
                 "id": "dmidecode@1:3.2-5.el8",
                 "info": Object {
                   "name": "dmidecode",
-                  "purl": "pkg:rpm/dmidecode@1:3.2-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dmidecode@1:3.2-5.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:3.2-5.el8",
                 },
               },
@@ -3326,7 +3326,7 @@ Object {
                 "id": "dnf@4.2.17-6.el8",
                 "info": Object {
                   "name": "dnf",
-                  "purl": "pkg:rpm/dnf@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dnf@4.2.17-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.17-6.el8",
                 },
               },
@@ -3334,7 +3334,7 @@ Object {
                 "id": "dnf-data@4.2.17-6.el8",
                 "info": Object {
                   "name": "dnf-data",
-                  "purl": "pkg:rpm/dnf-data@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dnf-data@4.2.17-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.17-6.el8",
                 },
               },
@@ -3342,7 +3342,7 @@ Object {
                 "id": "dnf-plugin-subscription-manager@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "dnf-plugin-subscription-manager",
-                  "purl": "pkg:rpm/dnf-plugin-subscription-manager@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dnf-plugin-subscription-manager@1.26.17-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -3350,7 +3350,7 @@ Object {
                 "id": "dnf-plugins-core@4.0.12-3.el8",
                 "info": Object {
                   "name": "dnf-plugins-core",
-                  "purl": "pkg:rpm/dnf-plugins-core@4.0.12-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dnf-plugins-core@4.0.12-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.0.12-3.el8",
                 },
               },
@@ -3358,7 +3358,7 @@ Object {
                 "id": "dwz@0.12-9.el8",
                 "info": Object {
                   "name": "dwz",
-                  "purl": "pkg:rpm/dwz@0.12-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/dwz@0.12-9.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.12-9.el8",
                 },
               },
@@ -3366,7 +3366,7 @@ Object {
                 "id": "efi-srpm-macros@3-2.el8",
                 "info": Object {
                   "name": "efi-srpm-macros",
-                  "purl": "pkg:rpm/efi-srpm-macros@3-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/efi-srpm-macros@3-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3-2.el8",
                 },
               },
@@ -3374,7 +3374,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/elfutils-default-yama-scope@0.178-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -3382,7 +3382,7 @@ Object {
                 "id": "elfutils-libelf@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/elfutils-libelf@0.178-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -3390,7 +3390,7 @@ Object {
                 "id": "elfutils-libs@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/elfutils-libs@0.178-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -3398,7 +3398,7 @@ Object {
                 "id": "emacs-filesystem@1:26.1-5.el8",
                 "info": Object {
                   "name": "emacs-filesystem",
-                  "purl": "pkg:rpm/emacs-filesystem@1:26.1-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/emacs-filesystem@1:26.1-5.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:26.1-5.el8",
                 },
               },
@@ -3406,7 +3406,7 @@ Object {
                 "id": "environment-modules@4.1.4-4.el8",
                 "info": Object {
                   "name": "environment-modules",
-                  "purl": "pkg:rpm/environment-modules@4.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/environment-modules@4.1.4-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.1.4-4.el8",
                 },
               },
@@ -3414,7 +3414,7 @@ Object {
                 "id": "expat@2.2.5-3.el8",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/expat@2.2.5-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.5-3.el8",
                 },
               },
@@ -3422,7 +3422,7 @@ Object {
                 "id": "expat-devel@2.2.5-3.el8",
                 "info": Object {
                   "name": "expat-devel",
-                  "purl": "pkg:rpm/expat-devel@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/expat-devel@2.2.5-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.5-3.el8",
                 },
               },
@@ -3430,7 +3430,7 @@ Object {
                 "id": "file@5.33-13.el8",
                 "info": Object {
                   "name": "file",
-                  "purl": "pkg:rpm/file@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/file@5.33-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.33-13.el8",
                 },
               },
@@ -3438,7 +3438,7 @@ Object {
                 "id": "file-libs@5.33-13.el8",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/file-libs@5.33-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.33-13.el8",
                 },
               },
@@ -3446,7 +3446,7 @@ Object {
                 "id": "filesystem@3.8-2.el8",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.8-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/filesystem@3.8-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.8-2.el8",
                 },
               },
@@ -3454,7 +3454,7 @@ Object {
                 "id": "findutils@1:4.6.0-20.el8",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.6.0-20.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/findutils@1:4.6.0-20.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:4.6.0-20.el8",
                 },
               },
@@ -3462,7 +3462,7 @@ Object {
                 "id": "fipscheck@1.5.0-4.el8",
                 "info": Object {
                   "name": "fipscheck",
-                  "purl": "pkg:rpm/fipscheck@1.5.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/fipscheck@1.5.0-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.0-4.el8",
                 },
               },
@@ -3470,7 +3470,7 @@ Object {
                 "id": "fipscheck-lib@1.5.0-4.el8",
                 "info": Object {
                   "name": "fipscheck-lib",
-                  "purl": "pkg:rpm/fipscheck-lib@1.5.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/fipscheck-lib@1.5.0-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.0-4.el8",
                 },
               },
@@ -3478,7 +3478,7 @@ Object {
                 "id": "fontconfig@2.13.1-3.el8",
                 "info": Object {
                   "name": "fontconfig",
-                  "purl": "pkg:rpm/fontconfig@2.13.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/fontconfig@2.13.1-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.13.1-3.el8",
                 },
               },
@@ -3486,7 +3486,7 @@ Object {
                 "id": "fontconfig-devel@2.13.1-3.el8",
                 "info": Object {
                   "name": "fontconfig-devel",
-                  "purl": "pkg:rpm/fontconfig-devel@2.13.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/fontconfig-devel@2.13.1-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.13.1-3.el8",
                 },
               },
@@ -3494,7 +3494,7 @@ Object {
                 "id": "fontpackages-filesystem@1.44-22.el8",
                 "info": Object {
                   "name": "fontpackages-filesystem",
-                  "purl": "pkg:rpm/fontpackages-filesystem@1.44-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/fontpackages-filesystem@1.44-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.44-22.el8",
                 },
               },
@@ -3502,7 +3502,7 @@ Object {
                 "id": "freetype@2.9.1-4.el8",
                 "info": Object {
                   "name": "freetype",
-                  "purl": "pkg:rpm/freetype@2.9.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/freetype@2.9.1-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.1-4.el8",
                 },
               },
@@ -3510,7 +3510,7 @@ Object {
                 "id": "freetype-devel@2.9.1-4.el8",
                 "info": Object {
                   "name": "freetype-devel",
-                  "purl": "pkg:rpm/freetype-devel@2.9.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/freetype-devel@2.9.1-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.1-4.el8",
                 },
               },
@@ -3518,7 +3518,7 @@ Object {
                 "id": "gawk@4.2.1-1.el8",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.2.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gawk@4.2.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.1-1.el8",
                 },
               },
@@ -3526,7 +3526,7 @@ Object {
                 "id": "gc@7.6.4-3.el8",
                 "info": Object {
                   "name": "gc",
-                  "purl": "pkg:rpm/gc@7.6.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gc@7.6.4-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.6.4-3.el8",
                 },
               },
@@ -3534,7 +3534,7 @@ Object {
                 "id": "gcc@8.3.1-5.el8",
                 "info": Object {
                   "name": "gcc",
-                  "purl": "pkg:rpm/gcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gcc@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -3542,7 +3542,7 @@ Object {
                 "id": "gcc-c++@8.3.1-5.el8",
                 "info": Object {
                   "name": "gcc-c++",
-                  "purl": "pkg:rpm/gcc-c%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gcc-c%2B%2B@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -3550,7 +3550,7 @@ Object {
                 "id": "gcc-gdb-plugin@8.3.1-5.el8",
                 "info": Object {
                   "name": "gcc-gdb-plugin",
-                  "purl": "pkg:rpm/gcc-gdb-plugin@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gcc-gdb-plugin@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -3558,7 +3558,7 @@ Object {
                 "id": "gd@2.2.5-6.el8",
                 "info": Object {
                   "name": "gd",
-                  "purl": "pkg:rpm/gd@2.2.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gd@2.2.5-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.5-6.el8",
                 },
               },
@@ -3566,7 +3566,7 @@ Object {
                 "id": "gd-devel@2.2.5-6.el8",
                 "info": Object {
                   "name": "gd-devel",
-                  "purl": "pkg:rpm/gd-devel@2.2.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gd-devel@2.2.5-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.5-6.el8",
                 },
               },
@@ -3574,7 +3574,7 @@ Object {
                 "id": "gdb@8.2-11.el8",
                 "info": Object {
                   "name": "gdb",
-                  "purl": "pkg:rpm/gdb@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gdb@8.2-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.2-11.el8",
                 },
               },
@@ -3582,7 +3582,7 @@ Object {
                 "id": "gdb-gdbserver@8.2-11.el8",
                 "info": Object {
                   "name": "gdb-gdbserver",
-                  "purl": "pkg:rpm/gdb-gdbserver@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gdb-gdbserver@8.2-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.2-11.el8",
                 },
               },
@@ -3590,7 +3590,7 @@ Object {
                 "id": "gdb-headless@8.2-11.el8",
                 "info": Object {
                   "name": "gdb-headless",
-                  "purl": "pkg:rpm/gdb-headless@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gdb-headless@8.2-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.2-11.el8",
                 },
               },
@@ -3598,7 +3598,7 @@ Object {
                 "id": "gdbm@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gdbm@1:1.18-1.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -3606,7 +3606,7 @@ Object {
                 "id": "gdbm-libs@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm-libs",
-                  "purl": "pkg:rpm/gdbm-libs@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gdbm-libs@1:1.18-1.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -3614,7 +3614,7 @@ Object {
                 "id": "gettext@0.19.8.1-17.el8",
                 "info": Object {
                   "name": "gettext",
-                  "purl": "pkg:rpm/gettext@0.19.8.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gettext@0.19.8.1-17.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.19.8.1-17.el8",
                 },
               },
@@ -3622,7 +3622,7 @@ Object {
                 "id": "gettext-libs@0.19.8.1-17.el8",
                 "info": Object {
                   "name": "gettext-libs",
-                  "purl": "pkg:rpm/gettext-libs@0.19.8.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gettext-libs@0.19.8.1-17.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.19.8.1-17.el8",
                 },
               },
@@ -3630,7 +3630,7 @@ Object {
                 "id": "ghc-srpm-macros@1.4.2-7.el8",
                 "info": Object {
                   "name": "ghc-srpm-macros",
-                  "purl": "pkg:rpm/ghc-srpm-macros@1.4.2-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/ghc-srpm-macros@1.4.2-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-7.el8",
                 },
               },
@@ -3638,7 +3638,7 @@ Object {
                 "id": "git@2.18.4-2.el8_2",
                 "info": Object {
                   "name": "git",
-                  "purl": "pkg:rpm/git@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/git@2.18.4-2.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.18.4-2.el8_2",
                 },
               },
@@ -3646,7 +3646,7 @@ Object {
                 "id": "git-core@2.18.4-2.el8_2",
                 "info": Object {
                   "name": "git-core",
-                  "purl": "pkg:rpm/git-core@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/git-core@2.18.4-2.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.18.4-2.el8_2",
                 },
               },
@@ -3654,7 +3654,7 @@ Object {
                 "id": "git-core-doc@2.18.4-2.el8_2",
                 "info": Object {
                   "name": "git-core-doc",
-                  "purl": "pkg:rpm/git-core-doc@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/git-core-doc@2.18.4-2.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.18.4-2.el8_2",
                 },
               },
@@ -3662,7 +3662,7 @@ Object {
                 "id": "glib2@2.56.4-8.el8",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.4-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/glib2@2.56.4-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.56.4-8.el8",
                 },
               },
@@ -3670,7 +3670,7 @@ Object {
                 "id": "glibc@2.28-101.el8",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/glibc@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3678,7 +3678,7 @@ Object {
                 "id": "glibc-common@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/glibc-common@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3686,7 +3686,7 @@ Object {
                 "id": "glibc-devel@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-devel",
-                  "purl": "pkg:rpm/glibc-devel@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/glibc-devel@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3694,7 +3694,7 @@ Object {
                 "id": "glibc-headers@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-headers",
-                  "purl": "pkg:rpm/glibc-headers@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/glibc-headers@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3702,7 +3702,7 @@ Object {
                 "id": "glibc-langpack-en@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/glibc-langpack-en@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/glibc-langpack-en@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3710,7 +3710,7 @@ Object {
                 "id": "glibc-locale-source@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-locale-source",
-                  "purl": "pkg:rpm/glibc-locale-source@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/glibc-locale-source@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3718,7 +3718,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/glibc-minimal-langpack@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -3726,7 +3726,7 @@ Object {
                 "id": "gmp@1:6.1.2-10.el8",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.1.2-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gmp@1:6.1.2-10.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:6.1.2-10.el8",
                 },
               },
@@ -3734,7 +3734,7 @@ Object {
                 "id": "gnupg2@2.2.9-1.el8",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gnupg2@2.2.9-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.9-1.el8",
                 },
               },
@@ -3742,7 +3742,7 @@ Object {
                 "id": "gnutls@3.6.8-11.el8_2",
                 "info": Object {
                   "name": "gnutls",
-                  "purl": "pkg:rpm/gnutls@3.6.8-11.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gnutls@3.6.8-11.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.6.8-11.el8_2",
                 },
               },
@@ -3750,7 +3750,7 @@ Object {
                 "id": "go-srpm-macros@2-16.el8",
                 "info": Object {
                   "name": "go-srpm-macros",
-                  "purl": "pkg:rpm/go-srpm-macros@2-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/go-srpm-macros@2-16.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2-16.el8",
                 },
               },
@@ -3758,7 +3758,7 @@ Object {
                 "id": "gobject-introspection@1.56.1-1.el8",
                 "info": Object {
                   "name": "gobject-introspection",
-                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gobject-introspection@1.56.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.56.1-1.el8",
                 },
               },
@@ -3766,7 +3766,7 @@ Object {
                 "id": "gpg-pubkey@fd431d51-4ae0493b",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@fd431d51-4ae0493b?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "fd431d51-4ae0493b",
                 },
               },
@@ -3774,7 +3774,7 @@ Object {
                 "id": "gpgme@1.10.0-6.el8",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gpgme@1.10.0-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.10.0-6.el8",
                 },
               },
@@ -3782,7 +3782,7 @@ Object {
                 "id": "grep@3.1-6.el8",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@3.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/grep@3.1-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1-6.el8",
                 },
               },
@@ -3790,7 +3790,7 @@ Object {
                 "id": "groff-base@1.22.3-18.el8",
                 "info": Object {
                   "name": "groff-base",
-                  "purl": "pkg:rpm/groff-base@1.22.3-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/groff-base@1.22.3-18.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.22.3-18.el8",
                 },
               },
@@ -3798,7 +3798,7 @@ Object {
                 "id": "guile@5:2.0.14-7.el8",
                 "info": Object {
                   "name": "guile",
-                  "purl": "pkg:rpm/guile@5:2.0.14-7.el8?epoch=5&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/guile@5:2.0.14-7.el8?distro=rhel-8.2&epoch=5&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5:2.0.14-7.el8",
                 },
               },
@@ -3806,7 +3806,7 @@ Object {
                 "id": "gzip@1.9-9.el8",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.9-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/gzip@1.9-9.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.9-9.el8",
                 },
               },
@@ -3814,7 +3814,7 @@ Object {
                 "id": "ima-evm-utils@1.1-5.el8",
                 "info": Object {
                   "name": "ima-evm-utils",
-                  "purl": "pkg:rpm/ima-evm-utils@1.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/ima-evm-utils@1.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1-5.el8",
                 },
               },
@@ -3822,7 +3822,7 @@ Object {
                 "id": "info@6.5-6.el8",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@6.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/info@6.5-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.5-6.el8",
                 },
               },
@@ -3830,7 +3830,7 @@ Object {
                 "id": "iptables-libs@1.8.4-10.el8",
                 "info": Object {
                   "name": "iptables-libs",
-                  "purl": "pkg:rpm/iptables-libs@1.8.4-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/iptables-libs@1.8.4-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.4-10.el8",
                 },
               },
@@ -3838,7 +3838,7 @@ Object {
                 "id": "isl@0.16.1-6.el8",
                 "info": Object {
                   "name": "isl",
-                  "purl": "pkg:rpm/isl@0.16.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/isl@0.16.1-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.16.1-6.el8",
                 },
               },
@@ -3846,7 +3846,7 @@ Object {
                 "id": "jbigkit-libs@2.1-14.el8",
                 "info": Object {
                   "name": "jbigkit-libs",
-                  "purl": "pkg:rpm/jbigkit-libs@2.1-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/jbigkit-libs@2.1-14.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.1-14.el8",
                 },
               },
@@ -3854,7 +3854,7 @@ Object {
                 "id": "json-c@0.13.1-0.2.el8",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.13.1-0.2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/json-c@0.13.1-0.2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.13.1-0.2.el8",
                 },
               },
@@ -3862,7 +3862,7 @@ Object {
                 "id": "json-glib@1.4.4-1.el8",
                 "info": Object {
                   "name": "json-glib",
-                  "purl": "pkg:rpm/json-glib@1.4.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/json-glib@1.4.4-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.4-1.el8",
                 },
               },
@@ -3870,7 +3870,7 @@ Object {
                 "id": "kernel-headers@4.18.0-193.6.3.el8_2",
                 "info": Object {
                   "name": "kernel-headers",
-                  "purl": "pkg:rpm/kernel-headers@4.18.0-193.6.3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/kernel-headers@4.18.0-193.6.3.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.18.0-193.6.3.el8_2",
                 },
               },
@@ -3878,7 +3878,7 @@ Object {
                 "id": "keyutils-libs@1.5.10-6.el8",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/keyutils-libs@1.5.10-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.10-6.el8",
                 },
               },
@@ -3886,7 +3886,7 @@ Object {
                 "id": "keyutils-libs-devel@1.5.10-6.el8",
                 "info": Object {
                   "name": "keyutils-libs-devel",
-                  "purl": "pkg:rpm/keyutils-libs-devel@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/keyutils-libs-devel@1.5.10-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.10-6.el8",
                 },
               },
@@ -3894,7 +3894,7 @@ Object {
                 "id": "kmod-libs@25-16.el8",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/kmod-libs@25-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/kmod-libs@25-16.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "25-16.el8",
                 },
               },
@@ -3902,7 +3902,7 @@ Object {
                 "id": "krb5-devel@1.17-18.el8",
                 "info": Object {
                   "name": "krb5-devel",
-                  "purl": "pkg:rpm/krb5-devel@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/krb5-devel@1.17-18.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-18.el8",
                 },
               },
@@ -3910,7 +3910,7 @@ Object {
                 "id": "krb5-libs@1.17-18.el8",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/krb5-libs@1.17-18.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-18.el8",
                 },
               },
@@ -3918,7 +3918,7 @@ Object {
                 "id": "langpacks-en@1.0-12.el8",
                 "info": Object {
                   "name": "langpacks-en",
-                  "purl": "pkg:rpm/langpacks-en@1.0-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/langpacks-en@1.0-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0-12.el8",
                 },
               },
@@ -3926,7 +3926,7 @@ Object {
                 "id": "less@530-1.el8",
                 "info": Object {
                   "name": "less",
-                  "purl": "pkg:rpm/less@530-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/less@530-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "530-1.el8",
                 },
               },
@@ -3934,7 +3934,7 @@ Object {
                 "id": "libICE@1.0.9-15.el8",
                 "info": Object {
                   "name": "libICE",
-                  "purl": "pkg:rpm/libICE@1.0.9-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libICE@1.0.9-15.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.9-15.el8",
                 },
               },
@@ -3942,7 +3942,7 @@ Object {
                 "id": "libSM@1.2.3-1.el8",
                 "info": Object {
                   "name": "libSM",
-                  "purl": "pkg:rpm/libSM@1.2.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libSM@1.2.3-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.3-1.el8",
                 },
               },
@@ -3950,7 +3950,7 @@ Object {
                 "id": "libX11@1.6.8-3.el8",
                 "info": Object {
                   "name": "libX11",
-                  "purl": "pkg:rpm/libX11@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libX11@1.6.8-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.8-3.el8",
                 },
               },
@@ -3958,7 +3958,7 @@ Object {
                 "id": "libX11-common@1.6.8-3.el8",
                 "info": Object {
                   "name": "libX11-common",
-                  "purl": "pkg:rpm/libX11-common@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libX11-common@1.6.8-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.8-3.el8",
                 },
               },
@@ -3966,7 +3966,7 @@ Object {
                 "id": "libX11-devel@1.6.8-3.el8",
                 "info": Object {
                   "name": "libX11-devel",
-                  "purl": "pkg:rpm/libX11-devel@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libX11-devel@1.6.8-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.8-3.el8",
                 },
               },
@@ -3974,7 +3974,7 @@ Object {
                 "id": "libX11-xcb@1.6.8-3.el8",
                 "info": Object {
                   "name": "libX11-xcb",
-                  "purl": "pkg:rpm/libX11-xcb@1.6.8-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libX11-xcb@1.6.8-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.8-3.el8",
                 },
               },
@@ -3982,7 +3982,7 @@ Object {
                 "id": "libXau@1.0.8-13.el8",
                 "info": Object {
                   "name": "libXau",
-                  "purl": "pkg:rpm/libXau@1.0.8-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libXau@1.0.8-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.8-13.el8",
                 },
               },
@@ -3990,7 +3990,7 @@ Object {
                 "id": "libXau-devel@1.0.8-13.el8",
                 "info": Object {
                   "name": "libXau-devel",
-                  "purl": "pkg:rpm/libXau-devel@1.0.8-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libXau-devel@1.0.8-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.8-13.el8",
                 },
               },
@@ -3998,7 +3998,7 @@ Object {
                 "id": "libXext@1.3.3-9.el8",
                 "info": Object {
                   "name": "libXext",
-                  "purl": "pkg:rpm/libXext@1.3.3-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libXext@1.3.3-9.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.3.3-9.el8",
                 },
               },
@@ -4006,7 +4006,7 @@ Object {
                 "id": "libXpm@3.5.12-8.el8",
                 "info": Object {
                   "name": "libXpm",
-                  "purl": "pkg:rpm/libXpm@3.5.12-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libXpm@3.5.12-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.5.12-8.el8",
                 },
               },
@@ -4014,7 +4014,7 @@ Object {
                 "id": "libXpm-devel@3.5.12-8.el8",
                 "info": Object {
                   "name": "libXpm-devel",
-                  "purl": "pkg:rpm/libXpm-devel@3.5.12-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libXpm-devel@3.5.12-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.5.12-8.el8",
                 },
               },
@@ -4022,7 +4022,7 @@ Object {
                 "id": "libXt@1.1.5-12.el8",
                 "info": Object {
                   "name": "libXt",
-                  "purl": "pkg:rpm/libXt@1.1.5-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libXt@1.1.5-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.5-12.el8",
                 },
               },
@@ -4030,7 +4030,7 @@ Object {
                 "id": "libacl@2.2.53-1.el8",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libacl@2.2.53-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -4038,7 +4038,7 @@ Object {
                 "id": "libarchive@3.3.2-8.el8_1",
                 "info": Object {
                   "name": "libarchive",
-                  "purl": "pkg:rpm/libarchive@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libarchive@3.3.2-8.el8_1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.3.2-8.el8_1",
                 },
               },
@@ -4046,7 +4046,7 @@ Object {
                 "id": "libassuan@2.5.1-3.el8",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.5.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libassuan@2.5.1-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.5.1-3.el8",
                 },
               },
@@ -4054,7 +4054,7 @@ Object {
                 "id": "libatomic_ops@7.6.2-3.el8",
                 "info": Object {
                   "name": "libatomic_ops",
-                  "purl": "pkg:rpm/libatomic_ops@7.6.2-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libatomic_ops@7.6.2-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.6.2-3.el8",
                 },
               },
@@ -4062,7 +4062,7 @@ Object {
                 "id": "libattr@2.4.48-3.el8",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.48-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libattr@2.4.48-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.4.48-3.el8",
                 },
               },
@@ -4070,7 +4070,7 @@ Object {
                 "id": "libbabeltrace@1.5.4-2.el8",
                 "info": Object {
                   "name": "libbabeltrace",
-                  "purl": "pkg:rpm/libbabeltrace@1.5.4-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libbabeltrace@1.5.4-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.4-2.el8",
                 },
               },
@@ -4078,7 +4078,7 @@ Object {
                 "id": "libblkid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libblkid@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4086,7 +4086,7 @@ Object {
                 "id": "libcap@2.26-3.el8",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.26-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libcap@2.26-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.26-3.el8",
                 },
               },
@@ -4094,7 +4094,7 @@ Object {
                 "id": "libcap-ng@0.7.9-5.el8",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.7.9-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libcap-ng@0.7.9-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.7.9-5.el8",
                 },
               },
@@ -4102,7 +4102,7 @@ Object {
                 "id": "libcom_err@1.45.4-3.el8",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libcom_err@1.45.4-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.45.4-3.el8",
                 },
               },
@@ -4110,7 +4110,7 @@ Object {
                 "id": "libcom_err-devel@1.45.4-3.el8",
                 "info": Object {
                   "name": "libcom_err-devel",
-                  "purl": "pkg:rpm/libcom_err-devel@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libcom_err-devel@1.45.4-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.45.4-3.el8",
                 },
               },
@@ -4118,7 +4118,7 @@ Object {
                 "id": "libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "libcomps",
-                  "purl": "pkg:rpm/libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libcomps@0.1.11-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -4126,7 +4126,7 @@ Object {
                 "id": "libcroco@0.6.12-4.el8",
                 "info": Object {
                   "name": "libcroco",
-                  "purl": "pkg:rpm/libcroco@0.6.12-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libcroco@0.6.12-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.6.12-4.el8",
                 },
               },
@@ -4134,7 +4134,7 @@ Object {
                 "id": "libcurl@7.61.1-12.el8",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libcurl@7.61.1-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -4142,7 +4142,7 @@ Object {
                 "id": "libcurl-devel@7.61.1-12.el8",
                 "info": Object {
                   "name": "libcurl-devel",
-                  "purl": "pkg:rpm/libcurl-devel@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libcurl-devel@7.61.1-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -4150,7 +4150,7 @@ Object {
                 "id": "libdb@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libdb@5.3.28-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -4158,7 +4158,7 @@ Object {
                 "id": "libdb-utils@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libdb-utils@5.3.28-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -4166,7 +4166,7 @@ Object {
                 "id": "libdnf@0.39.1-5.el8",
                 "info": Object {
                   "name": "libdnf",
-                  "purl": "pkg:rpm/libdnf@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libdnf@0.39.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.39.1-5.el8",
                 },
               },
@@ -4174,7 +4174,7 @@ Object {
                 "id": "libedit@3.1-23.20170329cvs.el8",
                 "info": Object {
                   "name": "libedit",
-                  "purl": "pkg:rpm/libedit@3.1-23.20170329cvs.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libedit@3.1-23.20170329cvs.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1-23.20170329cvs.el8",
                 },
               },
@@ -4182,7 +4182,7 @@ Object {
                 "id": "libfdisk@2.32.1-22.el8",
                 "info": Object {
                   "name": "libfdisk",
-                  "purl": "pkg:rpm/libfdisk@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libfdisk@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4190,7 +4190,7 @@ Object {
                 "id": "libffi@3.1-21.el8",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.1-21.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libffi@3.1-21.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1-21.el8",
                 },
               },
@@ -4198,7 +4198,7 @@ Object {
                 "id": "libgcc@8.3.1-5.el8",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libgcc@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -4206,7 +4206,7 @@ Object {
                 "id": "libgcrypt@1.8.3-4.el8",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libgcrypt@1.8.3-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.3-4.el8",
                 },
               },
@@ -4214,7 +4214,7 @@ Object {
                 "id": "libgcrypt-devel@1.8.3-4.el8",
                 "info": Object {
                   "name": "libgcrypt-devel",
-                  "purl": "pkg:rpm/libgcrypt-devel@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libgcrypt-devel@1.8.3-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.3-4.el8",
                 },
               },
@@ -4222,7 +4222,7 @@ Object {
                 "id": "libgomp@8.3.1-5.el8",
                 "info": Object {
                   "name": "libgomp",
-                  "purl": "pkg:rpm/libgomp@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libgomp@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -4230,7 +4230,7 @@ Object {
                 "id": "libgpg-error@1.31-1.el8",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libgpg-error@1.31-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.31-1.el8",
                 },
               },
@@ -4238,7 +4238,7 @@ Object {
                 "id": "libgpg-error-devel@1.31-1.el8",
                 "info": Object {
                   "name": "libgpg-error-devel",
-                  "purl": "pkg:rpm/libgpg-error-devel@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libgpg-error-devel@1.31-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.31-1.el8",
                 },
               },
@@ -4246,7 +4246,7 @@ Object {
                 "id": "libidn2@2.2.0-1.el8",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.2.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libidn2@2.2.0-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.2.0-1.el8",
                 },
               },
@@ -4254,7 +4254,7 @@ Object {
                 "id": "libipt@1.6.1-8.el8",
                 "info": Object {
                   "name": "libipt",
-                  "purl": "pkg:rpm/libipt@1.6.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libipt@1.6.1-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.6.1-8.el8",
                 },
               },
@@ -4262,7 +4262,7 @@ Object {
                 "id": "libjpeg-turbo@1.5.3-10.el8",
                 "info": Object {
                   "name": "libjpeg-turbo",
-                  "purl": "pkg:rpm/libjpeg-turbo@1.5.3-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libjpeg-turbo@1.5.3-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.3-10.el8",
                 },
               },
@@ -4270,7 +4270,7 @@ Object {
                 "id": "libjpeg-turbo-devel@1.5.3-10.el8",
                 "info": Object {
                   "name": "libjpeg-turbo-devel",
-                  "purl": "pkg:rpm/libjpeg-turbo-devel@1.5.3-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libjpeg-turbo-devel@1.5.3-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.3-10.el8",
                 },
               },
@@ -4278,7 +4278,7 @@ Object {
                 "id": "libkadm5@1.17-18.el8",
                 "info": Object {
                   "name": "libkadm5",
-                  "purl": "pkg:rpm/libkadm5@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libkadm5@1.17-18.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-18.el8",
                 },
               },
@@ -4286,7 +4286,7 @@ Object {
                 "id": "libksba@1.3.5-7.el8",
                 "info": Object {
                   "name": "libksba",
-                  "purl": "pkg:rpm/libksba@1.3.5-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libksba@1.3.5-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.3.5-7.el8",
                 },
               },
@@ -4294,7 +4294,7 @@ Object {
                 "id": "libmetalink@0.1.3-7.el8",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libmetalink@0.1.3-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.1.3-7.el8",
                 },
               },
@@ -4302,7 +4302,7 @@ Object {
                 "id": "libmodulemd1@1.8.16-0.2.8.2.1",
                 "info": Object {
                   "name": "libmodulemd1",
-                  "purl": "pkg:rpm/libmodulemd1@1.8.16-0.2.8.2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libmodulemd1@1.8.16-0.2.8.2.1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.16-0.2.8.2.1",
                 },
               },
@@ -4310,7 +4310,7 @@ Object {
                 "id": "libmount@2.32.1-22.el8",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libmount@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4318,7 +4318,7 @@ Object {
                 "id": "libmpc@1.0.2-9.el8",
                 "info": Object {
                   "name": "libmpc",
-                  "purl": "pkg:rpm/libmpc@1.0.2-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libmpc@1.0.2-9.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.2-9.el8",
                 },
               },
@@ -4326,7 +4326,7 @@ Object {
                 "id": "libnghttp2@1.33.0-3.el8_2.1",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.33.0-3.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libnghttp2@1.33.0-3.el8_2.1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.33.0-3.el8_2.1",
                 },
               },
@@ -4334,7 +4334,7 @@ Object {
                 "id": "libnl3@3.5.0-1.el8",
                 "info": Object {
                   "name": "libnl3",
-                  "purl": "pkg:rpm/libnl3@3.5.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libnl3@3.5.0-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.5.0-1.el8",
                 },
               },
@@ -4342,7 +4342,7 @@ Object {
                 "id": "libnsl2@1.2.0-2.20180605git4a062cf.el8",
                 "info": Object {
                   "name": "libnsl2",
-                  "purl": "pkg:rpm/libnsl2@1.2.0-2.20180605git4a062cf.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libnsl2@1.2.0-2.20180605git4a062cf.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.0-2.20180605git4a062cf.el8",
                 },
               },
@@ -4350,7 +4350,7 @@ Object {
                 "id": "libpcap@14:1.9.0-3.el8",
                 "info": Object {
                   "name": "libpcap",
-                  "purl": "pkg:rpm/libpcap@14:1.9.0-3.el8?epoch=14&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpcap@14:1.9.0-3.el8?distro=rhel-8.2&epoch=14&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "14:1.9.0-3.el8",
                 },
               },
@@ -4358,7 +4358,7 @@ Object {
                 "id": "libpipeline@1.5.0-2.el8",
                 "info": Object {
                   "name": "libpipeline",
-                  "purl": "pkg:rpm/libpipeline@1.5.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpipeline@1.5.0-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5.0-2.el8",
                 },
               },
@@ -4366,7 +4366,7 @@ Object {
                 "id": "libpkgconf@1.4.2-1.el8",
                 "info": Object {
                   "name": "libpkgconf",
-                  "purl": "pkg:rpm/libpkgconf@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpkgconf@1.4.2-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-1.el8",
                 },
               },
@@ -4374,7 +4374,7 @@ Object {
                 "id": "libpng@2:1.6.34-5.el8",
                 "info": Object {
                   "name": "libpng",
-                  "purl": "pkg:rpm/libpng@2:1.6.34-5.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpng@2:1.6.34-5.el8?distro=rhel-8.2&epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:1.6.34-5.el8",
                 },
               },
@@ -4382,7 +4382,7 @@ Object {
                 "id": "libpng-devel@2:1.6.34-5.el8",
                 "info": Object {
                   "name": "libpng-devel",
-                  "purl": "pkg:rpm/libpng-devel@2:1.6.34-5.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpng-devel@2:1.6.34-5.el8?distro=rhel-8.2&epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:1.6.34-5.el8",
                 },
               },
@@ -4390,7 +4390,7 @@ Object {
                 "id": "libpq@12.1-3.el8",
                 "info": Object {
                   "name": "libpq",
-                  "purl": "pkg:rpm/libpq@12.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpq@12.1-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "12.1-3.el8",
                 },
               },
@@ -4398,7 +4398,7 @@ Object {
                 "id": "libpq-devel@12.1-3.el8",
                 "info": Object {
                   "name": "libpq-devel",
-                  "purl": "pkg:rpm/libpq-devel@12.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpq-devel@12.1-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "12.1-3.el8",
                 },
               },
@@ -4406,7 +4406,7 @@ Object {
                 "id": "libpsl@0.20.2-5.el8",
                 "info": Object {
                   "name": "libpsl",
-                  "purl": "pkg:rpm/libpsl@0.20.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpsl@0.20.2-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.20.2-5.el8",
                 },
               },
@@ -4414,7 +4414,7 @@ Object {
                 "id": "libpwquality@1.4.0-9.el8",
                 "info": Object {
                   "name": "libpwquality",
-                  "purl": "pkg:rpm/libpwquality@1.4.0-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libpwquality@1.4.0-9.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.0-9.el8",
                 },
               },
@@ -4422,7 +4422,7 @@ Object {
                 "id": "librepo@1.11.0-2.el8",
                 "info": Object {
                   "name": "librepo",
-                  "purl": "pkg:rpm/librepo@1.11.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/librepo@1.11.0-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.11.0-2.el8",
                 },
               },
@@ -4430,7 +4430,7 @@ Object {
                 "id": "libreport-filesystem@2.9.5-10.el8",
                 "info": Object {
                   "name": "libreport-filesystem",
-                  "purl": "pkg:rpm/libreport-filesystem@2.9.5-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libreport-filesystem@2.9.5-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.5-10.el8",
                 },
               },
@@ -4438,7 +4438,7 @@ Object {
                 "id": "librhsm@0.0.3-3.el8",
                 "info": Object {
                   "name": "librhsm",
-                  "purl": "pkg:rpm/librhsm@0.0.3-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/librhsm@0.0.3-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.0.3-3.el8",
                 },
               },
@@ -4446,7 +4446,7 @@ Object {
                 "id": "libseccomp@2.4.1-1.el8",
                 "info": Object {
                   "name": "libseccomp",
-                  "purl": "pkg:rpm/libseccomp@2.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libseccomp@2.4.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.4.1-1.el8",
                 },
               },
@@ -4454,7 +4454,7 @@ Object {
                 "id": "libsecret@0.18.6-1.el8",
                 "info": Object {
                   "name": "libsecret",
-                  "purl": "pkg:rpm/libsecret@0.18.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libsecret@0.18.6-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.18.6-1.el8",
                 },
               },
@@ -4462,7 +4462,7 @@ Object {
                 "id": "libselinux@2.9-3.el8",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libselinux@2.9-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-3.el8",
                 },
               },
@@ -4470,7 +4470,7 @@ Object {
                 "id": "libselinux-devel@2.9-3.el8",
                 "info": Object {
                   "name": "libselinux-devel",
-                  "purl": "pkg:rpm/libselinux-devel@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libselinux-devel@2.9-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-3.el8",
                 },
               },
@@ -4478,7 +4478,7 @@ Object {
                 "id": "libsemanage@2.9-2.el8",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.9-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libsemanage@2.9-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-2.el8",
                 },
               },
@@ -4486,7 +4486,7 @@ Object {
                 "id": "libsepol@2.9-1.el8",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libsepol@2.9-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-1.el8",
                 },
               },
@@ -4494,7 +4494,7 @@ Object {
                 "id": "libsepol-devel@2.9-1.el8",
                 "info": Object {
                   "name": "libsepol-devel",
-                  "purl": "pkg:rpm/libsepol-devel@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libsepol-devel@2.9-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9-1.el8",
                 },
               },
@@ -4502,7 +4502,7 @@ Object {
                 "id": "libsigsegv@2.11-5.el8",
                 "info": Object {
                   "name": "libsigsegv",
-                  "purl": "pkg:rpm/libsigsegv@2.11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libsigsegv@2.11-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.11-5.el8",
                 },
               },
@@ -4510,7 +4510,7 @@ Object {
                 "id": "libsmartcols@2.32.1-22.el8",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libsmartcols@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4518,7 +4518,7 @@ Object {
                 "id": "libsolv@0.7.7-1.el8",
                 "info": Object {
                   "name": "libsolv",
-                  "purl": "pkg:rpm/libsolv@0.7.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libsolv@0.7.7-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.7.7-1.el8",
                 },
               },
@@ -4526,7 +4526,7 @@ Object {
                 "id": "libssh@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh",
-                  "purl": "pkg:rpm/libssh@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libssh@0.9.0-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -4534,7 +4534,7 @@ Object {
                 "id": "libssh-config@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh-config",
-                  "purl": "pkg:rpm/libssh-config@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libssh-config@0.9.0-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -4542,7 +4542,7 @@ Object {
                 "id": "libstdc++@8.3.1-5.el8",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libstdc%2B%2B@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -4550,7 +4550,7 @@ Object {
                 "id": "libstdc++-devel@8.3.1-5.el8",
                 "info": Object {
                   "name": "libstdc++-devel",
-                  "purl": "pkg:rpm/libstdc%2B%2B-devel@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libstdc%2B%2B-devel@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -4558,7 +4558,7 @@ Object {
                 "id": "libtasn1@4.13-3.el8",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.13-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libtasn1@4.13-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.13-3.el8",
                 },
               },
@@ -4566,7 +4566,7 @@ Object {
                 "id": "libtiff@4.0.9-17.el8",
                 "info": Object {
                   "name": "libtiff",
-                  "purl": "pkg:rpm/libtiff@4.0.9-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libtiff@4.0.9-17.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.0.9-17.el8",
                 },
               },
@@ -4574,7 +4574,7 @@ Object {
                 "id": "libtiff-devel@4.0.9-17.el8",
                 "info": Object {
                   "name": "libtiff-devel",
-                  "purl": "pkg:rpm/libtiff-devel@4.0.9-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libtiff-devel@4.0.9-17.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.0.9-17.el8",
                 },
               },
@@ -4582,7 +4582,7 @@ Object {
                 "id": "libtirpc@1.1.4-4.el8",
                 "info": Object {
                   "name": "libtirpc",
-                  "purl": "pkg:rpm/libtirpc@1.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libtirpc@1.1.4-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.4-4.el8",
                 },
               },
@@ -4590,7 +4590,7 @@ Object {
                 "id": "libtool-ltdl@2.4.6-25.el8",
                 "info": Object {
                   "name": "libtool-ltdl",
-                  "purl": "pkg:rpm/libtool-ltdl@2.4.6-25.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libtool-ltdl@2.4.6-25.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.4.6-25.el8",
                 },
               },
@@ -4598,7 +4598,7 @@ Object {
                 "id": "libunistring@0.9.9-3.el8",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libunistring@0.9.9-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.9.9-3.el8",
                 },
               },
@@ -4606,7 +4606,7 @@ Object {
                 "id": "libusbx@1.0.22-1.el8",
                 "info": Object {
                   "name": "libusbx",
-                  "purl": "pkg:rpm/libusbx@1.0.22-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libusbx@1.0.22-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.22-1.el8",
                 },
               },
@@ -4614,7 +4614,7 @@ Object {
                 "id": "libuser@0.62-23.el8",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.62-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libuser@0.62-23.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.62-23.el8",
                 },
               },
@@ -4622,7 +4622,7 @@ Object {
                 "id": "libutempter@1.1.6-14.el8",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.6-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libutempter@1.1.6-14.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.6-14.el8",
                 },
               },
@@ -4630,7 +4630,7 @@ Object {
                 "id": "libuuid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libuuid@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4638,7 +4638,7 @@ Object {
                 "id": "libuuid-devel@2.32.1-22.el8",
                 "info": Object {
                   "name": "libuuid-devel",
-                  "purl": "pkg:rpm/libuuid-devel@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libuuid-devel@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -4646,7 +4646,7 @@ Object {
                 "id": "libuv@1:1.23.1-1.el8",
                 "info": Object {
                   "name": "libuv",
-                  "purl": "pkg:rpm/libuv@1:1.23.1-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libuv@1:1.23.1-1.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.23.1-1.el8",
                 },
               },
@@ -4654,7 +4654,7 @@ Object {
                 "id": "libverto@0.3.0-5.el8",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libverto@0.3.0-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.3.0-5.el8",
                 },
               },
@@ -4662,7 +4662,7 @@ Object {
                 "id": "libverto-devel@0.3.0-5.el8",
                 "info": Object {
                   "name": "libverto-devel",
-                  "purl": "pkg:rpm/libverto-devel@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libverto-devel@0.3.0-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.3.0-5.el8",
                 },
               },
@@ -4670,7 +4670,7 @@ Object {
                 "id": "libwebp@1.0.0-1.el8",
                 "info": Object {
                   "name": "libwebp",
-                  "purl": "pkg:rpm/libwebp@1.0.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libwebp@1.0.0-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.0-1.el8",
                 },
               },
@@ -4678,7 +4678,7 @@ Object {
                 "id": "libwebp-devel@1.0.0-1.el8",
                 "info": Object {
                   "name": "libwebp-devel",
-                  "purl": "pkg:rpm/libwebp-devel@1.0.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libwebp-devel@1.0.0-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.0.0-1.el8",
                 },
               },
@@ -4686,7 +4686,7 @@ Object {
                 "id": "libxcb@1.13.1-1.el8",
                 "info": Object {
                   "name": "libxcb",
-                  "purl": "pkg:rpm/libxcb@1.13.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libxcb@1.13.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.13.1-1.el8",
                 },
               },
@@ -4694,7 +4694,7 @@ Object {
                 "id": "libxcb-devel@1.13.1-1.el8",
                 "info": Object {
                   "name": "libxcb-devel",
-                  "purl": "pkg:rpm/libxcb-devel@1.13.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libxcb-devel@1.13.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.13.1-1.el8",
                 },
               },
@@ -4702,7 +4702,7 @@ Object {
                 "id": "libxcrypt@4.1.1-4.el8",
                 "info": Object {
                   "name": "libxcrypt",
-                  "purl": "pkg:rpm/libxcrypt@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libxcrypt@4.1.1-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.1.1-4.el8",
                 },
               },
@@ -4710,7 +4710,7 @@ Object {
                 "id": "libxcrypt-devel@4.1.1-4.el8",
                 "info": Object {
                   "name": "libxcrypt-devel",
-                  "purl": "pkg:rpm/libxcrypt-devel@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libxcrypt-devel@4.1.1-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.1.1-4.el8",
                 },
               },
@@ -4718,7 +4718,7 @@ Object {
                 "id": "libxml2@2.9.7-7.el8",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libxml2@2.9.7-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -4726,7 +4726,7 @@ Object {
                 "id": "libxml2-devel@2.9.7-7.el8",
                 "info": Object {
                   "name": "libxml2-devel",
-                  "purl": "pkg:rpm/libxml2-devel@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libxml2-devel@2.9.7-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -4734,7 +4734,7 @@ Object {
                 "id": "libxslt@1.1.32-4.el8",
                 "info": Object {
                   "name": "libxslt",
-                  "purl": "pkg:rpm/libxslt@1.1.32-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libxslt@1.1.32-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.32-4.el8",
                 },
               },
@@ -4742,7 +4742,7 @@ Object {
                 "id": "libxslt-devel@1.1.32-4.el8",
                 "info": Object {
                   "name": "libxslt-devel",
-                  "purl": "pkg:rpm/libxslt-devel@1.1.32-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libxslt-devel@1.1.32-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.32-4.el8",
                 },
               },
@@ -4750,7 +4750,7 @@ Object {
                 "id": "libyaml@0.1.7-5.el8",
                 "info": Object {
                   "name": "libyaml",
-                  "purl": "pkg:rpm/libyaml@0.1.7-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libyaml@0.1.7-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.1.7-5.el8",
                 },
               },
@@ -4758,7 +4758,7 @@ Object {
                 "id": "libzstd@1.4.2-2.el8",
                 "info": Object {
                   "name": "libzstd",
-                  "purl": "pkg:rpm/libzstd@1.4.2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/libzstd@1.4.2-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-2.el8",
                 },
               },
@@ -4766,7 +4766,7 @@ Object {
                 "id": "lsof@4.91-2.el8",
                 "info": Object {
                   "name": "lsof",
-                  "purl": "pkg:rpm/lsof@4.91-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/lsof@4.91-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.91-2.el8",
                 },
               },
@@ -4774,7 +4774,7 @@ Object {
                 "id": "lua-libs@5.3.4-11.el8",
                 "info": Object {
                   "name": "lua-libs",
-                  "purl": "pkg:rpm/lua-libs@5.3.4-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/lua-libs@5.3.4-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.3.4-11.el8",
                 },
               },
@@ -4782,7 +4782,7 @@ Object {
                 "id": "lz4-libs@1.8.1.2-4.el8",
                 "info": Object {
                   "name": "lz4-libs",
-                  "purl": "pkg:rpm/lz4-libs@1.8.1.2-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/lz4-libs@1.8.1.2-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.8.1.2-4.el8",
                 },
               },
@@ -4790,7 +4790,7 @@ Object {
                 "id": "m4@1.4.18-7.el8",
                 "info": Object {
                   "name": "m4",
-                  "purl": "pkg:rpm/m4@1.4.18-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/m4@1.4.18-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.18-7.el8",
                 },
               },
@@ -4798,7 +4798,7 @@ Object {
                 "id": "make@1:4.2.1-10.el8",
                 "info": Object {
                   "name": "make",
-                  "purl": "pkg:rpm/make@1:4.2.1-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/make@1:4.2.1-10.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:4.2.1-10.el8",
                 },
               },
@@ -4806,7 +4806,7 @@ Object {
                 "id": "man-db@2.7.6.1-17.el8",
                 "info": Object {
                   "name": "man-db",
-                  "purl": "pkg:rpm/man-db@2.7.6.1-17.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/man-db@2.7.6.1-17.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.7.6.1-17.el8",
                 },
               },
@@ -4814,7 +4814,7 @@ Object {
                 "id": "mariadb-connector-c@3.0.7-1.el8",
                 "info": Object {
                   "name": "mariadb-connector-c",
-                  "purl": "pkg:rpm/mariadb-connector-c@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/mariadb-connector-c@3.0.7-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0.7-1.el8",
                 },
               },
@@ -4822,7 +4822,7 @@ Object {
                 "id": "mariadb-connector-c-config@3.0.7-1.el8",
                 "info": Object {
                   "name": "mariadb-connector-c-config",
-                  "purl": "pkg:rpm/mariadb-connector-c-config@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/mariadb-connector-c-config@3.0.7-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0.7-1.el8",
                 },
               },
@@ -4830,7 +4830,7 @@ Object {
                 "id": "mariadb-connector-c-devel@3.0.7-1.el8",
                 "info": Object {
                   "name": "mariadb-connector-c-devel",
-                  "purl": "pkg:rpm/mariadb-connector-c-devel@3.0.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/mariadb-connector-c-devel@3.0.7-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0.7-1.el8",
                 },
               },
@@ -4838,7 +4838,7 @@ Object {
                 "id": "mpfr@3.1.6-1.el8",
                 "info": Object {
                   "name": "mpfr",
-                  "purl": "pkg:rpm/mpfr@3.1.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/mpfr@3.1.6-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1.6-1.el8",
                 },
               },
@@ -4846,7 +4846,7 @@ Object {
                 "id": "ncurses@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/ncurses@6.1-7.20180224.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -4854,7 +4854,7 @@ Object {
                 "id": "ncurses-base@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/ncurses-base@6.1-7.20180224.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -4862,7 +4862,7 @@ Object {
                 "id": "ncurses-libs@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/ncurses-libs@6.1-7.20180224.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -4870,7 +4870,7 @@ Object {
                 "id": "nettle@3.4.1-1.el8",
                 "info": Object {
                   "name": "nettle",
-                  "purl": "pkg:rpm/nettle@3.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/nettle@3.4.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.4.1-1.el8",
                 },
               },
@@ -4878,7 +4878,7 @@ Object {
                 "id": "nodejs@1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 "info": Object {
                   "name": "nodejs",
-                  "purl": "pkg:rpm/nodejs@1:10.21.0-3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/nodejs@1:10.21.0-3.module%2Bel8.2.0%2B7071%2Bd2377ea3?distro=rhel-8.2&epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 },
               },
@@ -4886,7 +4886,7 @@ Object {
                 "id": "nodejs-full-i18n@1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 "info": Object {
                   "name": "nodejs-full-i18n",
-                  "purl": "pkg:rpm/nodejs-full-i18n@1:10.21.0-3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/nodejs-full-i18n@1:10.21.0-3.module%2Bel8.2.0%2B7071%2Bd2377ea3?distro=rhel-8.2&epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 },
               },
@@ -4894,7 +4894,7 @@ Object {
                 "id": "nodejs-nodemon@1.18.3-1.module+el8+2632+6c5111ed",
                 "info": Object {
                   "name": "nodejs-nodemon",
-                  "purl": "pkg:rpm/nodejs-nodemon@1.18.3-1.module%2Bel8%2B2632%2B6c5111ed?module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/nodejs-nodemon@1.18.3-1.module%2Bel8%2B2632%2B6c5111ed?distro=rhel-8.2&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.18.3-1.module+el8+2632+6c5111ed",
                 },
               },
@@ -4902,7 +4902,7 @@ Object {
                 "id": "npm@1:6.14.4-1.10.21.0.3.module+el8.2.0+7071+d2377ea3",
                 "info": Object {
                   "name": "npm",
-                  "purl": "pkg:rpm/npm@1:6.14.4-1.10.21.0.3.module%2Bel8.2.0%2B7071%2Bd2377ea3?epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/npm@1:6.14.4-1.10.21.0.3.module%2Bel8.2.0%2B7071%2Bd2377ea3?distro=rhel-8.2&epoch=1&module=nodejs%3A10&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:6.14.4-1.10.21.0.3.module+el8.2.0+7071+d2377ea3",
                 },
               },
@@ -4910,7 +4910,7 @@ Object {
                 "id": "npth@1.5-4.el8",
                 "info": Object {
                   "name": "npth",
-                  "purl": "pkg:rpm/npth@1.5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/npth@1.5-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.5-4.el8",
                 },
               },
@@ -4918,7 +4918,7 @@ Object {
                 "id": "nss_wrapper@1.1.5-3.el8",
                 "info": Object {
                   "name": "nss_wrapper",
-                  "purl": "pkg:rpm/nss_wrapper@1.1.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/nss_wrapper@1.1.5-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.1.5-3.el8",
                 },
               },
@@ -4926,7 +4926,7 @@ Object {
                 "id": "ocaml-srpm-macros@5-4.el8",
                 "info": Object {
                   "name": "ocaml-srpm-macros",
-                  "purl": "pkg:rpm/ocaml-srpm-macros@5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/ocaml-srpm-macros@5-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5-4.el8",
                 },
               },
@@ -4934,7 +4934,7 @@ Object {
                 "id": "openblas-srpm-macros@2-2.el8",
                 "info": Object {
                   "name": "openblas-srpm-macros",
-                  "purl": "pkg:rpm/openblas-srpm-macros@2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/openblas-srpm-macros@2-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2-2.el8",
                 },
               },
@@ -4942,7 +4942,7 @@ Object {
                 "id": "openldap@2.4.46-11.el8",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.46-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/openldap@2.4.46-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.4.46-11.el8",
                 },
               },
@@ -4950,7 +4950,7 @@ Object {
                 "id": "openssh@8.0p1-4.el8_1",
                 "info": Object {
                   "name": "openssh",
-                  "purl": "pkg:rpm/openssh@8.0p1-4.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/openssh@8.0p1-4.el8_1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.0p1-4.el8_1",
                 },
               },
@@ -4958,7 +4958,7 @@ Object {
                 "id": "openssh-clients@8.0p1-4.el8_1",
                 "info": Object {
                   "name": "openssh-clients",
-                  "purl": "pkg:rpm/openssh-clients@8.0p1-4.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/openssh-clients@8.0p1-4.el8_1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.0p1-4.el8_1",
                 },
               },
@@ -4966,7 +4966,7 @@ Object {
                 "id": "openssl@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl",
-                  "purl": "pkg:rpm/openssl@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/openssl@1:1.1.1c-15.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -4974,7 +4974,7 @@ Object {
                 "id": "openssl-devel@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl-devel",
-                  "purl": "pkg:rpm/openssl-devel@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/openssl-devel@1:1.1.1c-15.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -4982,7 +4982,7 @@ Object {
                 "id": "openssl-libs@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/openssl-libs@1:1.1.1c-15.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -4990,7 +4990,7 @@ Object {
                 "id": "p11-kit@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/p11-kit@0.23.14-5.el8_0?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -4998,7 +4998,7 @@ Object {
                 "id": "p11-kit-trust@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/p11-kit-trust@0.23.14-5.el8_0?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -5006,7 +5006,7 @@ Object {
                 "id": "pam@1.3.1-8.el8",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.3.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pam@1.3.1-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.3.1-8.el8",
                 },
               },
@@ -5014,7 +5014,7 @@ Object {
                 "id": "passwd@0.80-3.el8",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.80-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/passwd@0.80-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.80-3.el8",
                 },
               },
@@ -5022,7 +5022,7 @@ Object {
                 "id": "patch@2.7.6-11.el8",
                 "info": Object {
                   "name": "patch",
-                  "purl": "pkg:rpm/patch@2.7.6-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/patch@2.7.6-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.7.6-11.el8",
                 },
               },
@@ -5030,7 +5030,7 @@ Object {
                 "id": "pcre@8.42-4.el8",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.42-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pcre@8.42-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.42-4.el8",
                 },
               },
@@ -5038,7 +5038,7 @@ Object {
                 "id": "pcre2@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2",
-                  "purl": "pkg:rpm/pcre2@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pcre2@10.32-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -5046,7 +5046,7 @@ Object {
                 "id": "pcre2-devel@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2-devel",
-                  "purl": "pkg:rpm/pcre2-devel@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pcre2-devel@10.32-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -5054,7 +5054,7 @@ Object {
                 "id": "pcre2-utf16@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2-utf16",
-                  "purl": "pkg:rpm/pcre2-utf16@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pcre2-utf16@10.32-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -5062,7 +5062,7 @@ Object {
                 "id": "pcre2-utf32@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2-utf32",
-                  "purl": "pkg:rpm/pcre2-utf32@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pcre2-utf32@10.32-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -5070,7 +5070,7 @@ Object {
                 "id": "perl-Carp@1.42-396.el8",
                 "info": Object {
                   "name": "perl-Carp",
-                  "purl": "pkg:rpm/perl-Carp@1.42-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Carp@1.42-396.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.42-396.el8",
                 },
               },
@@ -5078,7 +5078,7 @@ Object {
                 "id": "perl-Data-Dumper@2.167-399.el8",
                 "info": Object {
                   "name": "perl-Data-Dumper",
-                  "purl": "pkg:rpm/perl-Data-Dumper@2.167-399.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Data-Dumper@2.167-399.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.167-399.el8",
                 },
               },
@@ -5086,7 +5086,7 @@ Object {
                 "id": "perl-Digest@1.17-395.el8",
                 "info": Object {
                   "name": "perl-Digest",
-                  "purl": "pkg:rpm/perl-Digest@1.17-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Digest@1.17-395.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-395.el8",
                 },
               },
@@ -5094,7 +5094,7 @@ Object {
                 "id": "perl-Digest-MD5@2.55-396.el8",
                 "info": Object {
                   "name": "perl-Digest-MD5",
-                  "purl": "pkg:rpm/perl-Digest-MD5@2.55-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Digest-MD5@2.55-396.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.55-396.el8",
                 },
               },
@@ -5102,7 +5102,7 @@ Object {
                 "id": "perl-Encode@4:2.97-3.el8",
                 "info": Object {
                   "name": "perl-Encode",
-                  "purl": "pkg:rpm/perl-Encode@4:2.97-3.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Encode@4:2.97-3.el8?distro=rhel-8.2&epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:2.97-3.el8",
                 },
               },
@@ -5110,7 +5110,7 @@ Object {
                 "id": "perl-Errno@1.28-416.el8",
                 "info": Object {
                   "name": "perl-Errno",
-                  "purl": "pkg:rpm/perl-Errno@1.28-416.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Errno@1.28-416.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.28-416.el8",
                 },
               },
@@ -5118,7 +5118,7 @@ Object {
                 "id": "perl-Error@1:0.17025-2.el8",
                 "info": Object {
                   "name": "perl-Error",
-                  "purl": "pkg:rpm/perl-Error@1:0.17025-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Error@1:0.17025-2.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:0.17025-2.el8",
                 },
               },
@@ -5126,7 +5126,7 @@ Object {
                 "id": "perl-Exporter@5.72-396.el8",
                 "info": Object {
                   "name": "perl-Exporter",
-                  "purl": "pkg:rpm/perl-Exporter@5.72-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Exporter@5.72-396.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.72-396.el8",
                 },
               },
@@ -5134,7 +5134,7 @@ Object {
                 "id": "perl-File-Path@2.15-2.el8",
                 "info": Object {
                   "name": "perl-File-Path",
-                  "purl": "pkg:rpm/perl-File-Path@2.15-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-File-Path@2.15-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.15-2.el8",
                 },
               },
@@ -5142,7 +5142,7 @@ Object {
                 "id": "perl-File-Temp@0.230.600-1.el8",
                 "info": Object {
                   "name": "perl-File-Temp",
-                  "purl": "pkg:rpm/perl-File-Temp@0.230.600-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-File-Temp@0.230.600-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.230.600-1.el8",
                 },
               },
@@ -5150,7 +5150,7 @@ Object {
                 "id": "perl-Getopt-Long@1:2.50-4.el8",
                 "info": Object {
                   "name": "perl-Getopt-Long",
-                  "purl": "pkg:rpm/perl-Getopt-Long@1:2.50-4.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Getopt-Long@1:2.50-4.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:2.50-4.el8",
                 },
               },
@@ -5158,7 +5158,7 @@ Object {
                 "id": "perl-Git@2.18.4-2.el8_2",
                 "info": Object {
                   "name": "perl-Git",
-                  "purl": "pkg:rpm/perl-Git@2.18.4-2.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Git@2.18.4-2.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.18.4-2.el8_2",
                 },
               },
@@ -5166,7 +5166,7 @@ Object {
                 "id": "perl-HTTP-Tiny@0.074-1.el8",
                 "info": Object {
                   "name": "perl-HTTP-Tiny",
-                  "purl": "pkg:rpm/perl-HTTP-Tiny@0.074-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-HTTP-Tiny@0.074-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.074-1.el8",
                 },
               },
@@ -5174,7 +5174,7 @@ Object {
                 "id": "perl-IO@1.38-416.el8",
                 "info": Object {
                   "name": "perl-IO",
-                  "purl": "pkg:rpm/perl-IO@1.38-416.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-IO@1.38-416.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.38-416.el8",
                 },
               },
@@ -5182,7 +5182,7 @@ Object {
                 "id": "perl-IO-Socket-IP@0.39-5.el8",
                 "info": Object {
                   "name": "perl-IO-Socket-IP",
-                  "purl": "pkg:rpm/perl-IO-Socket-IP@0.39-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-IO-Socket-IP@0.39-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.39-5.el8",
                 },
               },
@@ -5190,7 +5190,7 @@ Object {
                 "id": "perl-IO-Socket-SSL@2.066-4.el8",
                 "info": Object {
                   "name": "perl-IO-Socket-SSL",
-                  "purl": "pkg:rpm/perl-IO-Socket-SSL@2.066-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-IO-Socket-SSL@2.066-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.066-4.el8",
                 },
               },
@@ -5198,7 +5198,7 @@ Object {
                 "id": "perl-MIME-Base64@3.15-396.el8",
                 "info": Object {
                   "name": "perl-MIME-Base64",
-                  "purl": "pkg:rpm/perl-MIME-Base64@3.15-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-MIME-Base64@3.15-396.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.15-396.el8",
                 },
               },
@@ -5206,7 +5206,7 @@ Object {
                 "id": "perl-Mozilla-CA@20160104-7.el8",
                 "info": Object {
                   "name": "perl-Mozilla-CA",
-                  "purl": "pkg:rpm/perl-Mozilla-CA@20160104-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Mozilla-CA@20160104-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "20160104-7.el8",
                 },
               },
@@ -5214,7 +5214,7 @@ Object {
                 "id": "perl-Net-SSLeay@1.88-1.el8",
                 "info": Object {
                   "name": "perl-Net-SSLeay",
-                  "purl": "pkg:rpm/perl-Net-SSLeay@1.88-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Net-SSLeay@1.88-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.88-1.el8",
                 },
               },
@@ -5222,7 +5222,7 @@ Object {
                 "id": "perl-PathTools@3.74-1.el8",
                 "info": Object {
                   "name": "perl-PathTools",
-                  "purl": "pkg:rpm/perl-PathTools@3.74-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-PathTools@3.74-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.74-1.el8",
                 },
               },
@@ -5230,7 +5230,7 @@ Object {
                 "id": "perl-Pod-Escapes@1:1.07-395.el8",
                 "info": Object {
                   "name": "perl-Pod-Escapes",
-                  "purl": "pkg:rpm/perl-Pod-Escapes@1:1.07-395.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Pod-Escapes@1:1.07-395.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.07-395.el8",
                 },
               },
@@ -5238,7 +5238,7 @@ Object {
                 "id": "perl-Pod-Perldoc@3.28-396.el8",
                 "info": Object {
                   "name": "perl-Pod-Perldoc",
-                  "purl": "pkg:rpm/perl-Pod-Perldoc@3.28-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Pod-Perldoc@3.28-396.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.28-396.el8",
                 },
               },
@@ -5246,7 +5246,7 @@ Object {
                 "id": "perl-Pod-Simple@1:3.35-395.el8",
                 "info": Object {
                   "name": "perl-Pod-Simple",
-                  "purl": "pkg:rpm/perl-Pod-Simple@1:3.35-395.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Pod-Simple@1:3.35-395.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:3.35-395.el8",
                 },
               },
@@ -5254,7 +5254,7 @@ Object {
                 "id": "perl-Pod-Usage@4:1.69-395.el8",
                 "info": Object {
                   "name": "perl-Pod-Usage",
-                  "purl": "pkg:rpm/perl-Pod-Usage@4:1.69-395.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Pod-Usage@4:1.69-395.el8?distro=rhel-8.2&epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:1.69-395.el8",
                 },
               },
@@ -5262,7 +5262,7 @@ Object {
                 "id": "perl-Scalar-List-Utils@3:1.49-2.el8",
                 "info": Object {
                   "name": "perl-Scalar-List-Utils",
-                  "purl": "pkg:rpm/perl-Scalar-List-Utils@3:1.49-2.el8?epoch=3&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Scalar-List-Utils@3:1.49-2.el8?distro=rhel-8.2&epoch=3&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3:1.49-2.el8",
                 },
               },
@@ -5270,7 +5270,7 @@ Object {
                 "id": "perl-Socket@4:2.027-3.el8",
                 "info": Object {
                   "name": "perl-Socket",
-                  "purl": "pkg:rpm/perl-Socket@4:2.027-3.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Socket@4:2.027-3.el8?distro=rhel-8.2&epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:2.027-3.el8",
                 },
               },
@@ -5278,7 +5278,7 @@ Object {
                 "id": "perl-Storable@1:3.11-3.el8",
                 "info": Object {
                   "name": "perl-Storable",
-                  "purl": "pkg:rpm/perl-Storable@1:3.11-3.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Storable@1:3.11-3.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:3.11-3.el8",
                 },
               },
@@ -5286,7 +5286,7 @@ Object {
                 "id": "perl-Term-ANSIColor@4.06-396.el8",
                 "info": Object {
                   "name": "perl-Term-ANSIColor",
-                  "purl": "pkg:rpm/perl-Term-ANSIColor@4.06-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Term-ANSIColor@4.06-396.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.06-396.el8",
                 },
               },
@@ -5294,7 +5294,7 @@ Object {
                 "id": "perl-Term-Cap@1.17-395.el8",
                 "info": Object {
                   "name": "perl-Term-Cap",
-                  "purl": "pkg:rpm/perl-Term-Cap@1.17-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Term-Cap@1.17-395.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.17-395.el8",
                 },
               },
@@ -5302,7 +5302,7 @@ Object {
                 "id": "perl-TermReadKey@2.37-7.el8",
                 "info": Object {
                   "name": "perl-TermReadKey",
-                  "purl": "pkg:rpm/perl-TermReadKey@2.37-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-TermReadKey@2.37-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.37-7.el8",
                 },
               },
@@ -5310,7 +5310,7 @@ Object {
                 "id": "perl-Text-ParseWords@3.30-395.el8",
                 "info": Object {
                   "name": "perl-Text-ParseWords",
-                  "purl": "pkg:rpm/perl-Text-ParseWords@3.30-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Text-ParseWords@3.30-395.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.30-395.el8",
                 },
               },
@@ -5318,7 +5318,7 @@ Object {
                 "id": "perl-Text-Tabs+Wrap@2013.0523-395.el8",
                 "info": Object {
                   "name": "perl-Text-Tabs+Wrap",
-                  "purl": "pkg:rpm/perl-Text-Tabs%2BWrap@2013.0523-395.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Text-Tabs%2BWrap@2013.0523-395.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2013.0523-395.el8",
                 },
               },
@@ -5326,7 +5326,7 @@ Object {
                 "id": "perl-Thread-Queue@3.13-1.el8",
                 "info": Object {
                   "name": "perl-Thread-Queue",
-                  "purl": "pkg:rpm/perl-Thread-Queue@3.13-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Thread-Queue@3.13-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.13-1.el8",
                 },
               },
@@ -5334,7 +5334,7 @@ Object {
                 "id": "perl-Time-Local@1:1.280-1.el8",
                 "info": Object {
                   "name": "perl-Time-Local",
-                  "purl": "pkg:rpm/perl-Time-Local@1:1.280-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Time-Local@1:1.280-1.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:1.280-1.el8",
                 },
               },
@@ -5342,7 +5342,7 @@ Object {
                 "id": "perl-URI@1.73-3.el8",
                 "info": Object {
                   "name": "perl-URI",
-                  "purl": "pkg:rpm/perl-URI@1.73-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-URI@1.73-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.73-3.el8",
                 },
               },
@@ -5350,7 +5350,7 @@ Object {
                 "id": "perl-Unicode-Normalize@1.25-396.el8",
                 "info": Object {
                   "name": "perl-Unicode-Normalize",
-                  "purl": "pkg:rpm/perl-Unicode-Normalize@1.25-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-Unicode-Normalize@1.25-396.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.25-396.el8",
                 },
               },
@@ -5358,7 +5358,7 @@ Object {
                 "id": "perl-constant@1.33-396.el8",
                 "info": Object {
                   "name": "perl-constant",
-                  "purl": "pkg:rpm/perl-constant@1.33-396.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-constant@1.33-396.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.33-396.el8",
                 },
               },
@@ -5366,7 +5366,7 @@ Object {
                 "id": "perl-interpreter@4:5.26.3-416.el8",
                 "info": Object {
                   "name": "perl-interpreter",
-                  "purl": "pkg:rpm/perl-interpreter@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-interpreter@4:5.26.3-416.el8?distro=rhel-8.2&epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:5.26.3-416.el8",
                 },
               },
@@ -5374,7 +5374,7 @@ Object {
                 "id": "perl-libnet@3.11-3.el8",
                 "info": Object {
                   "name": "perl-libnet",
-                  "purl": "pkg:rpm/perl-libnet@3.11-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-libnet@3.11-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.11-3.el8",
                 },
               },
@@ -5382,7 +5382,7 @@ Object {
                 "id": "perl-libs@4:5.26.3-416.el8",
                 "info": Object {
                   "name": "perl-libs",
-                  "purl": "pkg:rpm/perl-libs@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-libs@4:5.26.3-416.el8?distro=rhel-8.2&epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:5.26.3-416.el8",
                 },
               },
@@ -5390,7 +5390,7 @@ Object {
                 "id": "perl-macros@4:5.26.3-416.el8",
                 "info": Object {
                   "name": "perl-macros",
-                  "purl": "pkg:rpm/perl-macros@4:5.26.3-416.el8?epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-macros@4:5.26.3-416.el8?distro=rhel-8.2&epoch=4&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4:5.26.3-416.el8",
                 },
               },
@@ -5398,7 +5398,7 @@ Object {
                 "id": "perl-parent@1:0.237-1.el8",
                 "info": Object {
                   "name": "perl-parent",
-                  "purl": "pkg:rpm/perl-parent@1:0.237-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-parent@1:0.237-1.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:0.237-1.el8",
                 },
               },
@@ -5406,7 +5406,7 @@ Object {
                 "id": "perl-podlators@4.11-1.el8",
                 "info": Object {
                   "name": "perl-podlators",
-                  "purl": "pkg:rpm/perl-podlators@4.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-podlators@4.11-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.11-1.el8",
                 },
               },
@@ -5414,7 +5414,7 @@ Object {
                 "id": "perl-srpm-macros@1-25.el8",
                 "info": Object {
                   "name": "perl-srpm-macros",
-                  "purl": "pkg:rpm/perl-srpm-macros@1-25.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-srpm-macros@1-25.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1-25.el8",
                 },
               },
@@ -5422,7 +5422,7 @@ Object {
                 "id": "perl-threads@1:2.21-2.el8",
                 "info": Object {
                   "name": "perl-threads",
-                  "purl": "pkg:rpm/perl-threads@1:2.21-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-threads@1:2.21-2.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:2.21-2.el8",
                 },
               },
@@ -5430,7 +5430,7 @@ Object {
                 "id": "perl-threads-shared@1.58-2.el8",
                 "info": Object {
                   "name": "perl-threads-shared",
-                  "purl": "pkg:rpm/perl-threads-shared@1.58-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/perl-threads-shared@1.58-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.58-2.el8",
                 },
               },
@@ -5438,7 +5438,7 @@ Object {
                 "id": "pkgconf@1.4.2-1.el8",
                 "info": Object {
                   "name": "pkgconf",
-                  "purl": "pkg:rpm/pkgconf@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pkgconf@1.4.2-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-1.el8",
                 },
               },
@@ -5446,7 +5446,7 @@ Object {
                 "id": "pkgconf-m4@1.4.2-1.el8",
                 "info": Object {
                   "name": "pkgconf-m4",
-                  "purl": "pkg:rpm/pkgconf-m4@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pkgconf-m4@1.4.2-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-1.el8",
                 },
               },
@@ -5454,7 +5454,7 @@ Object {
                 "id": "pkgconf-pkg-config@1.4.2-1.el8",
                 "info": Object {
                   "name": "pkgconf-pkg-config",
-                  "purl": "pkg:rpm/pkgconf-pkg-config@1.4.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/pkgconf-pkg-config@1.4.2-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.4.2-1.el8",
                 },
               },
@@ -5462,7 +5462,7 @@ Object {
                 "id": "platform-python@3.6.8-23.el8",
                 "info": Object {
                   "name": "platform-python",
-                  "purl": "pkg:rpm/platform-python@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/platform-python@3.6.8-23.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.6.8-23.el8",
                 },
               },
@@ -5470,7 +5470,7 @@ Object {
                 "id": "platform-python-setuptools@39.2.0-5.el8",
                 "info": Object {
                   "name": "platform-python-setuptools",
-                  "purl": "pkg:rpm/platform-python-setuptools@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/platform-python-setuptools@39.2.0-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -5478,7 +5478,7 @@ Object {
                 "id": "popt@1.16-14.el8",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.16-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/popt@1.16-14.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.16-14.el8",
                 },
               },
@@ -5486,7 +5486,7 @@ Object {
                 "id": "procps-ng@3.3.15-1.el8",
                 "info": Object {
                   "name": "procps-ng",
-                  "purl": "pkg:rpm/procps-ng@3.3.15-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/procps-ng@3.3.15-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.3.15-1.el8",
                 },
               },
@@ -5494,7 +5494,7 @@ Object {
                 "id": "publicsuffix-list-dafsa@20180723-1.el8",
                 "info": Object {
                   "name": "publicsuffix-list-dafsa",
-                  "purl": "pkg:rpm/publicsuffix-list-dafsa@20180723-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/publicsuffix-list-dafsa@20180723-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "20180723-1.el8",
                 },
               },
@@ -5502,7 +5502,7 @@ Object {
                 "id": "python-srpm-macros@3-38.el8",
                 "info": Object {
                   "name": "python-srpm-macros",
-                  "purl": "pkg:rpm/python-srpm-macros@3-38.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python-srpm-macros@3-38.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3-38.el8",
                 },
               },
@@ -5510,7 +5510,7 @@ Object {
                 "id": "python3-dateutil@1:2.6.1-6.el8",
                 "info": Object {
                   "name": "python3-dateutil",
-                  "purl": "pkg:rpm/python3-dateutil@1:2.6.1-6.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dateutil@1:2.6.1-6.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:2.6.1-6.el8",
                 },
               },
@@ -5518,7 +5518,7 @@ Object {
                 "id": "python3-dbus@1.2.4-15.el8",
                 "info": Object {
                   "name": "python3-dbus",
-                  "purl": "pkg:rpm/python3-dbus@1.2.4-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dbus@1.2.4-15.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.4-15.el8",
                 },
               },
@@ -5526,7 +5526,7 @@ Object {
                 "id": "python3-decorator@4.2.1-2.el8",
                 "info": Object {
                   "name": "python3-decorator",
-                  "purl": "pkg:rpm/python3-decorator@4.2.1-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-decorator@4.2.1-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.1-2.el8",
                 },
               },
@@ -5534,7 +5534,7 @@ Object {
                 "id": "python3-dmidecode@3.12.2-15.el8",
                 "info": Object {
                   "name": "python3-dmidecode",
-                  "purl": "pkg:rpm/python3-dmidecode@3.12.2-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dmidecode@3.12.2-15.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.12.2-15.el8",
                 },
               },
@@ -5542,7 +5542,7 @@ Object {
                 "id": "python3-dnf@4.2.17-6.el8",
                 "info": Object {
                   "name": "python3-dnf",
-                  "purl": "pkg:rpm/python3-dnf@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dnf@4.2.17-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.17-6.el8",
                 },
               },
@@ -5550,7 +5550,7 @@ Object {
                 "id": "python3-dnf-plugins-core@4.0.12-3.el8",
                 "info": Object {
                   "name": "python3-dnf-plugins-core",
-                  "purl": "pkg:rpm/python3-dnf-plugins-core@4.0.12-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dnf-plugins-core@4.0.12-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.0.12-3.el8",
                 },
               },
@@ -5558,7 +5558,7 @@ Object {
                 "id": "python3-ethtool@0.14-3.el8",
                 "info": Object {
                   "name": "python3-ethtool",
-                  "purl": "pkg:rpm/python3-ethtool@0.14-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-ethtool@0.14-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.14-3.el8",
                 },
               },
@@ -5566,7 +5566,7 @@ Object {
                 "id": "python3-gobject-base@3.28.3-1.el8",
                 "info": Object {
                   "name": "python3-gobject-base",
-                  "purl": "pkg:rpm/python3-gobject-base@3.28.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-gobject-base@3.28.3-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.28.3-1.el8",
                 },
               },
@@ -5574,7 +5574,7 @@ Object {
                 "id": "python3-gpg@1.10.0-6.el8",
                 "info": Object {
                   "name": "python3-gpg",
-                  "purl": "pkg:rpm/python3-gpg@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-gpg@1.10.0-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.10.0-6.el8",
                 },
               },
@@ -5582,7 +5582,7 @@ Object {
                 "id": "python3-hawkey@0.39.1-5.el8",
                 "info": Object {
                   "name": "python3-hawkey",
-                  "purl": "pkg:rpm/python3-hawkey@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-hawkey@0.39.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.39.1-5.el8",
                 },
               },
@@ -5590,7 +5590,7 @@ Object {
                 "id": "python3-iniparse@0.4-31.el8",
                 "info": Object {
                   "name": "python3-iniparse",
-                  "purl": "pkg:rpm/python3-iniparse@0.4-31.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-iniparse@0.4-31.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.4-31.el8",
                 },
               },
@@ -5598,7 +5598,7 @@ Object {
                 "id": "python3-inotify@0.9.6-13.el8",
                 "info": Object {
                   "name": "python3-inotify",
-                  "purl": "pkg:rpm/python3-inotify@0.9.6-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-inotify@0.9.6-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.9.6-13.el8",
                 },
               },
@@ -5606,7 +5606,7 @@ Object {
                 "id": "python3-libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "python3-libcomps",
-                  "purl": "pkg:rpm/python3-libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-libcomps@0.1.11-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -5614,7 +5614,7 @@ Object {
                 "id": "python3-libdnf@0.39.1-5.el8",
                 "info": Object {
                   "name": "python3-libdnf",
-                  "purl": "pkg:rpm/python3-libdnf@0.39.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-libdnf@0.39.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "0.39.1-5.el8",
                 },
               },
@@ -5622,7 +5622,7 @@ Object {
                 "id": "python3-librepo@1.11.0-2.el8",
                 "info": Object {
                   "name": "python3-librepo",
-                  "purl": "pkg:rpm/python3-librepo@1.11.0-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-librepo@1.11.0-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.11.0-2.el8",
                 },
               },
@@ -5630,7 +5630,7 @@ Object {
                 "id": "python3-libs@3.6.8-23.el8",
                 "info": Object {
                   "name": "python3-libs",
-                  "purl": "pkg:rpm/python3-libs@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-libs@3.6.8-23.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.6.8-23.el8",
                 },
               },
@@ -5638,7 +5638,7 @@ Object {
                 "id": "python3-libxml2@2.9.7-7.el8",
                 "info": Object {
                   "name": "python3-libxml2",
-                  "purl": "pkg:rpm/python3-libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-libxml2@2.9.7-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -5646,7 +5646,7 @@ Object {
                 "id": "python3-pip-wheel@9.0.3-16.el8",
                 "info": Object {
                   "name": "python3-pip-wheel",
-                  "purl": "pkg:rpm/python3-pip-wheel@9.0.3-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-pip-wheel@9.0.3-16.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "9.0.3-16.el8",
                 },
               },
@@ -5654,7 +5654,7 @@ Object {
                 "id": "python3-rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "python3-rpm",
-                  "purl": "pkg:rpm/python3-rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-rpm@4.14.2-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -5662,7 +5662,7 @@ Object {
                 "id": "python3-rpm-macros@3-38.el8",
                 "info": Object {
                   "name": "python3-rpm-macros",
-                  "purl": "pkg:rpm/python3-rpm-macros@3-38.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-rpm-macros@3-38.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3-38.el8",
                 },
               },
@@ -5670,7 +5670,7 @@ Object {
                 "id": "python3-setuptools-wheel@39.2.0-5.el8",
                 "info": Object {
                   "name": "python3-setuptools-wheel",
-                  "purl": "pkg:rpm/python3-setuptools-wheel@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-setuptools-wheel@39.2.0-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -5678,7 +5678,7 @@ Object {
                 "id": "python3-six@1.11.0-8.el8",
                 "info": Object {
                   "name": "python3-six",
-                  "purl": "pkg:rpm/python3-six@1.11.0-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-six@1.11.0-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.11.0-8.el8",
                 },
               },
@@ -5686,7 +5686,7 @@ Object {
                 "id": "python3-subscription-manager-rhsm@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "python3-subscription-manager-rhsm",
-                  "purl": "pkg:rpm/python3-subscription-manager-rhsm@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-subscription-manager-rhsm@1.26.17-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -5694,7 +5694,7 @@ Object {
                 "id": "python3-syspurpose@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "python3-syspurpose",
-                  "purl": "pkg:rpm/python3-syspurpose@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/python3-syspurpose@1.26.17-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -5702,7 +5702,7 @@ Object {
                 "id": "qt5-srpm-macros@5.12.5-3.el8",
                 "info": Object {
                   "name": "qt5-srpm-macros",
-                  "purl": "pkg:rpm/qt5-srpm-macros@5.12.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/qt5-srpm-macros@5.12.5-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.12.5-3.el8",
                 },
               },
@@ -5710,7 +5710,7 @@ Object {
                 "id": "readline@7.0-10.el8",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@7.0-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/readline@7.0-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "7.0-10.el8",
                 },
               },
@@ -5718,7 +5718,7 @@ Object {
                 "id": "redhat-release@8.2-1.0.el8",
                 "info": Object {
                   "name": "redhat-release",
-                  "purl": "pkg:rpm/redhat-release@8.2-1.0.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/redhat-release@8.2-1.0.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.2-1.0.el8",
                 },
               },
@@ -5726,7 +5726,7 @@ Object {
                 "id": "redhat-rpm-config@122-1.el8",
                 "info": Object {
                   "name": "redhat-rpm-config",
-                  "purl": "pkg:rpm/redhat-rpm-config@122-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/redhat-rpm-config@122-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "122-1.el8",
                 },
               },
@@ -5734,7 +5734,7 @@ Object {
                 "id": "rootfiles@8.1-22.el8",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/rootfiles@8.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "8.1-22.el8",
                 },
               },
@@ -5742,7 +5742,7 @@ Object {
                 "id": "rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/rpm@4.14.2-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -5750,7 +5750,7 @@ Object {
                 "id": "rpm-build-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/rpm-build-libs@4.14.2-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -5758,7 +5758,7 @@ Object {
                 "id": "rpm-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/rpm-libs@4.14.2-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -5766,7 +5766,7 @@ Object {
                 "id": "rsync@3.1.3-7.el8",
                 "info": Object {
                   "name": "rsync",
-                  "purl": "pkg:rpm/rsync@3.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/rsync@3.1.3-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.1.3-7.el8",
                 },
               },
@@ -5774,7 +5774,7 @@ Object {
                 "id": "rust-srpm-macros@5-2.el8",
                 "info": Object {
                   "name": "rust-srpm-macros",
-                  "purl": "pkg:rpm/rust-srpm-macros@5-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/rust-srpm-macros@5-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5-2.el8",
                 },
               },
@@ -5782,7 +5782,7 @@ Object {
                 "id": "scl-utils@1:2.0.2-12.el8",
                 "info": Object {
                   "name": "scl-utils",
-                  "purl": "pkg:rpm/scl-utils@1:2.0.2-12.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/scl-utils@1:2.0.2-12.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:2.0.2-12.el8",
                 },
               },
@@ -5790,7 +5790,7 @@ Object {
                 "id": "sed@4.5-1.el8",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.5-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/sed@4.5-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.5-1.el8",
                 },
               },
@@ -5798,7 +5798,7 @@ Object {
                 "id": "setup@2.12.2-5.el8",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.12.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/setup@2.12.2-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.12.2-5.el8",
                 },
               },
@@ -5806,7 +5806,7 @@ Object {
                 "id": "shadow-utils@2:4.6-8.el8",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.6-8.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/shadow-utils@2:4.6-8.el8?distro=rhel-8.2&epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:4.6-8.el8",
                 },
               },
@@ -5814,7 +5814,7 @@ Object {
                 "id": "sqlite@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/sqlite@3.26.0-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -5822,7 +5822,7 @@ Object {
                 "id": "sqlite-devel@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite-devel",
-                  "purl": "pkg:rpm/sqlite-devel@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/sqlite-devel@3.26.0-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -5830,7 +5830,7 @@ Object {
                 "id": "sqlite-libs@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite-libs",
-                  "purl": "pkg:rpm/sqlite-libs@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/sqlite-libs@3.26.0-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -5838,7 +5838,7 @@ Object {
                 "id": "subscription-manager@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "subscription-manager",
-                  "purl": "pkg:rpm/subscription-manager@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/subscription-manager@1.26.17-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -5846,7 +5846,7 @@ Object {
                 "id": "subscription-manager-rhsm-certificates@1.26.17-1.el8_2",
                 "info": Object {
                   "name": "subscription-manager-rhsm-certificates",
-                  "purl": "pkg:rpm/subscription-manager-rhsm-certificates@1.26.17-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/subscription-manager-rhsm-certificates@1.26.17-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.26.17-1.el8_2",
                 },
               },
@@ -5854,7 +5854,7 @@ Object {
                 "id": "systemd@239-30.el8_2",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/systemd@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/systemd@239-30.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "239-30.el8_2",
                 },
               },
@@ -5862,7 +5862,7 @@ Object {
                 "id": "systemd-libs@239-30.el8_2",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/systemd-libs@239-30.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "239-30.el8_2",
                 },
               },
@@ -5870,7 +5870,7 @@ Object {
                 "id": "systemd-pam@239-30.el8_2",
                 "info": Object {
                   "name": "systemd-pam",
-                  "purl": "pkg:rpm/systemd-pam@239-30.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/systemd-pam@239-30.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "239-30.el8_2",
                 },
               },
@@ -5878,7 +5878,7 @@ Object {
                 "id": "tar@2:1.30-4.el8",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.30-4.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/tar@2:1.30-4.el8?distro=rhel-8.2&epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:1.30-4.el8",
                 },
               },
@@ -5886,7 +5886,7 @@ Object {
                 "id": "tcl@1:8.6.8-2.el8",
                 "info": Object {
                   "name": "tcl",
-                  "purl": "pkg:rpm/tcl@1:8.6.8-2.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/tcl@1:8.6.8-2.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1:8.6.8-2.el8",
                 },
               },
@@ -5894,7 +5894,7 @@ Object {
                 "id": "tzdata@2020a-1.el8",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2020a-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/tzdata@2020a-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2020a-1.el8",
                 },
               },
@@ -5902,7 +5902,7 @@ Object {
                 "id": "unzip@6.0-43.el8",
                 "info": Object {
                   "name": "unzip",
-                  "purl": "pkg:rpm/unzip@6.0-43.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/unzip@6.0-43.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "6.0-43.el8",
                 },
               },
@@ -5910,7 +5910,7 @@ Object {
                 "id": "usermode@1.113-1.el8",
                 "info": Object {
                   "name": "usermode",
-                  "purl": "pkg:rpm/usermode@1.113-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/usermode@1.113-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.113-1.el8",
                 },
               },
@@ -5918,7 +5918,7 @@ Object {
                 "id": "util-linux@2.32.1-22.el8",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/util-linux@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -5926,7 +5926,7 @@ Object {
                 "id": "vim-minimal@2:8.0.1763-13.el8",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.0.1763-13.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/vim-minimal@2:8.0.1763-13.el8?distro=rhel-8.2&epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2:8.0.1763-13.el8",
                 },
               },
@@ -5934,7 +5934,7 @@ Object {
                 "id": "virt-what@1.18-6.el8",
                 "info": Object {
                   "name": "virt-what",
-                  "purl": "pkg:rpm/virt-what@1.18-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/virt-what@1.18-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.18-6.el8",
                 },
               },
@@ -5942,7 +5942,7 @@ Object {
                 "id": "wget@1.19.5-8.el8_1.1",
                 "info": Object {
                   "name": "wget",
-                  "purl": "pkg:rpm/wget@1.19.5-8.el8_1.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/wget@1.19.5-8.el8_1.1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.19.5-8.el8_1.1",
                 },
               },
@@ -5950,7 +5950,7 @@ Object {
                 "id": "which@2.21-12.el8",
                 "info": Object {
                   "name": "which",
-                  "purl": "pkg:rpm/which@2.21-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/which@2.21-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2.21-12.el8",
                 },
               },
@@ -5958,7 +5958,7 @@ Object {
                 "id": "xorg-x11-proto-devel@2018.4-1.el8",
                 "info": Object {
                   "name": "xorg-x11-proto-devel",
-                  "purl": "pkg:rpm/xorg-x11-proto-devel@2018.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/xorg-x11-proto-devel@2018.4-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "2018.4-1.el8",
                 },
               },
@@ -5966,7 +5966,7 @@ Object {
                 "id": "xz@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz",
-                  "purl": "pkg:rpm/xz@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/xz@5.2.4-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -5974,7 +5974,7 @@ Object {
                 "id": "xz-devel@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz-devel",
-                  "purl": "pkg:rpm/xz-devel@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/xz-devel@5.2.4-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -5982,7 +5982,7 @@ Object {
                 "id": "xz-libs@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/xz-libs@5.2.4-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -5990,7 +5990,7 @@ Object {
                 "id": "yum@4.2.17-6.el8",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@4.2.17-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/yum@4.2.17-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "4.2.17-6.el8",
                 },
               },
@@ -5998,7 +5998,7 @@ Object {
                 "id": "zip@3.0-23.el8",
                 "info": Object {
                   "name": "zip",
-                  "purl": "pkg:rpm/zip@3.0-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/zip@3.0-23.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "3.0-23.el8",
                 },
               },
@@ -6006,7 +6006,7 @@ Object {
                 "id": "zlib@1.2.11-13.el8",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.11-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/zlib@1.2.11-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.11-13.el8",
                 },
               },
@@ -6014,7 +6014,7 @@ Object {
                 "id": "zlib-devel@1.2.11-13.el8",
                 "info": Object {
                   "name": "zlib-devel",
-                  "purl": "pkg:rpm/zlib-devel@1.2.11-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
+                  "purl": "pkg:rpm/rhel/zlib-devel@1.2.11-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms%2Crhel-8-for-x86_64-baseos-beta-rpms%2Crhel-8-for-x86_64-appstream-beta-rpms%2Crhel-8-for-x86_64-baseos-htb-rpms%2Crhel-8-for-x86_64-appstream-htb-rpms",
                   "version": "1.2.11-13.el8",
                 },
               },
@@ -7586,7 +7586,7 @@ Object {
                 "id": "acl@2.2.53-1.el8",
                 "info": Object {
                   "name": "acl",
-                  "purl": "pkg:rpm/acl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/acl@2.2.53-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -7594,7 +7594,7 @@ Object {
                 "id": "audit-libs@3.0-0.17.20191104git1c2f876.el8",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@3.0-0.17.20191104git1c2f876.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/audit-libs@3.0-0.17.20191104git1c2f876.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.0-0.17.20191104git1c2f876.el8",
                 },
               },
@@ -7602,7 +7602,7 @@ Object {
                 "id": "basesystem@11-5.el8",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/basesystem@11-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "11-5.el8",
                 },
               },
@@ -7610,7 +7610,7 @@ Object {
                 "id": "bash@4.4.19-10.el8",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.4.19-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/bash@4.4.19-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.4.19-10.el8",
                 },
               },
@@ -7618,7 +7618,7 @@ Object {
                 "id": "brotli@1.0.6-1.el8",
                 "info": Object {
                   "name": "brotli",
-                  "purl": "pkg:rpm/brotli@1.0.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/brotli@1.0.6-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.0.6-1.el8",
                 },
               },
@@ -7626,7 +7626,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-26.el8",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-26.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/bzip2-libs@1.0.6-26.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.0.6-26.el8",
                 },
               },
@@ -7634,7 +7634,7 @@ Object {
                 "id": "ca-certificates@2020.2.41-80.0.el8_2",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2020.2.41-80.0.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/ca-certificates@2020.2.41-80.0.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2020.2.41-80.0.el8_2",
                 },
               },
@@ -7642,7 +7642,7 @@ Object {
                 "id": "chkconfig@1.11-1.el8",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.11-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/chkconfig@1.11-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.11-1.el8",
                 },
               },
@@ -7650,7 +7650,7 @@ Object {
                 "id": "coreutils-single@8.30-7.el8_2.1",
                 "info": Object {
                   "name": "coreutils-single",
-                  "purl": "pkg:rpm/coreutils-single@8.30-7.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/coreutils-single@8.30-7.el8_2.1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.30-7.el8_2.1",
                 },
               },
@@ -7658,7 +7658,7 @@ Object {
                 "id": "cracklib@2.9.6-15.el8",
                 "info": Object {
                   "name": "cracklib",
-                  "purl": "pkg:rpm/cracklib@2.9.6-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/cracklib@2.9.6-15.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9.6-15.el8",
                 },
               },
@@ -7666,7 +7666,7 @@ Object {
                 "id": "crypto-policies@20191128-2.git23e1bf1.el8",
                 "info": Object {
                   "name": "crypto-policies",
-                  "purl": "pkg:rpm/crypto-policies@20191128-2.git23e1bf1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/crypto-policies@20191128-2.git23e1bf1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "20191128-2.git23e1bf1.el8",
                 },
               },
@@ -7674,7 +7674,7 @@ Object {
                 "id": "cryptsetup-libs@2.2.2-1.el8",
                 "info": Object {
                   "name": "cryptsetup-libs",
-                  "purl": "pkg:rpm/cryptsetup-libs@2.2.2-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/cryptsetup-libs@2.2.2-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.2-1.el8",
                 },
               },
@@ -7682,7 +7682,7 @@ Object {
                 "id": "curl@7.61.1-12.el8",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/curl@7.61.1-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -7690,7 +7690,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.27-1.el8",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.27-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/cyrus-sasl-lib@2.1.27-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.1.27-1.el8",
                 },
               },
@@ -7698,7 +7698,7 @@ Object {
                 "id": "dbus@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus",
-                  "purl": "pkg:rpm/dbus@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dbus@1:1.12.8-10.el8_2?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7706,7 +7706,7 @@ Object {
                 "id": "dbus-common@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus-common",
-                  "purl": "pkg:rpm/dbus-common@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-common@1:1.12.8-10.el8_2?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7714,7 +7714,7 @@ Object {
                 "id": "dbus-daemon@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus-daemon",
-                  "purl": "pkg:rpm/dbus-daemon@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-daemon@1:1.12.8-10.el8_2?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7722,7 +7722,7 @@ Object {
                 "id": "dbus-glib@0.110-2.el8",
                 "info": Object {
                   "name": "dbus-glib",
-                  "purl": "pkg:rpm/dbus-glib@0.110-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-glib@0.110-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.110-2.el8",
                 },
               },
@@ -7730,7 +7730,7 @@ Object {
                 "id": "dbus-libs@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus-libs",
-                  "purl": "pkg:rpm/dbus-libs@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-libs@1:1.12.8-10.el8_2?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7738,7 +7738,7 @@ Object {
                 "id": "dbus-tools@1:1.12.8-10.el8_2",
                 "info": Object {
                   "name": "dbus-tools",
-                  "purl": "pkg:rpm/dbus-tools@1:1.12.8-10.el8_2?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dbus-tools@1:1.12.8-10.el8_2?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.12.8-10.el8_2",
                 },
               },
@@ -7746,7 +7746,7 @@ Object {
                 "id": "device-mapper@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper",
-                  "purl": "pkg:rpm/device-mapper@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/device-mapper@8:1.02.169-3.el8?distro=rhel-8.2&epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -7754,7 +7754,7 @@ Object {
                 "id": "device-mapper-libs@8:1.02.169-3.el8",
                 "info": Object {
                   "name": "device-mapper-libs",
-                  "purl": "pkg:rpm/device-mapper-libs@8:1.02.169-3.el8?epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/device-mapper-libs@8:1.02.169-3.el8?distro=rhel-8.2&epoch=8&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8:1.02.169-3.el8",
                 },
               },
@@ -7762,7 +7762,7 @@ Object {
                 "id": "dmidecode@1:3.2-5.el8",
                 "info": Object {
                   "name": "dmidecode",
-                  "purl": "pkg:rpm/dmidecode@1:3.2-5.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dmidecode@1:3.2-5.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:3.2-5.el8",
                 },
               },
@@ -7770,7 +7770,7 @@ Object {
                 "id": "dnf@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "dnf",
-                  "purl": "pkg:rpm/dnf@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dnf@4.2.17-7.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -7778,7 +7778,7 @@ Object {
                 "id": "dnf-data@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "dnf-data",
-                  "purl": "pkg:rpm/dnf-data@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dnf-data@4.2.17-7.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -7786,7 +7786,7 @@ Object {
                 "id": "dnf-plugin-subscription-manager@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "dnf-plugin-subscription-manager",
-                  "purl": "pkg:rpm/dnf-plugin-subscription-manager@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/dnf-plugin-subscription-manager@1.26.20-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -7794,7 +7794,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/elfutils-default-yama-scope@0.178-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -7802,7 +7802,7 @@ Object {
                 "id": "elfutils-libelf@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/elfutils-libelf@0.178-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -7810,7 +7810,7 @@ Object {
                 "id": "elfutils-libs@0.178-7.el8",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.178-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/elfutils-libs@0.178-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.178-7.el8",
                 },
               },
@@ -7818,7 +7818,7 @@ Object {
                 "id": "expat@2.2.5-3.el8",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.2.5-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/expat@2.2.5-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.5-3.el8",
                 },
               },
@@ -7826,7 +7826,7 @@ Object {
                 "id": "file-libs@5.33-13.el8",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.33-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/file-libs@5.33-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.33-13.el8",
                 },
               },
@@ -7834,7 +7834,7 @@ Object {
                 "id": "filesystem@3.8-2.el8",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.8-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/filesystem@3.8-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.8-2.el8",
                 },
               },
@@ -7842,7 +7842,7 @@ Object {
                 "id": "findutils@1:4.6.0-20.el8",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.6.0-20.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/findutils@1:4.6.0-20.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:4.6.0-20.el8",
                 },
               },
@@ -7850,7 +7850,7 @@ Object {
                 "id": "gawk@4.2.1-1.el8",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.2.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gawk@4.2.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.1-1.el8",
                 },
               },
@@ -7858,7 +7858,7 @@ Object {
                 "id": "gdb-gdbserver@8.2-11.el8",
                 "info": Object {
                   "name": "gdb-gdbserver",
-                  "purl": "pkg:rpm/gdb-gdbserver@8.2-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gdb-gdbserver@8.2-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.2-11.el8",
                 },
               },
@@ -7866,7 +7866,7 @@ Object {
                 "id": "gdbm@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gdbm@1:1.18-1.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -7874,7 +7874,7 @@ Object {
                 "id": "gdbm-libs@1:1.18-1.el8",
                 "info": Object {
                   "name": "gdbm-libs",
-                  "purl": "pkg:rpm/gdbm-libs@1:1.18-1.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gdbm-libs@1:1.18-1.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.18-1.el8",
                 },
               },
@@ -7882,7 +7882,7 @@ Object {
                 "id": "glib2@2.56.4-8.el8",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.4-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/glib2@2.56.4-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.56.4-8.el8",
                 },
               },
@@ -7890,7 +7890,7 @@ Object {
                 "id": "glibc@2.28-101.el8",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/glibc@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -7898,7 +7898,7 @@ Object {
                 "id": "glibc-common@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/glibc-common@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -7906,7 +7906,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.28-101.el8",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.28-101.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/glibc-minimal-langpack@2.28-101.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.28-101.el8",
                 },
               },
@@ -7914,7 +7914,7 @@ Object {
                 "id": "gmp@1:6.1.2-10.el8",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.1.2-10.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gmp@1:6.1.2-10.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:6.1.2-10.el8",
                 },
               },
@@ -7922,7 +7922,7 @@ Object {
                 "id": "gnupg2@2.2.9-1.el8",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gnupg2@2.2.9-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.9-1.el8",
                 },
               },
@@ -7930,7 +7930,7 @@ Object {
                 "id": "gnutls@3.6.8-11.el8_2",
                 "info": Object {
                   "name": "gnutls",
-                  "purl": "pkg:rpm/gnutls@3.6.8-11.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gnutls@3.6.8-11.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.6.8-11.el8_2",
                 },
               },
@@ -7938,7 +7938,7 @@ Object {
                 "id": "gobject-introspection@1.56.1-1.el8",
                 "info": Object {
                   "name": "gobject-introspection",
-                  "purl": "pkg:rpm/gobject-introspection@1.56.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gobject-introspection@1.56.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.56.1-1.el8",
                 },
               },
@@ -7946,7 +7946,7 @@ Object {
                 "id": "gpg-pubkey@fd431d51-4ae0493b",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@fd431d51-4ae0493b?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "fd431d51-4ae0493b",
                 },
               },
@@ -7954,7 +7954,7 @@ Object {
                 "id": "gpgme@1.10.0-6.el8",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gpgme@1.10.0-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.10.0-6.el8",
                 },
               },
@@ -7962,7 +7962,7 @@ Object {
                 "id": "grep@3.1-6.el8",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@3.1-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/grep@3.1-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.1-6.el8",
                 },
               },
@@ -7970,7 +7970,7 @@ Object {
                 "id": "gzip@1.9-9.el8",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:rpm/gzip@1.9-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/gzip@1.9-9.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.9-9.el8",
                 },
               },
@@ -7978,7 +7978,7 @@ Object {
                 "id": "ima-evm-utils@1.1-5.el8",
                 "info": Object {
                   "name": "ima-evm-utils",
-                  "purl": "pkg:rpm/ima-evm-utils@1.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/ima-evm-utils@1.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.1-5.el8",
                 },
               },
@@ -7986,7 +7986,7 @@ Object {
                 "id": "info@6.5-6.el8",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@6.5-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/info@6.5-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "6.5-6.el8",
                 },
               },
@@ -7994,7 +7994,7 @@ Object {
                 "id": "iptables-libs@1.8.4-10.el8_2.1",
                 "info": Object {
                   "name": "iptables-libs",
-                  "purl": "pkg:rpm/iptables-libs@1.8.4-10.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/iptables-libs@1.8.4-10.el8_2.1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.8.4-10.el8_2.1",
                 },
               },
@@ -8002,7 +8002,7 @@ Object {
                 "id": "json-c@0.13.1-0.2.el8",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.13.1-0.2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/json-c@0.13.1-0.2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.13.1-0.2.el8",
                 },
               },
@@ -8010,7 +8010,7 @@ Object {
                 "id": "json-glib@1.4.4-1.el8",
                 "info": Object {
                   "name": "json-glib",
-                  "purl": "pkg:rpm/json-glib@1.4.4-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/json-glib@1.4.4-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.4.4-1.el8",
                 },
               },
@@ -8018,7 +8018,7 @@ Object {
                 "id": "keyutils-libs@1.5.10-6.el8",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.10-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/keyutils-libs@1.5.10-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.5.10-6.el8",
                 },
               },
@@ -8026,7 +8026,7 @@ Object {
                 "id": "kmod-libs@25-16.el8",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/kmod-libs@25-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/kmod-libs@25-16.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "25-16.el8",
                 },
               },
@@ -8034,7 +8034,7 @@ Object {
                 "id": "krb5-libs@1.17-18.el8",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.17-18.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/krb5-libs@1.17-18.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.17-18.el8",
                 },
               },
@@ -8042,7 +8042,7 @@ Object {
                 "id": "langpacks-en@1.0-12.el8",
                 "info": Object {
                   "name": "langpacks-en",
-                  "purl": "pkg:rpm/langpacks-en@1.0-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/langpacks-en@1.0-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.0-12.el8",
                 },
               },
@@ -8050,7 +8050,7 @@ Object {
                 "id": "libacl@2.2.53-1.el8",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.53-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libacl@2.2.53-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.53-1.el8",
                 },
               },
@@ -8058,7 +8058,7 @@ Object {
                 "id": "libarchive@3.3.2-8.el8_1",
                 "info": Object {
                   "name": "libarchive",
-                  "purl": "pkg:rpm/libarchive@3.3.2-8.el8_1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libarchive@3.3.2-8.el8_1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.3.2-8.el8_1",
                 },
               },
@@ -8066,7 +8066,7 @@ Object {
                 "id": "libassuan@2.5.1-3.el8",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.5.1-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libassuan@2.5.1-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.5.1-3.el8",
                 },
               },
@@ -8074,7 +8074,7 @@ Object {
                 "id": "libattr@2.4.48-3.el8",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.48-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libattr@2.4.48-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.4.48-3.el8",
                 },
               },
@@ -8082,7 +8082,7 @@ Object {
                 "id": "libblkid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libblkid@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8090,7 +8090,7 @@ Object {
                 "id": "libcap@2.26-3.el8",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.26-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libcap@2.26-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.26-3.el8",
                 },
               },
@@ -8098,7 +8098,7 @@ Object {
                 "id": "libcap-ng@0.7.9-5.el8",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.7.9-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libcap-ng@0.7.9-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.7.9-5.el8",
                 },
               },
@@ -8106,7 +8106,7 @@ Object {
                 "id": "libcom_err@1.45.4-3.el8",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.45.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libcom_err@1.45.4-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.45.4-3.el8",
                 },
               },
@@ -8114,7 +8114,7 @@ Object {
                 "id": "libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "libcomps",
-                  "purl": "pkg:rpm/libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libcomps@0.1.11-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -8122,7 +8122,7 @@ Object {
                 "id": "libcurl@7.61.1-12.el8",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libcurl@7.61.1-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "7.61.1-12.el8",
                 },
               },
@@ -8130,7 +8130,7 @@ Object {
                 "id": "libdb@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libdb@5.3.28-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -8138,7 +8138,7 @@ Object {
                 "id": "libdb-utils@5.3.28-37.el8",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.28-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libdb-utils@5.3.28-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.3.28-37.el8",
                 },
               },
@@ -8146,7 +8146,7 @@ Object {
                 "id": "libdnf@0.39.1-6.el8_2",
                 "info": Object {
                   "name": "libdnf",
-                  "purl": "pkg:rpm/libdnf@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libdnf@0.39.1-6.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.39.1-6.el8_2",
                 },
               },
@@ -8154,7 +8154,7 @@ Object {
                 "id": "libfdisk@2.32.1-22.el8",
                 "info": Object {
                   "name": "libfdisk",
-                  "purl": "pkg:rpm/libfdisk@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libfdisk@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8162,7 +8162,7 @@ Object {
                 "id": "libffi@3.1-21.el8",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.1-21.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libffi@3.1-21.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.1-21.el8",
                 },
               },
@@ -8170,7 +8170,7 @@ Object {
                 "id": "libgcc@8.3.1-5.el8",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libgcc@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -8178,7 +8178,7 @@ Object {
                 "id": "libgcrypt@1.8.3-4.el8",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.8.3-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libgcrypt@1.8.3-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.8.3-4.el8",
                 },
               },
@@ -8186,7 +8186,7 @@ Object {
                 "id": "libgpg-error@1.31-1.el8",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.31-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libgpg-error@1.31-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.31-1.el8",
                 },
               },
@@ -8194,7 +8194,7 @@ Object {
                 "id": "libidn2@2.2.0-1.el8",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.2.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libidn2@2.2.0-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.2.0-1.el8",
                 },
               },
@@ -8202,7 +8202,7 @@ Object {
                 "id": "libksba@1.3.5-7.el8",
                 "info": Object {
                   "name": "libksba",
-                  "purl": "pkg:rpm/libksba@1.3.5-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libksba@1.3.5-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.3.5-7.el8",
                 },
               },
@@ -8210,7 +8210,7 @@ Object {
                 "id": "libmetalink@0.1.3-7.el8",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.3-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libmetalink@0.1.3-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.1.3-7.el8",
                 },
               },
@@ -8218,7 +8218,7 @@ Object {
                 "id": "libmodulemd1@1.8.16-0.2.8.2.1",
                 "info": Object {
                   "name": "libmodulemd1",
-                  "purl": "pkg:rpm/libmodulemd1@1.8.16-0.2.8.2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libmodulemd1@1.8.16-0.2.8.2.1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.8.16-0.2.8.2.1",
                 },
               },
@@ -8226,7 +8226,7 @@ Object {
                 "id": "libmount@2.32.1-22.el8",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libmount@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8234,7 +8234,7 @@ Object {
                 "id": "libnghttp2@1.33.0-3.el8_2.1",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.33.0-3.el8_2.1?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libnghttp2@1.33.0-3.el8_2.1?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.33.0-3.el8_2.1",
                 },
               },
@@ -8242,7 +8242,7 @@ Object {
                 "id": "libnl3@3.5.0-1.el8",
                 "info": Object {
                   "name": "libnl3",
-                  "purl": "pkg:rpm/libnl3@3.5.0-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libnl3@3.5.0-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.5.0-1.el8",
                 },
               },
@@ -8250,7 +8250,7 @@ Object {
                 "id": "libnsl2@1.2.0-2.20180605git4a062cf.el8",
                 "info": Object {
                   "name": "libnsl2",
-                  "purl": "pkg:rpm/libnsl2@1.2.0-2.20180605git4a062cf.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libnsl2@1.2.0-2.20180605git4a062cf.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.2.0-2.20180605git4a062cf.el8",
                 },
               },
@@ -8258,7 +8258,7 @@ Object {
                 "id": "libpcap@14:1.9.0-3.el8",
                 "info": Object {
                   "name": "libpcap",
-                  "purl": "pkg:rpm/libpcap@14:1.9.0-3.el8?epoch=14&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libpcap@14:1.9.0-3.el8?distro=rhel-8.2&epoch=14&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "14:1.9.0-3.el8",
                 },
               },
@@ -8266,7 +8266,7 @@ Object {
                 "id": "libpsl@0.20.2-5.el8",
                 "info": Object {
                   "name": "libpsl",
-                  "purl": "pkg:rpm/libpsl@0.20.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libpsl@0.20.2-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.20.2-5.el8",
                 },
               },
@@ -8274,7 +8274,7 @@ Object {
                 "id": "libpwquality@1.4.0-9.el8",
                 "info": Object {
                   "name": "libpwquality",
-                  "purl": "pkg:rpm/libpwquality@1.4.0-9.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libpwquality@1.4.0-9.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.4.0-9.el8",
                 },
               },
@@ -8282,7 +8282,7 @@ Object {
                 "id": "librepo@1.11.0-3.el8_2",
                 "info": Object {
                   "name": "librepo",
-                  "purl": "pkg:rpm/librepo@1.11.0-3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/librepo@1.11.0-3.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.11.0-3.el8_2",
                 },
               },
@@ -8290,7 +8290,7 @@ Object {
                 "id": "libreport-filesystem@2.9.5-10.el8",
                 "info": Object {
                   "name": "libreport-filesystem",
-                  "purl": "pkg:rpm/libreport-filesystem@2.9.5-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libreport-filesystem@2.9.5-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9.5-10.el8",
                 },
               },
@@ -8298,7 +8298,7 @@ Object {
                 "id": "librhsm@0.0.3-3.el8",
                 "info": Object {
                   "name": "librhsm",
-                  "purl": "pkg:rpm/librhsm@0.0.3-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/librhsm@0.0.3-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.0.3-3.el8",
                 },
               },
@@ -8306,7 +8306,7 @@ Object {
                 "id": "libseccomp@2.4.1-1.el8",
                 "info": Object {
                   "name": "libseccomp",
-                  "purl": "pkg:rpm/libseccomp@2.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libseccomp@2.4.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.4.1-1.el8",
                 },
               },
@@ -8314,7 +8314,7 @@ Object {
                 "id": "libselinux@2.9-3.el8",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libselinux@2.9-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9-3.el8",
                 },
               },
@@ -8322,7 +8322,7 @@ Object {
                 "id": "libsemanage@2.9-2.el8",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@2.9-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libsemanage@2.9-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9-2.el8",
                 },
               },
@@ -8330,7 +8330,7 @@ Object {
                 "id": "libsepol@2.9-1.el8",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.9-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libsepol@2.9-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9-1.el8",
                 },
               },
@@ -8338,7 +8338,7 @@ Object {
                 "id": "libsigsegv@2.11-5.el8",
                 "info": Object {
                   "name": "libsigsegv",
-                  "purl": "pkg:rpm/libsigsegv@2.11-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libsigsegv@2.11-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.11-5.el8",
                 },
               },
@@ -8346,7 +8346,7 @@ Object {
                 "id": "libsmartcols@2.32.1-22.el8",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libsmartcols@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8354,7 +8354,7 @@ Object {
                 "id": "libsolv@0.7.7-1.el8",
                 "info": Object {
                   "name": "libsolv",
-                  "purl": "pkg:rpm/libsolv@0.7.7-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libsolv@0.7.7-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.7.7-1.el8",
                 },
               },
@@ -8362,7 +8362,7 @@ Object {
                 "id": "libssh@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh",
-                  "purl": "pkg:rpm/libssh@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libssh@0.9.0-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -8370,7 +8370,7 @@ Object {
                 "id": "libssh-config@0.9.0-4.el8",
                 "info": Object {
                   "name": "libssh-config",
-                  "purl": "pkg:rpm/libssh-config@0.9.0-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libssh-config@0.9.0-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.9.0-4.el8",
                 },
               },
@@ -8378,7 +8378,7 @@ Object {
                 "id": "libstdc++@8.3.1-5.el8",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@8.3.1-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libstdc%2B%2B@8.3.1-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.3.1-5.el8",
                 },
               },
@@ -8386,7 +8386,7 @@ Object {
                 "id": "libtasn1@4.13-3.el8",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.13-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libtasn1@4.13-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.13-3.el8",
                 },
               },
@@ -8394,7 +8394,7 @@ Object {
                 "id": "libtirpc@1.1.4-4.el8",
                 "info": Object {
                   "name": "libtirpc",
-                  "purl": "pkg:rpm/libtirpc@1.1.4-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libtirpc@1.1.4-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.1.4-4.el8",
                 },
               },
@@ -8402,7 +8402,7 @@ Object {
                 "id": "libunistring@0.9.9-3.el8",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.9-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libunistring@0.9.9-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.9.9-3.el8",
                 },
               },
@@ -8410,7 +8410,7 @@ Object {
                 "id": "libusbx@1.0.22-1.el8",
                 "info": Object {
                   "name": "libusbx",
-                  "purl": "pkg:rpm/libusbx@1.0.22-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libusbx@1.0.22-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.0.22-1.el8",
                 },
               },
@@ -8418,7 +8418,7 @@ Object {
                 "id": "libuser@0.62-23.el8",
                 "info": Object {
                   "name": "libuser",
-                  "purl": "pkg:rpm/libuser@0.62-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libuser@0.62-23.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.62-23.el8",
                 },
               },
@@ -8426,7 +8426,7 @@ Object {
                 "id": "libutempter@1.1.6-14.el8",
                 "info": Object {
                   "name": "libutempter",
-                  "purl": "pkg:rpm/libutempter@1.1.6-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libutempter@1.1.6-14.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.1.6-14.el8",
                 },
               },
@@ -8434,7 +8434,7 @@ Object {
                 "id": "libuuid@2.32.1-22.el8",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libuuid@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8442,7 +8442,7 @@ Object {
                 "id": "libverto@0.3.0-5.el8",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.3.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libverto@0.3.0-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.3.0-5.el8",
                 },
               },
@@ -8450,7 +8450,7 @@ Object {
                 "id": "libxcrypt@4.1.1-4.el8",
                 "info": Object {
                   "name": "libxcrypt",
-                  "purl": "pkg:rpm/libxcrypt@4.1.1-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libxcrypt@4.1.1-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.1.1-4.el8",
                 },
               },
@@ -8458,7 +8458,7 @@ Object {
                 "id": "libxml2@2.9.7-7.el8",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libxml2@2.9.7-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -8466,7 +8466,7 @@ Object {
                 "id": "libyaml@0.1.7-5.el8",
                 "info": Object {
                   "name": "libyaml",
-                  "purl": "pkg:rpm/libyaml@0.1.7-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libyaml@0.1.7-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.1.7-5.el8",
                 },
               },
@@ -8474,7 +8474,7 @@ Object {
                 "id": "libzstd@1.4.2-2.el8",
                 "info": Object {
                   "name": "libzstd",
-                  "purl": "pkg:rpm/libzstd@1.4.2-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/libzstd@1.4.2-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.4.2-2.el8",
                 },
               },
@@ -8482,7 +8482,7 @@ Object {
                 "id": "lua-libs@5.3.4-11.el8",
                 "info": Object {
                   "name": "lua-libs",
-                  "purl": "pkg:rpm/lua-libs@5.3.4-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/lua-libs@5.3.4-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.3.4-11.el8",
                 },
               },
@@ -8490,7 +8490,7 @@ Object {
                 "id": "lz4-libs@1.8.1.2-4.el8",
                 "info": Object {
                   "name": "lz4-libs",
-                  "purl": "pkg:rpm/lz4-libs@1.8.1.2-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/lz4-libs@1.8.1.2-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.8.1.2-4.el8",
                 },
               },
@@ -8498,7 +8498,7 @@ Object {
                 "id": "mpfr@3.1.6-1.el8",
                 "info": Object {
                   "name": "mpfr",
-                  "purl": "pkg:rpm/mpfr@3.1.6-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/mpfr@3.1.6-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.1.6-1.el8",
                 },
               },
@@ -8506,7 +8506,7 @@ Object {
                 "id": "ncurses-base@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/ncurses-base@6.1-7.20180224.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -8514,7 +8514,7 @@ Object {
                 "id": "ncurses-libs@6.1-7.20180224.el8",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.1-7.20180224.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/ncurses-libs@6.1-7.20180224.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "6.1-7.20180224.el8",
                 },
               },
@@ -8522,7 +8522,7 @@ Object {
                 "id": "nettle@3.4.1-1.el8",
                 "info": Object {
                   "name": "nettle",
-                  "purl": "pkg:rpm/nettle@3.4.1-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/nettle@3.4.1-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.4.1-1.el8",
                 },
               },
@@ -8530,7 +8530,7 @@ Object {
                 "id": "npth@1.5-4.el8",
                 "info": Object {
                   "name": "npth",
-                  "purl": "pkg:rpm/npth@1.5-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/npth@1.5-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.5-4.el8",
                 },
               },
@@ -8538,7 +8538,7 @@ Object {
                 "id": "openldap@2.4.46-11.el8",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.46-11.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/openldap@2.4.46-11.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.4.46-11.el8",
                 },
               },
@@ -8546,7 +8546,7 @@ Object {
                 "id": "openssl-libs@1:1.1.1c-15.el8",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.1.1c-15.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/openssl-libs@1:1.1.1c-15.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:1.1.1c-15.el8",
                 },
               },
@@ -8554,7 +8554,7 @@ Object {
                 "id": "p11-kit@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/p11-kit@0.23.14-5.el8_0?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -8562,7 +8562,7 @@ Object {
                 "id": "p11-kit-trust@0.23.14-5.el8_0",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.14-5.el8_0?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/p11-kit-trust@0.23.14-5.el8_0?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.23.14-5.el8_0",
                 },
               },
@@ -8570,7 +8570,7 @@ Object {
                 "id": "pam@1.3.1-8.el8",
                 "info": Object {
                   "name": "pam",
-                  "purl": "pkg:rpm/pam@1.3.1-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/pam@1.3.1-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.3.1-8.el8",
                 },
               },
@@ -8578,7 +8578,7 @@ Object {
                 "id": "passwd@0.80-3.el8",
                 "info": Object {
                   "name": "passwd",
-                  "purl": "pkg:rpm/passwd@0.80-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/passwd@0.80-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.80-3.el8",
                 },
               },
@@ -8586,7 +8586,7 @@ Object {
                 "id": "pcre@8.42-4.el8",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.42-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/pcre@8.42-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.42-4.el8",
                 },
               },
@@ -8594,7 +8594,7 @@ Object {
                 "id": "pcre2@10.32-1.el8",
                 "info": Object {
                   "name": "pcre2",
-                  "purl": "pkg:rpm/pcre2@10.32-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/pcre2@10.32-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "10.32-1.el8",
                 },
               },
@@ -8602,7 +8602,7 @@ Object {
                 "id": "platform-python@3.6.8-23.el8",
                 "info": Object {
                   "name": "platform-python",
-                  "purl": "pkg:rpm/platform-python@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/platform-python@3.6.8-23.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.6.8-23.el8",
                 },
               },
@@ -8610,7 +8610,7 @@ Object {
                 "id": "platform-python-setuptools@39.2.0-5.el8",
                 "info": Object {
                   "name": "platform-python-setuptools",
-                  "purl": "pkg:rpm/platform-python-setuptools@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/platform-python-setuptools@39.2.0-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -8618,7 +8618,7 @@ Object {
                 "id": "popt@1.16-14.el8",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.16-14.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/popt@1.16-14.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.16-14.el8",
                 },
               },
@@ -8626,7 +8626,7 @@ Object {
                 "id": "publicsuffix-list-dafsa@20180723-1.el8",
                 "info": Object {
                   "name": "publicsuffix-list-dafsa",
-                  "purl": "pkg:rpm/publicsuffix-list-dafsa@20180723-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/publicsuffix-list-dafsa@20180723-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "20180723-1.el8",
                 },
               },
@@ -8634,7 +8634,7 @@ Object {
                 "id": "python3-dateutil@1:2.6.1-6.el8",
                 "info": Object {
                   "name": "python3-dateutil",
-                  "purl": "pkg:rpm/python3-dateutil@1:2.6.1-6.el8?epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dateutil@1:2.6.1-6.el8?distro=rhel-8.2&epoch=1&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1:2.6.1-6.el8",
                 },
               },
@@ -8642,7 +8642,7 @@ Object {
                 "id": "python3-dbus@1.2.4-15.el8",
                 "info": Object {
                   "name": "python3-dbus",
-                  "purl": "pkg:rpm/python3-dbus@1.2.4-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dbus@1.2.4-15.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.2.4-15.el8",
                 },
               },
@@ -8650,7 +8650,7 @@ Object {
                 "id": "python3-decorator@4.2.1-2.el8",
                 "info": Object {
                   "name": "python3-decorator",
-                  "purl": "pkg:rpm/python3-decorator@4.2.1-2.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-decorator@4.2.1-2.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.1-2.el8",
                 },
               },
@@ -8658,7 +8658,7 @@ Object {
                 "id": "python3-dmidecode@3.12.2-15.el8",
                 "info": Object {
                   "name": "python3-dmidecode",
-                  "purl": "pkg:rpm/python3-dmidecode@3.12.2-15.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dmidecode@3.12.2-15.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.12.2-15.el8",
                 },
               },
@@ -8666,7 +8666,7 @@ Object {
                 "id": "python3-dnf@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "python3-dnf",
-                  "purl": "pkg:rpm/python3-dnf@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dnf@4.2.17-7.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -8674,7 +8674,7 @@ Object {
                 "id": "python3-dnf-plugins-core@4.0.12-4.el8_2",
                 "info": Object {
                   "name": "python3-dnf-plugins-core",
-                  "purl": "pkg:rpm/python3-dnf-plugins-core@4.0.12-4.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-dnf-plugins-core@4.0.12-4.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.0.12-4.el8_2",
                 },
               },
@@ -8682,7 +8682,7 @@ Object {
                 "id": "python3-ethtool@0.14-3.el8",
                 "info": Object {
                   "name": "python3-ethtool",
-                  "purl": "pkg:rpm/python3-ethtool@0.14-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-ethtool@0.14-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.14-3.el8",
                 },
               },
@@ -8690,7 +8690,7 @@ Object {
                 "id": "python3-gobject-base@3.28.3-1.el8",
                 "info": Object {
                   "name": "python3-gobject-base",
-                  "purl": "pkg:rpm/python3-gobject-base@3.28.3-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-gobject-base@3.28.3-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.28.3-1.el8",
                 },
               },
@@ -8698,7 +8698,7 @@ Object {
                 "id": "python3-gpg@1.10.0-6.el8",
                 "info": Object {
                   "name": "python3-gpg",
-                  "purl": "pkg:rpm/python3-gpg@1.10.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-gpg@1.10.0-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.10.0-6.el8",
                 },
               },
@@ -8706,7 +8706,7 @@ Object {
                 "id": "python3-hawkey@0.39.1-6.el8_2",
                 "info": Object {
                   "name": "python3-hawkey",
-                  "purl": "pkg:rpm/python3-hawkey@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-hawkey@0.39.1-6.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.39.1-6.el8_2",
                 },
               },
@@ -8714,7 +8714,7 @@ Object {
                 "id": "python3-iniparse@0.4-31.el8",
                 "info": Object {
                   "name": "python3-iniparse",
-                  "purl": "pkg:rpm/python3-iniparse@0.4-31.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-iniparse@0.4-31.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.4-31.el8",
                 },
               },
@@ -8722,7 +8722,7 @@ Object {
                 "id": "python3-inotify@0.9.6-13.el8",
                 "info": Object {
                   "name": "python3-inotify",
-                  "purl": "pkg:rpm/python3-inotify@0.9.6-13.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-inotify@0.9.6-13.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.9.6-13.el8",
                 },
               },
@@ -8730,7 +8730,7 @@ Object {
                 "id": "python3-libcomps@0.1.11-4.el8",
                 "info": Object {
                   "name": "python3-libcomps",
-                  "purl": "pkg:rpm/python3-libcomps@0.1.11-4.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-libcomps@0.1.11-4.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.1.11-4.el8",
                 },
               },
@@ -8738,7 +8738,7 @@ Object {
                 "id": "python3-libdnf@0.39.1-6.el8_2",
                 "info": Object {
                   "name": "python3-libdnf",
-                  "purl": "pkg:rpm/python3-libdnf@0.39.1-6.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-libdnf@0.39.1-6.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "0.39.1-6.el8_2",
                 },
               },
@@ -8746,7 +8746,7 @@ Object {
                 "id": "python3-librepo@1.11.0-3.el8_2",
                 "info": Object {
                   "name": "python3-librepo",
-                  "purl": "pkg:rpm/python3-librepo@1.11.0-3.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-librepo@1.11.0-3.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.11.0-3.el8_2",
                 },
               },
@@ -8754,7 +8754,7 @@ Object {
                 "id": "python3-libs@3.6.8-23.el8",
                 "info": Object {
                   "name": "python3-libs",
-                  "purl": "pkg:rpm/python3-libs@3.6.8-23.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-libs@3.6.8-23.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.6.8-23.el8",
                 },
               },
@@ -8762,7 +8762,7 @@ Object {
                 "id": "python3-libxml2@2.9.7-7.el8",
                 "info": Object {
                   "name": "python3-libxml2",
-                  "purl": "pkg:rpm/python3-libxml2@2.9.7-7.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-libxml2@2.9.7-7.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.9.7-7.el8",
                 },
               },
@@ -8770,7 +8770,7 @@ Object {
                 "id": "python3-pip-wheel@9.0.3-16.el8",
                 "info": Object {
                   "name": "python3-pip-wheel",
-                  "purl": "pkg:rpm/python3-pip-wheel@9.0.3-16.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-pip-wheel@9.0.3-16.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "9.0.3-16.el8",
                 },
               },
@@ -8778,7 +8778,7 @@ Object {
                 "id": "python3-rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "python3-rpm",
-                  "purl": "pkg:rpm/python3-rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-rpm@4.14.2-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -8786,7 +8786,7 @@ Object {
                 "id": "python3-setuptools-wheel@39.2.0-5.el8",
                 "info": Object {
                   "name": "python3-setuptools-wheel",
-                  "purl": "pkg:rpm/python3-setuptools-wheel@39.2.0-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-setuptools-wheel@39.2.0-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "39.2.0-5.el8",
                 },
               },
@@ -8794,7 +8794,7 @@ Object {
                 "id": "python3-six@1.11.0-8.el8",
                 "info": Object {
                   "name": "python3-six",
-                  "purl": "pkg:rpm/python3-six@1.11.0-8.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-six@1.11.0-8.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.11.0-8.el8",
                 },
               },
@@ -8802,7 +8802,7 @@ Object {
                 "id": "python3-subscription-manager-rhsm@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "python3-subscription-manager-rhsm",
-                  "purl": "pkg:rpm/python3-subscription-manager-rhsm@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-subscription-manager-rhsm@1.26.20-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -8810,7 +8810,7 @@ Object {
                 "id": "python3-syspurpose@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "python3-syspurpose",
-                  "purl": "pkg:rpm/python3-syspurpose@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/python3-syspurpose@1.26.20-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -8818,7 +8818,7 @@ Object {
                 "id": "readline@7.0-10.el8",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@7.0-10.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/readline@7.0-10.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "7.0-10.el8",
                 },
               },
@@ -8826,7 +8826,7 @@ Object {
                 "id": "redhat-release@8.2-1.0.el8",
                 "info": Object {
                   "name": "redhat-release",
-                  "purl": "pkg:rpm/redhat-release@8.2-1.0.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/redhat-release@8.2-1.0.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.2-1.0.el8",
                 },
               },
@@ -8834,7 +8834,7 @@ Object {
                 "id": "rootfiles@8.1-22.el8",
                 "info": Object {
                   "name": "rootfiles",
-                  "purl": "pkg:rpm/rootfiles@8.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/rootfiles@8.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "8.1-22.el8",
                 },
               },
@@ -8842,7 +8842,7 @@ Object {
                 "id": "rpm@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/rpm@4.14.2-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -8850,7 +8850,7 @@ Object {
                 "id": "rpm-build-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/rpm-build-libs@4.14.2-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -8858,7 +8858,7 @@ Object {
                 "id": "rpm-libs@4.14.2-37.el8",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.14.2-37.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/rpm-libs@4.14.2-37.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.14.2-37.el8",
                 },
               },
@@ -8866,7 +8866,7 @@ Object {
                 "id": "sed@4.5-1.el8",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.5-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/sed@4.5-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.5-1.el8",
                 },
               },
@@ -8874,7 +8874,7 @@ Object {
                 "id": "setup@2.12.2-5.el8",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.12.2-5.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/setup@2.12.2-5.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.12.2-5.el8",
                 },
               },
@@ -8882,7 +8882,7 @@ Object {
                 "id": "shadow-utils@2:4.6-8.el8",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.6-8.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/shadow-utils@2:4.6-8.el8?distro=rhel-8.2&epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2:4.6-8.el8",
                 },
               },
@@ -8890,7 +8890,7 @@ Object {
                 "id": "sqlite-libs@3.26.0-6.el8",
                 "info": Object {
                   "name": "sqlite-libs",
-                  "purl": "pkg:rpm/sqlite-libs@3.26.0-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/sqlite-libs@3.26.0-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "3.26.0-6.el8",
                 },
               },
@@ -8898,7 +8898,7 @@ Object {
                 "id": "subscription-manager@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "subscription-manager",
-                  "purl": "pkg:rpm/subscription-manager@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/subscription-manager@1.26.20-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -8906,7 +8906,7 @@ Object {
                 "id": "subscription-manager-rhsm-certificates@1.26.20-1.el8_2",
                 "info": Object {
                   "name": "subscription-manager-rhsm-certificates",
-                  "purl": "pkg:rpm/subscription-manager-rhsm-certificates@1.26.20-1.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/subscription-manager-rhsm-certificates@1.26.20-1.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.26.20-1.el8_2",
                 },
               },
@@ -8914,7 +8914,7 @@ Object {
                 "id": "systemd@239-31.el8_2.2",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/systemd@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/systemd@239-31.el8_2.2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "239-31.el8_2.2",
                 },
               },
@@ -8922,7 +8922,7 @@ Object {
                 "id": "systemd-libs@239-31.el8_2.2",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/systemd-libs@239-31.el8_2.2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "239-31.el8_2.2",
                 },
               },
@@ -8930,7 +8930,7 @@ Object {
                 "id": "systemd-pam@239-31.el8_2.2",
                 "info": Object {
                   "name": "systemd-pam",
-                  "purl": "pkg:rpm/systemd-pam@239-31.el8_2.2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/systemd-pam@239-31.el8_2.2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "239-31.el8_2.2",
                 },
               },
@@ -8938,7 +8938,7 @@ Object {
                 "id": "tar@2:1.30-4.el8",
                 "info": Object {
                   "name": "tar",
-                  "purl": "pkg:rpm/tar@2:1.30-4.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/tar@2:1.30-4.el8?distro=rhel-8.2&epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2:1.30-4.el8",
                 },
               },
@@ -8946,7 +8946,7 @@ Object {
                 "id": "tzdata@2020a-1.el8",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2020a-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/tzdata@2020a-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2020a-1.el8",
                 },
               },
@@ -8954,7 +8954,7 @@ Object {
                 "id": "usermode@1.113-1.el8",
                 "info": Object {
                   "name": "usermode",
-                  "purl": "pkg:rpm/usermode@1.113-1.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/usermode@1.113-1.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.113-1.el8",
                 },
               },
@@ -8962,7 +8962,7 @@ Object {
                 "id": "util-linux@2.32.1-22.el8",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:rpm/util-linux@2.32.1-22.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/util-linux@2.32.1-22.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.32.1-22.el8",
                 },
               },
@@ -8970,7 +8970,7 @@ Object {
                 "id": "vim-minimal@2:8.0.1763-13.el8",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.0.1763-13.el8?epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/vim-minimal@2:8.0.1763-13.el8?distro=rhel-8.2&epoch=2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2:8.0.1763-13.el8",
                 },
               },
@@ -8978,7 +8978,7 @@ Object {
                 "id": "virt-what@1.18-6.el8",
                 "info": Object {
                   "name": "virt-what",
-                  "purl": "pkg:rpm/virt-what@1.18-6.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/virt-what@1.18-6.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.18-6.el8",
                 },
               },
@@ -8986,7 +8986,7 @@ Object {
                 "id": "which@2.21-12.el8",
                 "info": Object {
                   "name": "which",
-                  "purl": "pkg:rpm/which@2.21-12.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/which@2.21-12.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "2.21-12.el8",
                 },
               },
@@ -8994,7 +8994,7 @@ Object {
                 "id": "xz-libs@5.2.4-3.el8",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.4-3.el8?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/xz-libs@5.2.4-3.el8?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "5.2.4-3.el8",
                 },
               },
@@ -9002,7 +9002,7 @@ Object {
                 "id": "yum@4.2.17-7.el8_2",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@4.2.17-7.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/yum@4.2.17-7.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "4.2.17-7.el8_2",
                 },
               },
@@ -9010,7 +9010,7 @@ Object {
                 "id": "zlib@1.2.11-16.el8_2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.11-16.el8_2?repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
+                  "purl": "pkg:rpm/rhel/zlib@1.2.11-16.el8_2?distro=rhel-8.2&repositories=rhel-8-for-x86_64-baseos-rpms%2Crhel-8-for-x86_64-appstream-rpms",
                   "version": "1.2.11-16.el8_2",
                 },
               },

--- a/test/system/package-managers/__snapshots__/deb.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/deb.spec.ts.snap
@@ -1152,7 +1152,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
-                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit-common@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1160,7 +1160,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
-                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
+                  "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?distro=debian-buster&upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1168,7 +1168,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
-                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit1@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1176,7 +1176,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage-common@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1184,7 +1184,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
+                  "purl": "pkg:deb/debian/libsepol1@2.8-1?distro=debian-buster&upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1192,7 +1192,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage1@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1200,7 +1200,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?distro=debian-buster&upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1208,7 +1208,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam0g@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1216,7 +1216,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1224,7 +1224,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1232,7 +1232,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/passwd@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1240,7 +1240,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.118",
+                  "purl": "pkg:deb/debian/adduser@3.118?distro=debian-buster",
                   "version": "3.118",
                 },
               },
@@ -1248,7 +1248,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?distro=debian-buster&upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1256,7 +1256,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
-                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
+                  "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?distro=debian-buster&upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1264,7 +1264,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
+                  "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?distro=debian-buster&upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1272,7 +1272,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?distro=debian-buster",
                   "version": "1.8.4-5",
                 },
               },
@@ -1280,7 +1280,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@241-7~deb10u4?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u4?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1288,7 +1288,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@241-7~deb10u4?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@241-7~deb10u4?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1296,7 +1296,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2.1",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2.1?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2.1?distro=debian-buster&upstream=apt",
                   "version": "1.8.2.1",
                 },
               },
@@ -1304,7 +1304,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?distro=debian-buster",
                   "version": "2019.1",
                 },
               },
@@ -1312,7 +1312,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.35-1?distro=debian-buster&upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1320,7 +1320,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
+                  "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?distro=debian-buster&upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1328,7 +1328,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
-                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
+                  "purl": "pkg:deb/debian/libgmp10@2:6.1.2%2Bdfsg-4?distro=debian-buster&upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1336,7 +1336,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
-                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
+                  "purl": "pkg:deb/debian/libunistring2@0.9.10-1?distro=debian-buster&upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1344,7 +1344,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
-                  "purl": "pkg:deb/libidn2-0@2.0.5-1%2Bdeb10u1?upstream=libidn2",
+                  "purl": "pkg:deb/debian/libidn2-0@2.0.5-1%2Bdeb10u1?distro=debian-buster&upstream=libidn2",
                   "version": "2.0.5-1+deb10u1",
                 },
               },
@@ -1352,7 +1352,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.13-3",
+                  "purl": "pkg:deb/debian/libtasn1-6@4.13-3?distro=debian-buster",
                   "version": "4.13-3",
                 },
               },
@@ -1360,7 +1360,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libnettle6@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1368,7 +1368,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
-                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1376,7 +1376,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
-                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
+                  "purl": "pkg:deb/debian/libffi6@3.2.1-9?distro=debian-buster&upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1384,7 +1384,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
+                  "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?distro=debian-buster&upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1392,7 +1392,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
-                  "purl": "pkg:deb/libgnutls30@3.6.7-4%2Bdeb10u5?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls30@3.6.7-4%2Bdeb10u5?distro=debian-buster&upstream=gnutls28",
                   "version": "3.6.7-4+deb10u5",
                 },
               },
@@ -1400,7 +1400,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
-                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
+                  "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?distro=debian-buster&upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1408,7 +1408,7 @@ Object {
                 "id": "apt@1.8.2.1",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.8.2.1",
+                  "purl": "pkg:deb/debian/apt@1.8.2.1?distro=debian-buster",
                   "version": "1.8.2.1",
                 },
               },
@@ -1423,7 +1423,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?distro=debian-buster&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1431,7 +1431,7 @@ Object {
                 "id": "base-files@10.3+deb10u5",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u5",
+                  "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u5?distro=debian-buster",
                   "version": "10.3+deb10u5",
                 },
               },
@@ -1439,7 +1439,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.249?distro=debian-buster&upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1447,7 +1447,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.46",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.46?distro=debian-buster",
                   "version": "3.5.46",
                 },
               },
@@ -1455,7 +1455,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.6.1",
+                  "purl": "pkg:deb/debian/debianutils@4.8.6.1?distro=debian-buster",
                   "version": "4.8.6.1",
                 },
               },
@@ -1463,7 +1463,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
-                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1471,7 +1471,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@5.0-4",
+                  "purl": "pkg:deb/debian/bash@5.0-4?distro=debian-buster",
                   "version": "5.0-4",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.30-3",
+                  "purl": "pkg:deb/debian/coreutils@8.30-3?distro=debian-buster",
                   "version": "8.30-3",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.10.2-5",
+                  "purl": "pkg:deb/debian/dash@0.5.10.2-5?distro=debian-buster",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1509,7 +1509,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.7-3",
+                  "purl": "pkg:deb/debian/diffutils@1:3.7-3?distro=debian-buster",
                   "version": "1:3.7-3",
                 },
               },
@@ -1524,7 +1524,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
-                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1532,7 +1532,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
-                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1540,7 +1540,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1548,7 +1548,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1556,7 +1556,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1564,7 +1564,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u3",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u3?distro=debian-buster",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1572,7 +1572,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
+                  "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?distro=debian-buster",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1594,7 +1594,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.28-10?distro=debian-buster&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1609,7 +1609,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@3.3-1",
+                  "purl": "pkg:deb/debian/grep@3.3-1?distro=debian-buster",
                   "version": "3.3-1",
                 },
               },
@@ -1617,7 +1617,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.9-3",
+                  "purl": "pkg:deb/debian/gzip@1.9-3?distro=debian-buster",
                   "version": "1.9-3",
                 },
               },
@@ -1625,7 +1625,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.21",
+                  "purl": "pkg:deb/debian/hostname@3.21?distro=debian-buster",
                   "version": "3.21",
                 },
               },
@@ -1633,7 +1633,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
+                  "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?distro=debian-buster",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1648,7 +1648,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
-                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1656,7 +1656,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1664,7 +1664,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1672,7 +1672,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.7-1",
+                  "purl": "pkg:deb/debian/sed@4.7-1?distro=debian-buster",
                   "version": "4.7-1",
                 },
               },
@@ -1702,7 +1702,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1710,7 +1710,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
+                  "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?distro=debian-buster",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1718,7 +1718,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?distro=debian-buster&upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1733,7 +1733,7 @@ Object {
                 "id": "tzdata@2020a-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/tzdata@2020a-0%2Bdeb10u1?distro=debian-buster",
                   "version": "2020a-0+deb10u1",
                 },
               },
@@ -1741,7 +1741,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.33.1-0.1?distro=debian-buster&upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1749,7 +1749,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1757,7 +1757,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1765,7 +1765,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1773,7 +1773,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
-                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1781,7 +1781,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
@@ -870,7 +870,7 @@ Object {
                 "id": "amazon-linux-extras@1.6.11-1.amzn2",
                 "info": Object {
                   "name": "amazon-linux-extras",
-                  "purl": "pkg:rpm/amazon-linux-extras@1.6.11-1.amzn2",
+                  "purl": "pkg:rpm/amzn/amazon-linux-extras@1.6.11-1.amzn2?distro=amzn-2",
                   "version": "1.6.11-1.amzn2",
                 },
               },
@@ -878,7 +878,7 @@ Object {
                 "id": "basesystem@10.0-7.amzn2.0.1",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/basesystem@10.0-7.amzn2.0.1?distro=amzn-2",
                   "version": "10.0-7.amzn2.0.1",
                 },
               },
@@ -886,7 +886,7 @@ Object {
                 "id": "bash@4.2.46-33.amzn2",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-33.amzn2",
+                  "purl": "pkg:rpm/amzn/bash@4.2.46-33.amzn2?distro=amzn-2",
                   "version": "4.2.46-33.amzn2",
                 },
               },
@@ -894,7 +894,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.amzn2.0.2",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/bzip2-libs@1.0.6-13.amzn2.0.2?distro=amzn-2",
                   "version": "1.0.6-13.amzn2.0.2",
                 },
               },
@@ -902,7 +902,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.amzn2.0.2",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/ca-certificates@2019.2.32-76.amzn2.0.2?distro=amzn-2",
                   "version": "2019.2.32-76.amzn2.0.2",
                 },
               },
@@ -910,7 +910,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.amzn2.0.2",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/chkconfig@1.7.4-1.amzn2.0.2?distro=amzn-2",
                   "version": "1.7.4-1.amzn2.0.2",
                 },
               },
@@ -918,7 +918,7 @@ Object {
                 "id": "coreutils@8.22-24.amzn2",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.amzn2",
+                  "purl": "pkg:rpm/amzn/coreutils@8.22-24.amzn2?distro=amzn-2",
                   "version": "8.22-24.amzn2",
                 },
               },
@@ -926,7 +926,7 @@ Object {
                 "id": "cpio@2.11-27.amzn2",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.amzn2",
+                  "purl": "pkg:rpm/amzn/cpio@2.11-27.amzn2?distro=amzn-2",
                   "version": "2.11-27.amzn2",
                 },
               },
@@ -934,7 +934,7 @@ Object {
                 "id": "curl@7.61.1-12.amzn2.0.2",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/curl@7.61.1-12.amzn2.0.2?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.2",
                 },
               },
@@ -942,7 +942,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.amzn2",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.amzn2",
+                  "purl": "pkg:rpm/amzn/cyrus-sasl-lib@2.1.26-23.amzn2?distro=amzn-2",
                   "version": "2.1.26-23.amzn2",
                 },
               },
@@ -950,7 +950,7 @@ Object {
                 "id": "diffutils@3.3-5.amzn2",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/diffutils@3.3-5.amzn2?distro=amzn-2",
                   "version": "3.3-5.amzn2",
                 },
               },
@@ -958,7 +958,7 @@ Object {
                 "id": "elfutils-libelf@0.176-2.amzn2",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-2.amzn2",
+                  "purl": "pkg:rpm/amzn/elfutils-libelf@0.176-2.amzn2?distro=amzn-2",
                   "version": "0.176-2.amzn2",
                 },
               },
@@ -966,7 +966,7 @@ Object {
                 "id": "expat@2.1.0-10.amzn2.0.2",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/expat@2.1.0-10.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-10.amzn2.0.2",
                 },
               },
@@ -974,7 +974,7 @@ Object {
                 "id": "file-libs@5.11-36.amzn2.0.1",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-36.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/file-libs@5.11-36.amzn2.0.1?distro=amzn-2",
                   "version": "5.11-36.amzn2.0.1",
                 },
               },
@@ -982,7 +982,7 @@ Object {
                 "id": "filesystem@3.2-25.amzn2.0.4",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/filesystem@3.2-25.amzn2.0.4?distro=amzn-2",
                   "version": "3.2-25.amzn2.0.4",
                 },
               },
@@ -990,7 +990,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.amzn2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/findutils@1:4.5.11-6.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:4.5.11-6.amzn2",
                 },
               },
@@ -998,7 +998,7 @@ Object {
                 "id": "gawk@4.0.2-4.amzn2.1.2",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.amzn2.1.2",
+                  "purl": "pkg:rpm/amzn/gawk@4.0.2-4.amzn2.1.2?distro=amzn-2",
                   "version": "4.0.2-4.amzn2.1.2",
                 },
               },
@@ -1006,7 +1006,7 @@ Object {
                 "id": "gdbm@1:1.13-6.amzn2.0.2",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.13-6.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gdbm@1:1.13-6.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:1.13-6.amzn2.0.2",
                 },
               },
@@ -1014,7 +1014,7 @@ Object {
                 "id": "glib2@2.56.1-5.amzn2.0.1",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-5.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/glib2@2.56.1-5.amzn2.0.1?distro=amzn-2",
                   "version": "2.56.1-5.amzn2.0.1",
                 },
               },
@@ -1022,7 +1022,7 @@ Object {
                 "id": "glibc@2.26-35.amzn2",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.26-35.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc@2.26-35.amzn2?distro=amzn-2",
                   "version": "2.26-35.amzn2",
                 },
               },
@@ -1030,7 +1030,7 @@ Object {
                 "id": "glibc-common@2.26-35.amzn2",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.26-35.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-common@2.26-35.amzn2?distro=amzn-2",
                   "version": "2.26-35.amzn2",
                 },
               },
@@ -1038,7 +1038,7 @@ Object {
                 "id": "glibc-langpack-en@2.26-35.amzn2",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/glibc-langpack-en@2.26-35.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-langpack-en@2.26-35.amzn2?distro=amzn-2",
                   "version": "2.26-35.amzn2",
                 },
               },
@@ -1046,7 +1046,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.26-35.amzn2",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.26-35.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-minimal-langpack@2.26-35.amzn2?distro=amzn-2",
                   "version": "2.26-35.amzn2",
                 },
               },
@@ -1054,7 +1054,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.amzn2.0.2",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gmp@1:6.0.0-15.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:6.0.0-15.amzn2.0.2",
                 },
               },
@@ -1062,7 +1062,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.amzn2.0.4",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/gnupg2@2.0.22-5.amzn2.0.4?distro=amzn-2",
                   "version": "2.0.22-5.amzn2.0.4",
                 },
               },
@@ -1070,7 +1070,7 @@ Object {
                 "id": "gpg-pubkey@c87f5b1a-593863f8",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@c87f5b1a-593863f8",
+                  "purl": "pkg:rpm/amzn/gpg-pubkey@c87f5b1a-593863f8?distro=amzn-2",
                   "version": "c87f5b1a-593863f8",
                 },
               },
@@ -1078,7 +1078,7 @@ Object {
                 "id": "gpgme@1.3.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/gpgme@1.3.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "1.3.2-5.amzn2.0.2",
                 },
               },
@@ -1086,7 +1086,7 @@ Object {
                 "id": "grep@2.20-3.amzn2.0.2",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/grep@2.20-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.20-3.amzn2.0.2",
                 },
               },
@@ -1094,7 +1094,7 @@ Object {
                 "id": "info@5.1-5.amzn2",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.amzn2",
+                  "purl": "pkg:rpm/amzn/info@5.1-5.amzn2?distro=amzn-2",
                   "version": "5.1-5.amzn2",
                 },
               },
@@ -1102,7 +1102,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.amzn2.0.2",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/keyutils-libs@1.5.8-3.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.8-3.amzn2.0.2",
                 },
               },
@@ -1110,7 +1110,7 @@ Object {
                 "id": "krb5-libs@1.15.1-37.amzn2.2.2",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-37.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/krb5-libs@1.15.1-37.amzn2.2.2?distro=amzn-2",
                   "version": "1.15.1-37.amzn2.2.2",
                 },
               },
@@ -1118,7 +1118,7 @@ Object {
                 "id": "libacl@2.2.51-14.amzn2",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-14.amzn2",
+                  "purl": "pkg:rpm/amzn/libacl@2.2.51-14.amzn2?distro=amzn-2",
                   "version": "2.2.51-14.amzn2",
                 },
               },
@@ -1126,7 +1126,7 @@ Object {
                 "id": "libassuan@2.1.0-3.amzn2.0.2",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libassuan@2.1.0-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-3.amzn2.0.2",
                 },
               },
@@ -1134,7 +1134,7 @@ Object {
                 "id": "libattr@2.4.46-12.amzn2.0.2",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libattr@2.4.46-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.4.46-12.amzn2.0.2",
                 },
               },
@@ -1142,7 +1142,7 @@ Object {
                 "id": "libblkid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libblkid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1150,7 +1150,7 @@ Object {
                 "id": "libcap@2.22-9.amzn2.0.2",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcap@2.22-9.amzn2.0.2?distro=amzn-2",
                   "version": "2.22-9.amzn2.0.2",
                 },
               },
@@ -1158,7 +1158,7 @@ Object {
                 "id": "libcom_err@1.42.9-12.amzn2.0.2",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcom_err@1.42.9-12.amzn2.0.2?distro=amzn-2",
                   "version": "1.42.9-12.amzn2.0.2",
                 },
               },
@@ -1166,7 +1166,7 @@ Object {
                 "id": "libcrypt@2.26-35.amzn2",
                 "info": Object {
                   "name": "libcrypt",
-                  "purl": "pkg:rpm/libcrypt@2.26-35.amzn2",
+                  "purl": "pkg:rpm/amzn/libcrypt@2.26-35.amzn2?distro=amzn-2",
                   "version": "2.26-35.amzn2",
                 },
               },
@@ -1174,7 +1174,7 @@ Object {
                 "id": "libcurl@7.61.1-12.amzn2.0.2",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcurl@7.61.1-12.amzn2.0.2?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.2",
                 },
               },
@@ -1182,7 +1182,7 @@ Object {
                 "id": "libdb@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -1190,7 +1190,7 @@ Object {
                 "id": "libdb-utils@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb-utils@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -1198,7 +1198,7 @@ Object {
                 "id": "libffi@3.0.13-18.amzn2.0.2",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-18.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libffi@3.0.13-18.amzn2.0.2?distro=amzn-2",
                   "version": "3.0.13-18.amzn2.0.2",
                 },
               },
@@ -1206,7 +1206,7 @@ Object {
                 "id": "libgcc@7.3.1-9.amzn2",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@7.3.1-9.amzn2",
+                  "purl": "pkg:rpm/amzn/libgcc@7.3.1-9.amzn2?distro=amzn-2",
                   "version": "7.3.1-9.amzn2",
                 },
               },
@@ -1214,7 +1214,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.amzn2.0.2",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libgcrypt@1.5.3-14.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.3-14.amzn2.0.2",
                 },
               },
@@ -1222,7 +1222,7 @@ Object {
                 "id": "libgpg-error@1.12-3.amzn2.0.3",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libgpg-error@1.12-3.amzn2.0.3?distro=amzn-2",
                   "version": "1.12-3.amzn2.0.3",
                 },
               },
@@ -1230,7 +1230,7 @@ Object {
                 "id": "libidn2@2.3.0-1.amzn2",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.3.0-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libidn2@2.3.0-1.amzn2?distro=amzn-2",
                   "version": "2.3.0-1.amzn2",
                 },
               },
@@ -1238,7 +1238,7 @@ Object {
                 "id": "libmetalink@0.1.2-7.amzn2.0.2",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.2-7.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libmetalink@0.1.2-7.amzn2.0.2?distro=amzn-2",
                   "version": "0.1.2-7.amzn2.0.2",
                 },
               },
@@ -1246,7 +1246,7 @@ Object {
                 "id": "libmount@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libmount@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1254,7 +1254,7 @@ Object {
                 "id": "libnghttp2@1.41.0-1.amzn2",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.41.0-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libnghttp2@1.41.0-1.amzn2?distro=amzn-2",
                   "version": "1.41.0-1.amzn2",
                 },
               },
@@ -1262,7 +1262,7 @@ Object {
                 "id": "libselinux@2.5-12.amzn2.0.2",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libselinux@2.5-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-12.amzn2.0.2",
                 },
               },
@@ -1270,7 +1270,7 @@ Object {
                 "id": "libsepol@2.5-8.1.amzn2.0.2",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-8.1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libsepol@2.5-8.1.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-8.1.amzn2.0.2",
                 },
               },
@@ -1278,7 +1278,7 @@ Object {
                 "id": "libssh2@1.4.3-12.amzn2.2.2",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.4.3-12.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/libssh2@1.4.3-12.amzn2.2.2?distro=amzn-2",
                   "version": "1.4.3-12.amzn2.2.2",
                 },
               },
@@ -1286,7 +1286,7 @@ Object {
                 "id": "libstdc++@7.3.1-9.amzn2",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@7.3.1-9.amzn2",
+                  "purl": "pkg:rpm/amzn/libstdc%2B%2B@7.3.1-9.amzn2?distro=amzn-2",
                   "version": "7.3.1-9.amzn2",
                 },
               },
@@ -1294,7 +1294,7 @@ Object {
                 "id": "libtasn1@4.10-1.amzn2.0.2",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libtasn1@4.10-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.10-1.amzn2.0.2",
                 },
               },
@@ -1302,7 +1302,7 @@ Object {
                 "id": "libunistring@0.9.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libunistring@0.9.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.9.3-9.amzn2.0.2",
                 },
               },
@@ -1310,7 +1310,7 @@ Object {
                 "id": "libuuid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libuuid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -1318,7 +1318,7 @@ Object {
                 "id": "libverto@0.2.5-4.amzn2.0.2",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libverto@0.2.5-4.amzn2.0.2?distro=amzn-2",
                   "version": "0.2.5-4.amzn2.0.2",
                 },
               },
@@ -1326,7 +1326,7 @@ Object {
                 "id": "libxml2@2.9.1-6.amzn2.4.1",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.amzn2.4.1",
+                  "purl": "pkg:rpm/amzn/libxml2@2.9.1-6.amzn2.4.1?distro=amzn-2",
                   "version": "2.9.1-6.amzn2.4.1",
                 },
               },
@@ -1334,7 +1334,7 @@ Object {
                 "id": "lua@5.1.4-15.amzn2.0.2",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/lua@5.1.4-15.amzn2.0.2?distro=amzn-2",
                   "version": "5.1.4-15.amzn2.0.2",
                 },
               },
@@ -1342,7 +1342,7 @@ Object {
                 "id": "ncurses@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1350,7 +1350,7 @@ Object {
                 "id": "ncurses-base@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-base@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1358,7 +1358,7 @@ Object {
                 "id": "ncurses-libs@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-libs@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -1366,7 +1366,7 @@ Object {
                 "id": "nspr@4.21.0-1.amzn2.0.2",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/nspr@4.21.0-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.21.0-1.amzn2.0.2",
                 },
               },
@@ -1374,7 +1374,7 @@ Object {
                 "id": "nss@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1382,7 +1382,7 @@ Object {
                 "id": "nss-pem@1.0.3-5.amzn2",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-pem@1.0.3-5.amzn2?distro=amzn-2",
                   "version": "1.0.3-5.amzn2",
                 },
               },
@@ -1390,7 +1390,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -1398,7 +1398,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn-freebl@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -1406,7 +1406,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-sysinit@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1414,7 +1414,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-tools@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -1422,7 +1422,7 @@ Object {
                 "id": "nss-util@3.44.0-4.amzn2",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-util@3.44.0-4.amzn2?distro=amzn-2",
                   "version": "3.44.0-4.amzn2",
                 },
               },
@@ -1430,7 +1430,7 @@ Object {
                 "id": "openldap@2.4.44-15.amzn2",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-15.amzn2",
+                  "purl": "pkg:rpm/amzn/openldap@2.4.44-15.amzn2?distro=amzn-2",
                   "version": "2.4.44-15.amzn2",
                 },
               },
@@ -1438,7 +1438,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.amzn2.0.3",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.amzn2.0.3?epoch=1",
+                  "purl": "pkg:rpm/amzn/openssl-libs@1:1.0.2k-19.amzn2.0.3?distro=amzn-2&epoch=1",
                   "version": "1:1.0.2k-19.amzn2.0.3",
                 },
               },
@@ -1446,7 +1446,7 @@ Object {
                 "id": "p11-kit@0.23.19-1.amzn2",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.19-1.amzn2",
+                  "purl": "pkg:rpm/amzn/p11-kit@0.23.19-1.amzn2?distro=amzn-2",
                   "version": "0.23.19-1.amzn2",
                 },
               },
@@ -1454,7 +1454,7 @@ Object {
                 "id": "p11-kit-trust@0.23.19-1.amzn2",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.19-1.amzn2",
+                  "purl": "pkg:rpm/amzn/p11-kit-trust@0.23.19-1.amzn2?distro=amzn-2",
                   "version": "0.23.19-1.amzn2",
                 },
               },
@@ -1462,7 +1462,7 @@ Object {
                 "id": "pcre@8.32-17.amzn2.0.2",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pcre@8.32-17.amzn2.0.2?distro=amzn-2",
                   "version": "8.32-17.amzn2.0.2",
                 },
               },
@@ -1470,7 +1470,7 @@ Object {
                 "id": "pinentry@0.8.1-17.amzn2.0.2",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pinentry@0.8.1-17.amzn2.0.2?distro=amzn-2",
                   "version": "0.8.1-17.amzn2.0.2",
                 },
               },
@@ -1478,7 +1478,7 @@ Object {
                 "id": "popt@1.13-16.amzn2.0.2",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/popt@1.13-16.amzn2.0.2?distro=amzn-2",
                   "version": "1.13-16.amzn2.0.2",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "pth@2.0.7-23.amzn2.0.2",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pth@2.0.7-23.amzn2.0.2?distro=amzn-2",
                   "version": "2.0.7-23.amzn2.0.2",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "pygpgme@0.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pygpgme@0.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.3-9.amzn2.0.2",
                 },
               },
@@ -1502,7 +1502,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.amzn2.0.2",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyliblzma@0.5.3-11.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.3-11.amzn2.0.2",
                 },
               },
@@ -1510,7 +1510,7 @@ Object {
                 "id": "python@2.7.18-1.amzn2",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.18-1.amzn2",
+                  "purl": "pkg:rpm/amzn/python@2.7.18-1.amzn2?distro=amzn-2",
                   "version": "2.7.18-1.amzn2",
                 },
               },
@@ -1518,7 +1518,7 @@ Object {
                 "id": "python-iniparse@0.4-9.amzn2",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.amzn2",
+                  "purl": "pkg:rpm/amzn/python-iniparse@0.4-9.amzn2?distro=amzn-2",
                   "version": "0.4-9.amzn2",
                 },
               },
@@ -1526,7 +1526,7 @@ Object {
                 "id": "python-libs@2.7.18-1.amzn2",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.18-1.amzn2",
+                  "purl": "pkg:rpm/amzn/python-libs@2.7.18-1.amzn2?distro=amzn-2",
                   "version": "2.7.18-1.amzn2",
                 },
               },
@@ -1534,7 +1534,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.amzn2.0.2",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/python-pycurl@7.19.0-19.amzn2.0.2?distro=amzn-2",
                   "version": "7.19.0-19.amzn2.0.2",
                 },
               },
@@ -1542,7 +1542,7 @@ Object {
                 "id": "python-urlgrabber@3.10-9.amzn2.0.1",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-9.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/python-urlgrabber@3.10-9.amzn2.0.1?distro=amzn-2",
                   "version": "3.10-9.amzn2.0.1",
                 },
               },
@@ -1550,7 +1550,7 @@ Object {
                 "id": "python2-rpm@4.11.3-40.amzn2.0.4",
                 "info": Object {
                   "name": "python2-rpm",
-                  "purl": "pkg:rpm/python2-rpm@4.11.3-40.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/python2-rpm@4.11.3-40.amzn2.0.4?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.4",
                 },
               },
@@ -1558,7 +1558,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.amzn2.0.2",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyxattr@0.5.1-5.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.1-5.amzn2.0.2",
                 },
               },
@@ -1566,7 +1566,7 @@ Object {
                 "id": "readline@6.2-10.amzn2.0.2",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/readline@6.2-10.amzn2.0.2?distro=amzn-2",
                   "version": "6.2-10.amzn2.0.2",
                 },
               },
@@ -1574,7 +1574,7 @@ Object {
                 "id": "rpm@4.11.3-40.amzn2.0.4",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-40.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/rpm@4.11.3-40.amzn2.0.4?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.4",
                 },
               },
@@ -1582,7 +1582,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-40.amzn2.0.4",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-40.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/rpm-build-libs@4.11.3-40.amzn2.0.4?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.4",
                 },
               },
@@ -1590,7 +1590,7 @@ Object {
                 "id": "rpm-libs@4.11.3-40.amzn2.0.4",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-40.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/rpm-libs@4.11.3-40.amzn2.0.4?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.4",
                 },
               },
@@ -1598,7 +1598,7 @@ Object {
                 "id": "sed@4.2.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/sed@4.2.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "4.2.2-5.amzn2.0.2",
                 },
               },
@@ -1606,7 +1606,7 @@ Object {
                 "id": "setup@2.8.71-10.amzn2.0.1",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-10.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/setup@2.8.71-10.amzn2.0.1?distro=amzn-2",
                   "version": "2.8.71-10.amzn2.0.1",
                 },
               },
@@ -1614,7 +1614,7 @@ Object {
                 "id": "shared-mime-info@1.8-4.amzn2",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-4.amzn2",
+                  "purl": "pkg:rpm/amzn/shared-mime-info@1.8-4.amzn2?distro=amzn-2",
                   "version": "1.8-4.amzn2",
                 },
               },
@@ -1622,7 +1622,7 @@ Object {
                 "id": "sqlite@3.7.17-8.amzn2.1.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.amzn2.1.1",
+                  "purl": "pkg:rpm/amzn/sqlite@3.7.17-8.amzn2.1.1?distro=amzn-2",
                   "version": "3.7.17-8.amzn2.1.1",
                 },
               },
@@ -1630,7 +1630,7 @@ Object {
                 "id": "system-release@1:2-12.amzn2",
                 "info": Object {
                   "name": "system-release",
-                  "purl": "pkg:rpm/system-release@1:2-12.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/system-release@1:2-12.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:2-12.amzn2",
                 },
               },
@@ -1638,7 +1638,7 @@ Object {
                 "id": "tzdata@2019c-1.amzn2",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2019c-1.amzn2",
+                  "purl": "pkg:rpm/amzn/tzdata@2019c-1.amzn2?distro=amzn-2",
                   "version": "2019c-1.amzn2",
                 },
               },
@@ -1646,7 +1646,7 @@ Object {
                 "id": "vim-minimal@2:8.1.1602-1.amzn2",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.1.1602-1.amzn2?epoch=2",
+                  "purl": "pkg:rpm/amzn/vim-minimal@2:8.1.1602-1.amzn2?distro=amzn-2&epoch=2",
                   "version": "2:8.1.1602-1.amzn2",
                 },
               },
@@ -1654,7 +1654,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.amzn2.0.2",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/xz-libs@5.2.2-1.amzn2.0.2?distro=amzn-2",
                   "version": "5.2.2-1.amzn2.0.2",
                 },
               },
@@ -1662,7 +1662,7 @@ Object {
                 "id": "yum@3.4.3-158.amzn2.0.4",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-158.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/yum@3.4.3-158.amzn2.0.4?distro=amzn-2",
                   "version": "3.4.3-158.amzn2.0.4",
                 },
               },
@@ -1670,7 +1670,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.amzn2.0.2",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/yum-metadata-parser@1.1.4-10.amzn2.0.2?distro=amzn-2",
                   "version": "1.1.4-10.amzn2.0.2",
                 },
               },
@@ -1678,7 +1678,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-ovl@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -1686,7 +1686,7 @@ Object {
                 "id": "yum-plugin-priorities@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-priorities",
-                  "purl": "pkg:rpm/yum-plugin-priorities@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-priorities@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "zlib@1.2.7-18.amzn2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.amzn2",
+                  "purl": "pkg:rpm/amzn/zlib@1.2.7-18.amzn2?distro=amzn-2",
                   "version": "1.2.7-18.amzn2",
                 },
               },
@@ -2796,7 +2796,7 @@ Object {
                 "id": "alternatives@1.15-2.amzn2022",
                 "info": Object {
                   "name": "alternatives",
-                  "purl": "pkg:rpm/alternatives@1.15-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/alternatives@1.15-2.amzn2022?distro=amzn-2022",
                   "version": "1.15-2.amzn2022",
                 },
               },
@@ -2804,7 +2804,7 @@ Object {
                 "id": "audit-libs@3.0.6-1.amzn2022",
                 "info": Object {
                   "name": "audit-libs",
-                  "purl": "pkg:rpm/audit-libs@3.0.6-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/audit-libs@3.0.6-1.amzn2022?distro=amzn-2022",
                   "version": "3.0.6-1.amzn2022",
                 },
               },
@@ -2812,7 +2812,7 @@ Object {
                 "id": "basesystem@11-11.amzn2022",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@11-11.amzn2022",
+                  "purl": "pkg:rpm/amzn/basesystem@11-11.amzn2022?distro=amzn-2022",
                   "version": "11-11.amzn2022",
                 },
               },
@@ -2820,7 +2820,7 @@ Object {
                 "id": "bash@5.1.8-2.amzn2022",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@5.1.8-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/bash@5.1.8-2.amzn2022?distro=amzn-2022",
                   "version": "5.1.8-2.amzn2022",
                 },
               },
@@ -2828,7 +2828,7 @@ Object {
                 "id": "bzip2-libs@1.0.8-6.amzn2022",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.8-6.amzn2022",
+                  "purl": "pkg:rpm/amzn/bzip2-libs@1.0.8-6.amzn2022?distro=amzn-2022",
                   "version": "1.0.8-6.amzn2022",
                 },
               },
@@ -2836,7 +2836,7 @@ Object {
                 "id": "ca-certificates@2021.2.50-1.0.amzn2022.0.2",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2021.2.50-1.0.amzn2022.0.2",
+                  "purl": "pkg:rpm/amzn/ca-certificates@2021.2.50-1.0.amzn2022.0.2?distro=amzn-2022",
                   "version": "2021.2.50-1.0.amzn2022.0.2",
                 },
               },
@@ -2844,7 +2844,7 @@ Object {
                 "id": "coreutils@8.32-30.amzn2022.0.1",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.32-30.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/coreutils@8.32-30.amzn2022.0.1?distro=amzn-2022",
                   "version": "8.32-30.amzn2022.0.1",
                 },
               },
@@ -2852,7 +2852,7 @@ Object {
                 "id": "coreutils-common@8.32-30.amzn2022.0.1",
                 "info": Object {
                   "name": "coreutils-common",
-                  "purl": "pkg:rpm/coreutils-common@8.32-30.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/coreutils-common@8.32-30.amzn2022.0.1?distro=amzn-2022",
                   "version": "8.32-30.amzn2022.0.1",
                 },
               },
@@ -2860,7 +2860,7 @@ Object {
                 "id": "crypto-policies@20210213-1.git5c710c0.amzn2022",
                 "info": Object {
                   "name": "crypto-policies",
-                  "purl": "pkg:rpm/crypto-policies@20210213-1.git5c710c0.amzn2022",
+                  "purl": "pkg:rpm/amzn/crypto-policies@20210213-1.git5c710c0.amzn2022?distro=amzn-2022",
                   "version": "20210213-1.git5c710c0.amzn2022",
                 },
               },
@@ -2868,7 +2868,7 @@ Object {
                 "id": "curl@7.79.1-2.amzn2022",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.79.1-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/curl@7.79.1-2.amzn2022?distro=amzn-2022",
                   "version": "7.79.1-2.amzn2022",
                 },
               },
@@ -2876,7 +2876,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.27-9.amzn2022",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.27-9.amzn2022",
+                  "purl": "pkg:rpm/amzn/cyrus-sasl-lib@2.1.27-9.amzn2022?distro=amzn-2022",
                   "version": "2.1.27-9.amzn2022",
                 },
               },
@@ -2884,7 +2884,7 @@ Object {
                 "id": "dnf@4.9.0-1.amzn2022",
                 "info": Object {
                   "name": "dnf",
-                  "purl": "pkg:rpm/dnf@4.9.0-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/dnf@4.9.0-1.amzn2022?distro=amzn-2022",
                   "version": "4.9.0-1.amzn2022",
                 },
               },
@@ -2892,7 +2892,7 @@ Object {
                 "id": "dnf-data@4.9.0-1.amzn2022",
                 "info": Object {
                   "name": "dnf-data",
-                  "purl": "pkg:rpm/dnf-data@4.9.0-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/dnf-data@4.9.0-1.amzn2022?distro=amzn-2022",
                   "version": "4.9.0-1.amzn2022",
                 },
               },
@@ -2900,7 +2900,7 @@ Object {
                 "id": "elfutils-default-yama-scope@0.185-2.amzn2022.0.1",
                 "info": Object {
                   "name": "elfutils-default-yama-scope",
-                  "purl": "pkg:rpm/elfutils-default-yama-scope@0.185-2.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/elfutils-default-yama-scope@0.185-2.amzn2022.0.1?distro=amzn-2022",
                   "version": "0.185-2.amzn2022.0.1",
                 },
               },
@@ -2908,7 +2908,7 @@ Object {
                 "id": "elfutils-libelf@0.185-2.amzn2022.0.1",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.185-2.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/elfutils-libelf@0.185-2.amzn2022.0.1?distro=amzn-2022",
                   "version": "0.185-2.amzn2022.0.1",
                 },
               },
@@ -2916,7 +2916,7 @@ Object {
                 "id": "elfutils-libs@0.185-2.amzn2022.0.1",
                 "info": Object {
                   "name": "elfutils-libs",
-                  "purl": "pkg:rpm/elfutils-libs@0.185-2.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/elfutils-libs@0.185-2.amzn2022.0.1?distro=amzn-2022",
                   "version": "0.185-2.amzn2022.0.1",
                 },
               },
@@ -2924,7 +2924,7 @@ Object {
                 "id": "expat@2.4.7-1.amzn2022",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.4.7-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/expat@2.4.7-1.amzn2022?distro=amzn-2022",
                   "version": "2.4.7-1.amzn2022",
                 },
               },
@@ -2932,7 +2932,7 @@ Object {
                 "id": "file-libs@5.39-7.amzn2022",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.39-7.amzn2022",
+                  "purl": "pkg:rpm/amzn/file-libs@5.39-7.amzn2022?distro=amzn-2022",
                   "version": "5.39-7.amzn2022",
                 },
               },
@@ -2940,7 +2940,7 @@ Object {
                 "id": "filesystem@3.14-5.amzn2022",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.14-5.amzn2022",
+                  "purl": "pkg:rpm/amzn/filesystem@3.14-5.amzn2022?distro=amzn-2022",
                   "version": "3.14-5.amzn2022",
                 },
               },
@@ -2948,7 +2948,7 @@ Object {
                 "id": "gawk@5.1.0-3.amzn2022",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@5.1.0-3.amzn2022",
+                  "purl": "pkg:rpm/amzn/gawk@5.1.0-3.amzn2022?distro=amzn-2022",
                   "version": "5.1.0-3.amzn2022",
                 },
               },
@@ -2956,7 +2956,7 @@ Object {
                 "id": "gdbm-libs@1:1.19-2.amzn2022",
                 "info": Object {
                   "name": "gdbm-libs",
-                  "purl": "pkg:rpm/gdbm-libs@1:1.19-2.amzn2022?epoch=1",
+                  "purl": "pkg:rpm/amzn/gdbm-libs@1:1.19-2.amzn2022?distro=amzn-2022&epoch=1",
                   "version": "1:1.19-2.amzn2022",
                 },
               },
@@ -2964,7 +2964,7 @@ Object {
                 "id": "glib2@2.68.4-1.amzn2022",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.68.4-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/glib2@2.68.4-1.amzn2022?distro=amzn-2022",
                   "version": "2.68.4-1.amzn2022",
                 },
               },
@@ -2972,7 +2972,7 @@ Object {
                 "id": "glibc@2.34-8.amzn2022",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.34-8.amzn2022",
+                  "purl": "pkg:rpm/amzn/glibc@2.34-8.amzn2022?distro=amzn-2022",
                   "version": "2.34-8.amzn2022",
                 },
               },
@@ -2980,7 +2980,7 @@ Object {
                 "id": "glibc-common@2.34-8.amzn2022",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.34-8.amzn2022",
+                  "purl": "pkg:rpm/amzn/glibc-common@2.34-8.amzn2022?distro=amzn-2022",
                   "version": "2.34-8.amzn2022",
                 },
               },
@@ -2988,7 +2988,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.34-8.amzn2022",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.34-8.amzn2022",
+                  "purl": "pkg:rpm/amzn/glibc-minimal-langpack@2.34-8.amzn2022?distro=amzn-2022",
                   "version": "2.34-8.amzn2022",
                 },
               },
@@ -2996,7 +2996,7 @@ Object {
                 "id": "gmp@1:6.2.0-6.amzn2022",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.2.0-6.amzn2022?epoch=1",
+                  "purl": "pkg:rpm/amzn/gmp@1:6.2.0-6.amzn2022?distro=amzn-2022&epoch=1",
                   "version": "1:6.2.0-6.amzn2022",
                 },
               },
@@ -3004,7 +3004,7 @@ Object {
                 "id": "gnupg2@2.2.27-4.amzn2022",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.2.27-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/gnupg2@2.2.27-4.amzn2022?distro=amzn-2022",
                   "version": "2.2.27-4.amzn2022",
                 },
               },
@@ -3012,7 +3012,7 @@ Object {
                 "id": "gnutls@3.7.2-2.amzn2022.0.1",
                 "info": Object {
                   "name": "gnutls",
-                  "purl": "pkg:rpm/gnutls@3.7.2-2.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/gnutls@3.7.2-2.amzn2022.0.1?distro=amzn-2022",
                   "version": "3.7.2-2.amzn2022.0.1",
                 },
               },
@@ -3020,7 +3020,7 @@ Object {
                 "id": "gpgme@1.15.1-6.amzn2022",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.15.1-6.amzn2022",
+                  "purl": "pkg:rpm/amzn/gpgme@1.15.1-6.amzn2022?distro=amzn-2022",
                   "version": "1.15.1-6.amzn2022",
                 },
               },
@@ -3028,7 +3028,7 @@ Object {
                 "id": "grep@3.6-4.amzn2022",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@3.6-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/grep@3.6-4.amzn2022?distro=amzn-2022",
                   "version": "3.6-4.amzn2022",
                 },
               },
@@ -3036,7 +3036,7 @@ Object {
                 "id": "ima-evm-utils@1.3.2-2.amzn2022.0.1",
                 "info": Object {
                   "name": "ima-evm-utils",
-                  "purl": "pkg:rpm/ima-evm-utils@1.3.2-2.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/ima-evm-utils@1.3.2-2.amzn2022.0.1?distro=amzn-2022",
                   "version": "1.3.2-2.amzn2022.0.1",
                 },
               },
@@ -3044,7 +3044,7 @@ Object {
                 "id": "json-c@0.14-8.amzn2022",
                 "info": Object {
                   "name": "json-c",
-                  "purl": "pkg:rpm/json-c@0.14-8.amzn2022",
+                  "purl": "pkg:rpm/amzn/json-c@0.14-8.amzn2022?distro=amzn-2022",
                   "version": "0.14-8.amzn2022",
                 },
               },
@@ -3052,7 +3052,7 @@ Object {
                 "id": "keyutils-libs@1.6.1-2.amzn2022",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.6.1-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/keyutils-libs@1.6.1-2.amzn2022?distro=amzn-2022",
                   "version": "1.6.1-2.amzn2022",
                 },
               },
@@ -3060,7 +3060,7 @@ Object {
                 "id": "krb5-libs@1.19.2-5.amzn2022",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.19.2-5.amzn2022",
+                  "purl": "pkg:rpm/amzn/krb5-libs@1.19.2-5.amzn2022?distro=amzn-2022",
                   "version": "1.19.2-5.amzn2022",
                 },
               },
@@ -3068,7 +3068,7 @@ Object {
                 "id": "libacl@2.3.1-2.amzn2022",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.3.1-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libacl@2.3.1-2.amzn2022?distro=amzn-2022",
                   "version": "2.3.1-2.amzn2022",
                 },
               },
@@ -3076,7 +3076,7 @@ Object {
                 "id": "libarchive@3.5.3-1.amzn2022",
                 "info": Object {
                   "name": "libarchive",
-                  "purl": "pkg:rpm/libarchive@3.5.3-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libarchive@3.5.3-1.amzn2022?distro=amzn-2022",
                   "version": "3.5.3-1.amzn2022",
                 },
               },
@@ -3084,7 +3084,7 @@ Object {
                 "id": "libassuan@2.5.5-1.amzn2022",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.5.5-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libassuan@2.5.5-1.amzn2022?distro=amzn-2022",
                   "version": "2.5.5-1.amzn2022",
                 },
               },
@@ -3092,7 +3092,7 @@ Object {
                 "id": "libattr@2.5.1-3.amzn2022",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.5.1-3.amzn2022",
+                  "purl": "pkg:rpm/amzn/libattr@2.5.1-3.amzn2022?distro=amzn-2022",
                   "version": "2.5.1-3.amzn2022",
                 },
               },
@@ -3100,7 +3100,7 @@ Object {
                 "id": "libblkid@2.36.2-1.amzn2022",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.36.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libblkid@2.36.2-1.amzn2022?distro=amzn-2022",
                   "version": "2.36.2-1.amzn2022",
                 },
               },
@@ -3108,7 +3108,7 @@ Object {
                 "id": "libbrotli@1.0.9-4.amzn2022",
                 "info": Object {
                   "name": "libbrotli",
-                  "purl": "pkg:rpm/libbrotli@1.0.9-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/libbrotli@1.0.9-4.amzn2022?distro=amzn-2022",
                   "version": "1.0.9-4.amzn2022",
                 },
               },
@@ -3116,7 +3116,7 @@ Object {
                 "id": "libcap@2.48-2.amzn2022",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.48-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libcap@2.48-2.amzn2022?distro=amzn-2022",
                   "version": "2.48-2.amzn2022",
                 },
               },
@@ -3124,7 +3124,7 @@ Object {
                 "id": "libcap-ng@0.8.2-4.amzn2022",
                 "info": Object {
                   "name": "libcap-ng",
-                  "purl": "pkg:rpm/libcap-ng@0.8.2-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/libcap-ng@0.8.2-4.amzn2022?distro=amzn-2022",
                   "version": "0.8.2-4.amzn2022",
                 },
               },
@@ -3132,7 +3132,7 @@ Object {
                 "id": "libcom_err@1.45.6-5.amzn2022",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.45.6-5.amzn2022",
+                  "purl": "pkg:rpm/amzn/libcom_err@1.45.6-5.amzn2022?distro=amzn-2022",
                   "version": "1.45.6-5.amzn2022",
                 },
               },
@@ -3140,7 +3140,7 @@ Object {
                 "id": "libcomps@0.1.18-1.amzn2022",
                 "info": Object {
                   "name": "libcomps",
-                  "purl": "pkg:rpm/libcomps@0.1.18-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libcomps@0.1.18-1.amzn2022?distro=amzn-2022",
                   "version": "0.1.18-1.amzn2022",
                 },
               },
@@ -3148,7 +3148,7 @@ Object {
                 "id": "libcurl@7.79.1-2.amzn2022",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.79.1-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libcurl@7.79.1-2.amzn2022?distro=amzn-2022",
                   "version": "7.79.1-2.amzn2022",
                 },
               },
@@ -3156,7 +3156,7 @@ Object {
                 "id": "libdb@5.3.28-49.amzn2022",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.28-49.amzn2022",
+                  "purl": "pkg:rpm/amzn/libdb@5.3.28-49.amzn2022?distro=amzn-2022",
                   "version": "5.3.28-49.amzn2022",
                 },
               },
@@ -3164,7 +3164,7 @@ Object {
                 "id": "libdnf@0.64.0-1.amzn2022.0.1",
                 "info": Object {
                   "name": "libdnf",
-                  "purl": "pkg:rpm/libdnf@0.64.0-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/libdnf@0.64.0-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "0.64.0-1.amzn2022.0.1",
                 },
               },
@@ -3172,7 +3172,7 @@ Object {
                 "id": "libffi@3.1-28.amzn2022",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.1-28.amzn2022",
+                  "purl": "pkg:rpm/amzn/libffi@3.1-28.amzn2022?distro=amzn-2022",
                   "version": "3.1-28.amzn2022",
                 },
               },
@@ -3180,7 +3180,7 @@ Object {
                 "id": "libgcc@11.2.1-10.amzn2022.0.1",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@11.2.1-10.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/libgcc@11.2.1-10.amzn2022.0.1?distro=amzn-2022",
                   "version": "11.2.1-10.amzn2022.0.1",
                 },
               },
@@ -3188,7 +3188,7 @@ Object {
                 "id": "libgcrypt@1.9.3-3.amzn2022.0.1",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.9.3-3.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/libgcrypt@1.9.3-3.amzn2022.0.1?distro=amzn-2022",
                   "version": "1.9.3-3.amzn2022.0.1",
                 },
               },
@@ -3196,7 +3196,7 @@ Object {
                 "id": "libgomp@11.2.1-10.amzn2022.0.1",
                 "info": Object {
                   "name": "libgomp",
-                  "purl": "pkg:rpm/libgomp@11.2.1-10.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/libgomp@11.2.1-10.amzn2022.0.1?distro=amzn-2022",
                   "version": "11.2.1-10.amzn2022.0.1",
                 },
               },
@@ -3204,7 +3204,7 @@ Object {
                 "id": "libgpg-error@1.42-1.amzn2022",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.42-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libgpg-error@1.42-1.amzn2022?distro=amzn-2022",
                   "version": "1.42-1.amzn2022",
                 },
               },
@@ -3212,7 +3212,7 @@ Object {
                 "id": "libidn2@2.3.2-1.amzn2022",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.3.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libidn2@2.3.2-1.amzn2022?distro=amzn-2022",
                   "version": "2.3.2-1.amzn2022",
                 },
               },
@@ -3220,7 +3220,7 @@ Object {
                 "id": "libksba@1.6.0-1.amzn2022",
                 "info": Object {
                   "name": "libksba",
-                  "purl": "pkg:rpm/libksba@1.6.0-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libksba@1.6.0-1.amzn2022?distro=amzn-2022",
                   "version": "1.6.0-1.amzn2022",
                 },
               },
@@ -3228,7 +3228,7 @@ Object {
                 "id": "libmodulemd@2.13.0-2.amzn2022",
                 "info": Object {
                   "name": "libmodulemd",
-                  "purl": "pkg:rpm/libmodulemd@2.13.0-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libmodulemd@2.13.0-2.amzn2022?distro=amzn-2022",
                   "version": "2.13.0-2.amzn2022",
                 },
               },
@@ -3236,7 +3236,7 @@ Object {
                 "id": "libmount@2.36.2-1.amzn2022",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.36.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libmount@2.36.2-1.amzn2022?distro=amzn-2022",
                   "version": "2.36.2-1.amzn2022",
                 },
               },
@@ -3244,7 +3244,7 @@ Object {
                 "id": "libnghttp2@1.45.1-1.amzn2022.0.1",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.45.1-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/libnghttp2@1.45.1-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "1.45.1-1.amzn2022.0.1",
                 },
               },
@@ -3252,7 +3252,7 @@ Object {
                 "id": "libnsl2@1.3.0-2.amzn2022",
                 "info": Object {
                   "name": "libnsl2",
-                  "purl": "pkg:rpm/libnsl2@1.3.0-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libnsl2@1.3.0-2.amzn2022?distro=amzn-2022",
                   "version": "1.3.0-2.amzn2022",
                 },
               },
@@ -3260,7 +3260,7 @@ Object {
                 "id": "libpsl@0.21.1-3.amzn2022",
                 "info": Object {
                   "name": "libpsl",
-                  "purl": "pkg:rpm/libpsl@0.21.1-3.amzn2022",
+                  "purl": "pkg:rpm/amzn/libpsl@0.21.1-3.amzn2022?distro=amzn-2022",
                   "version": "0.21.1-3.amzn2022",
                 },
               },
@@ -3268,7 +3268,7 @@ Object {
                 "id": "librepo@1.14.2-1.amzn2022.0.1",
                 "info": Object {
                   "name": "librepo",
-                  "purl": "pkg:rpm/librepo@1.14.2-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/librepo@1.14.2-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "1.14.2-1.amzn2022.0.1",
                 },
               },
@@ -3276,7 +3276,7 @@ Object {
                 "id": "libreport-filesystem@2.15.2-2.amzn2022",
                 "info": Object {
                   "name": "libreport-filesystem",
-                  "purl": "pkg:rpm/libreport-filesystem@2.15.2-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libreport-filesystem@2.15.2-2.amzn2022?distro=amzn-2022",
                   "version": "2.15.2-2.amzn2022",
                 },
               },
@@ -3284,7 +3284,7 @@ Object {
                 "id": "libselinux@3.2-1.amzn2022",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@3.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libselinux@3.2-1.amzn2022?distro=amzn-2022",
                   "version": "3.2-1.amzn2022",
                 },
               },
@@ -3292,7 +3292,7 @@ Object {
                 "id": "libsemanage@3.2-1.amzn2022",
                 "info": Object {
                   "name": "libsemanage",
-                  "purl": "pkg:rpm/libsemanage@3.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libsemanage@3.2-1.amzn2022?distro=amzn-2022",
                   "version": "3.2-1.amzn2022",
                 },
               },
@@ -3300,7 +3300,7 @@ Object {
                 "id": "libsepol@3.3-2.amzn2022",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@3.3-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libsepol@3.3-2.amzn2022?distro=amzn-2022",
                   "version": "3.3-2.amzn2022",
                 },
               },
@@ -3308,7 +3308,7 @@ Object {
                 "id": "libsigsegv@2.13-2.amzn2022",
                 "info": Object {
                   "name": "libsigsegv",
-                  "purl": "pkg:rpm/libsigsegv@2.13-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libsigsegv@2.13-2.amzn2022?distro=amzn-2022",
                   "version": "2.13-2.amzn2022",
                 },
               },
@@ -3316,7 +3316,7 @@ Object {
                 "id": "libsmartcols@2.36.2-1.amzn2022",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/libsmartcols@2.36.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libsmartcols@2.36.2-1.amzn2022?distro=amzn-2022",
                   "version": "2.36.2-1.amzn2022",
                 },
               },
@@ -3324,7 +3324,7 @@ Object {
                 "id": "libsolv@0.7.17-3.amzn2022",
                 "info": Object {
                   "name": "libsolv",
-                  "purl": "pkg:rpm/libsolv@0.7.17-3.amzn2022",
+                  "purl": "pkg:rpm/amzn/libsolv@0.7.17-3.amzn2022?distro=amzn-2022",
                   "version": "0.7.17-3.amzn2022",
                 },
               },
@@ -3332,7 +3332,7 @@ Object {
                 "id": "libssh@0.9.6-1.amzn2022.0.1",
                 "info": Object {
                   "name": "libssh",
-                  "purl": "pkg:rpm/libssh@0.9.6-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/libssh@0.9.6-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "0.9.6-1.amzn2022.0.1",
                 },
               },
@@ -3340,7 +3340,7 @@ Object {
                 "id": "libssh-config@0.9.6-1.amzn2022.0.1",
                 "info": Object {
                   "name": "libssh-config",
-                  "purl": "pkg:rpm/libssh-config@0.9.6-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/libssh-config@0.9.6-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "0.9.6-1.amzn2022.0.1",
                 },
               },
@@ -3348,7 +3348,7 @@ Object {
                 "id": "libstdc++@11.2.1-10.amzn2022.0.1",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@11.2.1-10.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/libstdc%2B%2B@11.2.1-10.amzn2022.0.1?distro=amzn-2022",
                   "version": "11.2.1-10.amzn2022.0.1",
                 },
               },
@@ -3356,7 +3356,7 @@ Object {
                 "id": "libtasn1@4.16.0-4.amzn2022",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.16.0-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/libtasn1@4.16.0-4.amzn2022?distro=amzn-2022",
                   "version": "4.16.0-4.amzn2022",
                 },
               },
@@ -3364,7 +3364,7 @@ Object {
                 "id": "libtirpc@1.3.2-0.rc1.amzn2022",
                 "info": Object {
                   "name": "libtirpc",
-                  "purl": "pkg:rpm/libtirpc@1.3.2-0.rc1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libtirpc@1.3.2-0.rc1.amzn2022?distro=amzn-2022",
                   "version": "1.3.2-0.rc1.amzn2022",
                 },
               },
@@ -3372,7 +3372,7 @@ Object {
                 "id": "libunistring@0.9.10-10.amzn2022",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.10-10.amzn2022",
+                  "purl": "pkg:rpm/amzn/libunistring@0.9.10-10.amzn2022?distro=amzn-2022",
                   "version": "0.9.10-10.amzn2022",
                 },
               },
@@ -3380,7 +3380,7 @@ Object {
                 "id": "libusbx@1.0.24-2.amzn2022",
                 "info": Object {
                   "name": "libusbx",
-                  "purl": "pkg:rpm/libusbx@1.0.24-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/libusbx@1.0.24-2.amzn2022?distro=amzn-2022",
                   "version": "1.0.24-2.amzn2022",
                 },
               },
@@ -3388,7 +3388,7 @@ Object {
                 "id": "libuuid@2.36.2-1.amzn2022",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.36.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libuuid@2.36.2-1.amzn2022?distro=amzn-2022",
                   "version": "2.36.2-1.amzn2022",
                 },
               },
@@ -3396,7 +3396,7 @@ Object {
                 "id": "libverto@0.3.2-1.amzn2022",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.3.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libverto@0.3.2-1.amzn2022?distro=amzn-2022",
                   "version": "0.3.2-1.amzn2022",
                 },
               },
@@ -3404,7 +3404,7 @@ Object {
                 "id": "libxcrypt@4.4.26-4.amzn2022",
                 "info": Object {
                   "name": "libxcrypt",
-                  "purl": "pkg:rpm/libxcrypt@4.4.26-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/libxcrypt@4.4.26-4.amzn2022?distro=amzn-2022",
                   "version": "4.4.26-4.amzn2022",
                 },
               },
@@ -3412,7 +3412,7 @@ Object {
                 "id": "libxml2@2.9.12-4.amzn2022",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.12-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/libxml2@2.9.12-4.amzn2022?distro=amzn-2022",
                   "version": "2.9.12-4.amzn2022",
                 },
               },
@@ -3420,7 +3420,7 @@ Object {
                 "id": "libyaml@0.2.5-5.amzn2022",
                 "info": Object {
                   "name": "libyaml",
-                  "purl": "pkg:rpm/libyaml@0.2.5-5.amzn2022",
+                  "purl": "pkg:rpm/amzn/libyaml@0.2.5-5.amzn2022?distro=amzn-2022",
                   "version": "0.2.5-5.amzn2022",
                 },
               },
@@ -3428,7 +3428,7 @@ Object {
                 "id": "libzstd@1.5.2-1.amzn2022",
                 "info": Object {
                   "name": "libzstd",
-                  "purl": "pkg:rpm/libzstd@1.5.2-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/libzstd@1.5.2-1.amzn2022?distro=amzn-2022",
                   "version": "1.5.2-1.amzn2022",
                 },
               },
@@ -3436,7 +3436,7 @@ Object {
                 "id": "lua-libs@5.4.4-1.amzn2022",
                 "info": Object {
                   "name": "lua-libs",
-                  "purl": "pkg:rpm/lua-libs@5.4.4-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/lua-libs@5.4.4-1.amzn2022?distro=amzn-2022",
                   "version": "5.4.4-1.amzn2022",
                 },
               },
@@ -3444,7 +3444,7 @@ Object {
                 "id": "lz4-libs@1.9.3-2.amzn2022",
                 "info": Object {
                   "name": "lz4-libs",
-                  "purl": "pkg:rpm/lz4-libs@1.9.3-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/lz4-libs@1.9.3-2.amzn2022?distro=amzn-2022",
                   "version": "1.9.3-2.amzn2022",
                 },
               },
@@ -3452,7 +3452,7 @@ Object {
                 "id": "mpfr@4.1.0-7.amzn2022",
                 "info": Object {
                   "name": "mpfr",
-                  "purl": "pkg:rpm/mpfr@4.1.0-7.amzn2022",
+                  "purl": "pkg:rpm/amzn/mpfr@4.1.0-7.amzn2022?distro=amzn-2022",
                   "version": "4.1.0-7.amzn2022",
                 },
               },
@@ -3460,7 +3460,7 @@ Object {
                 "id": "ncurses-base@6.2-4.20200222.amzn2022",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.2-4.20200222.amzn2022",
+                  "purl": "pkg:rpm/amzn/ncurses-base@6.2-4.20200222.amzn2022?distro=amzn-2022",
                   "version": "6.2-4.20200222.amzn2022",
                 },
               },
@@ -3468,7 +3468,7 @@ Object {
                 "id": "ncurses-libs@6.2-4.20200222.amzn2022",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.2-4.20200222.amzn2022",
+                  "purl": "pkg:rpm/amzn/ncurses-libs@6.2-4.20200222.amzn2022?distro=amzn-2022",
                   "version": "6.2-4.20200222.amzn2022",
                 },
               },
@@ -3476,7 +3476,7 @@ Object {
                 "id": "nettle@3.7.3-1.amzn2022",
                 "info": Object {
                   "name": "nettle",
-                  "purl": "pkg:rpm/nettle@3.7.3-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/nettle@3.7.3-1.amzn2022?distro=amzn-2022",
                   "version": "3.7.3-1.amzn2022",
                 },
               },
@@ -3484,7 +3484,7 @@ Object {
                 "id": "npth@1.6-6.amzn2022",
                 "info": Object {
                   "name": "npth",
-                  "purl": "pkg:rpm/npth@1.6-6.amzn2022",
+                  "purl": "pkg:rpm/amzn/npth@1.6-6.amzn2022?distro=amzn-2022",
                   "version": "1.6-6.amzn2022",
                 },
               },
@@ -3492,7 +3492,7 @@ Object {
                 "id": "openldap@2.4.57-6.amzn2022.0.1",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.57-6.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/openldap@2.4.57-6.amzn2022.0.1?distro=amzn-2022",
                   "version": "2.4.57-6.amzn2022.0.1",
                 },
               },
@@ -3500,7 +3500,7 @@ Object {
                 "id": "openssl-libs@1:3.0.0-1.amzn2022.0.1",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:3.0.0-1.amzn2022.0.1?epoch=1",
+                  "purl": "pkg:rpm/amzn/openssl-libs@1:3.0.0-1.amzn2022.0.1?distro=amzn-2022&epoch=1",
                   "version": "1:3.0.0-1.amzn2022.0.1",
                 },
               },
@@ -3508,7 +3508,7 @@ Object {
                 "id": "openssl1.1@1:1.1.1l-2.amzn2022.0.1",
                 "info": Object {
                   "name": "openssl1.1",
-                  "purl": "pkg:rpm/openssl1.1@1:1.1.1l-2.amzn2022.0.1?epoch=1",
+                  "purl": "pkg:rpm/amzn/openssl1.1@1:1.1.1l-2.amzn2022.0.1?distro=amzn-2022&epoch=1",
                   "version": "1:1.1.1l-2.amzn2022.0.1",
                 },
               },
@@ -3516,7 +3516,7 @@ Object {
                 "id": "p11-kit@0.23.22-3.amzn2022",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.22-3.amzn2022",
+                  "purl": "pkg:rpm/amzn/p11-kit@0.23.22-3.amzn2022?distro=amzn-2022",
                   "version": "0.23.22-3.amzn2022",
                 },
               },
@@ -3524,7 +3524,7 @@ Object {
                 "id": "p11-kit-trust@0.23.22-3.amzn2022",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.22-3.amzn2022",
+                  "purl": "pkg:rpm/amzn/p11-kit-trust@0.23.22-3.amzn2022?distro=amzn-2022",
                   "version": "0.23.22-3.amzn2022",
                 },
               },
@@ -3532,7 +3532,7 @@ Object {
                 "id": "pcre@8.44-3.amzn2022.1",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.44-3.amzn2022.1",
+                  "purl": "pkg:rpm/amzn/pcre@8.44-3.amzn2022.1?distro=amzn-2022",
                   "version": "8.44-3.amzn2022.1",
                 },
               },
@@ -3540,7 +3540,7 @@ Object {
                 "id": "pcre2@10.36-4.amzn2022",
                 "info": Object {
                   "name": "pcre2",
-                  "purl": "pkg:rpm/pcre2@10.36-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/pcre2@10.36-4.amzn2022?distro=amzn-2022",
                   "version": "10.36-4.amzn2022",
                 },
               },
@@ -3548,7 +3548,7 @@ Object {
                 "id": "pcre2-syntax@10.36-4.amzn2022",
                 "info": Object {
                   "name": "pcre2-syntax",
-                  "purl": "pkg:rpm/pcre2-syntax@10.36-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/pcre2-syntax@10.36-4.amzn2022?distro=amzn-2022",
                   "version": "10.36-4.amzn2022",
                 },
               },
@@ -3556,7 +3556,7 @@ Object {
                 "id": "popt@1.18-6.amzn2022",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.18-6.amzn2022",
+                  "purl": "pkg:rpm/amzn/popt@1.18-6.amzn2022?distro=amzn-2022",
                   "version": "1.18-6.amzn2022",
                 },
               },
@@ -3564,7 +3564,7 @@ Object {
                 "id": "publicsuffix-list-dafsa@20190417-5.amzn2022",
                 "info": Object {
                   "name": "publicsuffix-list-dafsa",
-                  "purl": "pkg:rpm/publicsuffix-list-dafsa@20190417-5.amzn2022",
+                  "purl": "pkg:rpm/amzn/publicsuffix-list-dafsa@20190417-5.amzn2022?distro=amzn-2022",
                   "version": "20190417-5.amzn2022",
                 },
               },
@@ -3572,7 +3572,7 @@ Object {
                 "id": "python-pip-wheel@21.0.1-4.amzn2022",
                 "info": Object {
                   "name": "python-pip-wheel",
-                  "purl": "pkg:rpm/python-pip-wheel@21.0.1-4.amzn2022",
+                  "purl": "pkg:rpm/amzn/python-pip-wheel@21.0.1-4.amzn2022?distro=amzn-2022",
                   "version": "21.0.1-4.amzn2022",
                 },
               },
@@ -3580,7 +3580,7 @@ Object {
                 "id": "python-setuptools-wheel@53.0.0-2.amzn2022",
                 "info": Object {
                   "name": "python-setuptools-wheel",
-                  "purl": "pkg:rpm/python-setuptools-wheel@53.0.0-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/python-setuptools-wheel@53.0.0-2.amzn2022?distro=amzn-2022",
                   "version": "53.0.0-2.amzn2022",
                 },
               },
@@ -3588,7 +3588,7 @@ Object {
                 "id": "python3@3.9.8-1.amzn2022.0.1",
                 "info": Object {
                   "name": "python3",
-                  "purl": "pkg:rpm/python3@3.9.8-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/python3@3.9.8-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "3.9.8-1.amzn2022.0.1",
                 },
               },
@@ -3596,7 +3596,7 @@ Object {
                 "id": "python3-dnf@4.9.0-1.amzn2022",
                 "info": Object {
                   "name": "python3-dnf",
-                  "purl": "pkg:rpm/python3-dnf@4.9.0-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/python3-dnf@4.9.0-1.amzn2022?distro=amzn-2022",
                   "version": "4.9.0-1.amzn2022",
                 },
               },
@@ -3604,7 +3604,7 @@ Object {
                 "id": "python3-gpg@1.15.1-6.amzn2022",
                 "info": Object {
                   "name": "python3-gpg",
-                  "purl": "pkg:rpm/python3-gpg@1.15.1-6.amzn2022",
+                  "purl": "pkg:rpm/amzn/python3-gpg@1.15.1-6.amzn2022?distro=amzn-2022",
                   "version": "1.15.1-6.amzn2022",
                 },
               },
@@ -3612,7 +3612,7 @@ Object {
                 "id": "python3-hawkey@0.64.0-1.amzn2022.0.1",
                 "info": Object {
                   "name": "python3-hawkey",
-                  "purl": "pkg:rpm/python3-hawkey@0.64.0-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/python3-hawkey@0.64.0-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "0.64.0-1.amzn2022.0.1",
                 },
               },
@@ -3620,7 +3620,7 @@ Object {
                 "id": "python3-libcomps@0.1.18-1.amzn2022",
                 "info": Object {
                   "name": "python3-libcomps",
-                  "purl": "pkg:rpm/python3-libcomps@0.1.18-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/python3-libcomps@0.1.18-1.amzn2022?distro=amzn-2022",
                   "version": "0.1.18-1.amzn2022",
                 },
               },
@@ -3628,7 +3628,7 @@ Object {
                 "id": "python3-libdnf@0.64.0-1.amzn2022.0.1",
                 "info": Object {
                   "name": "python3-libdnf",
-                  "purl": "pkg:rpm/python3-libdnf@0.64.0-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/python3-libdnf@0.64.0-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "0.64.0-1.amzn2022.0.1",
                 },
               },
@@ -3636,7 +3636,7 @@ Object {
                 "id": "python3-libs@3.9.8-1.amzn2022.0.1",
                 "info": Object {
                   "name": "python3-libs",
-                  "purl": "pkg:rpm/python3-libs@3.9.8-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/python3-libs@3.9.8-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "3.9.8-1.amzn2022.0.1",
                 },
               },
@@ -3644,7 +3644,7 @@ Object {
                 "id": "python3-rpm@4.16.1.3-1.amzn2022.0.1",
                 "info": Object {
                   "name": "python3-rpm",
-                  "purl": "pkg:rpm/python3-rpm@4.16.1.3-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/python3-rpm@4.16.1.3-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "4.16.1.3-1.amzn2022.0.1",
                 },
               },
@@ -3652,7 +3652,7 @@ Object {
                 "id": "readline@8.1-2.amzn2022",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@8.1-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/readline@8.1-2.amzn2022?distro=amzn-2022",
                   "version": "8.1-2.amzn2022",
                 },
               },
@@ -3660,7 +3660,7 @@ Object {
                 "id": "rpm@4.16.1.3-1.amzn2022.0.1",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.16.1.3-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/rpm@4.16.1.3-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "4.16.1.3-1.amzn2022.0.1",
                 },
               },
@@ -3668,7 +3668,7 @@ Object {
                 "id": "rpm-build-libs@4.16.1.3-1.amzn2022.0.1",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.16.1.3-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/rpm-build-libs@4.16.1.3-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "4.16.1.3-1.amzn2022.0.1",
                 },
               },
@@ -3676,7 +3676,7 @@ Object {
                 "id": "rpm-libs@4.16.1.3-1.amzn2022.0.1",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.16.1.3-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/rpm-libs@4.16.1.3-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "4.16.1.3-1.amzn2022.0.1",
                 },
               },
@@ -3684,7 +3684,7 @@ Object {
                 "id": "rpm-sign-libs@4.16.1.3-1.amzn2022.0.1",
                 "info": Object {
                   "name": "rpm-sign-libs",
-                  "purl": "pkg:rpm/rpm-sign-libs@4.16.1.3-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/rpm-sign-libs@4.16.1.3-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "4.16.1.3-1.amzn2022.0.1",
                 },
               },
@@ -3692,7 +3692,7 @@ Object {
                 "id": "sed@4.8-7.amzn2022",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.8-7.amzn2022",
+                  "purl": "pkg:rpm/amzn/sed@4.8-7.amzn2022?distro=amzn-2022",
                   "version": "4.8-7.amzn2022",
                 },
               },
@@ -3700,7 +3700,7 @@ Object {
                 "id": "setup@2.13.7-3.amzn2022",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.13.7-3.amzn2022",
+                  "purl": "pkg:rpm/amzn/setup@2.13.7-3.amzn2022?distro=amzn-2022",
                   "version": "2.13.7-3.amzn2022",
                 },
               },
@@ -3708,7 +3708,7 @@ Object {
                 "id": "shadow-utils@2:4.8.1-9.amzn2022",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/shadow-utils@2:4.8.1-9.amzn2022?epoch=2",
+                  "purl": "pkg:rpm/amzn/shadow-utils@2:4.8.1-9.amzn2022?distro=amzn-2022&epoch=2",
                   "version": "2:4.8.1-9.amzn2022",
                 },
               },
@@ -3716,7 +3716,7 @@ Object {
                 "id": "sqlite-libs@3.34.1-2.amzn2022",
                 "info": Object {
                   "name": "sqlite-libs",
-                  "purl": "pkg:rpm/sqlite-libs@3.34.1-2.amzn2022",
+                  "purl": "pkg:rpm/amzn/sqlite-libs@3.34.1-2.amzn2022?distro=amzn-2022",
                   "version": "3.34.1-2.amzn2022",
                 },
               },
@@ -3724,7 +3724,7 @@ Object {
                 "id": "system-release@2022.0.20220504-0.amzn2022",
                 "info": Object {
                   "name": "system-release",
-                  "purl": "pkg:rpm/system-release@2022.0.20220504-0.amzn2022",
+                  "purl": "pkg:rpm/amzn/system-release@2022.0.20220504-0.amzn2022?distro=amzn-2022",
                   "version": "2022.0.20220504-0.amzn2022",
                 },
               },
@@ -3732,7 +3732,7 @@ Object {
                 "id": "systemd-libs@248.10-1.amzn2022.0.1",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/systemd-libs@248.10-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/systemd-libs@248.10-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "248.10-1.amzn2022.0.1",
                 },
               },
@@ -3740,7 +3740,7 @@ Object {
                 "id": "tpm2-tss@3.1.0-1.amzn2022.0.1",
                 "info": Object {
                   "name": "tpm2-tss",
-                  "purl": "pkg:rpm/tpm2-tss@3.1.0-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/tpm2-tss@3.1.0-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "3.1.0-1.amzn2022.0.1",
                 },
               },
@@ -3748,7 +3748,7 @@ Object {
                 "id": "tzdata@2022a-1.amzn2022",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2022a-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/tzdata@2022a-1.amzn2022?distro=amzn-2022",
                   "version": "2022a-1.amzn2022",
                 },
               },
@@ -3756,7 +3756,7 @@ Object {
                 "id": "vim-data@2:8.2.4314-1.amzn2022",
                 "info": Object {
                   "name": "vim-data",
-                  "purl": "pkg:rpm/vim-data@2:8.2.4314-1.amzn2022?epoch=2",
+                  "purl": "pkg:rpm/amzn/vim-data@2:8.2.4314-1.amzn2022?distro=amzn-2022&epoch=2",
                   "version": "2:8.2.4314-1.amzn2022",
                 },
               },
@@ -3764,7 +3764,7 @@ Object {
                 "id": "vim-minimal@2:8.2.4314-1.amzn2022",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.2.4314-1.amzn2022?epoch=2",
+                  "purl": "pkg:rpm/amzn/vim-minimal@2:8.2.4314-1.amzn2022?distro=amzn-2022&epoch=2",
                   "version": "2:8.2.4314-1.amzn2022",
                 },
               },
@@ -3772,7 +3772,7 @@ Object {
                 "id": "xz-libs@5.2.5-9.amzn2022",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.5-9.amzn2022",
+                  "purl": "pkg:rpm/amzn/xz-libs@5.2.5-9.amzn2022?distro=amzn-2022",
                   "version": "5.2.5-9.amzn2022",
                 },
               },
@@ -3780,7 +3780,7 @@ Object {
                 "id": "yum@4.9.0-1.amzn2022",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@4.9.0-1.amzn2022",
+                  "purl": "pkg:rpm/amzn/yum@4.9.0-1.amzn2022?distro=amzn-2022",
                   "version": "4.9.0-1.amzn2022",
                 },
               },
@@ -3788,7 +3788,7 @@ Object {
                 "id": "zchunk-libs@1.1.15-1.amzn2022.0.1",
                 "info": Object {
                   "name": "zchunk-libs",
-                  "purl": "pkg:rpm/zchunk-libs@1.1.15-1.amzn2022.0.1",
+                  "purl": "pkg:rpm/amzn/zchunk-libs@1.1.15-1.amzn2022.0.1?distro=amzn-2022",
                   "version": "1.1.15-1.amzn2022.0.1",
                 },
               },
@@ -3796,7 +3796,7 @@ Object {
                 "id": "zlib@1.2.11-27.amzn2022",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.11-27.amzn2022",
+                  "purl": "pkg:rpm/amzn/zlib@1.2.11-27.amzn2022?distro=amzn-2022",
                   "version": "1.2.11-27.amzn2022",
                 },
               },

--- a/test/system/platforms/__snapshots__/amd.spec.ts.snap
+++ b/test/system/platforms/__snapshots__/amd.spec.ts.snap
@@ -1168,7 +1168,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
-                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit-common@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1176,7 +1176,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
-                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
+                  "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?distro=debian-buster&upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1184,7 +1184,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
-                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit1@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1192,7 +1192,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage-common@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1200,7 +1200,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
+                  "purl": "pkg:deb/debian/libsepol1@2.8-1?distro=debian-buster&upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1208,7 +1208,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage1@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1216,7 +1216,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?distro=debian-buster&upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1224,7 +1224,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam0g@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1232,7 +1232,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1240,7 +1240,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1248,7 +1248,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/passwd@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1256,7 +1256,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.118",
+                  "purl": "pkg:deb/debian/adduser@3.118?distro=debian-buster",
                   "version": "3.118",
                 },
               },
@@ -1264,7 +1264,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?distro=debian-buster&upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1272,7 +1272,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
-                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
+                  "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?distro=debian-buster&upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1280,7 +1280,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
+                  "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?distro=debian-buster&upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1288,7 +1288,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?distro=debian-buster",
                   "version": "1.8.4-5",
                 },
               },
@@ -1296,7 +1296,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@241-7~deb10u4?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u4?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1304,7 +1304,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@241-7~deb10u4?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@241-7~deb10u4?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -1312,7 +1312,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2.1",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2.1?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2.1?distro=debian-buster&upstream=apt",
                   "version": "1.8.2.1",
                 },
               },
@@ -1320,7 +1320,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?distro=debian-buster",
                   "version": "2019.1",
                 },
               },
@@ -1328,7 +1328,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.35-1?distro=debian-buster&upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1336,7 +1336,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
+                  "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?distro=debian-buster&upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1344,7 +1344,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
-                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
+                  "purl": "pkg:deb/debian/libgmp10@2:6.1.2%2Bdfsg-4?distro=debian-buster&upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1352,7 +1352,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
-                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
+                  "purl": "pkg:deb/debian/libunistring2@0.9.10-1?distro=debian-buster&upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1360,7 +1360,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
-                  "purl": "pkg:deb/libidn2-0@2.0.5-1%2Bdeb10u1?upstream=libidn2",
+                  "purl": "pkg:deb/debian/libidn2-0@2.0.5-1%2Bdeb10u1?distro=debian-buster&upstream=libidn2",
                   "version": "2.0.5-1+deb10u1",
                 },
               },
@@ -1368,7 +1368,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.13-3",
+                  "purl": "pkg:deb/debian/libtasn1-6@4.13-3?distro=debian-buster",
                   "version": "4.13-3",
                 },
               },
@@ -1376,7 +1376,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libnettle6@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1384,7 +1384,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
-                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1392,7 +1392,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
-                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
+                  "purl": "pkg:deb/debian/libffi6@3.2.1-9?distro=debian-buster&upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1400,7 +1400,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
+                  "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?distro=debian-buster&upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1408,7 +1408,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
-                  "purl": "pkg:deb/libgnutls30@3.6.7-4%2Bdeb10u5?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls30@3.6.7-4%2Bdeb10u5?distro=debian-buster&upstream=gnutls28",
                   "version": "3.6.7-4+deb10u5",
                 },
               },
@@ -1416,7 +1416,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
-                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
+                  "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?distro=debian-buster&upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1424,7 +1424,7 @@ Object {
                 "id": "apt@1.8.2.1",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.8.2.1",
+                  "purl": "pkg:deb/debian/apt@1.8.2.1?distro=debian-buster",
                   "version": "1.8.2.1",
                 },
               },
@@ -1439,7 +1439,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?distro=debian-buster&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1447,7 +1447,7 @@ Object {
                 "id": "base-files@10.3+deb10u6",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u6",
+                  "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u6?distro=debian-buster",
                   "version": "10.3+deb10u6",
                 },
               },
@@ -1455,7 +1455,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.249?distro=debian-buster&upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1463,7 +1463,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.46",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.46?distro=debian-buster",
                   "version": "3.5.46",
                 },
               },
@@ -1471,7 +1471,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.6.1",
+                  "purl": "pkg:deb/debian/debianutils@4.8.6.1?distro=debian-buster",
                   "version": "4.8.6.1",
                 },
               },
@@ -1479,7 +1479,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
-                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1487,7 +1487,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@5.0-4",
+                  "purl": "pkg:deb/debian/bash@5.0-4?distro=debian-buster",
                   "version": "5.0-4",
                 },
               },
@@ -1502,7 +1502,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.30-3",
+                  "purl": "pkg:deb/debian/coreutils@8.30-3?distro=debian-buster",
                   "version": "8.30-3",
                 },
               },
@@ -1510,7 +1510,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.10.2-5",
+                  "purl": "pkg:deb/debian/dash@0.5.10.2-5?distro=debian-buster",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1525,7 +1525,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.7-3",
+                  "purl": "pkg:deb/debian/diffutils@1:3.7-3?distro=debian-buster",
                   "version": "1:3.7-3",
                 },
               },
@@ -1540,7 +1540,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
-                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1548,7 +1548,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
-                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1556,7 +1556,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1564,7 +1564,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1572,7 +1572,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1580,7 +1580,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u3",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u3?distro=debian-buster",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -1588,7 +1588,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
+                  "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?distro=debian-buster",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1610,7 +1610,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.28-10?distro=debian-buster&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1625,7 +1625,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@3.3-1",
+                  "purl": "pkg:deb/debian/grep@3.3-1?distro=debian-buster",
                   "version": "3.3-1",
                 },
               },
@@ -1633,7 +1633,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.9-3",
+                  "purl": "pkg:deb/debian/gzip@1.9-3?distro=debian-buster",
                   "version": "1.9-3",
                 },
               },
@@ -1641,7 +1641,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.21",
+                  "purl": "pkg:deb/debian/hostname@3.21?distro=debian-buster",
                   "version": "3.21",
                 },
               },
@@ -1649,7 +1649,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
+                  "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?distro=debian-buster",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1664,7 +1664,7 @@ Object {
                 "id": "lsb/lsb-base@10.2019051400",
                 "info": Object {
                   "name": "lsb/lsb-base",
-                  "purl": "pkg:deb/lsb-base@10.2019051400?upstream=lsb",
+                  "purl": "pkg:deb/debian/lsb-base@10.2019051400?distro=debian-buster&upstream=lsb",
                   "version": "10.2019051400",
                 },
               },
@@ -1672,7 +1672,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
-                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1680,7 +1680,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1688,7 +1688,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -1696,7 +1696,7 @@ Object {
                 "id": "openssl/libssl1.1@1.1.1d-0+deb10u3",
                 "info": Object {
                   "name": "openssl/libssl1.1",
-                  "purl": "pkg:deb/libssl1.1@1.1.1d-0%2Bdeb10u3?upstream=openssl",
+                  "purl": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u3?distro=debian-buster&upstream=openssl",
                   "version": "1.1.1d-0+deb10u3",
                 },
               },
@@ -1704,7 +1704,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1726,7 +1726,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.7-1",
+                  "purl": "pkg:deb/debian/sed@4.7-1?distro=debian-buster",
                   "version": "4.7-1",
                 },
               },
@@ -1734,7 +1734,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1742,7 +1742,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
+                  "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?distro=debian-buster",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1750,7 +1750,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?distro=debian-buster&upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1765,7 +1765,7 @@ Object {
                 "id": "tzdata@2020a-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/tzdata@2020a-0%2Bdeb10u1?distro=debian-buster",
                   "version": "2020a-0+deb10u1",
                 },
               },
@@ -1773,7 +1773,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.33.1-0.1?distro=debian-buster&upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1781,7 +1781,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1789,7 +1789,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1797,7 +1797,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1805,7 +1805,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
-                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1813,7 +1813,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3108,7 +3108,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
-                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit-common@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -3116,7 +3116,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
-                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
+                  "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?distro=debian-buster&upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -3124,7 +3124,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
-                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit1@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -3132,7 +3132,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage-common@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -3140,7 +3140,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
+                  "purl": "pkg:deb/debian/libsepol1@2.8-1?distro=debian-buster&upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -3148,7 +3148,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage1@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -3156,7 +3156,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?distro=debian-buster&upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -3164,7 +3164,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam0g@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -3172,7 +3172,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -3180,7 +3180,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -3188,7 +3188,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/passwd@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -3196,7 +3196,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.118",
+                  "purl": "pkg:deb/debian/adduser@3.118?distro=debian-buster",
                   "version": "3.118",
                 },
               },
@@ -3204,7 +3204,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?distro=debian-buster&upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -3212,7 +3212,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
-                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
+                  "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?distro=debian-buster&upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -3220,7 +3220,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
+                  "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?distro=debian-buster&upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -3228,7 +3228,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?distro=debian-buster",
                   "version": "1.8.4-5",
                 },
               },
@@ -3236,7 +3236,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@241-7~deb10u4?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u4?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -3244,7 +3244,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u4",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@241-7~deb10u4?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@241-7~deb10u4?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u4",
                 },
               },
@@ -3252,7 +3252,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2.1",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2.1?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2.1?distro=debian-buster&upstream=apt",
                   "version": "1.8.2.1",
                 },
               },
@@ -3260,7 +3260,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?distro=debian-buster",
                   "version": "2019.1",
                 },
               },
@@ -3268,7 +3268,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.35-1?distro=debian-buster&upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -3276,7 +3276,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
+                  "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?distro=debian-buster&upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -3284,7 +3284,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
-                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
+                  "purl": "pkg:deb/debian/libgmp10@2:6.1.2%2Bdfsg-4?distro=debian-buster&upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -3292,7 +3292,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
-                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
+                  "purl": "pkg:deb/debian/libunistring2@0.9.10-1?distro=debian-buster&upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -3300,7 +3300,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1+deb10u1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
-                  "purl": "pkg:deb/libidn2-0@2.0.5-1%2Bdeb10u1?upstream=libidn2",
+                  "purl": "pkg:deb/debian/libidn2-0@2.0.5-1%2Bdeb10u1?distro=debian-buster&upstream=libidn2",
                   "version": "2.0.5-1+deb10u1",
                 },
               },
@@ -3308,7 +3308,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.13-3",
+                  "purl": "pkg:deb/debian/libtasn1-6@4.13-3?distro=debian-buster",
                   "version": "4.13-3",
                 },
               },
@@ -3316,7 +3316,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libnettle6@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -3324,7 +3324,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
-                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -3332,7 +3332,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
-                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
+                  "purl": "pkg:deb/debian/libffi6@3.2.1-9?distro=debian-buster&upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -3340,7 +3340,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
+                  "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?distro=debian-buster&upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -3348,7 +3348,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4+deb10u5",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
-                  "purl": "pkg:deb/libgnutls30@3.6.7-4%2Bdeb10u5?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls30@3.6.7-4%2Bdeb10u5?distro=debian-buster&upstream=gnutls28",
                   "version": "3.6.7-4+deb10u5",
                 },
               },
@@ -3356,7 +3356,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
-                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
+                  "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?distro=debian-buster&upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -3364,7 +3364,7 @@ Object {
                 "id": "apt@1.8.2.1",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.8.2.1",
+                  "purl": "pkg:deb/debian/apt@1.8.2.1?distro=debian-buster",
                   "version": "1.8.2.1",
                 },
               },
@@ -3379,7 +3379,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?distro=debian-buster&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -3387,7 +3387,7 @@ Object {
                 "id": "base-files@10.3+deb10u6",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u6",
+                  "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u6?distro=debian-buster",
                   "version": "10.3+deb10u6",
                 },
               },
@@ -3395,7 +3395,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.249?distro=debian-buster&upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -3403,7 +3403,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.46",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.46?distro=debian-buster",
                   "version": "3.5.46",
                 },
               },
@@ -3411,7 +3411,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.6.1",
+                  "purl": "pkg:deb/debian/debianutils@4.8.6.1?distro=debian-buster",
                   "version": "4.8.6.1",
                 },
               },
@@ -3419,7 +3419,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
-                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -3427,7 +3427,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@5.0-4",
+                  "purl": "pkg:deb/debian/bash@5.0-4?distro=debian-buster",
                   "version": "5.0-4",
                 },
               },
@@ -3442,7 +3442,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.30-3",
+                  "purl": "pkg:deb/debian/coreutils@8.30-3?distro=debian-buster",
                   "version": "8.30-3",
                 },
               },
@@ -3450,7 +3450,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.10.2-5",
+                  "purl": "pkg:deb/debian/dash@0.5.10.2-5?distro=debian-buster",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -3465,7 +3465,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.7-3",
+                  "purl": "pkg:deb/debian/diffutils@1:3.7-3?distro=debian-buster",
                   "version": "1:3.7-3",
                 },
               },
@@ -3480,7 +3480,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
-                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -3488,7 +3488,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
-                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -3496,7 +3496,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u3?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u3?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -3504,7 +3504,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3512,7 +3512,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3520,7 +3520,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u3",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u3",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u3?distro=debian-buster",
                   "version": "1.44.5-1+deb10u3",
                 },
               },
@@ -3528,7 +3528,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
+                  "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?distro=debian-buster",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -3550,7 +3550,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.28-10?distro=debian-buster&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -3565,7 +3565,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@3.3-1",
+                  "purl": "pkg:deb/debian/grep@3.3-1?distro=debian-buster",
                   "version": "3.3-1",
                 },
               },
@@ -3573,7 +3573,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.9-3",
+                  "purl": "pkg:deb/debian/gzip@1.9-3?distro=debian-buster",
                   "version": "1.9-3",
                 },
               },
@@ -3581,7 +3581,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.21",
+                  "purl": "pkg:deb/debian/hostname@3.21?distro=debian-buster",
                   "version": "3.21",
                 },
               },
@@ -3589,7 +3589,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
+                  "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?distro=debian-buster",
                   "version": "1.56+nmu1",
                 },
               },
@@ -3604,7 +3604,7 @@ Object {
                 "id": "lsb/lsb-base@10.2019051400",
                 "info": Object {
                   "name": "lsb/lsb-base",
-                  "purl": "pkg:deb/lsb-base@10.2019051400?upstream=lsb",
+                  "purl": "pkg:deb/debian/lsb-base@10.2019051400?distro=debian-buster&upstream=lsb",
                   "version": "10.2019051400",
                 },
               },
@@ -3612,7 +3612,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
-                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -3620,7 +3620,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -3628,7 +3628,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u2",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u2",
                 },
               },
@@ -3636,7 +3636,7 @@ Object {
                 "id": "openssl/libssl1.1@1.1.1d-0+deb10u3",
                 "info": Object {
                   "name": "openssl/libssl1.1",
-                  "purl": "pkg:deb/libssl1.1@1.1.1d-0%2Bdeb10u3?upstream=openssl",
+                  "purl": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u3?distro=debian-buster&upstream=openssl",
                   "version": "1.1.1d-0+deb10u3",
                 },
               },
@@ -3644,7 +3644,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -3666,7 +3666,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.7-1",
+                  "purl": "pkg:deb/debian/sed@4.7-1?distro=debian-buster",
                   "version": "4.7-1",
                 },
               },
@@ -3674,7 +3674,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -3682,7 +3682,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
+                  "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?distro=debian-buster",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3690,7 +3690,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?distro=debian-buster&upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -3705,7 +3705,7 @@ Object {
                 "id": "tzdata@2020a-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2020a-0%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/tzdata@2020a-0%2Bdeb10u1?distro=debian-buster",
                   "version": "2020a-0+deb10u1",
                 },
               },
@@ -3713,7 +3713,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.33.1-0.1?distro=debian-buster&upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -3721,7 +3721,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3729,7 +3729,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3737,7 +3737,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3745,7 +3745,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
-                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -3753,7 +3753,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/system/red-hat-repositories/__snapshots__/red-hat-repositories.spec.ts.snap
+++ b/test/system/red-hat-repositories/__snapshots__/red-hat-repositories.spec.ts.snap
@@ -1152,7 +1152,7 @@ Object {
                 "id": "audit/libaudit-common@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit-common",
-                  "purl": "pkg:deb/libaudit-common@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit-common@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1160,7 +1160,7 @@ Object {
                 "id": "libcap-ng/libcap-ng0@0.7.9-2",
                 "info": Object {
                   "name": "libcap-ng/libcap-ng0",
-                  "purl": "pkg:deb/libcap-ng0@0.7.9-2?upstream=libcap-ng",
+                  "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?distro=debian-buster&upstream=libcap-ng",
                   "version": "0.7.9-2",
                 },
               },
@@ -1168,7 +1168,7 @@ Object {
                 "id": "audit/libaudit1@1:2.8.4-3",
                 "info": Object {
                   "name": "audit/libaudit1",
-                  "purl": "pkg:deb/libaudit1@1:2.8.4-3?upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit1@1:2.8.4-3?distro=debian-buster&upstream=audit",
                   "version": "1:2.8.4-3",
                 },
               },
@@ -1176,7 +1176,7 @@ Object {
                 "id": "libsemanage/libsemanage-common@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage-common",
-                  "purl": "pkg:deb/libsemanage-common@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage-common@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1184,7 +1184,7 @@ Object {
                 "id": "libsepol/libsepol1@2.8-1",
                 "info": Object {
                   "name": "libsepol/libsepol1",
-                  "purl": "pkg:deb/libsepol1@2.8-1?upstream=libsepol",
+                  "purl": "pkg:deb/debian/libsepol1@2.8-1?distro=debian-buster&upstream=libsepol",
                   "version": "2.8-1",
                 },
               },
@@ -1192,7 +1192,7 @@ Object {
                 "id": "libsemanage/libsemanage1@2.8-2",
                 "info": Object {
                   "name": "libsemanage/libsemanage1",
-                  "purl": "pkg:deb/libsemanage1@2.8-2?upstream=libsemanage",
+                  "purl": "pkg:deb/debian/libsemanage1@2.8-2?distro=debian-buster&upstream=libsemanage",
                   "version": "2.8-2",
                 },
               },
@@ -1200,7 +1200,7 @@ Object {
                 "id": "db5.3/libdb5.3@5.3.28+dfsg1-0.5",
                 "info": Object {
                   "name": "db5.3/libdb5.3",
-                  "purl": "pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.5?upstream=db5.3",
+                  "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?distro=debian-buster&upstream=db5.3",
                   "version": "5.3.28+dfsg1-0.5",
                 },
               },
@@ -1208,7 +1208,7 @@ Object {
                 "id": "pam/libpam0g@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam0g",
-                  "purl": "pkg:deb/libpam0g@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam0g@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1216,7 +1216,7 @@ Object {
                 "id": "pam/libpam-modules-bin@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules-bin",
-                  "purl": "pkg:deb/libpam-modules-bin@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1224,7 +1224,7 @@ Object {
                 "id": "pam/libpam-modules@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-modules",
-                  "purl": "pkg:deb/libpam-modules@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1232,7 +1232,7 @@ Object {
                 "id": "shadow/passwd@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/passwd",
-                  "purl": "pkg:deb/passwd@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/passwd@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1240,7 +1240,7 @@ Object {
                 "id": "adduser@3.118",
                 "info": Object {
                   "name": "adduser",
-                  "purl": "pkg:deb/adduser@3.118",
+                  "purl": "pkg:deb/debian/adduser@3.118?distro=debian-buster",
                   "version": "3.118",
                 },
               },
@@ -1248,7 +1248,7 @@ Object {
                 "id": "gcc-8/libstdc++6@8.3.0-6",
                 "info": Object {
                   "name": "gcc-8/libstdc++6",
-                  "purl": "pkg:deb/libstdc%2B%2B6@8.3.0-6?upstream=gcc-8",
+                  "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?distro=debian-buster&upstream=gcc-8",
                   "version": "8.3.0-6",
                 },
               },
@@ -1256,7 +1256,7 @@ Object {
                 "id": "libzstd/libzstd1@1.3.8+dfsg-3",
                 "info": Object {
                   "name": "libzstd/libzstd1",
-                  "purl": "pkg:deb/libzstd1@1.3.8%2Bdfsg-3?upstream=libzstd",
+                  "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?distro=debian-buster&upstream=libzstd",
                   "version": "1.3.8+dfsg-3",
                 },
               },
@@ -1264,7 +1264,7 @@ Object {
                 "id": "lz4/liblz4-1@1.8.3-1",
                 "info": Object {
                   "name": "lz4/liblz4-1",
-                  "purl": "pkg:deb/liblz4-1@1.8.3-1?upstream=lz4",
+                  "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?distro=debian-buster&upstream=lz4",
                   "version": "1.8.3-1",
                 },
               },
@@ -1272,7 +1272,7 @@ Object {
                 "id": "libgcrypt20@1.8.4-5",
                 "info": Object {
                   "name": "libgcrypt20",
-                  "purl": "pkg:deb/libgcrypt20@1.8.4-5",
+                  "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?distro=debian-buster",
                   "version": "1.8.4-5",
                 },
               },
@@ -1280,7 +1280,7 @@ Object {
                 "id": "systemd/libsystemd0@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libsystemd0",
-                  "purl": "pkg:deb/libsystemd0@241-7~deb10u1?upstream=systemd",
+                  "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u1?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1288,7 +1288,7 @@ Object {
                 "id": "systemd/libudev1@241-7~deb10u1",
                 "info": Object {
                   "name": "systemd/libudev1",
-                  "purl": "pkg:deb/libudev1@241-7~deb10u1?upstream=systemd",
+                  "purl": "pkg:deb/debian/libudev1@241-7~deb10u1?distro=debian-buster&upstream=systemd",
                   "version": "241-7~deb10u1",
                 },
               },
@@ -1296,7 +1296,7 @@ Object {
                 "id": "apt/libapt-pkg5.0@1.8.2",
                 "info": Object {
                   "name": "apt/libapt-pkg5.0",
-                  "purl": "pkg:deb/libapt-pkg5.0@1.8.2?upstream=apt",
+                  "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2?distro=debian-buster&upstream=apt",
                   "version": "1.8.2",
                 },
               },
@@ -1304,7 +1304,7 @@ Object {
                 "id": "debian-archive-keyring@2019.1",
                 "info": Object {
                   "name": "debian-archive-keyring",
-                  "purl": "pkg:deb/debian-archive-keyring@2019.1",
+                  "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?distro=debian-buster",
                   "version": "2019.1",
                 },
               },
@@ -1312,7 +1312,7 @@ Object {
                 "id": "libgpg-error/libgpg-error0@1.35-1",
                 "info": Object {
                   "name": "libgpg-error/libgpg-error0",
-                  "purl": "pkg:deb/libgpg-error0@1.35-1?upstream=libgpg-error",
+                  "purl": "pkg:deb/debian/libgpg-error0@1.35-1?distro=debian-buster&upstream=libgpg-error",
                   "version": "1.35-1",
                 },
               },
@@ -1320,7 +1320,7 @@ Object {
                 "id": "gnupg2/gpgv@2.2.12-1+deb10u1",
                 "info": Object {
                   "name": "gnupg2/gpgv",
-                  "purl": "pkg:deb/gpgv@2.2.12-1%2Bdeb10u1?upstream=gnupg2",
+                  "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?distro=debian-buster&upstream=gnupg2",
                   "version": "2.2.12-1+deb10u1",
                 },
               },
@@ -1328,7 +1328,7 @@ Object {
                 "id": "gmp/libgmp10@2:6.1.2+dfsg-4",
                 "info": Object {
                   "name": "gmp/libgmp10",
-                  "purl": "pkg:deb/libgmp10@2:6.1.2%2Bdfsg-4?upstream=gmp",
+                  "purl": "pkg:deb/debian/libgmp10@2:6.1.2%2Bdfsg-4?distro=debian-buster&upstream=gmp",
                   "version": "2:6.1.2+dfsg-4",
                 },
               },
@@ -1336,7 +1336,7 @@ Object {
                 "id": "libunistring/libunistring2@0.9.10-1",
                 "info": Object {
                   "name": "libunistring/libunistring2",
-                  "purl": "pkg:deb/libunistring2@0.9.10-1?upstream=libunistring",
+                  "purl": "pkg:deb/debian/libunistring2@0.9.10-1?distro=debian-buster&upstream=libunistring",
                   "version": "0.9.10-1",
                 },
               },
@@ -1344,7 +1344,7 @@ Object {
                 "id": "libidn2/libidn2-0@2.0.5-1",
                 "info": Object {
                   "name": "libidn2/libidn2-0",
-                  "purl": "pkg:deb/libidn2-0@2.0.5-1?upstream=libidn2",
+                  "purl": "pkg:deb/debian/libidn2-0@2.0.5-1?distro=debian-buster&upstream=libidn2",
                   "version": "2.0.5-1",
                 },
               },
@@ -1352,7 +1352,7 @@ Object {
                 "id": "libtasn1-6@4.13-3",
                 "info": Object {
                   "name": "libtasn1-6",
-                  "purl": "pkg:deb/libtasn1-6@4.13-3",
+                  "purl": "pkg:deb/debian/libtasn1-6@4.13-3?distro=debian-buster",
                   "version": "4.13-3",
                 },
               },
@@ -1360,7 +1360,7 @@ Object {
                 "id": "nettle/libnettle6@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libnettle6",
-                  "purl": "pkg:deb/libnettle6@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libnettle6@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1368,7 +1368,7 @@ Object {
                 "id": "nettle/libhogweed4@3.4.1-1",
                 "info": Object {
                   "name": "nettle/libhogweed4",
-                  "purl": "pkg:deb/libhogweed4@3.4.1-1?upstream=nettle",
+                  "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?distro=debian-buster&upstream=nettle",
                   "version": "3.4.1-1",
                 },
               },
@@ -1376,7 +1376,7 @@ Object {
                 "id": "libffi/libffi6@3.2.1-9",
                 "info": Object {
                   "name": "libffi/libffi6",
-                  "purl": "pkg:deb/libffi6@3.2.1-9?upstream=libffi",
+                  "purl": "pkg:deb/debian/libffi6@3.2.1-9?distro=debian-buster&upstream=libffi",
                   "version": "3.2.1-9",
                 },
               },
@@ -1384,7 +1384,7 @@ Object {
                 "id": "p11-kit/libp11-kit0@0.23.15-2",
                 "info": Object {
                   "name": "p11-kit/libp11-kit0",
-                  "purl": "pkg:deb/libp11-kit0@0.23.15-2?upstream=p11-kit",
+                  "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?distro=debian-buster&upstream=p11-kit",
                   "version": "0.23.15-2",
                 },
               },
@@ -1392,7 +1392,7 @@ Object {
                 "id": "gnutls28/libgnutls30@3.6.7-4",
                 "info": Object {
                   "name": "gnutls28/libgnutls30",
-                  "purl": "pkg:deb/libgnutls30@3.6.7-4?upstream=gnutls28",
+                  "purl": "pkg:deb/debian/libgnutls30@3.6.7-4?distro=debian-buster&upstream=gnutls28",
                   "version": "3.6.7-4",
                 },
               },
@@ -1400,7 +1400,7 @@ Object {
                 "id": "libseccomp/libseccomp2@2.3.3-4",
                 "info": Object {
                   "name": "libseccomp/libseccomp2",
-                  "purl": "pkg:deb/libseccomp2@2.3.3-4?upstream=libseccomp",
+                  "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?distro=debian-buster&upstream=libseccomp",
                   "version": "2.3.3-4",
                 },
               },
@@ -1408,7 +1408,7 @@ Object {
                 "id": "apt@1.8.2",
                 "info": Object {
                   "name": "apt",
-                  "purl": "pkg:deb/apt@1.8.2",
+                  "purl": "pkg:deb/debian/apt@1.8.2?distro=debian-buster",
                   "version": "1.8.2",
                 },
               },
@@ -1423,7 +1423,7 @@ Object {
                 "id": "mawk/mawk@1.3.3-17+b3",
                 "info": Object {
                   "name": "mawk/mawk",
-                  "purl": "pkg:deb/mawk@1.3.3-17%2Bb3?upstream=mawk%401.3.3-17",
+                  "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?distro=debian-buster&upstream=mawk%401.3.3-17",
                   "version": "1.3.3-17+b3",
                 },
               },
@@ -1431,7 +1431,7 @@ Object {
                 "id": "base-files@10.3+deb10u1",
                 "info": Object {
                   "name": "base-files",
-                  "purl": "pkg:deb/base-files@10.3%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u1?distro=debian-buster",
                   "version": "10.3+deb10u1",
                 },
               },
@@ -1439,7 +1439,7 @@ Object {
                 "id": "cdebconf/libdebconfclient0@0.249",
                 "info": Object {
                   "name": "cdebconf/libdebconfclient0",
-                  "purl": "pkg:deb/libdebconfclient0@0.249?upstream=cdebconf",
+                  "purl": "pkg:deb/debian/libdebconfclient0@0.249?distro=debian-buster&upstream=cdebconf",
                   "version": "0.249",
                 },
               },
@@ -1447,7 +1447,7 @@ Object {
                 "id": "base-passwd@3.5.46",
                 "info": Object {
                   "name": "base-passwd",
-                  "purl": "pkg:deb/base-passwd@3.5.46",
+                  "purl": "pkg:deb/debian/base-passwd@3.5.46?distro=debian-buster",
                   "version": "3.5.46",
                 },
               },
@@ -1455,7 +1455,7 @@ Object {
                 "id": "debianutils@4.8.6.1",
                 "info": Object {
                   "name": "debianutils",
-                  "purl": "pkg:deb/debianutils@4.8.6.1",
+                  "purl": "pkg:deb/debian/debianutils@4.8.6.1?distro=debian-buster",
                   "version": "4.8.6.1",
                 },
               },
@@ -1463,7 +1463,7 @@ Object {
                 "id": "ncurses/libtinfo6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libtinfo6",
-                  "purl": "pkg:deb/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1471,7 +1471,7 @@ Object {
                 "id": "bash@5.0-4",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:deb/bash@5.0-4",
+                  "purl": "pkg:deb/debian/bash@5.0-4?distro=debian-buster",
                   "version": "5.0-4",
                 },
               },
@@ -1486,7 +1486,7 @@ Object {
                 "id": "coreutils@8.30-3",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:deb/coreutils@8.30-3",
+                  "purl": "pkg:deb/debian/coreutils@8.30-3?distro=debian-buster",
                   "version": "8.30-3",
                 },
               },
@@ -1494,7 +1494,7 @@ Object {
                 "id": "dash@0.5.10.2-5",
                 "info": Object {
                   "name": "dash",
-                  "purl": "pkg:deb/dash@0.5.10.2-5",
+                  "purl": "pkg:deb/debian/dash@0.5.10.2-5?distro=debian-buster",
                   "version": "0.5.10.2-5",
                 },
               },
@@ -1509,7 +1509,7 @@ Object {
                 "id": "diffutils@1:3.7-3",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:deb/diffutils@1:3.7-3",
+                  "purl": "pkg:deb/debian/diffutils@1:3.7-3?distro=debian-buster",
                   "version": "1:3.7-3",
                 },
               },
@@ -1524,7 +1524,7 @@ Object {
                 "id": "e2fsprogs/libcom-err2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libcom-err2",
-                  "purl": "pkg:deb/libcom-err2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1532,7 +1532,7 @@ Object {
                 "id": "e2fsprogs/libext2fs2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libext2fs2",
-                  "purl": "pkg:deb/libext2fs2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1540,7 +1540,7 @@ Object {
                 "id": "e2fsprogs/libss2@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs/libss2",
-                  "purl": "pkg:deb/libss2@1.44.5-1%2Bdeb10u1?upstream=e2fsprogs",
+                  "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u1?distro=debian-buster&upstream=e2fsprogs",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1548,7 +1548,7 @@ Object {
                 "id": "util-linux/libuuid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libuuid1",
-                  "purl": "pkg:deb/libuuid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1556,7 +1556,7 @@ Object {
                 "id": "util-linux/libblkid1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libblkid1",
-                  "purl": "pkg:deb/libblkid1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1564,7 +1564,7 @@ Object {
                 "id": "e2fsprogs@1.44.5-1+deb10u1",
                 "info": Object {
                   "name": "e2fsprogs",
-                  "purl": "pkg:deb/e2fsprogs@1.44.5-1%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u1?distro=debian-buster",
                   "version": "1.44.5-1+deb10u1",
                 },
               },
@@ -1572,7 +1572,7 @@ Object {
                 "id": "findutils@4.6.0+git+20190209-2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:deb/findutils@4.6.0%2Bgit%2B20190209-2",
+                  "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?distro=debian-buster",
                   "version": "4.6.0+git+20190209-2",
                 },
               },
@@ -1594,7 +1594,7 @@ Object {
                 "id": "glibc/libc-bin@2.28-10",
                 "info": Object {
                   "name": "glibc/libc-bin",
-                  "purl": "pkg:deb/libc-bin@2.28-10?upstream=glibc",
+                  "purl": "pkg:deb/debian/libc-bin@2.28-10?distro=debian-buster&upstream=glibc",
                   "version": "2.28-10",
                 },
               },
@@ -1609,7 +1609,7 @@ Object {
                 "id": "grep@3.3-1",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:deb/grep@3.3-1",
+                  "purl": "pkg:deb/debian/grep@3.3-1?distro=debian-buster",
                   "version": "3.3-1",
                 },
               },
@@ -1617,7 +1617,7 @@ Object {
                 "id": "gzip@1.9-3",
                 "info": Object {
                   "name": "gzip",
-                  "purl": "pkg:deb/gzip@1.9-3",
+                  "purl": "pkg:deb/debian/gzip@1.9-3?distro=debian-buster",
                   "version": "1.9-3",
                 },
               },
@@ -1625,7 +1625,7 @@ Object {
                 "id": "hostname@3.21",
                 "info": Object {
                   "name": "hostname",
-                  "purl": "pkg:deb/hostname@3.21",
+                  "purl": "pkg:deb/debian/hostname@3.21?distro=debian-buster",
                   "version": "3.21",
                 },
               },
@@ -1633,7 +1633,7 @@ Object {
                 "id": "init-system-helpers@1.56+nmu1",
                 "info": Object {
                   "name": "init-system-helpers",
-                  "purl": "pkg:deb/init-system-helpers@1.56%2Bnmu1",
+                  "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?distro=debian-buster",
                   "version": "1.56+nmu1",
                 },
               },
@@ -1648,7 +1648,7 @@ Object {
                 "id": "ncurses/libncursesw6@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/libncursesw6",
-                  "purl": "pkg:deb/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1656,7 +1656,7 @@ Object {
                 "id": "ncurses/ncurses-base@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-base",
-                  "purl": "pkg:deb/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1664,7 +1664,7 @@ Object {
                 "id": "ncurses/ncurses-bin@6.1+20181013-2+deb10u1",
                 "info": Object {
                   "name": "ncurses/ncurses-bin",
-                  "purl": "pkg:deb/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?upstream=ncurses",
+                  "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u1?distro=debian-buster&upstream=ncurses",
                   "version": "6.1+20181013-2+deb10u1",
                 },
               },
@@ -1672,7 +1672,7 @@ Object {
                 "id": "pam/libpam-runtime@1.3.1-5",
                 "info": Object {
                   "name": "pam/libpam-runtime",
-                  "purl": "pkg:deb/libpam-runtime@1.3.1-5?upstream=pam",
+                  "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?distro=debian-buster&upstream=pam",
                   "version": "1.3.1-5",
                 },
               },
@@ -1694,7 +1694,7 @@ Object {
                 "id": "sed@4.7-1",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:deb/sed@4.7-1",
+                  "purl": "pkg:deb/debian/sed@4.7-1?distro=debian-buster",
                   "version": "4.7-1",
                 },
               },
@@ -1702,7 +1702,7 @@ Object {
                 "id": "shadow/login@1:4.5-1.1",
                 "info": Object {
                   "name": "shadow/login",
-                  "purl": "pkg:deb/login@1:4.5-1.1?upstream=shadow",
+                  "purl": "pkg:deb/debian/login@1:4.5-1.1?distro=debian-buster&upstream=shadow",
                   "version": "1:4.5-1.1",
                 },
               },
@@ -1710,7 +1710,7 @@ Object {
                 "id": "util-linux@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux",
-                  "purl": "pkg:deb/util-linux@2.33.1-0.1",
+                  "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?distro=debian-buster",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1718,7 +1718,7 @@ Object {
                 "id": "sysvinit/sysvinit-utils@2.93-8",
                 "info": Object {
                   "name": "sysvinit/sysvinit-utils",
-                  "purl": "pkg:deb/sysvinit-utils@2.93-8?upstream=sysvinit",
+                  "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?distro=debian-buster&upstream=sysvinit",
                   "version": "2.93-8",
                 },
               },
@@ -1733,7 +1733,7 @@ Object {
                 "id": "tzdata@2019b-0+deb10u1",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:deb/tzdata@2019b-0%2Bdeb10u1",
+                  "purl": "pkg:deb/debian/tzdata@2019b-0%2Bdeb10u1?distro=debian-buster",
                   "version": "2019b-0+deb10u1",
                 },
               },
@@ -1741,7 +1741,7 @@ Object {
                 "id": "util-linux/bsdutils@1:2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/bsdutils",
-                  "purl": "pkg:deb/bsdutils@1:2.33.1-0.1?upstream=util-linux%402.33.1-0.1",
+                  "purl": "pkg:deb/debian/bsdutils@1:2.33.1-0.1?distro=debian-buster&upstream=util-linux%402.33.1-0.1",
                   "version": "1:2.33.1-0.1",
                 },
               },
@@ -1749,7 +1749,7 @@ Object {
                 "id": "util-linux/libfdisk1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libfdisk1",
-                  "purl": "pkg:deb/libfdisk1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1757,7 +1757,7 @@ Object {
                 "id": "util-linux/libmount1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libmount1",
-                  "purl": "pkg:deb/libmount1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1765,7 +1765,7 @@ Object {
                 "id": "util-linux/libsmartcols1@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/libsmartcols1",
-                  "purl": "pkg:deb/libsmartcols1@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1773,7 +1773,7 @@ Object {
                 "id": "util-linux/fdisk@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/fdisk",
-                  "purl": "pkg:deb/fdisk@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },
@@ -1781,7 +1781,7 @@ Object {
                 "id": "util-linux/mount@2.33.1-0.1",
                 "info": Object {
                   "name": "util-linux/mount",
-                  "purl": "pkg:deb/mount@2.33.1-0.1?upstream=util-linux",
+                  "purl": "pkg:deb/debian/mount@2.33.1-0.1?distro=debian-buster&upstream=util-linux",
                   "version": "2.33.1-0.1",
                 },
               },

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -2898,7 +2898,7 @@ Object {
                 "id": "amazon-linux-extras@1.6.10-1.amzn2",
                 "info": Object {
                   "name": "amazon-linux-extras",
-                  "purl": "pkg:rpm/amazon-linux-extras@1.6.10-1.amzn2",
+                  "purl": "pkg:rpm/amzn/amazon-linux-extras@1.6.10-1.amzn2?distro=amzn-2",
                   "version": "1.6.10-1.amzn2",
                 },
               },
@@ -2906,7 +2906,7 @@ Object {
                 "id": "basesystem@10.0-7.amzn2.0.1",
                 "info": Object {
                   "name": "basesystem",
-                  "purl": "pkg:rpm/basesystem@10.0-7.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/basesystem@10.0-7.amzn2.0.1?distro=amzn-2",
                   "version": "10.0-7.amzn2.0.1",
                 },
               },
@@ -2914,7 +2914,7 @@ Object {
                 "id": "bash@4.2.46-33.amzn2",
                 "info": Object {
                   "name": "bash",
-                  "purl": "pkg:rpm/bash@4.2.46-33.amzn2",
+                  "purl": "pkg:rpm/amzn/bash@4.2.46-33.amzn2?distro=amzn-2",
                   "version": "4.2.46-33.amzn2",
                 },
               },
@@ -2922,7 +2922,7 @@ Object {
                 "id": "bzip2-libs@1.0.6-13.amzn2.0.2",
                 "info": Object {
                   "name": "bzip2-libs",
-                  "purl": "pkg:rpm/bzip2-libs@1.0.6-13.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/bzip2-libs@1.0.6-13.amzn2.0.2?distro=amzn-2",
                   "version": "1.0.6-13.amzn2.0.2",
                 },
               },
@@ -2930,7 +2930,7 @@ Object {
                 "id": "ca-certificates@2019.2.32-76.amzn2.0.1",
                 "info": Object {
                   "name": "ca-certificates",
-                  "purl": "pkg:rpm/ca-certificates@2019.2.32-76.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/ca-certificates@2019.2.32-76.amzn2.0.1?distro=amzn-2",
                   "version": "2019.2.32-76.amzn2.0.1",
                 },
               },
@@ -2938,7 +2938,7 @@ Object {
                 "id": "chkconfig@1.7.4-1.amzn2.0.2",
                 "info": Object {
                   "name": "chkconfig",
-                  "purl": "pkg:rpm/chkconfig@1.7.4-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/chkconfig@1.7.4-1.amzn2.0.2?distro=amzn-2",
                   "version": "1.7.4-1.amzn2.0.2",
                 },
               },
@@ -2946,7 +2946,7 @@ Object {
                 "id": "coreutils@8.22-24.amzn2",
                 "info": Object {
                   "name": "coreutils",
-                  "purl": "pkg:rpm/coreutils@8.22-24.amzn2",
+                  "purl": "pkg:rpm/amzn/coreutils@8.22-24.amzn2?distro=amzn-2",
                   "version": "8.22-24.amzn2",
                 },
               },
@@ -2954,7 +2954,7 @@ Object {
                 "id": "cpio@2.11-27.amzn2",
                 "info": Object {
                   "name": "cpio",
-                  "purl": "pkg:rpm/cpio@2.11-27.amzn2",
+                  "purl": "pkg:rpm/amzn/cpio@2.11-27.amzn2?distro=amzn-2",
                   "version": "2.11-27.amzn2",
                 },
               },
@@ -2962,7 +2962,7 @@ Object {
                 "id": "curl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "curl",
-                  "purl": "pkg:rpm/curl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/curl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -2970,7 +2970,7 @@ Object {
                 "id": "cyrus-sasl-lib@2.1.26-23.amzn2",
                 "info": Object {
                   "name": "cyrus-sasl-lib",
-                  "purl": "pkg:rpm/cyrus-sasl-lib@2.1.26-23.amzn2",
+                  "purl": "pkg:rpm/amzn/cyrus-sasl-lib@2.1.26-23.amzn2?distro=amzn-2",
                   "version": "2.1.26-23.amzn2",
                 },
               },
@@ -2978,7 +2978,7 @@ Object {
                 "id": "diffutils@3.3-5.amzn2",
                 "info": Object {
                   "name": "diffutils",
-                  "purl": "pkg:rpm/diffutils@3.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/diffutils@3.3-5.amzn2?distro=amzn-2",
                   "version": "3.3-5.amzn2",
                 },
               },
@@ -2986,7 +2986,7 @@ Object {
                 "id": "elfutils-libelf@0.176-2.amzn2",
                 "info": Object {
                   "name": "elfutils-libelf",
-                  "purl": "pkg:rpm/elfutils-libelf@0.176-2.amzn2",
+                  "purl": "pkg:rpm/amzn/elfutils-libelf@0.176-2.amzn2?distro=amzn-2",
                   "version": "0.176-2.amzn2",
                 },
               },
@@ -2994,7 +2994,7 @@ Object {
                 "id": "expat@2.1.0-10.amzn2.0.2",
                 "info": Object {
                   "name": "expat",
-                  "purl": "pkg:rpm/expat@2.1.0-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/expat@2.1.0-10.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-10.amzn2.0.2",
                 },
               },
@@ -3002,7 +3002,7 @@ Object {
                 "id": "file-libs@5.11-35.amzn2.0.2",
                 "info": Object {
                   "name": "file-libs",
-                  "purl": "pkg:rpm/file-libs@5.11-35.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/file-libs@5.11-35.amzn2.0.2?distro=amzn-2",
                   "version": "5.11-35.amzn2.0.2",
                 },
               },
@@ -3010,7 +3010,7 @@ Object {
                 "id": "filesystem@3.2-25.amzn2.0.4",
                 "info": Object {
                   "name": "filesystem",
-                  "purl": "pkg:rpm/filesystem@3.2-25.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/filesystem@3.2-25.amzn2.0.4?distro=amzn-2",
                   "version": "3.2-25.amzn2.0.4",
                 },
               },
@@ -3018,7 +3018,7 @@ Object {
                 "id": "findutils@1:4.5.11-6.amzn2",
                 "info": Object {
                   "name": "findutils",
-                  "purl": "pkg:rpm/findutils@1:4.5.11-6.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/findutils@1:4.5.11-6.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:4.5.11-6.amzn2",
                 },
               },
@@ -3026,7 +3026,7 @@ Object {
                 "id": "gawk@4.0.2-4.amzn2.1.2",
                 "info": Object {
                   "name": "gawk",
-                  "purl": "pkg:rpm/gawk@4.0.2-4.amzn2.1.2",
+                  "purl": "pkg:rpm/amzn/gawk@4.0.2-4.amzn2.1.2?distro=amzn-2",
                   "version": "4.0.2-4.amzn2.1.2",
                 },
               },
@@ -3034,7 +3034,7 @@ Object {
                 "id": "gdbm@1:1.13-6.amzn2.0.2",
                 "info": Object {
                   "name": "gdbm",
-                  "purl": "pkg:rpm/gdbm@1:1.13-6.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gdbm@1:1.13-6.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:1.13-6.amzn2.0.2",
                 },
               },
@@ -3042,7 +3042,7 @@ Object {
                 "id": "glib2@2.56.1-4.amzn2",
                 "info": Object {
                   "name": "glib2",
-                  "purl": "pkg:rpm/glib2@2.56.1-4.amzn2",
+                  "purl": "pkg:rpm/amzn/glib2@2.56.1-4.amzn2?distro=amzn-2",
                   "version": "2.56.1-4.amzn2",
                 },
               },
@@ -3050,7 +3050,7 @@ Object {
                 "id": "glibc@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/glibc@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -3058,7 +3058,7 @@ Object {
                 "id": "glibc-common@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/glibc-common@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-common@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -3066,7 +3066,7 @@ Object {
                 "id": "glibc-langpack-en@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/glibc-langpack-en@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-langpack-en@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -3074,7 +3074,7 @@ Object {
                 "id": "glibc-minimal-langpack@2.26-34.amzn2",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/glibc-minimal-langpack@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/glibc-minimal-langpack@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -3082,7 +3082,7 @@ Object {
                 "id": "gmp@1:6.0.0-15.amzn2.0.2",
                 "info": Object {
                   "name": "gmp",
-                  "purl": "pkg:rpm/gmp@1:6.0.0-15.amzn2.0.2?epoch=1",
+                  "purl": "pkg:rpm/amzn/gmp@1:6.0.0-15.amzn2.0.2?distro=amzn-2&epoch=1",
                   "version": "1:6.0.0-15.amzn2.0.2",
                 },
               },
@@ -3090,7 +3090,7 @@ Object {
                 "id": "gnupg2@2.0.22-5.amzn2.0.4",
                 "info": Object {
                   "name": "gnupg2",
-                  "purl": "pkg:rpm/gnupg2@2.0.22-5.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/gnupg2@2.0.22-5.amzn2.0.4?distro=amzn-2",
                   "version": "2.0.22-5.amzn2.0.4",
                 },
               },
@@ -3098,7 +3098,7 @@ Object {
                 "id": "gpg-pubkey@c87f5b1a-593863f8",
                 "info": Object {
                   "name": "gpg-pubkey",
-                  "purl": "pkg:rpm/gpg-pubkey@c87f5b1a-593863f8",
+                  "purl": "pkg:rpm/amzn/gpg-pubkey@c87f5b1a-593863f8?distro=amzn-2",
                   "version": "c87f5b1a-593863f8",
                 },
               },
@@ -3106,7 +3106,7 @@ Object {
                 "id": "gpgme@1.3.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "gpgme",
-                  "purl": "pkg:rpm/gpgme@1.3.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/gpgme@1.3.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "1.3.2-5.amzn2.0.2",
                 },
               },
@@ -3114,7 +3114,7 @@ Object {
                 "id": "grep@2.20-3.amzn2.0.2",
                 "info": Object {
                   "name": "grep",
-                  "purl": "pkg:rpm/grep@2.20-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/grep@2.20-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.20-3.amzn2.0.2",
                 },
               },
@@ -3122,7 +3122,7 @@ Object {
                 "id": "info@5.1-5.amzn2",
                 "info": Object {
                   "name": "info",
-                  "purl": "pkg:rpm/info@5.1-5.amzn2",
+                  "purl": "pkg:rpm/amzn/info@5.1-5.amzn2?distro=amzn-2",
                   "version": "5.1-5.amzn2",
                 },
               },
@@ -3130,7 +3130,7 @@ Object {
                 "id": "keyutils-libs@1.5.8-3.amzn2.0.2",
                 "info": Object {
                   "name": "keyutils-libs",
-                  "purl": "pkg:rpm/keyutils-libs@1.5.8-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/keyutils-libs@1.5.8-3.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.8-3.amzn2.0.2",
                 },
               },
@@ -3138,7 +3138,7 @@ Object {
                 "id": "krb5-libs@1.15.1-37.amzn2.2.2",
                 "info": Object {
                   "name": "krb5-libs",
-                  "purl": "pkg:rpm/krb5-libs@1.15.1-37.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/krb5-libs@1.15.1-37.amzn2.2.2?distro=amzn-2",
                   "version": "1.15.1-37.amzn2.2.2",
                 },
               },
@@ -3146,7 +3146,7 @@ Object {
                 "id": "libacl@2.2.51-14.amzn2",
                 "info": Object {
                   "name": "libacl",
-                  "purl": "pkg:rpm/libacl@2.2.51-14.amzn2",
+                  "purl": "pkg:rpm/amzn/libacl@2.2.51-14.amzn2?distro=amzn-2",
                   "version": "2.2.51-14.amzn2",
                 },
               },
@@ -3154,7 +3154,7 @@ Object {
                 "id": "libassuan@2.1.0-3.amzn2.0.2",
                 "info": Object {
                   "name": "libassuan",
-                  "purl": "pkg:rpm/libassuan@2.1.0-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libassuan@2.1.0-3.amzn2.0.2?distro=amzn-2",
                   "version": "2.1.0-3.amzn2.0.2",
                 },
               },
@@ -3162,7 +3162,7 @@ Object {
                 "id": "libattr@2.4.46-12.amzn2.0.2",
                 "info": Object {
                   "name": "libattr",
-                  "purl": "pkg:rpm/libattr@2.4.46-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libattr@2.4.46-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.4.46-12.amzn2.0.2",
                 },
               },
@@ -3170,7 +3170,7 @@ Object {
                 "id": "libblkid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/libblkid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libblkid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -3178,7 +3178,7 @@ Object {
                 "id": "libcap@2.22-9.amzn2.0.2",
                 "info": Object {
                   "name": "libcap",
-                  "purl": "pkg:rpm/libcap@2.22-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcap@2.22-9.amzn2.0.2?distro=amzn-2",
                   "version": "2.22-9.amzn2.0.2",
                 },
               },
@@ -3186,7 +3186,7 @@ Object {
                 "id": "libcom_err@1.42.9-12.amzn2.0.2",
                 "info": Object {
                   "name": "libcom_err",
-                  "purl": "pkg:rpm/libcom_err@1.42.9-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libcom_err@1.42.9-12.amzn2.0.2?distro=amzn-2",
                   "version": "1.42.9-12.amzn2.0.2",
                 },
               },
@@ -3194,7 +3194,7 @@ Object {
                 "id": "libcrypt@2.26-34.amzn2",
                 "info": Object {
                   "name": "libcrypt",
-                  "purl": "pkg:rpm/libcrypt@2.26-34.amzn2",
+                  "purl": "pkg:rpm/amzn/libcrypt@2.26-34.amzn2?distro=amzn-2",
                   "version": "2.26-34.amzn2",
                 },
               },
@@ -3202,7 +3202,7 @@ Object {
                 "id": "libcurl@7.61.1-12.amzn2.0.1",
                 "info": Object {
                   "name": "libcurl",
-                  "purl": "pkg:rpm/libcurl@7.61.1-12.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/libcurl@7.61.1-12.amzn2.0.1?distro=amzn-2",
                   "version": "7.61.1-12.amzn2.0.1",
                 },
               },
@@ -3210,7 +3210,7 @@ Object {
                 "id": "libdb@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb",
-                  "purl": "pkg:rpm/libdb@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -3218,7 +3218,7 @@ Object {
                 "id": "libdb-utils@5.3.21-24.amzn2.0.3",
                 "info": Object {
                   "name": "libdb-utils",
-                  "purl": "pkg:rpm/libdb-utils@5.3.21-24.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libdb-utils@5.3.21-24.amzn2.0.3?distro=amzn-2",
                   "version": "5.3.21-24.amzn2.0.3",
                 },
               },
@@ -3226,7 +3226,7 @@ Object {
                 "id": "libffi@3.0.13-18.amzn2.0.2",
                 "info": Object {
                   "name": "libffi",
-                  "purl": "pkg:rpm/libffi@3.0.13-18.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libffi@3.0.13-18.amzn2.0.2?distro=amzn-2",
                   "version": "3.0.13-18.amzn2.0.2",
                 },
               },
@@ -3234,7 +3234,7 @@ Object {
                 "id": "libgcc@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/libgcc@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libgcc@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -3242,7 +3242,7 @@ Object {
                 "id": "libgcrypt@1.5.3-14.amzn2.0.2",
                 "info": Object {
                   "name": "libgcrypt",
-                  "purl": "pkg:rpm/libgcrypt@1.5.3-14.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libgcrypt@1.5.3-14.amzn2.0.2?distro=amzn-2",
                   "version": "1.5.3-14.amzn2.0.2",
                 },
               },
@@ -3250,7 +3250,7 @@ Object {
                 "id": "libgpg-error@1.12-3.amzn2.0.3",
                 "info": Object {
                   "name": "libgpg-error",
-                  "purl": "pkg:rpm/libgpg-error@1.12-3.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/libgpg-error@1.12-3.amzn2.0.3?distro=amzn-2",
                   "version": "1.12-3.amzn2.0.3",
                 },
               },
@@ -3258,7 +3258,7 @@ Object {
                 "id": "libidn2@2.3.0-1.amzn2",
                 "info": Object {
                   "name": "libidn2",
-                  "purl": "pkg:rpm/libidn2@2.3.0-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libidn2@2.3.0-1.amzn2?distro=amzn-2",
                   "version": "2.3.0-1.amzn2",
                 },
               },
@@ -3266,7 +3266,7 @@ Object {
                 "id": "libmetalink@0.1.2-7.amzn2.0.2",
                 "info": Object {
                   "name": "libmetalink",
-                  "purl": "pkg:rpm/libmetalink@0.1.2-7.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libmetalink@0.1.2-7.amzn2.0.2?distro=amzn-2",
                   "version": "0.1.2-7.amzn2.0.2",
                 },
               },
@@ -3274,7 +3274,7 @@ Object {
                 "id": "libmount@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/libmount@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libmount@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -3282,7 +3282,7 @@ Object {
                 "id": "libnghttp2@1.39.2-1.amzn2",
                 "info": Object {
                   "name": "libnghttp2",
-                  "purl": "pkg:rpm/libnghttp2@1.39.2-1.amzn2",
+                  "purl": "pkg:rpm/amzn/libnghttp2@1.39.2-1.amzn2?distro=amzn-2",
                   "version": "1.39.2-1.amzn2",
                 },
               },
@@ -3290,7 +3290,7 @@ Object {
                 "id": "libselinux@2.5-12.amzn2.0.2",
                 "info": Object {
                   "name": "libselinux",
-                  "purl": "pkg:rpm/libselinux@2.5-12.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libselinux@2.5-12.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-12.amzn2.0.2",
                 },
               },
@@ -3298,7 +3298,7 @@ Object {
                 "id": "libsepol@2.5-8.1.amzn2.0.2",
                 "info": Object {
                   "name": "libsepol",
-                  "purl": "pkg:rpm/libsepol@2.5-8.1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libsepol@2.5-8.1.amzn2.0.2?distro=amzn-2",
                   "version": "2.5-8.1.amzn2.0.2",
                 },
               },
@@ -3306,7 +3306,7 @@ Object {
                 "id": "libssh2@1.4.3-12.amzn2.2.2",
                 "info": Object {
                   "name": "libssh2",
-                  "purl": "pkg:rpm/libssh2@1.4.3-12.amzn2.2.2",
+                  "purl": "pkg:rpm/amzn/libssh2@1.4.3-12.amzn2.2.2?distro=amzn-2",
                   "version": "1.4.3-12.amzn2.2.2",
                 },
               },
@@ -3314,7 +3314,7 @@ Object {
                 "id": "libstdc++@7.3.1-6.amzn2.0.4",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/libstdc%2B%2B@7.3.1-6.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libstdc%2B%2B@7.3.1-6.amzn2.0.4?distro=amzn-2",
                   "version": "7.3.1-6.amzn2.0.4",
                 },
               },
@@ -3322,7 +3322,7 @@ Object {
                 "id": "libtasn1@4.10-1.amzn2.0.2",
                 "info": Object {
                   "name": "libtasn1",
-                  "purl": "pkg:rpm/libtasn1@4.10-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libtasn1@4.10-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.10-1.amzn2.0.2",
                 },
               },
@@ -3330,7 +3330,7 @@ Object {
                 "id": "libunistring@0.9.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "libunistring",
-                  "purl": "pkg:rpm/libunistring@0.9.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libunistring@0.9.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.9.3-9.amzn2.0.2",
                 },
               },
@@ -3338,7 +3338,7 @@ Object {
                 "id": "libuuid@2.30.2-2.amzn2.0.4",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/libuuid@2.30.2-2.amzn2.0.4",
+                  "purl": "pkg:rpm/amzn/libuuid@2.30.2-2.amzn2.0.4?distro=amzn-2",
                   "version": "2.30.2-2.amzn2.0.4",
                 },
               },
@@ -3346,7 +3346,7 @@ Object {
                 "id": "libverto@0.2.5-4.amzn2.0.2",
                 "info": Object {
                   "name": "libverto",
-                  "purl": "pkg:rpm/libverto@0.2.5-4.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/libverto@0.2.5-4.amzn2.0.2?distro=amzn-2",
                   "version": "0.2.5-4.amzn2.0.2",
                 },
               },
@@ -3354,7 +3354,7 @@ Object {
                 "id": "libxml2@2.9.1-6.amzn2.3.3",
                 "info": Object {
                   "name": "libxml2",
-                  "purl": "pkg:rpm/libxml2@2.9.1-6.amzn2.3.3",
+                  "purl": "pkg:rpm/amzn/libxml2@2.9.1-6.amzn2.3.3?distro=amzn-2",
                   "version": "2.9.1-6.amzn2.3.3",
                 },
               },
@@ -3362,7 +3362,7 @@ Object {
                 "id": "lua@5.1.4-15.amzn2.0.2",
                 "info": Object {
                   "name": "lua",
-                  "purl": "pkg:rpm/lua@5.1.4-15.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/lua@5.1.4-15.amzn2.0.2?distro=amzn-2",
                   "version": "5.1.4-15.amzn2.0.2",
                 },
               },
@@ -3370,7 +3370,7 @@ Object {
                 "id": "ncurses@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses",
-                  "purl": "pkg:rpm/ncurses@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -3378,7 +3378,7 @@ Object {
                 "id": "ncurses-base@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-base",
-                  "purl": "pkg:rpm/ncurses-base@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-base@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -3386,7 +3386,7 @@ Object {
                 "id": "ncurses-libs@6.0-8.20170212.amzn2.1.3",
                 "info": Object {
                   "name": "ncurses-libs",
-                  "purl": "pkg:rpm/ncurses-libs@6.0-8.20170212.amzn2.1.3",
+                  "purl": "pkg:rpm/amzn/ncurses-libs@6.0-8.20170212.amzn2.1.3?distro=amzn-2",
                   "version": "6.0-8.20170212.amzn2.1.3",
                 },
               },
@@ -3394,7 +3394,7 @@ Object {
                 "id": "nspr@4.21.0-1.amzn2.0.2",
                 "info": Object {
                   "name": "nspr",
-                  "purl": "pkg:rpm/nspr@4.21.0-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/nspr@4.21.0-1.amzn2.0.2?distro=amzn-2",
                   "version": "4.21.0-1.amzn2.0.2",
                 },
               },
@@ -3402,7 +3402,7 @@ Object {
                 "id": "nss@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss",
-                  "purl": "pkg:rpm/nss@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -3410,7 +3410,7 @@ Object {
                 "id": "nss-pem@1.0.3-5.amzn2",
                 "info": Object {
                   "name": "nss-pem",
-                  "purl": "pkg:rpm/nss-pem@1.0.3-5.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-pem@1.0.3-5.amzn2?distro=amzn-2",
                   "version": "1.0.3-5.amzn2",
                 },
               },
@@ -3418,7 +3418,7 @@ Object {
                 "id": "nss-softokn@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn",
-                  "purl": "pkg:rpm/nss-softokn@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -3426,7 +3426,7 @@ Object {
                 "id": "nss-softokn-freebl@3.44.0-8.amzn2",
                 "info": Object {
                   "name": "nss-softokn-freebl",
-                  "purl": "pkg:rpm/nss-softokn-freebl@3.44.0-8.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-softokn-freebl@3.44.0-8.amzn2?distro=amzn-2",
                   "version": "3.44.0-8.amzn2",
                 },
               },
@@ -3434,7 +3434,7 @@ Object {
                 "id": "nss-sysinit@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-sysinit",
-                  "purl": "pkg:rpm/nss-sysinit@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-sysinit@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -3442,7 +3442,7 @@ Object {
                 "id": "nss-tools@3.44.0-7.amzn2",
                 "info": Object {
                   "name": "nss-tools",
-                  "purl": "pkg:rpm/nss-tools@3.44.0-7.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-tools@3.44.0-7.amzn2?distro=amzn-2",
                   "version": "3.44.0-7.amzn2",
                 },
               },
@@ -3450,7 +3450,7 @@ Object {
                 "id": "nss-util@3.44.0-4.amzn2",
                 "info": Object {
                   "name": "nss-util",
-                  "purl": "pkg:rpm/nss-util@3.44.0-4.amzn2",
+                  "purl": "pkg:rpm/amzn/nss-util@3.44.0-4.amzn2?distro=amzn-2",
                   "version": "3.44.0-4.amzn2",
                 },
               },
@@ -3458,7 +3458,7 @@ Object {
                 "id": "openldap@2.4.44-15.amzn2",
                 "info": Object {
                   "name": "openldap",
-                  "purl": "pkg:rpm/openldap@2.4.44-15.amzn2",
+                  "purl": "pkg:rpm/amzn/openldap@2.4.44-15.amzn2?distro=amzn-2",
                   "version": "2.4.44-15.amzn2",
                 },
               },
@@ -3466,7 +3466,7 @@ Object {
                 "id": "openssl-libs@1:1.0.2k-19.amzn2.0.3",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/openssl-libs@1:1.0.2k-19.amzn2.0.3?epoch=1",
+                  "purl": "pkg:rpm/amzn/openssl-libs@1:1.0.2k-19.amzn2.0.3?distro=amzn-2&epoch=1",
                   "version": "1:1.0.2k-19.amzn2.0.3",
                 },
               },
@@ -3474,7 +3474,7 @@ Object {
                 "id": "p11-kit@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit",
-                  "purl": "pkg:rpm/p11-kit@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -3482,7 +3482,7 @@ Object {
                 "id": "p11-kit-trust@0.23.5-3.amzn2.0.2",
                 "info": Object {
                   "name": "p11-kit-trust",
-                  "purl": "pkg:rpm/p11-kit-trust@0.23.5-3.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/p11-kit-trust@0.23.5-3.amzn2.0.2?distro=amzn-2",
                   "version": "0.23.5-3.amzn2.0.2",
                 },
               },
@@ -3490,7 +3490,7 @@ Object {
                 "id": "pcre@8.32-17.amzn2.0.2",
                 "info": Object {
                   "name": "pcre",
-                  "purl": "pkg:rpm/pcre@8.32-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pcre@8.32-17.amzn2.0.2?distro=amzn-2",
                   "version": "8.32-17.amzn2.0.2",
                 },
               },
@@ -3498,7 +3498,7 @@ Object {
                 "id": "pinentry@0.8.1-17.amzn2.0.2",
                 "info": Object {
                   "name": "pinentry",
-                  "purl": "pkg:rpm/pinentry@0.8.1-17.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pinentry@0.8.1-17.amzn2.0.2?distro=amzn-2",
                   "version": "0.8.1-17.amzn2.0.2",
                 },
               },
@@ -3506,7 +3506,7 @@ Object {
                 "id": "popt@1.13-16.amzn2.0.2",
                 "info": Object {
                   "name": "popt",
-                  "purl": "pkg:rpm/popt@1.13-16.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/popt@1.13-16.amzn2.0.2?distro=amzn-2",
                   "version": "1.13-16.amzn2.0.2",
                 },
               },
@@ -3514,7 +3514,7 @@ Object {
                 "id": "pth@2.0.7-23.amzn2.0.2",
                 "info": Object {
                   "name": "pth",
-                  "purl": "pkg:rpm/pth@2.0.7-23.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pth@2.0.7-23.amzn2.0.2?distro=amzn-2",
                   "version": "2.0.7-23.amzn2.0.2",
                 },
               },
@@ -3522,7 +3522,7 @@ Object {
                 "id": "pygpgme@0.3-9.amzn2.0.2",
                 "info": Object {
                   "name": "pygpgme",
-                  "purl": "pkg:rpm/pygpgme@0.3-9.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pygpgme@0.3-9.amzn2.0.2?distro=amzn-2",
                   "version": "0.3-9.amzn2.0.2",
                 },
               },
@@ -3530,7 +3530,7 @@ Object {
                 "id": "pyliblzma@0.5.3-11.amzn2.0.2",
                 "info": Object {
                   "name": "pyliblzma",
-                  "purl": "pkg:rpm/pyliblzma@0.5.3-11.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyliblzma@0.5.3-11.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.3-11.amzn2.0.2",
                 },
               },
@@ -3538,7 +3538,7 @@ Object {
                 "id": "python@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python",
-                  "purl": "pkg:rpm/python@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -3546,7 +3546,7 @@ Object {
                 "id": "python-iniparse@0.4-9.amzn2",
                 "info": Object {
                   "name": "python-iniparse",
-                  "purl": "pkg:rpm/python-iniparse@0.4-9.amzn2",
+                  "purl": "pkg:rpm/amzn/python-iniparse@0.4-9.amzn2?distro=amzn-2",
                   "version": "0.4-9.amzn2",
                 },
               },
@@ -3554,7 +3554,7 @@ Object {
                 "id": "python-libs@2.7.16-5.amzn2",
                 "info": Object {
                   "name": "python-libs",
-                  "purl": "pkg:rpm/python-libs@2.7.16-5.amzn2",
+                  "purl": "pkg:rpm/amzn/python-libs@2.7.16-5.amzn2?distro=amzn-2",
                   "version": "2.7.16-5.amzn2",
                 },
               },
@@ -3562,7 +3562,7 @@ Object {
                 "id": "python-pycurl@7.19.0-19.amzn2.0.2",
                 "info": Object {
                   "name": "python-pycurl",
-                  "purl": "pkg:rpm/python-pycurl@7.19.0-19.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/python-pycurl@7.19.0-19.amzn2.0.2?distro=amzn-2",
                   "version": "7.19.0-19.amzn2.0.2",
                 },
               },
@@ -3570,7 +3570,7 @@ Object {
                 "id": "python-urlgrabber@3.10-9.amzn2.0.1",
                 "info": Object {
                   "name": "python-urlgrabber",
-                  "purl": "pkg:rpm/python-urlgrabber@3.10-9.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/python-urlgrabber@3.10-9.amzn2.0.1?distro=amzn-2",
                   "version": "3.10-9.amzn2.0.1",
                 },
               },
@@ -3578,7 +3578,7 @@ Object {
                 "id": "python2-rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "python2-rpm",
-                  "purl": "pkg:rpm/python2-rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/python2-rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -3586,7 +3586,7 @@ Object {
                 "id": "pyxattr@0.5.1-5.amzn2.0.2",
                 "info": Object {
                   "name": "pyxattr",
-                  "purl": "pkg:rpm/pyxattr@0.5.1-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/pyxattr@0.5.1-5.amzn2.0.2?distro=amzn-2",
                   "version": "0.5.1-5.amzn2.0.2",
                 },
               },
@@ -3594,7 +3594,7 @@ Object {
                 "id": "readline@6.2-10.amzn2.0.2",
                 "info": Object {
                   "name": "readline",
-                  "purl": "pkg:rpm/readline@6.2-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/readline@6.2-10.amzn2.0.2?distro=amzn-2",
                   "version": "6.2-10.amzn2.0.2",
                 },
               },
@@ -3602,7 +3602,7 @@ Object {
                 "id": "rpm@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/rpm@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -3610,7 +3610,7 @@ Object {
                 "id": "rpm-build-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/rpm-build-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-build-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -3618,7 +3618,7 @@ Object {
                 "id": "rpm-libs@4.11.3-40.amzn2.0.3",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/rpm-libs@4.11.3-40.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/rpm-libs@4.11.3-40.amzn2.0.3?distro=amzn-2",
                   "version": "4.11.3-40.amzn2.0.3",
                 },
               },
@@ -3626,7 +3626,7 @@ Object {
                 "id": "sed@4.2.2-5.amzn2.0.2",
                 "info": Object {
                   "name": "sed",
-                  "purl": "pkg:rpm/sed@4.2.2-5.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/sed@4.2.2-5.amzn2.0.2?distro=amzn-2",
                   "version": "4.2.2-5.amzn2.0.2",
                 },
               },
@@ -3634,7 +3634,7 @@ Object {
                 "id": "setup@2.8.71-10.amzn2.0.1",
                 "info": Object {
                   "name": "setup",
-                  "purl": "pkg:rpm/setup@2.8.71-10.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/setup@2.8.71-10.amzn2.0.1?distro=amzn-2",
                   "version": "2.8.71-10.amzn2.0.1",
                 },
               },
@@ -3642,7 +3642,7 @@ Object {
                 "id": "shared-mime-info@1.8-4.amzn2",
                 "info": Object {
                   "name": "shared-mime-info",
-                  "purl": "pkg:rpm/shared-mime-info@1.8-4.amzn2",
+                  "purl": "pkg:rpm/amzn/shared-mime-info@1.8-4.amzn2?distro=amzn-2",
                   "version": "1.8-4.amzn2",
                 },
               },
@@ -3650,7 +3650,7 @@ Object {
                 "id": "sqlite@3.7.17-8.amzn2.1.1",
                 "info": Object {
                   "name": "sqlite",
-                  "purl": "pkg:rpm/sqlite@3.7.17-8.amzn2.1.1",
+                  "purl": "pkg:rpm/amzn/sqlite@3.7.17-8.amzn2.1.1?distro=amzn-2",
                   "version": "3.7.17-8.amzn2.1.1",
                 },
               },
@@ -3658,7 +3658,7 @@ Object {
                 "id": "system-release@1:2-11.amzn2",
                 "info": Object {
                   "name": "system-release",
-                  "purl": "pkg:rpm/system-release@1:2-11.amzn2?epoch=1",
+                  "purl": "pkg:rpm/amzn/system-release@1:2-11.amzn2?distro=amzn-2&epoch=1",
                   "version": "1:2-11.amzn2",
                 },
               },
@@ -3666,7 +3666,7 @@ Object {
                 "id": "tzdata@2019c-1.amzn2",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/tzdata@2019c-1.amzn2",
+                  "purl": "pkg:rpm/amzn/tzdata@2019c-1.amzn2?distro=amzn-2",
                   "version": "2019c-1.amzn2",
                 },
               },
@@ -3674,7 +3674,7 @@ Object {
                 "id": "vim-minimal@2:8.1.1602-1.amzn2",
                 "info": Object {
                   "name": "vim-minimal",
-                  "purl": "pkg:rpm/vim-minimal@2:8.1.1602-1.amzn2?epoch=2",
+                  "purl": "pkg:rpm/amzn/vim-minimal@2:8.1.1602-1.amzn2?distro=amzn-2&epoch=2",
                   "version": "2:8.1.1602-1.amzn2",
                 },
               },
@@ -3682,7 +3682,7 @@ Object {
                 "id": "xz-libs@5.2.2-1.amzn2.0.2",
                 "info": Object {
                   "name": "xz-libs",
-                  "purl": "pkg:rpm/xz-libs@5.2.2-1.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/xz-libs@5.2.2-1.amzn2.0.2?distro=amzn-2",
                   "version": "5.2.2-1.amzn2.0.2",
                 },
               },
@@ -3690,7 +3690,7 @@ Object {
                 "id": "yum@3.4.3-158.amzn2.0.3",
                 "info": Object {
                   "name": "yum",
-                  "purl": "pkg:rpm/yum@3.4.3-158.amzn2.0.3",
+                  "purl": "pkg:rpm/amzn/yum@3.4.3-158.amzn2.0.3?distro=amzn-2",
                   "version": "3.4.3-158.amzn2.0.3",
                 },
               },
@@ -3698,7 +3698,7 @@ Object {
                 "id": "yum-metadata-parser@1.1.4-10.amzn2.0.2",
                 "info": Object {
                   "name": "yum-metadata-parser",
-                  "purl": "pkg:rpm/yum-metadata-parser@1.1.4-10.amzn2.0.2",
+                  "purl": "pkg:rpm/amzn/yum-metadata-parser@1.1.4-10.amzn2.0.2?distro=amzn-2",
                   "version": "1.1.4-10.amzn2.0.2",
                 },
               },
@@ -3706,7 +3706,7 @@ Object {
                 "id": "yum-plugin-ovl@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-ovl",
-                  "purl": "pkg:rpm/yum-plugin-ovl@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-ovl@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -3714,7 +3714,7 @@ Object {
                 "id": "yum-plugin-priorities@1.1.31-46.amzn2.0.1",
                 "info": Object {
                   "name": "yum-plugin-priorities",
-                  "purl": "pkg:rpm/yum-plugin-priorities@1.1.31-46.amzn2.0.1",
+                  "purl": "pkg:rpm/amzn/yum-plugin-priorities@1.1.31-46.amzn2.0.1?distro=amzn-2",
                   "version": "1.1.31-46.amzn2.0.1",
                 },
               },
@@ -3722,7 +3722,7 @@ Object {
                 "id": "zlib@1.2.7-18.amzn2",
                 "info": Object {
                   "name": "zlib",
-                  "purl": "pkg:rpm/zlib@1.2.7-18.amzn2",
+                  "purl": "pkg:rpm/amzn/zlib@1.2.7-18.amzn2?distro=amzn-2",
                   "version": "1.2.7-18.amzn2",
                 },
               },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes purl generation for `apt` and `rpm` packages. The fix entails:
- Adding the vendor name as a namespace in PURLs
- For debian, mapping the version number to a corresponding codename
- Adding the `distro` qualifier in PURLs

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
