### PR TITLE
fix: use custom version compare function to support multiple version string compare groups

### DIFF
--- a/lib/analyzer/applications/python/pip.ts
+++ b/lib/analyzer/applications/python/pip.ts
@@ -4,6 +4,7 @@ import { eventLoopSpinner } from "event-loop-spinner";
 import * as path from "path";
 import * as semver from "semver";
 import { DepGraphFact } from "../../../facts";
+import { compareVersions } from "../../../python-parser/common";
 import { getPackageInfo } from "../../../python-parser/metadata-parser";
 import { getRequirements } from "../../../python-parser/requirements-parser";
 import {
@@ -115,7 +116,7 @@ export async function pipFilesToScannedProjects(
   // pre-sort each package name by version, descending
   for (const name of Object.keys(metadataItems)) {
     metadataItems[name].sort((v1, v2) => {
-      return semver.rcompare(v1.version, v2.version);
+      return compareVersions(v1.version, v2.version);
     });
   }
 

--- a/lib/python-parser/common.ts
+++ b/lib/python-parser/common.ts
@@ -16,3 +16,42 @@ export function specifierValidRange(
   const versionPartsLength = version.split(".").length;
   return versionPartsLength === 2 ? "^" : "~";
 }
+
+// This regex is used to extract the "semver" part from the version string.
+// See the tests for a better understanding (Also the reason why this is exported)
+export const VERSION_EXTRACTION_REGEX = /(?<VERSION>(\d+\.)*\d+).*/;
+
+function compareArrays(v1: number[], v2: number[]) {
+  const max = v1.length > v2.length ? v1.length : v2.length;
+  for (let i = 0; i < max; i++) {
+    if ((v1[i] || 0) < (v2[i] || 0)) {
+      return 1;
+    }
+    if ((v1[i] || 0) > (v2[i] || 0)) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * This function was taken from a different semver library and slightly modified.
+ * If passed to Array.prototype.sort, versions will be sorted in descending order.
+ */
+export function compareVersions(version1: string, version2: string) {
+  const v1Match = VERSION_EXTRACTION_REGEX.exec(version1);
+  const v2Match = VERSION_EXTRACTION_REGEX.exec(version2);
+
+  if (v1Match === null || v2Match === null) {
+    return 0;
+  }
+
+  const v1 = v1Match
+    .groups!.VERSION.split(".")
+    .map((part) => Number.parseInt(part, 10));
+  const v2 = v2Match
+    .groups!.VERSION.split(".")
+    .map((part) => Number.parseInt(part, 10));
+
+  return compareArrays(v1, v2);
+}

--- a/test/fixtures/python/non-semver-versions/requirements.txt
+++ b/test/fixtures/python/non-semver-versions/requirements.txt
@@ -1,3 +1,4 @@
 six~=1.14
 flask>=2.2.0
 rpc.py==0.4.2
+other.py>=7.4.2.3

--- a/test/fixtures/python/non-semver-versions/site-packages/other.py-7.4.2.15.dist-info/METADATA
+++ b/test/fixtures/python/non-semver-versions/site-packages/other.py-7.4.2.15.dist-info/METADATA
@@ -1,0 +1,234 @@
+Metadata-Version: 2.1
+Name: other.py
+Version: 7.4.2.15
+Summary: An fast and powerful RPC framework based on ASGI/WSGI.
+Home-page: https://github.com/abersheeran/rpc.py
+License: Apache-2.0
+Author: abersheeran
+Author-email: me@abersheeran.com
+Requires-Python: >=3.7,<4.0
+Classifier: License :: OSI Approved :: Apache Software License
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.7
+Classifier: Programming Language :: Python :: 3.8
+Classifier: Programming Language :: Python :: 3.9
+Classifier: Programming Language :: Python :: Implementation :: CPython
+Classifier: Programming Language :: Python :: Implementation :: PyPy
+Classifier: Topic :: Internet :: WWW/HTTP
+Classifier: Topic :: Internet :: WWW/HTTP :: WSGI :: Application
+Classifier: Typing :: Typed
+Provides-Extra: client
+Provides-Extra: full
+Provides-Extra: msgpack
+Provides-Extra: type
+Requires-Dist: httpx (>=0.16.0,<0.17.0); extra == "client" or extra == "full"
+Requires-Dist: msgpack (>=1.0.0,<2.0.0); extra == "full" or extra == "msgpack"
+Requires-Dist: pydantic (>=1.7,<2.0); extra == "full" or extra == "type"
+Requires-Dist: typing-extensions (>=3.7.4,<4.0.0); python_version < "3.8"
+Project-URL: Repository, https://github.com/abersheeran/rpc.py
+Description-Content-Type: text/markdown
+
+# rpc.py
+
+[![Codecov](https://img.shields.io/codecov/c/github/abersheeran/rpc.py?style=flat-square)](https://codecov.io/gh/abersheeran/rpc.py)
+
+An fast and powerful RPC framework based on ASGI/WSGI.
+
+Based on WSGI/ASGI, you can deploy the rpc.py server to any server and use http2 to get better performance.
+
+## Install
+
+Install from PyPi:
+
+```bash
+pip install rpc.py
+
+# need use client
+pip install rpc.py[client]
+
+# need use pydantic type hint or OpenAPI docs
+pip install rpc.py[type]
+
+# need use msgpack to serializer
+pip install rpc.py[msgpack]
+
+# or install all dependencies
+pip install rpc.py[full]
+```
+
+Install from github:
+
+```bash
+pip install git+https://github.com/abersheeran/rpc.py@setup.py
+```
+
+## Usage
+
+### Server side:
+
+<details markdown="1">
+<summary>Use <code>ASGI</code> mode to register <code>async def</code>...</summary>
+
+```python
+from typing import AsyncGenerator
+
+import uvicorn
+from rpcpy import RPC
+
+app = RPC(mode="ASGI")
+
+
+@app.register
+async def none() -> None:
+    return
+
+
+@app.register
+async def sayhi(name: str) -> str:
+    return f"hi {name}"
+
+
+@app.register
+async def yield_data(max_num: int) -> AsyncGenerator[int, None]:
+    for i in range(max_num):
+        yield i
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, interface="asgi3", port=65432)
+```
+</details>
+
+OR
+
+<details markdown="1">
+<summary>Use <code>WSGI</code> mode to register <code>def</code>...</summary>
+
+```python
+from typing import Generator
+
+import uvicorn
+from rpcpy import RPC
+
+app = RPC()
+
+
+@app.register
+def none() -> None:
+    return
+
+
+@app.register
+def sayhi(name: str) -> str:
+    return f"hi {name}"
+
+
+@app.register
+def yield_data(max_num: int) -> Generator[int, None, None]:
+    for i in range(max_num):
+        yield i
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, interface="wsgi", port=65432)
+```
+</details>
+
+### Client side:
+
+Notice: Regardless of whether the server uses the WSGI mode or the ASGI mode, the client can freely use the asynchronous or synchronous mode.
+
+<details markdown="1">
+<summary>Use <code>httpx.Client()</code> mode to register <code>def</code>...</summary>
+
+```python
+from typing import Generator
+
+import httpx
+from rpcpy.client import Client
+
+app = Client(httpx.Client(), base_url="http://127.0.0.1:65432/")
+
+
+@app.remote_call
+def none() -> None:
+    ...
+
+
+@app.remote_call
+def sayhi(name: str) -> str:
+    ...
+
+
+@app.remote_call
+def yield_data(max_num: int) -> Generator[int, None, None]:
+    yield
+```
+</details>
+
+OR
+
+<details markdown="1">
+<summary>Use <code>httpx.AsyncClient()</code> mode to register <code>async def</code>...</summary>
+
+```python
+from typing import AsyncGenerator
+
+import httpx
+from rpcpy.client import Client
+
+app = Client(httpx.AsyncClient(), base_url="http://127.0.0.1:65432/")
+
+
+@app.remote_call
+async def none() -> None:
+    ...
+
+
+@app.remote_call
+async def sayhi(name: str) -> str:
+    ...
+
+
+@app.remote_call
+async def yield_data(max_num: int) -> AsyncGenerator[int, None]:
+    yield
+```
+</details>
+
+### Sub-route
+
+If you need to deploy the rpc.py server under `example.com/sub-route/*`, you need to set `RPC(prefix="/sub-route/")` and modify the `Client(base_path=https://example.com/sub-route/)`.
+
+### Serialization
+
+Currently supports three serializers, JSON, Pickle and Msgpack. JSON is used by default. You can override the default `JSONSerializer` with parameters.
+
+```python
+import httpx
+from rpcpy import RPC
+from rpcpy.client import Client
+from rpcpy.serializers import PickleSerializer, MsgpackSerializer
+
+RPC(response_serializer=MsgpackSerializer())
+# Or
+Client(
+    ...,
+    request_serializer=PickleSerializer(),
+)
+```
+
+## Type hint and OpenAPI Doc
+
+Thanks to the great work of [pydantic](https://pydantic-docs.helpmanual.io/), which makes rpc.py allow you to use type annotation to annotate the types of function parameters and response values, and perform type verification and JSON serialization . At the same time, it is allowed to generate openapi documents for human reading.
+
+### OpenAPI Documents
+
+If you want to open the OpenAPI document, you need to initialize `RPC` like this `RPC(openapi={"title": "TITLE", "description": "DESCRIPTION", "version": "v1"})`.
+
+Then, visit the `"{prefix}openapi-docs"` of RPC and you will be able to see the automatically generated OpenAPI documentation. (If you do not set the `prefix`, the `prefix` is `"/"`)
+
+## Limitations
+
+Currently, file upload is not supported, but you can do this by passing a `bytes` object.
+

--- a/test/fixtures/python/non-semver-versions/site-packages/other.py-7.4.2.3.dist-info/METADATA
+++ b/test/fixtures/python/non-semver-versions/site-packages/other.py-7.4.2.3.dist-info/METADATA
@@ -1,0 +1,234 @@
+Metadata-Version: 2.1
+Name: other.py
+Version: 7.4.2.3
+Summary: An fast and powerful RPC framework based on ASGI/WSGI.
+Home-page: https://github.com/abersheeran/rpc.py
+License: Apache-2.0
+Author: abersheeran
+Author-email: me@abersheeran.com
+Requires-Python: >=3.7,<4.0
+Classifier: License :: OSI Approved :: Apache Software License
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.7
+Classifier: Programming Language :: Python :: 3.8
+Classifier: Programming Language :: Python :: 3.9
+Classifier: Programming Language :: Python :: Implementation :: CPython
+Classifier: Programming Language :: Python :: Implementation :: PyPy
+Classifier: Topic :: Internet :: WWW/HTTP
+Classifier: Topic :: Internet :: WWW/HTTP :: WSGI :: Application
+Classifier: Typing :: Typed
+Provides-Extra: client
+Provides-Extra: full
+Provides-Extra: msgpack
+Provides-Extra: type
+Requires-Dist: httpx (>=0.16.0,<0.17.0); extra == "client" or extra == "full"
+Requires-Dist: msgpack (>=1.0.0,<2.0.0); extra == "full" or extra == "msgpack"
+Requires-Dist: pydantic (>=1.7,<2.0); extra == "full" or extra == "type"
+Requires-Dist: typing-extensions (>=3.7.4,<4.0.0); python_version < "3.8"
+Project-URL: Repository, https://github.com/abersheeran/rpc.py
+Description-Content-Type: text/markdown
+
+# rpc.py
+
+[![Codecov](https://img.shields.io/codecov/c/github/abersheeran/rpc.py?style=flat-square)](https://codecov.io/gh/abersheeran/rpc.py)
+
+An fast and powerful RPC framework based on ASGI/WSGI.
+
+Based on WSGI/ASGI, you can deploy the rpc.py server to any server and use http2 to get better performance.
+
+## Install
+
+Install from PyPi:
+
+```bash
+pip install rpc.py
+
+# need use client
+pip install rpc.py[client]
+
+# need use pydantic type hint or OpenAPI docs
+pip install rpc.py[type]
+
+# need use msgpack to serializer
+pip install rpc.py[msgpack]
+
+# or install all dependencies
+pip install rpc.py[full]
+```
+
+Install from github:
+
+```bash
+pip install git+https://github.com/abersheeran/rpc.py@setup.py
+```
+
+## Usage
+
+### Server side:
+
+<details markdown="1">
+<summary>Use <code>ASGI</code> mode to register <code>async def</code>...</summary>
+
+```python
+from typing import AsyncGenerator
+
+import uvicorn
+from rpcpy import RPC
+
+app = RPC(mode="ASGI")
+
+
+@app.register
+async def none() -> None:
+    return
+
+
+@app.register
+async def sayhi(name: str) -> str:
+    return f"hi {name}"
+
+
+@app.register
+async def yield_data(max_num: int) -> AsyncGenerator[int, None]:
+    for i in range(max_num):
+        yield i
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, interface="asgi3", port=65432)
+```
+</details>
+
+OR
+
+<details markdown="1">
+<summary>Use <code>WSGI</code> mode to register <code>def</code>...</summary>
+
+```python
+from typing import Generator
+
+import uvicorn
+from rpcpy import RPC
+
+app = RPC()
+
+
+@app.register
+def none() -> None:
+    return
+
+
+@app.register
+def sayhi(name: str) -> str:
+    return f"hi {name}"
+
+
+@app.register
+def yield_data(max_num: int) -> Generator[int, None, None]:
+    for i in range(max_num):
+        yield i
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, interface="wsgi", port=65432)
+```
+</details>
+
+### Client side:
+
+Notice: Regardless of whether the server uses the WSGI mode or the ASGI mode, the client can freely use the asynchronous or synchronous mode.
+
+<details markdown="1">
+<summary>Use <code>httpx.Client()</code> mode to register <code>def</code>...</summary>
+
+```python
+from typing import Generator
+
+import httpx
+from rpcpy.client import Client
+
+app = Client(httpx.Client(), base_url="http://127.0.0.1:65432/")
+
+
+@app.remote_call
+def none() -> None:
+    ...
+
+
+@app.remote_call
+def sayhi(name: str) -> str:
+    ...
+
+
+@app.remote_call
+def yield_data(max_num: int) -> Generator[int, None, None]:
+    yield
+```
+</details>
+
+OR
+
+<details markdown="1">
+<summary>Use <code>httpx.AsyncClient()</code> mode to register <code>async def</code>...</summary>
+
+```python
+from typing import AsyncGenerator
+
+import httpx
+from rpcpy.client import Client
+
+app = Client(httpx.AsyncClient(), base_url="http://127.0.0.1:65432/")
+
+
+@app.remote_call
+async def none() -> None:
+    ...
+
+
+@app.remote_call
+async def sayhi(name: str) -> str:
+    ...
+
+
+@app.remote_call
+async def yield_data(max_num: int) -> AsyncGenerator[int, None]:
+    yield
+```
+</details>
+
+### Sub-route
+
+If you need to deploy the rpc.py server under `example.com/sub-route/*`, you need to set `RPC(prefix="/sub-route/")` and modify the `Client(base_path=https://example.com/sub-route/)`.
+
+### Serialization
+
+Currently supports three serializers, JSON, Pickle and Msgpack. JSON is used by default. You can override the default `JSONSerializer` with parameters.
+
+```python
+import httpx
+from rpcpy import RPC
+from rpcpy.client import Client
+from rpcpy.serializers import PickleSerializer, MsgpackSerializer
+
+RPC(response_serializer=MsgpackSerializer())
+# Or
+Client(
+    ...,
+    request_serializer=PickleSerializer(),
+)
+```
+
+## Type hint and OpenAPI Doc
+
+Thanks to the great work of [pydantic](https://pydantic-docs.helpmanual.io/), which makes rpc.py allow you to use type annotation to annotate the types of function parameters and response values, and perform type verification and JSON serialization . At the same time, it is allowed to generate openapi documents for human reading.
+
+### OpenAPI Documents
+
+If you want to open the OpenAPI document, you need to initialize `RPC` like this `RPC(openapi={"title": "TITLE", "description": "DESCRIPTION", "version": "v1"})`.
+
+Then, visit the `"{prefix}openapi-docs"` of RPC and you will be able to see the automatically generated OpenAPI documentation. (If you do not set the `prefix`, the `prefix` is `"/"`)
+
+## Limitations
+
+Currently, file upload is not supported, but you can do this by passing a `bytes` object.
+

--- a/test/lib/analyzer/python-pip-analyzer.spec.ts
+++ b/test/lib/analyzer/python-pip-analyzer.spec.ts
@@ -98,6 +98,9 @@ describe("pip analyzer", () => {
     expect(packageList.find((p) => p.name === "rpc.py").version).toEqual(
       "0.4.2",
     );
+    expect(packageList.find((p) => p.name === "other.py").version).toEqual(
+      "7.4.2.15",
+    );
   });
 
   it("uses the latest versions when no version info is available", async () => {

--- a/test/unit/python-common.spec.ts
+++ b/test/unit/python-common.spec.ts
@@ -1,4 +1,8 @@
-import { specifierValidRange } from "../../lib/python-parser/common";
+import {
+  compareVersions,
+  specifierValidRange,
+  VERSION_EXTRACTION_REGEX,
+} from "../../lib/python-parser/common";
 
 describe("python version specifier parsing", () => {
   it("makes no change when change is not necessary", () => {
@@ -17,5 +21,53 @@ describe("python version specifier parsing", () => {
   it("changes compatible release", () => {
     expect(specifierValidRange("~=", "1.2")).toEqual("^");
     expect(specifierValidRange("~=", "1.2.3")).toEqual("~");
+  });
+});
+
+describe("The regex should correctly group the versions", () => {
+  test.each([
+    ["1", "1"],
+    ["1.2", "1.2"],
+    ["11.34.56", "11.34.56"],
+    ["2.4.6.7", "2.4.6.7"],
+    ["3.4.5-f", "3.4.5"],
+    ["3.4.5-fds.3.34", "3.4.5"],
+    ["3.-4.4", "3"],
+  ])("Version String %s should become %s", (version, expected) => {
+    expect(VERSION_EXTRACTION_REGEX.exec(version)!.groups!.VERSION).toBe(
+      expected,
+    );
+  });
+
+  test("Version String sfd should not match", () => {
+    expect(VERSION_EXTRACTION_REGEX.exec("sfd")).toBeNull();
+  });
+});
+
+describe("compareVersions should support multiple compare groups", () => {
+  test.each([
+    ["1", "2", 1],
+    ["1.2", "1.5", 1],
+    ["11.999.56", "11.34.56", -1],
+    ["2.4.6.8", "2.4.6.7", -1],
+    ["3.4.5-f", "3.4.19-fjk", 1],
+    ["3.4.5-fds.99.34", "4.4.5", 1],
+    ["3.-4.4", "3", 0],
+    ["dfhjls", "442.6.43", 0],
+    ["dfhjls", "ads", 0],
+    ["dfhjls", "", 0],
+  ])(
+    "Version String %s when compared to %s should be %i",
+    (version1, version2, expected) => {
+      expect(compareVersions(version1, version2)).toBe(expected);
+    },
+  );
+  test("Correctly sorts in descending order", () => {
+    expect(["1", "2", "3.4", "1.4"].sort(compareVersions)).toEqual([
+      "3.4",
+      "2",
+      "1.4",
+      "1",
+    ]);
   });
 });


### PR DESCRIPTION
This fixes an issue where an exception would occur when a python dependency had a version that did not conform to semver specs, such as 1.18.3.9

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team