### PR TITLE
fix: remove ignored paths when discovering npm manifest files UNIFY-216

### DIFF
--- a/lib/analyzer/applications/types.ts
+++ b/lib/analyzer/applications/types.ts
@@ -32,6 +32,4 @@ export interface AggregatedJars {
   [path: string]: JarBuffer[];
 }
 
-export interface FilesByDir {
-  [directoryName: string]: string[];
-}
+export type FilesByDirMap = Map<string, Set<string>>;

--- a/lib/inputs/node/static.ts
+++ b/lib/inputs/node/static.ts
@@ -1,21 +1,13 @@
 import { basename } from "path";
-
-import * as path from "path";
 import { ExtractAction } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 
-const ignoredPaths = ["/usr", "/bin", "/opt", "C:\\"];
 const nodeAppFiles = ["package.json", "package-lock.json", "yarn.lock"];
 const deletedAppFiles = nodeAppFiles.map((file) => ".wh." + file);
 
 function filePathMatches(filePath: string): boolean {
   const fileName = basename(filePath);
-  const dirName = path.dirname(filePath);
-
-  return (
-    !ignoredPaths.some((ignorePath) => dirName.includes(ignorePath)) &&
-    (nodeAppFiles.includes(fileName) || deletedAppFiles.includes(fileName))
-  );
+  return nodeAppFiles.includes(fileName) || deletedAppFiles.includes(fileName);
 }
 
 export const getNodeAppFileContentAction: ExtractAction = {

--- a/test/lib/docker.spec.ts
+++ b/test/lib/docker.spec.ts
@@ -76,7 +76,7 @@ describe("docker", () => {
       const stdout = (await subProcess.execute("docker", ["inspect", imageID]))
         .stdout;
       expect(imageID).toEqual(
-        "sha256:948374285abd1b0da4cbd25be286095bd4a2e87b28234b4645bdcbe8fcdc388c",
+        "sha256:f800c324d2439563735dfc4de0da09a45b301687ded46936fcf2cf9256d4c6d3",
       );
       const imageDetails = JSON.parse(stdout);
       const architecture = imageDetails[0].Architecture;
@@ -113,7 +113,7 @@ describe("docker", () => {
       const stdout = (await subProcess.execute("docker", ["inspect", imageID]))
         .stdout;
       expect(imageID).toEqual(
-        "sha256:4162855bf127f33c36f3857212081bac16871b2b04eaef58920e2547b46d0782",
+        "sha256:bdbea07b48b33b5ffdd260fc11012b892651c4f0f84cc2b782103dd68989caa4",
       );
       const imageDetails = JSON.parse(stdout);
       const architecture = imageDetails[0].Architecture;

--- a/test/system/application-scans/__snapshots__/node.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/node.spec.ts.snap
@@ -22127,3 +22127,10239 @@ Object {
   ],
 }
 `;
+
+exports[`node application scans should generate a scanResult for a multi-project-image 1`] = `
+Array [
+  Object {
+    "facts": Array [
+      Object {
+        "data": Object {
+          "graph": Object {
+            "nodes": Array [
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "alpine-baselayout/alpine-baselayout@3.2.0-r3",
+                  },
+                  Object {
+                    "nodeId": "alpine-keys/alpine-keys@2.1-r2",
+                  },
+                  Object {
+                    "nodeId": "apk-tools/apk-tools@2.10.5-r0",
+                  },
+                  Object {
+                    "nodeId": "busybox/busybox@1.31.1-r9|2",
+                  },
+                  Object {
+                    "nodeId": "busybox/ssl_client@1.31.1-r9",
+                  },
+                  Object {
+                    "nodeId": "ca-certificates/ca-certificates-cacert@20191127-r1",
+                  },
+                  Object {
+                    "nodeId": "gcc/libgcc@9.2.0-r4",
+                  },
+                  Object {
+                    "nodeId": "gcc/libstdc++@9.2.0-r4|2",
+                  },
+                  Object {
+                    "nodeId": "libc-dev/libc-utils@0.7.2-r0",
+                  },
+                  Object {
+                    "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r0|2",
+                  },
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                  Object {
+                    "nodeId": "musl/musl-utils@1.1.24-r2|2",
+                  },
+                  Object {
+                    "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|2",
+                  },
+                  Object {
+                    "nodeId": "openssl/libssl1.1@1.1.1g-r0|2",
+                  },
+                  Object {
+                    "nodeId": "pax-utils/scanelf@1.2.4-r0|2",
+                  },
+                  Object {
+                    "nodeId": "zlib/zlib@1.2.11-r3|2",
+                  },
+                ],
+                "nodeId": "root-node",
+                "pkgId": "docker-image|multi-project-image.tar@",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "busybox/busybox@1.31.1-r9|1",
+                "pkgId": "busybox/busybox@1.31.1-r9",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                ],
+                "nodeId": "busybox/busybox@1.31.1-r9|2",
+                "pkgId": "busybox/busybox@1.31.1-r9",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "musl/musl@1.1.24-r2",
+                "pkgId": "musl/musl@1.1.24-r2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "busybox/busybox@1.31.1-r9|1",
+                  },
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                ],
+                "nodeId": "alpine-baselayout/alpine-baselayout@3.2.0-r3",
+                "pkgId": "alpine-baselayout/alpine-baselayout@3.2.0-r3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "alpine-keys/alpine-keys@2.1-r2",
+                "pkgId": "alpine-keys/alpine-keys@2.1-r2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+                "pkgId": "openssl/libcrypto1.1@1.1.1g-r0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                ],
+                "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|2",
+                "pkgId": "openssl/libcrypto1.1@1.1.1g-r0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "openssl/libssl1.1@1.1.1g-r0|1",
+                "pkgId": "openssl/libssl1.1@1.1.1g-r0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                  Object {
+                    "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+                  },
+                ],
+                "nodeId": "openssl/libssl1.1@1.1.1g-r0|2",
+                "pkgId": "openssl/libssl1.1@1.1.1g-r0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "zlib/zlib@1.2.11-r3|1",
+                "pkgId": "zlib/zlib@1.2.11-r3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                ],
+                "nodeId": "zlib/zlib@1.2.11-r3|2",
+                "pkgId": "zlib/zlib@1.2.11-r3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                  Object {
+                    "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+                  },
+                  Object {
+                    "nodeId": "openssl/libssl1.1@1.1.1g-r0|1",
+                  },
+                  Object {
+                    "nodeId": "zlib/zlib@1.2.11-r3|1",
+                  },
+                ],
+                "nodeId": "apk-tools/apk-tools@2.10.5-r0",
+                "pkgId": "apk-tools/apk-tools@2.10.5-r0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r0|1",
+                "pkgId": "libtls-standalone/libtls-standalone@2.9.1-r0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ca-certificates/ca-certificates-cacert@20191127-r1",
+                  },
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                  Object {
+                    "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+                  },
+                  Object {
+                    "nodeId": "openssl/libssl1.1@1.1.1g-r0|1",
+                  },
+                ],
+                "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r0|2",
+                "pkgId": "libtls-standalone/libtls-standalone@2.9.1-r0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r0|1",
+                  },
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                ],
+                "nodeId": "busybox/ssl_client@1.31.1-r9",
+                "pkgId": "busybox/ssl_client@1.31.1-r9",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ca-certificates/ca-certificates-cacert@20191127-r1",
+                "pkgId": "ca-certificates/ca-certificates-cacert@20191127-r1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                ],
+                "nodeId": "gcc/libstdc++@9.2.0-r4|1",
+                "pkgId": "gcc/libstdc++@9.2.0-r4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "gcc/libstdc++@9.2.0-r4|2",
+                "pkgId": "gcc/libstdc++@9.2.0-r4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "gcc/libstdc++@9.2.0-r4|1",
+                  },
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                ],
+                "nodeId": "gcc/libgcc@9.2.0-r4",
+                "pkgId": "gcc/libgcc@9.2.0-r4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "musl/musl-utils@1.1.24-r2|1",
+                "pkgId": "musl/musl-utils@1.1.24-r2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                  Object {
+                    "nodeId": "pax-utils/scanelf@1.2.4-r0|1",
+                  },
+                ],
+                "nodeId": "musl/musl-utils@1.1.24-r2|2",
+                "pkgId": "musl/musl-utils@1.1.24-r2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl-utils@1.1.24-r2|1",
+                  },
+                ],
+                "nodeId": "libc-dev/libc-utils@0.7.2-r0",
+                "pkgId": "libc-dev/libc-utils@0.7.2-r0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "pax-utils/scanelf@1.2.4-r0|1",
+                "pkgId": "pax-utils/scanelf@1.2.4-r0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "musl/musl@1.1.24-r2",
+                  },
+                ],
+                "nodeId": "pax-utils/scanelf@1.2.4-r0|2",
+                "pkgId": "pax-utils/scanelf@1.2.4-r0",
+              },
+            ],
+            "rootNodeId": "root-node",
+          },
+          "pkgManager": Object {
+            "name": "apk",
+            "repositories": Array [
+              Object {
+                "alias": "alpine:3.11.6",
+              },
+            ],
+          },
+          "pkgs": Array [
+            Object {
+              "id": "docker-image|multi-project-image.tar@",
+              "info": Object {
+                "name": "docker-image|multi-project-image.tar",
+                "version": undefined,
+              },
+            },
+            Object {
+              "id": "busybox/busybox@1.31.1-r9",
+              "info": Object {
+                "name": "busybox/busybox",
+                "version": "1.31.1-r9",
+              },
+            },
+            Object {
+              "id": "musl/musl@1.1.24-r2",
+              "info": Object {
+                "name": "musl/musl",
+                "version": "1.1.24-r2",
+              },
+            },
+            Object {
+              "id": "alpine-baselayout/alpine-baselayout@3.2.0-r3",
+              "info": Object {
+                "name": "alpine-baselayout/alpine-baselayout",
+                "version": "3.2.0-r3",
+              },
+            },
+            Object {
+              "id": "alpine-keys/alpine-keys@2.1-r2",
+              "info": Object {
+                "name": "alpine-keys/alpine-keys",
+                "version": "2.1-r2",
+              },
+            },
+            Object {
+              "id": "openssl/libcrypto1.1@1.1.1g-r0",
+              "info": Object {
+                "name": "openssl/libcrypto1.1",
+                "version": "1.1.1g-r0",
+              },
+            },
+            Object {
+              "id": "openssl/libssl1.1@1.1.1g-r0",
+              "info": Object {
+                "name": "openssl/libssl1.1",
+                "version": "1.1.1g-r0",
+              },
+            },
+            Object {
+              "id": "zlib/zlib@1.2.11-r3",
+              "info": Object {
+                "name": "zlib/zlib",
+                "version": "1.2.11-r3",
+              },
+            },
+            Object {
+              "id": "apk-tools/apk-tools@2.10.5-r0",
+              "info": Object {
+                "name": "apk-tools/apk-tools",
+                "version": "2.10.5-r0",
+              },
+            },
+            Object {
+              "id": "libtls-standalone/libtls-standalone@2.9.1-r0",
+              "info": Object {
+                "name": "libtls-standalone/libtls-standalone",
+                "version": "2.9.1-r0",
+              },
+            },
+            Object {
+              "id": "busybox/ssl_client@1.31.1-r9",
+              "info": Object {
+                "name": "busybox/ssl_client",
+                "version": "1.31.1-r9",
+              },
+            },
+            Object {
+              "id": "ca-certificates/ca-certificates-cacert@20191127-r1",
+              "info": Object {
+                "name": "ca-certificates/ca-certificates-cacert",
+                "version": "20191127-r1",
+              },
+            },
+            Object {
+              "id": "gcc/libstdc++@9.2.0-r4",
+              "info": Object {
+                "name": "gcc/libstdc++",
+                "version": "9.2.0-r4",
+              },
+            },
+            Object {
+              "id": "gcc/libgcc@9.2.0-r4",
+              "info": Object {
+                "name": "gcc/libgcc",
+                "version": "9.2.0-r4",
+              },
+            },
+            Object {
+              "id": "musl/musl-utils@1.1.24-r2",
+              "info": Object {
+                "name": "musl/musl-utils",
+                "version": "1.1.24-r2",
+              },
+            },
+            Object {
+              "id": "libc-dev/libc-utils@0.7.2-r0",
+              "info": Object {
+                "name": "libc-dev/libc-utils",
+                "version": "0.7.2-r0",
+              },
+            },
+            Object {
+              "id": "pax-utils/scanelf@1.2.4-r0",
+              "info": Object {
+                "name": "pax-utils/scanelf",
+                "version": "1.2.4-r0",
+              },
+            },
+          ],
+          "schemaVersion": "1.3.0",
+        },
+        "type": "depGraph",
+      },
+      Object {
+        "data": Array [
+          "c4498072cc4b8387944b987c04759d4bee7dcee8a0f710758faf68bddd03e61b",
+        ],
+        "type": "keyBinariesHashes",
+      },
+      Object {
+        "data": "sha256:d60c3644cc5048e48a45c9de94fec3f17ee2eb72eb835434dc13ec5b9d3c532b",
+        "type": "imageId",
+      },
+      Object {
+        "data": Array [
+          "sha256:3e207b409db364b595ba862cdc12be96dcdad8e36c59a03b7b3b61c946a5741a",
+          "sha256:9fb10d90048747932e482419d8c5089004573493f66b2c260289360b62b7e0ce",
+          "sha256:c4491b3ee70970a087ec1f32e424f08ccf014978acad19c09405222c21ea70ae",
+          "sha256:a1915d7a111100643f8bf07c38e43ae96c92f3763fdb925b75e05f4c0c23d476",
+          "sha256:fbda8a69857cff80df48e4ad4a53f7b3059b3365cdb955cfb90eb18cda07e014",
+          "sha256:eaa9918ba3f7c4e2af1d47ee2924c2004f416958014e48ab12ae280704257023",
+          "sha256:56e43adaa71af64c63fdaf4ec8e093fe625ff51b6a708d813f140e30159a682b",
+          "sha256:363af1a9de027fb35a2a8289042e419c00d7807f8e3d37b1b299fb9670dc4a44",
+          "sha256:0167d935f5a41e98bdb62050718387a540ddf4692b14e6e3fe51499dd8ca9bcd",
+          "sha256:7748240a53259e2229669b7570c6aa7aaff9c317f5cc790dfb7e8d2b94209d9b",
+        ],
+        "type": "imageLayers",
+      },
+      Object {
+        "data": "2024-07-22T14:05:29.829059334Z",
+        "type": "imageCreationTime",
+      },
+      Object {
+        "data": Array [
+          "sha256:3e207b409db364b595ba862cdc12be96dcdad8e36c59a03b7b3b61c946a5741a",
+          "sha256:9fb10d90048747932e482419d8c5089004573493f66b2c260289360b62b7e0ce",
+          "sha256:c4491b3ee70970a087ec1f32e424f08ccf014978acad19c09405222c21ea70ae",
+          "sha256:a1915d7a111100643f8bf07c38e43ae96c92f3763fdb925b75e05f4c0c23d476",
+          "sha256:fbda8a69857cff80df48e4ad4a53f7b3059b3365cdb955cfb90eb18cda07e014",
+          "sha256:eaa9918ba3f7c4e2af1d47ee2924c2004f416958014e48ab12ae280704257023",
+          "sha256:56e43adaa71af64c63fdaf4ec8e093fe625ff51b6a708d813f140e30159a682b",
+          "sha256:363af1a9de027fb35a2a8289042e419c00d7807f8e3d37b1b299fb9670dc4a44",
+          "sha256:0167d935f5a41e98bdb62050718387a540ddf4692b14e6e3fe51499dd8ca9bcd",
+          "sha256:7748240a53259e2229669b7570c6aa7aaff9c317f5cc790dfb7e8d2b94209d9b",
+        ],
+        "type": "rootFs",
+      },
+      Object {
+        "data": "Alpine Linux v3.11",
+        "type": "imageOsReleasePrettyName",
+      },
+    ],
+    "identity": Object {
+      "args": Object {
+        "platform": "linux/amd64",
+      },
+      "type": "apk",
+    },
+    "target": Object {
+      "image": "docker-image|multi-project-image.tar",
+    },
+  },
+  Object {
+    "facts": Array [
+      Object {
+        "data": Object {
+          "graph": Object {
+            "nodes": Array [
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "express@4.19.2",
+                  },
+                ],
+                "nodeId": "root-node",
+                "pkgId": "goof@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "info": Object {
+                  "labels": Object {
+                    "missingLockFileEntry": "true",
+                    "scope": "prod",
+                  },
+                },
+                "nodeId": "express@4.19.2",
+                "pkgId": "express@4.19.2",
+              },
+            ],
+            "rootNodeId": "root-node",
+          },
+          "pkgManager": Object {
+            "name": "npm",
+          },
+          "pkgs": Array [
+            Object {
+              "id": "goof@1.0.1",
+              "info": Object {
+                "name": "goof",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "express@4.19.2",
+              "info": Object {
+                "name": "express",
+                "version": "4.19.2",
+              },
+            },
+          ],
+          "schemaVersion": "1.3.0",
+        },
+        "type": "depGraph",
+      },
+      Object {
+        "data": Array [
+          "package.json",
+          "package-lock.json",
+        ],
+        "type": "testedFiles",
+      },
+      Object {
+        "data": "sha256:d60c3644cc5048e48a45c9de94fec3f17ee2eb72eb835434dc13ec5b9d3c532b",
+        "type": "imageId",
+      },
+    ],
+    "identity": Object {
+      "targetFile": "/usr/goof2/package.json",
+      "type": "npm",
+    },
+    "target": Object {
+      "image": "docker-image|multi-project-image.tar",
+    },
+  },
+  Object {
+    "facts": Array [
+      Object {
+        "data": Object {
+          "graph": Object {
+            "nodes": Array [
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "accepts@1.3.8",
+                  },
+                  Object {
+                    "nodeId": "array-flatten@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "content-disposition@0.5.4",
+                  },
+                  Object {
+                    "nodeId": "content-type@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "cookie@0.6.0",
+                  },
+                  Object {
+                    "nodeId": "cookie-signature@1.0.6",
+                  },
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "define-data-property@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "destroy@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "etag@1.8.1",
+                  },
+                  Object {
+                    "nodeId": "express@4.19.2",
+                  },
+                ],
+                "nodeId": "root-node",
+                "pkgId": "goof3@",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "mime-db@1.52.0",
+                "pkgId": "mime-db@1.52.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "mime-db@1.52.0",
+                  },
+                ],
+                "nodeId": "mime-types@2.1.35",
+                "pkgId": "mime-types@2.1.35",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "negotiator@0.6.3",
+                "pkgId": "negotiator@0.6.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "mime-types@2.1.35",
+                  },
+                  Object {
+                    "nodeId": "negotiator@0.6.3",
+                  },
+                ],
+                "nodeId": "accepts@1.3.8",
+                "pkgId": "accepts@1.3.8",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "array-flatten@1.1.1",
+                "pkgId": "array-flatten@1.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "safe-buffer@5.2.1",
+                "pkgId": "safe-buffer@5.2.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safe-buffer@5.2.1",
+                  },
+                ],
+                "nodeId": "content-disposition@0.5.4",
+                "pkgId": "content-disposition@0.5.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "content-type@1.0.5",
+                "pkgId": "content-type@1.0.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "cookie@0.6.0",
+                "pkgId": "cookie@0.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "cookie-signature@1.0.6",
+                "pkgId": "cookie-signature@1.0.6",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ms@2.0.0",
+                "pkgId": "ms@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ms@2.0.0",
+                  },
+                ],
+                "nodeId": "debug@2.6.9",
+                "pkgId": "debug@2.6.9",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "es-errors@1.3.0",
+                "pkgId": "es-errors@1.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "function-bind@1.1.2",
+                "pkgId": "function-bind@1.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "has-proto@1.0.3",
+                "pkgId": "has-proto@1.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "has-symbols@1.0.3",
+                "pkgId": "has-symbols@1.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "function-bind@1.1.2",
+                  },
+                ],
+                "nodeId": "hasown@2.0.2",
+                "pkgId": "hasown@2.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "function-bind@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "has-proto@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "has-symbols@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "hasown@2.0.2",
+                  },
+                ],
+                "nodeId": "get-intrinsic@1.2.4",
+                "pkgId": "get-intrinsic@1.2.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                ],
+                "nodeId": "es-define-property@1.0.0",
+                "pkgId": "es-define-property@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                ],
+                "nodeId": "gopd@1.0.1",
+                "pkgId": "gopd@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-define-property@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "gopd@1.0.1",
+                  },
+                ],
+                "nodeId": "define-data-property@1.1.4",
+                "pkgId": "define-data-property@1.1.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "destroy@1.2.0",
+                "pkgId": "destroy@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "encodeurl@1.0.2",
+                "pkgId": "encodeurl@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "escape-html@1.0.3",
+                "pkgId": "escape-html@1.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "etag@1.8.1",
+                "pkgId": "etag@1.8.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "bytes@3.1.2",
+                "pkgId": "bytes@3.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "depd@2.0.0",
+                "pkgId": "depd@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "inherits@2.0.4",
+                "pkgId": "inherits@2.0.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "setprototypeof@1.2.0",
+                "pkgId": "setprototypeof@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "statuses@2.0.1",
+                "pkgId": "statuses@2.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "toidentifier@1.0.1",
+                "pkgId": "toidentifier@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "depd@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "setprototypeof@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "statuses@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "toidentifier@1.0.1",
+                  },
+                ],
+                "nodeId": "http-errors@2.0.0",
+                "pkgId": "http-errors@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "safer-buffer@2.1.2",
+                "pkgId": "safer-buffer@2.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safer-buffer@2.1.2",
+                  },
+                ],
+                "nodeId": "iconv-lite@0.4.24",
+                "pkgId": "iconv-lite@0.4.24",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ee-first@1.1.1",
+                "pkgId": "ee-first@1.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ee-first@1.1.1",
+                  },
+                ],
+                "nodeId": "on-finished@2.4.1",
+                "pkgId": "on-finished@2.4.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-define-property@1.0.0",
+                  },
+                ],
+                "nodeId": "has-property-descriptors@1.0.2",
+                "pkgId": "has-property-descriptors@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "define-data-property@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "function-bind@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                  Object {
+                    "nodeId": "gopd@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "has-property-descriptors@1.0.2",
+                  },
+                ],
+                "nodeId": "set-function-length@1.2.2",
+                "pkgId": "set-function-length@1.2.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-define-property@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "function-bind@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                  Object {
+                    "nodeId": "set-function-length@1.2.2",
+                  },
+                ],
+                "nodeId": "call-bind@1.0.7",
+                "pkgId": "call-bind@1.0.7",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "object-inspect@1.13.1",
+                "pkgId": "object-inspect@1.13.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "call-bind@1.0.7",
+                  },
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                  Object {
+                    "nodeId": "object-inspect@1.13.1",
+                  },
+                ],
+                "nodeId": "side-channel@1.0.6",
+                "pkgId": "side-channel@1.0.6",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "side-channel@1.0.6",
+                  },
+                ],
+                "nodeId": "qs@6.11.0",
+                "pkgId": "qs@6.11.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "unpipe@1.0.0",
+                "pkgId": "unpipe@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bytes@3.1.2",
+                  },
+                  Object {
+                    "nodeId": "http-errors@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "iconv-lite@0.4.24",
+                  },
+                  Object {
+                    "nodeId": "unpipe@1.0.0",
+                  },
+                ],
+                "nodeId": "raw-body@2.5.2",
+                "pkgId": "raw-body@2.5.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "media-typer@0.3.0",
+                "pkgId": "media-typer@0.3.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "media-typer@0.3.0",
+                  },
+                  Object {
+                    "nodeId": "mime-types@2.1.35",
+                  },
+                ],
+                "nodeId": "type-is@1.6.18",
+                "pkgId": "type-is@1.6.18",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bytes@3.1.2",
+                  },
+                  Object {
+                    "nodeId": "content-type@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "depd@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "destroy@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "http-errors@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "iconv-lite@0.4.24",
+                  },
+                  Object {
+                    "nodeId": "on-finished@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "qs@6.11.0",
+                  },
+                  Object {
+                    "nodeId": "raw-body@2.5.2",
+                  },
+                  Object {
+                    "nodeId": "type-is@1.6.18",
+                  },
+                  Object {
+                    "nodeId": "unpipe@1.0.0",
+                  },
+                ],
+                "nodeId": "body-parser@1.20.2",
+                "pkgId": "body-parser@1.20.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "parseurl@1.3.3",
+                "pkgId": "parseurl@1.3.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "on-finished@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "parseurl@1.3.3",
+                  },
+                  Object {
+                    "nodeId": "statuses@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "unpipe@1.0.0",
+                  },
+                ],
+                "nodeId": "finalhandler@1.2.0",
+                "pkgId": "finalhandler@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "fresh@0.5.2",
+                "pkgId": "fresh@0.5.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "merge-descriptors@1.0.1",
+                "pkgId": "merge-descriptors@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "methods@1.1.2",
+                "pkgId": "methods@1.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "path-to-regexp@0.1.7",
+                "pkgId": "path-to-regexp@0.1.7",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "forwarded@0.2.0",
+                "pkgId": "forwarded@0.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ipaddr.js@1.9.1",
+                "pkgId": "ipaddr.js@1.9.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "forwarded@0.2.0",
+                  },
+                  Object {
+                    "nodeId": "ipaddr.js@1.9.1",
+                  },
+                ],
+                "nodeId": "proxy-addr@2.0.7",
+                "pkgId": "proxy-addr@2.0.7",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "range-parser@1.2.1",
+                "pkgId": "range-parser@1.2.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "mime@1.6.0",
+                "pkgId": "mime@1.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ms@2.1.3",
+                "pkgId": "ms@2.1.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "depd@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "destroy@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "etag@1.8.1",
+                  },
+                  Object {
+                    "nodeId": "fresh@0.5.2",
+                  },
+                  Object {
+                    "nodeId": "http-errors@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "mime@1.6.0",
+                  },
+                  Object {
+                    "nodeId": "ms@2.1.3",
+                  },
+                  Object {
+                    "nodeId": "on-finished@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "range-parser@1.2.1",
+                  },
+                  Object {
+                    "nodeId": "statuses@2.0.1",
+                  },
+                ],
+                "nodeId": "send@0.18.0",
+                "pkgId": "send@0.18.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "parseurl@1.3.3",
+                  },
+                  Object {
+                    "nodeId": "send@0.18.0",
+                  },
+                ],
+                "nodeId": "serve-static@1.15.0",
+                "pkgId": "serve-static@1.15.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "utils-merge@1.0.1",
+                "pkgId": "utils-merge@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "vary@1.1.2",
+                "pkgId": "vary@1.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "accepts@1.3.8",
+                  },
+                  Object {
+                    "nodeId": "array-flatten@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "body-parser@1.20.2",
+                  },
+                  Object {
+                    "nodeId": "content-disposition@0.5.4",
+                  },
+                  Object {
+                    "nodeId": "content-type@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "cookie@0.6.0",
+                  },
+                  Object {
+                    "nodeId": "cookie-signature@1.0.6",
+                  },
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "depd@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "etag@1.8.1",
+                  },
+                  Object {
+                    "nodeId": "finalhandler@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "fresh@0.5.2",
+                  },
+                  Object {
+                    "nodeId": "http-errors@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "merge-descriptors@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "methods@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "on-finished@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "parseurl@1.3.3",
+                  },
+                  Object {
+                    "nodeId": "path-to-regexp@0.1.7",
+                  },
+                  Object {
+                    "nodeId": "proxy-addr@2.0.7",
+                  },
+                  Object {
+                    "nodeId": "qs@6.11.0",
+                  },
+                  Object {
+                    "nodeId": "range-parser@1.2.1",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.2.1",
+                  },
+                  Object {
+                    "nodeId": "send@0.18.0",
+                  },
+                  Object {
+                    "nodeId": "serve-static@1.15.0",
+                  },
+                  Object {
+                    "nodeId": "setprototypeof@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "statuses@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "type-is@1.6.18",
+                  },
+                  Object {
+                    "nodeId": "utils-merge@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "vary@1.1.2",
+                  },
+                ],
+                "nodeId": "express@4.19.2",
+                "pkgId": "express@4.19.2",
+              },
+            ],
+            "rootNodeId": "root-node",
+          },
+          "pkgManager": Object {
+            "name": "npm",
+          },
+          "pkgs": Array [
+            Object {
+              "id": "goof3@",
+              "info": Object {
+                "name": "goof3",
+                "version": undefined,
+              },
+            },
+            Object {
+              "id": "mime-db@1.52.0",
+              "info": Object {
+                "name": "mime-db",
+                "version": "1.52.0",
+              },
+            },
+            Object {
+              "id": "mime-types@2.1.35",
+              "info": Object {
+                "name": "mime-types",
+                "version": "2.1.35",
+              },
+            },
+            Object {
+              "id": "negotiator@0.6.3",
+              "info": Object {
+                "name": "negotiator",
+                "version": "0.6.3",
+              },
+            },
+            Object {
+              "id": "accepts@1.3.8",
+              "info": Object {
+                "name": "accepts",
+                "version": "1.3.8",
+              },
+            },
+            Object {
+              "id": "array-flatten@1.1.1",
+              "info": Object {
+                "name": "array-flatten",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "safe-buffer@5.2.1",
+              "info": Object {
+                "name": "safe-buffer",
+                "version": "5.2.1",
+              },
+            },
+            Object {
+              "id": "content-disposition@0.5.4",
+              "info": Object {
+                "name": "content-disposition",
+                "version": "0.5.4",
+              },
+            },
+            Object {
+              "id": "content-type@1.0.5",
+              "info": Object {
+                "name": "content-type",
+                "version": "1.0.5",
+              },
+            },
+            Object {
+              "id": "cookie@0.6.0",
+              "info": Object {
+                "name": "cookie",
+                "version": "0.6.0",
+              },
+            },
+            Object {
+              "id": "cookie-signature@1.0.6",
+              "info": Object {
+                "name": "cookie-signature",
+                "version": "1.0.6",
+              },
+            },
+            Object {
+              "id": "ms@2.0.0",
+              "info": Object {
+                "name": "ms",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "debug@2.6.9",
+              "info": Object {
+                "name": "debug",
+                "version": "2.6.9",
+              },
+            },
+            Object {
+              "id": "es-errors@1.3.0",
+              "info": Object {
+                "name": "es-errors",
+                "version": "1.3.0",
+              },
+            },
+            Object {
+              "id": "function-bind@1.1.2",
+              "info": Object {
+                "name": "function-bind",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "has-proto@1.0.3",
+              "info": Object {
+                "name": "has-proto",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "has-symbols@1.0.3",
+              "info": Object {
+                "name": "has-symbols",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "hasown@2.0.2",
+              "info": Object {
+                "name": "hasown",
+                "version": "2.0.2",
+              },
+            },
+            Object {
+              "id": "get-intrinsic@1.2.4",
+              "info": Object {
+                "name": "get-intrinsic",
+                "version": "1.2.4",
+              },
+            },
+            Object {
+              "id": "es-define-property@1.0.0",
+              "info": Object {
+                "name": "es-define-property",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "gopd@1.0.1",
+              "info": Object {
+                "name": "gopd",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "define-data-property@1.1.4",
+              "info": Object {
+                "name": "define-data-property",
+                "version": "1.1.4",
+              },
+            },
+            Object {
+              "id": "destroy@1.2.0",
+              "info": Object {
+                "name": "destroy",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "encodeurl@1.0.2",
+              "info": Object {
+                "name": "encodeurl",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "escape-html@1.0.3",
+              "info": Object {
+                "name": "escape-html",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "etag@1.8.1",
+              "info": Object {
+                "name": "etag",
+                "version": "1.8.1",
+              },
+            },
+            Object {
+              "id": "bytes@3.1.2",
+              "info": Object {
+                "name": "bytes",
+                "version": "3.1.2",
+              },
+            },
+            Object {
+              "id": "depd@2.0.0",
+              "info": Object {
+                "name": "depd",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "inherits@2.0.4",
+              "info": Object {
+                "name": "inherits",
+                "version": "2.0.4",
+              },
+            },
+            Object {
+              "id": "setprototypeof@1.2.0",
+              "info": Object {
+                "name": "setprototypeof",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "statuses@2.0.1",
+              "info": Object {
+                "name": "statuses",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "toidentifier@1.0.1",
+              "info": Object {
+                "name": "toidentifier",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "http-errors@2.0.0",
+              "info": Object {
+                "name": "http-errors",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "safer-buffer@2.1.2",
+              "info": Object {
+                "name": "safer-buffer",
+                "version": "2.1.2",
+              },
+            },
+            Object {
+              "id": "iconv-lite@0.4.24",
+              "info": Object {
+                "name": "iconv-lite",
+                "version": "0.4.24",
+              },
+            },
+            Object {
+              "id": "ee-first@1.1.1",
+              "info": Object {
+                "name": "ee-first",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "on-finished@2.4.1",
+              "info": Object {
+                "name": "on-finished",
+                "version": "2.4.1",
+              },
+            },
+            Object {
+              "id": "has-property-descriptors@1.0.2",
+              "info": Object {
+                "name": "has-property-descriptors",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "set-function-length@1.2.2",
+              "info": Object {
+                "name": "set-function-length",
+                "version": "1.2.2",
+              },
+            },
+            Object {
+              "id": "call-bind@1.0.7",
+              "info": Object {
+                "name": "call-bind",
+                "version": "1.0.7",
+              },
+            },
+            Object {
+              "id": "object-inspect@1.13.1",
+              "info": Object {
+                "name": "object-inspect",
+                "version": "1.13.1",
+              },
+            },
+            Object {
+              "id": "side-channel@1.0.6",
+              "info": Object {
+                "name": "side-channel",
+                "version": "1.0.6",
+              },
+            },
+            Object {
+              "id": "qs@6.11.0",
+              "info": Object {
+                "name": "qs",
+                "version": "6.11.0",
+              },
+            },
+            Object {
+              "id": "unpipe@1.0.0",
+              "info": Object {
+                "name": "unpipe",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "raw-body@2.5.2",
+              "info": Object {
+                "name": "raw-body",
+                "version": "2.5.2",
+              },
+            },
+            Object {
+              "id": "media-typer@0.3.0",
+              "info": Object {
+                "name": "media-typer",
+                "version": "0.3.0",
+              },
+            },
+            Object {
+              "id": "type-is@1.6.18",
+              "info": Object {
+                "name": "type-is",
+                "version": "1.6.18",
+              },
+            },
+            Object {
+              "id": "body-parser@1.20.2",
+              "info": Object {
+                "name": "body-parser",
+                "version": "1.20.2",
+              },
+            },
+            Object {
+              "id": "parseurl@1.3.3",
+              "info": Object {
+                "name": "parseurl",
+                "version": "1.3.3",
+              },
+            },
+            Object {
+              "id": "finalhandler@1.2.0",
+              "info": Object {
+                "name": "finalhandler",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "fresh@0.5.2",
+              "info": Object {
+                "name": "fresh",
+                "version": "0.5.2",
+              },
+            },
+            Object {
+              "id": "merge-descriptors@1.0.1",
+              "info": Object {
+                "name": "merge-descriptors",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "methods@1.1.2",
+              "info": Object {
+                "name": "methods",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "path-to-regexp@0.1.7",
+              "info": Object {
+                "name": "path-to-regexp",
+                "version": "0.1.7",
+              },
+            },
+            Object {
+              "id": "forwarded@0.2.0",
+              "info": Object {
+                "name": "forwarded",
+                "version": "0.2.0",
+              },
+            },
+            Object {
+              "id": "ipaddr.js@1.9.1",
+              "info": Object {
+                "name": "ipaddr.js",
+                "version": "1.9.1",
+              },
+            },
+            Object {
+              "id": "proxy-addr@2.0.7",
+              "info": Object {
+                "name": "proxy-addr",
+                "version": "2.0.7",
+              },
+            },
+            Object {
+              "id": "range-parser@1.2.1",
+              "info": Object {
+                "name": "range-parser",
+                "version": "1.2.1",
+              },
+            },
+            Object {
+              "id": "mime@1.6.0",
+              "info": Object {
+                "name": "mime",
+                "version": "1.6.0",
+              },
+            },
+            Object {
+              "id": "ms@2.1.3",
+              "info": Object {
+                "name": "ms",
+                "version": "2.1.3",
+              },
+            },
+            Object {
+              "id": "send@0.18.0",
+              "info": Object {
+                "name": "send",
+                "version": "0.18.0",
+              },
+            },
+            Object {
+              "id": "serve-static@1.15.0",
+              "info": Object {
+                "name": "serve-static",
+                "version": "1.15.0",
+              },
+            },
+            Object {
+              "id": "utils-merge@1.0.1",
+              "info": Object {
+                "name": "utils-merge",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "vary@1.1.2",
+              "info": Object {
+                "name": "vary",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "express@4.19.2",
+              "info": Object {
+                "name": "express",
+                "version": "4.19.2",
+              },
+            },
+          ],
+          "schemaVersion": "1.3.0",
+        },
+        "type": "depGraph",
+      },
+      Object {
+        "data": "/usr/goof3/node_modules",
+        "type": "testedFiles",
+      },
+      Object {
+        "data": "sha256:d60c3644cc5048e48a45c9de94fec3f17ee2eb72eb835434dc13ec5b9d3c532b",
+        "type": "imageId",
+      },
+    ],
+    "identity": Object {
+      "targetFile": "/usr/goof3/node_modules",
+      "type": "npm",
+    },
+    "target": Object {
+      "image": "docker-image|multi-project-image.tar",
+    },
+  },
+  Object {
+    "facts": Array [
+      Object {
+        "data": Object {
+          "graph": Object {
+            "nodes": Array [
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "express@4.19.2",
+                  },
+                ],
+                "nodeId": "root-node",
+                "pkgId": "goof@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "mime-db@1.52.0",
+                "pkgId": "mime-db@1.52.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "mime-db@1.52.0",
+                  },
+                ],
+                "nodeId": "mime-types@2.1.35",
+                "pkgId": "mime-types@2.1.35",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "negotiator@0.6.3",
+                "pkgId": "negotiator@0.6.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "mime-types@2.1.35",
+                  },
+                  Object {
+                    "nodeId": "negotiator@0.6.3",
+                  },
+                ],
+                "nodeId": "accepts@1.3.8",
+                "pkgId": "accepts@1.3.8",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "array-flatten@1.1.1",
+                "pkgId": "array-flatten@1.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "bytes@3.1.2",
+                "pkgId": "bytes@3.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "content-type@1.0.5",
+                "pkgId": "content-type@1.0.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ms@2.0.0",
+                "pkgId": "ms@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ms@2.0.0",
+                  },
+                ],
+                "nodeId": "debug@2.6.9",
+                "pkgId": "debug@2.6.9",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "depd@2.0.0",
+                "pkgId": "depd@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "destroy@1.2.0",
+                "pkgId": "destroy@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "inherits@2.0.4",
+                "pkgId": "inherits@2.0.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "setprototypeof@1.2.0",
+                "pkgId": "setprototypeof@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "statuses@2.0.1",
+                "pkgId": "statuses@2.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "toidentifier@1.0.1",
+                "pkgId": "toidentifier@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "depd@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "setprototypeof@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "statuses@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "toidentifier@1.0.1",
+                  },
+                ],
+                "nodeId": "http-errors@2.0.0",
+                "pkgId": "http-errors@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "safer-buffer@2.1.2",
+                "pkgId": "safer-buffer@2.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safer-buffer@2.1.2",
+                  },
+                ],
+                "nodeId": "iconv-lite@0.4.24",
+                "pkgId": "iconv-lite@0.4.24",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ee-first@1.1.1",
+                "pkgId": "ee-first@1.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ee-first@1.1.1",
+                  },
+                ],
+                "nodeId": "on-finished@2.4.1",
+                "pkgId": "on-finished@2.4.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "es-errors@1.3.0",
+                "pkgId": "es-errors@1.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "function-bind@1.1.2",
+                "pkgId": "function-bind@1.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "has-proto@1.0.3",
+                "pkgId": "has-proto@1.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "has-symbols@1.0.3",
+                "pkgId": "has-symbols@1.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "function-bind@1.1.2",
+                  },
+                ],
+                "nodeId": "hasown@2.0.2",
+                "pkgId": "hasown@2.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "function-bind@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "has-proto@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "has-symbols@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "hasown@2.0.2",
+                  },
+                ],
+                "nodeId": "get-intrinsic@1.2.4",
+                "pkgId": "get-intrinsic@1.2.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                ],
+                "nodeId": "es-define-property@1.0.0",
+                "pkgId": "es-define-property@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                ],
+                "nodeId": "gopd@1.0.1",
+                "pkgId": "gopd@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-define-property@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "gopd@1.0.1",
+                  },
+                ],
+                "nodeId": "define-data-property@1.1.4",
+                "pkgId": "define-data-property@1.1.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-define-property@1.0.0",
+                  },
+                ],
+                "nodeId": "has-property-descriptors@1.0.2",
+                "pkgId": "has-property-descriptors@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "define-data-property@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "function-bind@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                  Object {
+                    "nodeId": "gopd@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "has-property-descriptors@1.0.2",
+                  },
+                ],
+                "nodeId": "set-function-length@1.2.2",
+                "pkgId": "set-function-length@1.2.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-define-property@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "function-bind@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                  Object {
+                    "nodeId": "set-function-length@1.2.2",
+                  },
+                ],
+                "nodeId": "call-bind@1.0.7",
+                "pkgId": "call-bind@1.0.7",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "object-inspect@1.13.1",
+                "pkgId": "object-inspect@1.13.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "call-bind@1.0.7",
+                  },
+                  Object {
+                    "nodeId": "es-errors@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "get-intrinsic@1.2.4",
+                  },
+                  Object {
+                    "nodeId": "object-inspect@1.13.1",
+                  },
+                ],
+                "nodeId": "side-channel@1.0.6",
+                "pkgId": "side-channel@1.0.6",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "side-channel@1.0.6",
+                  },
+                ],
+                "nodeId": "qs@6.11.0",
+                "pkgId": "qs@6.11.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "unpipe@1.0.0",
+                "pkgId": "unpipe@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bytes@3.1.2",
+                  },
+                  Object {
+                    "nodeId": "http-errors@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "iconv-lite@0.4.24",
+                  },
+                  Object {
+                    "nodeId": "unpipe@1.0.0",
+                  },
+                ],
+                "nodeId": "raw-body@2.5.2",
+                "pkgId": "raw-body@2.5.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "media-typer@0.3.0",
+                "pkgId": "media-typer@0.3.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "media-typer@0.3.0",
+                  },
+                  Object {
+                    "nodeId": "mime-types@2.1.35",
+                  },
+                ],
+                "nodeId": "type-is@1.6.18",
+                "pkgId": "type-is@1.6.18",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bytes@3.1.2",
+                  },
+                  Object {
+                    "nodeId": "content-type@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "depd@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "destroy@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "http-errors@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "iconv-lite@0.4.24",
+                  },
+                  Object {
+                    "nodeId": "on-finished@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "qs@6.11.0",
+                  },
+                  Object {
+                    "nodeId": "raw-body@2.5.2",
+                  },
+                  Object {
+                    "nodeId": "type-is@1.6.18",
+                  },
+                  Object {
+                    "nodeId": "unpipe@1.0.0",
+                  },
+                ],
+                "nodeId": "body-parser@1.20.2",
+                "pkgId": "body-parser@1.20.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "safe-buffer@5.2.1",
+                "pkgId": "safe-buffer@5.2.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safe-buffer@5.2.1",
+                  },
+                ],
+                "nodeId": "content-disposition@0.5.4",
+                "pkgId": "content-disposition@0.5.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "cookie@0.6.0",
+                "pkgId": "cookie@0.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "cookie-signature@1.0.6",
+                "pkgId": "cookie-signature@1.0.6",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "encodeurl@1.0.2",
+                "pkgId": "encodeurl@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "escape-html@1.0.3",
+                "pkgId": "escape-html@1.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "etag@1.8.1",
+                "pkgId": "etag@1.8.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "parseurl@1.3.3",
+                "pkgId": "parseurl@1.3.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "on-finished@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "parseurl@1.3.3",
+                  },
+                  Object {
+                    "nodeId": "statuses@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "unpipe@1.0.0",
+                  },
+                ],
+                "nodeId": "finalhandler@1.2.0",
+                "pkgId": "finalhandler@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "fresh@0.5.2",
+                "pkgId": "fresh@0.5.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "merge-descriptors@1.0.1",
+                "pkgId": "merge-descriptors@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "methods@1.1.2",
+                "pkgId": "methods@1.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "path-to-regexp@0.1.7",
+                "pkgId": "path-to-regexp@0.1.7",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "forwarded@0.2.0",
+                "pkgId": "forwarded@0.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ipaddr.js@1.9.1",
+                "pkgId": "ipaddr.js@1.9.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "forwarded@0.2.0",
+                  },
+                  Object {
+                    "nodeId": "ipaddr.js@1.9.1",
+                  },
+                ],
+                "nodeId": "proxy-addr@2.0.7",
+                "pkgId": "proxy-addr@2.0.7",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "range-parser@1.2.1",
+                "pkgId": "range-parser@1.2.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "mime@1.6.0",
+                "pkgId": "mime@1.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ms@2.1.3",
+                "pkgId": "ms@2.1.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "depd@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "destroy@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "etag@1.8.1",
+                  },
+                  Object {
+                    "nodeId": "fresh@0.5.2",
+                  },
+                  Object {
+                    "nodeId": "http-errors@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "mime@1.6.0",
+                  },
+                  Object {
+                    "nodeId": "ms@2.1.3",
+                  },
+                  Object {
+                    "nodeId": "on-finished@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "range-parser@1.2.1",
+                  },
+                  Object {
+                    "nodeId": "statuses@2.0.1",
+                  },
+                ],
+                "nodeId": "send@0.18.0",
+                "pkgId": "send@0.18.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "parseurl@1.3.3",
+                  },
+                  Object {
+                    "nodeId": "send@0.18.0",
+                  },
+                ],
+                "nodeId": "serve-static@1.15.0",
+                "pkgId": "serve-static@1.15.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "utils-merge@1.0.1",
+                "pkgId": "utils-merge@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "vary@1.1.2",
+                "pkgId": "vary@1.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "accepts@1.3.8",
+                  },
+                  Object {
+                    "nodeId": "array-flatten@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "body-parser@1.20.2",
+                  },
+                  Object {
+                    "nodeId": "content-disposition@0.5.4",
+                  },
+                  Object {
+                    "nodeId": "content-type@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "cookie@0.6.0",
+                  },
+                  Object {
+                    "nodeId": "cookie-signature@1.0.6",
+                  },
+                  Object {
+                    "nodeId": "debug@2.6.9",
+                  },
+                  Object {
+                    "nodeId": "depd@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "encodeurl@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "escape-html@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "etag@1.8.1",
+                  },
+                  Object {
+                    "nodeId": "finalhandler@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "fresh@0.5.2",
+                  },
+                  Object {
+                    "nodeId": "http-errors@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "merge-descriptors@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "methods@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "on-finished@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "parseurl@1.3.3",
+                  },
+                  Object {
+                    "nodeId": "path-to-regexp@0.1.7",
+                  },
+                  Object {
+                    "nodeId": "proxy-addr@2.0.7",
+                  },
+                  Object {
+                    "nodeId": "qs@6.11.0",
+                  },
+                  Object {
+                    "nodeId": "range-parser@1.2.1",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.2.1",
+                  },
+                  Object {
+                    "nodeId": "send@0.18.0",
+                  },
+                  Object {
+                    "nodeId": "serve-static@1.15.0",
+                  },
+                  Object {
+                    "nodeId": "setprototypeof@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "statuses@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "type-is@1.6.18",
+                  },
+                  Object {
+                    "nodeId": "utils-merge@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "vary@1.1.2",
+                  },
+                ],
+                "nodeId": "express@4.19.2",
+                "pkgId": "express@4.19.2",
+              },
+            ],
+            "rootNodeId": "root-node",
+          },
+          "pkgManager": Object {
+            "name": "npm",
+          },
+          "pkgs": Array [
+            Object {
+              "id": "goof@1.0.1",
+              "info": Object {
+                "name": "goof",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "mime-db@1.52.0",
+              "info": Object {
+                "name": "mime-db",
+                "version": "1.52.0",
+              },
+            },
+            Object {
+              "id": "mime-types@2.1.35",
+              "info": Object {
+                "name": "mime-types",
+                "version": "2.1.35",
+              },
+            },
+            Object {
+              "id": "negotiator@0.6.3",
+              "info": Object {
+                "name": "negotiator",
+                "version": "0.6.3",
+              },
+            },
+            Object {
+              "id": "accepts@1.3.8",
+              "info": Object {
+                "name": "accepts",
+                "version": "1.3.8",
+              },
+            },
+            Object {
+              "id": "array-flatten@1.1.1",
+              "info": Object {
+                "name": "array-flatten",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "bytes@3.1.2",
+              "info": Object {
+                "name": "bytes",
+                "version": "3.1.2",
+              },
+            },
+            Object {
+              "id": "content-type@1.0.5",
+              "info": Object {
+                "name": "content-type",
+                "version": "1.0.5",
+              },
+            },
+            Object {
+              "id": "ms@2.0.0",
+              "info": Object {
+                "name": "ms",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "debug@2.6.9",
+              "info": Object {
+                "name": "debug",
+                "version": "2.6.9",
+              },
+            },
+            Object {
+              "id": "depd@2.0.0",
+              "info": Object {
+                "name": "depd",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "destroy@1.2.0",
+              "info": Object {
+                "name": "destroy",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "inherits@2.0.4",
+              "info": Object {
+                "name": "inherits",
+                "version": "2.0.4",
+              },
+            },
+            Object {
+              "id": "setprototypeof@1.2.0",
+              "info": Object {
+                "name": "setprototypeof",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "statuses@2.0.1",
+              "info": Object {
+                "name": "statuses",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "toidentifier@1.0.1",
+              "info": Object {
+                "name": "toidentifier",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "http-errors@2.0.0",
+              "info": Object {
+                "name": "http-errors",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "safer-buffer@2.1.2",
+              "info": Object {
+                "name": "safer-buffer",
+                "version": "2.1.2",
+              },
+            },
+            Object {
+              "id": "iconv-lite@0.4.24",
+              "info": Object {
+                "name": "iconv-lite",
+                "version": "0.4.24",
+              },
+            },
+            Object {
+              "id": "ee-first@1.1.1",
+              "info": Object {
+                "name": "ee-first",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "on-finished@2.4.1",
+              "info": Object {
+                "name": "on-finished",
+                "version": "2.4.1",
+              },
+            },
+            Object {
+              "id": "es-errors@1.3.0",
+              "info": Object {
+                "name": "es-errors",
+                "version": "1.3.0",
+              },
+            },
+            Object {
+              "id": "function-bind@1.1.2",
+              "info": Object {
+                "name": "function-bind",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "has-proto@1.0.3",
+              "info": Object {
+                "name": "has-proto",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "has-symbols@1.0.3",
+              "info": Object {
+                "name": "has-symbols",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "hasown@2.0.2",
+              "info": Object {
+                "name": "hasown",
+                "version": "2.0.2",
+              },
+            },
+            Object {
+              "id": "get-intrinsic@1.2.4",
+              "info": Object {
+                "name": "get-intrinsic",
+                "version": "1.2.4",
+              },
+            },
+            Object {
+              "id": "es-define-property@1.0.0",
+              "info": Object {
+                "name": "es-define-property",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "gopd@1.0.1",
+              "info": Object {
+                "name": "gopd",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "define-data-property@1.1.4",
+              "info": Object {
+                "name": "define-data-property",
+                "version": "1.1.4",
+              },
+            },
+            Object {
+              "id": "has-property-descriptors@1.0.2",
+              "info": Object {
+                "name": "has-property-descriptors",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "set-function-length@1.2.2",
+              "info": Object {
+                "name": "set-function-length",
+                "version": "1.2.2",
+              },
+            },
+            Object {
+              "id": "call-bind@1.0.7",
+              "info": Object {
+                "name": "call-bind",
+                "version": "1.0.7",
+              },
+            },
+            Object {
+              "id": "object-inspect@1.13.1",
+              "info": Object {
+                "name": "object-inspect",
+                "version": "1.13.1",
+              },
+            },
+            Object {
+              "id": "side-channel@1.0.6",
+              "info": Object {
+                "name": "side-channel",
+                "version": "1.0.6",
+              },
+            },
+            Object {
+              "id": "qs@6.11.0",
+              "info": Object {
+                "name": "qs",
+                "version": "6.11.0",
+              },
+            },
+            Object {
+              "id": "unpipe@1.0.0",
+              "info": Object {
+                "name": "unpipe",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "raw-body@2.5.2",
+              "info": Object {
+                "name": "raw-body",
+                "version": "2.5.2",
+              },
+            },
+            Object {
+              "id": "media-typer@0.3.0",
+              "info": Object {
+                "name": "media-typer",
+                "version": "0.3.0",
+              },
+            },
+            Object {
+              "id": "type-is@1.6.18",
+              "info": Object {
+                "name": "type-is",
+                "version": "1.6.18",
+              },
+            },
+            Object {
+              "id": "body-parser@1.20.2",
+              "info": Object {
+                "name": "body-parser",
+                "version": "1.20.2",
+              },
+            },
+            Object {
+              "id": "safe-buffer@5.2.1",
+              "info": Object {
+                "name": "safe-buffer",
+                "version": "5.2.1",
+              },
+            },
+            Object {
+              "id": "content-disposition@0.5.4",
+              "info": Object {
+                "name": "content-disposition",
+                "version": "0.5.4",
+              },
+            },
+            Object {
+              "id": "cookie@0.6.0",
+              "info": Object {
+                "name": "cookie",
+                "version": "0.6.0",
+              },
+            },
+            Object {
+              "id": "cookie-signature@1.0.6",
+              "info": Object {
+                "name": "cookie-signature",
+                "version": "1.0.6",
+              },
+            },
+            Object {
+              "id": "encodeurl@1.0.2",
+              "info": Object {
+                "name": "encodeurl",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "escape-html@1.0.3",
+              "info": Object {
+                "name": "escape-html",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "etag@1.8.1",
+              "info": Object {
+                "name": "etag",
+                "version": "1.8.1",
+              },
+            },
+            Object {
+              "id": "parseurl@1.3.3",
+              "info": Object {
+                "name": "parseurl",
+                "version": "1.3.3",
+              },
+            },
+            Object {
+              "id": "finalhandler@1.2.0",
+              "info": Object {
+                "name": "finalhandler",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "fresh@0.5.2",
+              "info": Object {
+                "name": "fresh",
+                "version": "0.5.2",
+              },
+            },
+            Object {
+              "id": "merge-descriptors@1.0.1",
+              "info": Object {
+                "name": "merge-descriptors",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "methods@1.1.2",
+              "info": Object {
+                "name": "methods",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "path-to-regexp@0.1.7",
+              "info": Object {
+                "name": "path-to-regexp",
+                "version": "0.1.7",
+              },
+            },
+            Object {
+              "id": "forwarded@0.2.0",
+              "info": Object {
+                "name": "forwarded",
+                "version": "0.2.0",
+              },
+            },
+            Object {
+              "id": "ipaddr.js@1.9.1",
+              "info": Object {
+                "name": "ipaddr.js",
+                "version": "1.9.1",
+              },
+            },
+            Object {
+              "id": "proxy-addr@2.0.7",
+              "info": Object {
+                "name": "proxy-addr",
+                "version": "2.0.7",
+              },
+            },
+            Object {
+              "id": "range-parser@1.2.1",
+              "info": Object {
+                "name": "range-parser",
+                "version": "1.2.1",
+              },
+            },
+            Object {
+              "id": "mime@1.6.0",
+              "info": Object {
+                "name": "mime",
+                "version": "1.6.0",
+              },
+            },
+            Object {
+              "id": "ms@2.1.3",
+              "info": Object {
+                "name": "ms",
+                "version": "2.1.3",
+              },
+            },
+            Object {
+              "id": "send@0.18.0",
+              "info": Object {
+                "name": "send",
+                "version": "0.18.0",
+              },
+            },
+            Object {
+              "id": "serve-static@1.15.0",
+              "info": Object {
+                "name": "serve-static",
+                "version": "1.15.0",
+              },
+            },
+            Object {
+              "id": "utils-merge@1.0.1",
+              "info": Object {
+                "name": "utils-merge",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "vary@1.1.2",
+              "info": Object {
+                "name": "vary",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "express@4.19.2",
+              "info": Object {
+                "name": "express",
+                "version": "4.19.2",
+              },
+            },
+          ],
+          "schemaVersion": "1.3.0",
+        },
+        "type": "depGraph",
+      },
+      Object {
+        "data": "/usr/goof/package.json",
+        "type": "testedFiles",
+      },
+      Object {
+        "data": "sha256:d60c3644cc5048e48a45c9de94fec3f17ee2eb72eb835434dc13ec5b9d3c532b",
+        "type": "imageId",
+      },
+    ],
+    "identity": Object {
+      "targetFile": "/usr/goof/package.json",
+      "type": "npm",
+    },
+    "target": Object {
+      "image": "docker-image|multi-project-image.tar",
+    },
+  },
+  Object {
+    "facts": Array [
+      Object {
+        "data": Object {
+          "graph": Object {
+            "nodes": Array [
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "npm@6.14.5",
+                  },
+                ],
+                "nodeId": "root-node",
+                "pkgId": "lib@",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "jsonparse@1.3.1",
+                "pkgId": "jsonparse@1.3.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "through@2.3.8",
+                "pkgId": "through@2.3.8",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "jsonparse@1.3.1",
+                  },
+                  Object {
+                    "nodeId": "through@2.3.8",
+                  },
+                ],
+                "nodeId": "JSONStream@1.3.5",
+                "pkgId": "JSONStream@1.3.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "abbrev@1.1.1",
+                "pkgId": "abbrev@1.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ansicolors@0.3.2",
+                "pkgId": "ansicolors@0.3.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ansistyles@0.1.3",
+                "pkgId": "ansistyles@0.1.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "aproba@2.0.0",
+                "pkgId": "aproba@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "archy@1.0.0",
+                "pkgId": "archy@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "bluebird@3.5.5",
+                "pkgId": "bluebird@3.5.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "graceful-fs@4.2.4",
+                "pkgId": "graceful-fs@4.2.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "minimist@1.2.5",
+                "pkgId": "minimist@1.2.5",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "minimist@1.2.5",
+                  },
+                ],
+                "nodeId": "mkdirp@0.5.5",
+                "pkgId": "mkdirp@0.5.5",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                ],
+                "nodeId": "cmd-shim@3.0.3",
+                "pkgId": "cmd-shim@3.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "aproba@1.2.0",
+                "pkgId": "aproba@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "chownr@1.1.4",
+                "pkgId": "chownr@1.1.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "path-is-inside@1.0.2",
+                "pkgId": "path-is-inside@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "fs.realpath@1.0.0",
+                "pkgId": "fs.realpath@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "wrappy@1.0.2",
+                "pkgId": "wrappy@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "wrappy@1.0.2",
+                  },
+                ],
+                "nodeId": "once@1.4.0",
+                "pkgId": "once@1.4.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "once@1.4.0",
+                  },
+                  Object {
+                    "nodeId": "wrappy@1.0.2",
+                  },
+                ],
+                "nodeId": "inflight@1.0.6",
+                "pkgId": "inflight@1.0.6",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "inherits@2.0.4",
+                "pkgId": "inherits@2.0.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "balanced-match@1.0.0",
+                "pkgId": "balanced-match@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "concat-map@0.0.1",
+                "pkgId": "concat-map@0.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "balanced-match@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "concat-map@0.0.1",
+                  },
+                ],
+                "nodeId": "brace-expansion@1.1.11",
+                "pkgId": "brace-expansion@1.1.11",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "brace-expansion@1.1.11",
+                  },
+                ],
+                "nodeId": "minimatch@3.0.4",
+                "pkgId": "minimatch@3.0.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "path-is-absolute@1.0.1",
+                "pkgId": "path-is-absolute@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "fs.realpath@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "inflight@1.0.6",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "minimatch@3.0.4",
+                  },
+                  Object {
+                    "nodeId": "once@1.4.0",
+                  },
+                  Object {
+                    "nodeId": "path-is-absolute@1.0.1",
+                  },
+                ],
+                "nodeId": "glob@7.1.6",
+                "pkgId": "glob@7.1.6",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "glob@7.1.6",
+                  },
+                ],
+                "nodeId": "rimraf@2.7.1",
+                "pkgId": "rimraf@2.7.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "path-is-inside@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                ],
+                "nodeId": "fs-vacuum@1.2.10",
+                "pkgId": "fs-vacuum@1.2.10",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "iferr@0.1.5",
+                "pkgId": "iferr@0.1.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "infer-owner@1.0.4",
+                "pkgId": "infer-owner@1.0.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                ],
+                "nodeId": "read-cmd-shim@1.0.5",
+                "pkgId": "read-cmd-shim@1.0.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "slide@1.1.6",
+                "pkgId": "slide@1.1.6",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "chownr@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "cmd-shim@3.0.3",
+                  },
+                  Object {
+                    "nodeId": "fs-vacuum@1.2.10",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "iferr@0.1.5",
+                  },
+                  Object {
+                    "nodeId": "infer-owner@1.0.4",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "path-is-inside@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "read-cmd-shim@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "slide@1.1.6",
+                  },
+                ],
+                "nodeId": "gentle-fs@2.3.0",
+                "pkgId": "gentle-fs@2.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "npm-normalize-package-bin@1.0.1",
+                "pkgId": "npm-normalize-package-bin@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "imurmurhash@0.1.4",
+                "pkgId": "imurmurhash@0.1.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "signal-exit@3.0.2",
+                "pkgId": "signal-exit@3.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "imurmurhash@0.1.4",
+                  },
+                  Object {
+                    "nodeId": "signal-exit@3.0.2",
+                  },
+                ],
+                "nodeId": "write-file-atomic@2.4.3",
+                "pkgId": "write-file-atomic@2.4.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bluebird@3.5.5",
+                  },
+                  Object {
+                    "nodeId": "cmd-shim@3.0.3",
+                  },
+                  Object {
+                    "nodeId": "gentle-fs@2.3.0",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "npm-normalize-package-bin@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "write-file-atomic@2.4.3",
+                  },
+                ],
+                "nodeId": "bin-links@1.1.7",
+                "pkgId": "bin-links@1.1.7",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "byte-size@5.0.1",
+                "pkgId": "byte-size@5.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "figgy-pudding@3.5.1",
+                "pkgId": "figgy-pudding@3.5.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "yallist@3.0.3",
+                "pkgId": "yallist@3.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "yallist@3.0.3",
+                  },
+                ],
+                "nodeId": "lru-cache@5.1.1",
+                "pkgId": "lru-cache@5.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "buffer-from@1.0.0",
+                "pkgId": "buffer-from@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "core-util-is@1.0.2",
+                "pkgId": "core-util-is@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "isarray@1.0.0",
+                "pkgId": "isarray@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "process-nextick-args@2.0.0",
+                "pkgId": "process-nextick-args@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "safe-buffer@5.1.2",
+                "pkgId": "safe-buffer@5.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                ],
+                "nodeId": "string_decoder@1.1.1",
+                "pkgId": "string_decoder@1.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "util-deprecate@1.0.2",
+                "pkgId": "util-deprecate@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "core-util-is@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "isarray@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "process-nextick-args@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                  Object {
+                    "nodeId": "string_decoder@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "util-deprecate@1.0.2",
+                  },
+                ],
+                "nodeId": "readable-stream@2.3.6",
+                "pkgId": "readable-stream@2.3.6",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "typedarray@0.0.6",
+                "pkgId": "typedarray@0.0.6",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "buffer-from@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                  Object {
+                    "nodeId": "typedarray@0.0.6",
+                  },
+                ],
+                "nodeId": "concat-stream@1.6.2",
+                "pkgId": "concat-stream@1.6.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "once@1.4.0",
+                  },
+                ],
+                "nodeId": "end-of-stream@1.4.1",
+                "pkgId": "end-of-stream@1.4.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "stream-shift@1.0.0",
+                "pkgId": "stream-shift@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "end-of-stream@1.4.1",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                  Object {
+                    "nodeId": "stream-shift@1.0.0",
+                  },
+                ],
+                "nodeId": "duplexify@3.6.0",
+                "pkgId": "duplexify@3.6.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                ],
+                "nodeId": "flush-write-stream@1.0.3",
+                "pkgId": "flush-write-stream@1.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                ],
+                "nodeId": "from2@2.3.0",
+                "pkgId": "from2@2.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "cyclist@0.2.2",
+                "pkgId": "cyclist@0.2.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "cyclist@0.2.2",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                ],
+                "nodeId": "parallel-transform@1.1.0",
+                "pkgId": "parallel-transform@1.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "end-of-stream@1.4.1",
+                  },
+                  Object {
+                    "nodeId": "once@1.4.0",
+                  },
+                ],
+                "nodeId": "pump@3.0.0",
+                "pkgId": "pump@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "end-of-stream@1.4.1",
+                  },
+                  Object {
+                    "nodeId": "once@1.4.0",
+                  },
+                ],
+                "nodeId": "pump@2.0.1",
+                "pkgId": "pump@2.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "duplexify@3.6.0",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "pump@2.0.1",
+                  },
+                ],
+                "nodeId": "pumpify@1.5.1",
+                "pkgId": "pumpify@1.5.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "end-of-stream@1.4.1",
+                  },
+                  Object {
+                    "nodeId": "stream-shift@1.0.0",
+                  },
+                ],
+                "nodeId": "stream-each@1.2.2",
+                "pkgId": "stream-each@1.2.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "xtend@4.0.1",
+                "pkgId": "xtend@4.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                  Object {
+                    "nodeId": "xtend@4.0.1",
+                  },
+                ],
+                "nodeId": "through2@2.0.3",
+                "pkgId": "through2@2.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "concat-stream@1.6.2",
+                  },
+                  Object {
+                    "nodeId": "duplexify@3.6.0",
+                  },
+                  Object {
+                    "nodeId": "end-of-stream@1.4.1",
+                  },
+                  Object {
+                    "nodeId": "flush-write-stream@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "from2@2.3.0",
+                  },
+                  Object {
+                    "nodeId": "parallel-transform@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "pump@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "pumpify@1.5.1",
+                  },
+                  Object {
+                    "nodeId": "stream-each@1.2.2",
+                  },
+                  Object {
+                    "nodeId": "through2@2.0.3",
+                  },
+                ],
+                "nodeId": "mississippi@3.0.0",
+                "pkgId": "mississippi@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "iferr@0.1.5",
+                  },
+                  Object {
+                    "nodeId": "imurmurhash@0.1.4",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                ],
+                "nodeId": "fs-write-stream-atomic@1.0.10",
+                "pkgId": "fs-write-stream-atomic@1.0.10",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@1.2.0",
+                  },
+                ],
+                "nodeId": "run-queue@1.0.3",
+                "pkgId": "run-queue@1.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "fs-write-stream-atomic@1.0.10",
+                  },
+                  Object {
+                    "nodeId": "iferr@0.1.5",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                  Object {
+                    "nodeId": "run-queue@1.0.3",
+                  },
+                ],
+                "nodeId": "copy-concurrently@1.0.5",
+                "pkgId": "copy-concurrently@1.0.5",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "copy-concurrently@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "fs-write-stream-atomic@1.0.10",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                  Object {
+                    "nodeId": "run-queue@1.0.3",
+                  },
+                ],
+                "nodeId": "move-concurrently@1.0.1",
+                "pkgId": "move-concurrently@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "promise-inflight@1.0.1",
+                "pkgId": "promise-inflight@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                ],
+                "nodeId": "ssri@6.0.1",
+                "pkgId": "ssri@6.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "imurmurhash@0.1.4",
+                  },
+                ],
+                "nodeId": "unique-slug@2.0.0",
+                "pkgId": "unique-slug@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "unique-slug@2.0.0",
+                  },
+                ],
+                "nodeId": "unique-filename@1.1.1",
+                "pkgId": "unique-filename@1.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "y18n@4.0.0",
+                "pkgId": "y18n@4.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bluebird@3.5.5",
+                  },
+                  Object {
+                    "nodeId": "chownr@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "glob@7.1.6",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "infer-owner@1.0.4",
+                  },
+                  Object {
+                    "nodeId": "lru-cache@5.1.1",
+                  },
+                  Object {
+                    "nodeId": "mississippi@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "move-concurrently@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "promise-inflight@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                  Object {
+                    "nodeId": "ssri@6.0.1",
+                  },
+                  Object {
+                    "nodeId": "unique-filename@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "y18n@4.0.0",
+                  },
+                ],
+                "nodeId": "cacache@12.0.3",
+                "pkgId": "cacache@12.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "call-limit@1.1.1",
+                "pkgId": "call-limit@1.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ci-info@2.0.0",
+                "pkgId": "ci-info@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-fullwidth-code-point@2.0.0",
+                "pkgId": "is-fullwidth-code-point@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ansi-regex@3.0.0",
+                "pkgId": "ansi-regex@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ansi-regex@3.0.0",
+                  },
+                ],
+                "nodeId": "strip-ansi@4.0.0",
+                "pkgId": "strip-ansi@4.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "is-fullwidth-code-point@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "strip-ansi@4.0.0",
+                  },
+                ],
+                "nodeId": "string-width@2.1.1",
+                "pkgId": "string-width@2.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ansi-regex@2.1.1",
+                "pkgId": "ansi-regex@2.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ansi-regex@2.1.1",
+                  },
+                ],
+                "nodeId": "strip-ansi@3.0.1",
+                "pkgId": "strip-ansi@3.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "string-width@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "strip-ansi@3.0.1",
+                  },
+                ],
+                "nodeId": "cli-columns@3.1.2",
+                "pkgId": "cli-columns@3.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "colors@1.3.3",
+                "pkgId": "colors@1.3.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "object-assign@4.1.1",
+                "pkgId": "object-assign@4.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "colors@1.3.3",
+                  },
+                  Object {
+                    "nodeId": "object-assign@4.1.1",
+                  },
+                  Object {
+                    "nodeId": "string-width@2.1.1",
+                  },
+                ],
+                "nodeId": "cli-table3@0.5.1",
+                "pkgId": "cli-table3@0.5.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "clone@1.0.4",
+                "pkgId": "clone@1.0.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "clone@1.0.4",
+                  },
+                ],
+                "nodeId": "defaults@1.0.3",
+                "pkgId": "defaults@1.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "defaults@1.0.3",
+                  },
+                ],
+                "nodeId": "wcwidth@1.0.1",
+                "pkgId": "wcwidth@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "strip-ansi@3.0.1",
+                  },
+                  Object {
+                    "nodeId": "wcwidth@1.0.1",
+                  },
+                ],
+                "nodeId": "columnify@1.5.4",
+                "pkgId": "columnify@1.5.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ini@1.3.5",
+                "pkgId": "ini@1.3.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "proto-list@1.2.4",
+                "pkgId": "proto-list@1.2.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ini@1.3.5",
+                  },
+                  Object {
+                    "nodeId": "proto-list@1.2.4",
+                  },
+                ],
+                "nodeId": "config-chain@1.1.12",
+                "pkgId": "config-chain@1.1.12",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "detect-indent@5.0.0",
+                "pkgId": "detect-indent@5.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "detect-newline@2.1.0",
+                "pkgId": "detect-newline@2.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "asap@2.0.6",
+                "pkgId": "asap@2.0.6",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "asap@2.0.6",
+                  },
+                  Object {
+                    "nodeId": "wrappy@1.0.2",
+                  },
+                ],
+                "nodeId": "dezalgo@1.0.3",
+                "pkgId": "dezalgo@1.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "editor@1.0.0",
+                "pkgId": "editor@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "find-npm-prefix@1.0.2",
+                "pkgId": "find-npm-prefix@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "has-unicode@2.0.1",
+                "pkgId": "has-unicode@2.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "hosted-git-info@2.8.8",
+                "pkgId": "hosted-git-info@2.8.8",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "iferr@1.0.2",
+                "pkgId": "iferr@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "os-homedir@1.0.2",
+                "pkgId": "os-homedir@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "os-tmpdir@1.0.2",
+                "pkgId": "os-tmpdir@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "os-homedir@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "os-tmpdir@1.0.2",
+                  },
+                ],
+                "nodeId": "osenv@0.1.5",
+                "pkgId": "osenv@0.1.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "semver@5.7.1",
+                "pkgId": "semver@5.7.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "builtins@1.0.3",
+                "pkgId": "builtins@1.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "builtins@1.0.3",
+                  },
+                ],
+                "nodeId": "validate-npm-package-name@3.0.0",
+                "pkgId": "validate-npm-package-name@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "hosted-git-info@2.8.8",
+                  },
+                  Object {
+                    "nodeId": "osenv@0.1.5",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "validate-npm-package-name@3.0.0",
+                  },
+                ],
+                "nodeId": "npm-package-arg@6.1.1",
+                "pkgId": "npm-package-arg@6.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "mute-stream@0.0.7",
+                "pkgId": "mute-stream@0.0.7",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "mute-stream@0.0.7",
+                  },
+                ],
+                "nodeId": "read@1.0.7",
+                "pkgId": "read@1.0.7",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "read@1.0.7",
+                  },
+                ],
+                "nodeId": "promzard@0.3.0",
+                "pkgId": "promzard@0.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "json-parse-better-errors@1.0.2",
+                "pkgId": "json-parse-better-errors@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "path-parse@1.0.6",
+                "pkgId": "path-parse@1.0.6",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "path-parse@1.0.6",
+                  },
+                ],
+                "nodeId": "resolve@1.10.0",
+                "pkgId": "resolve@1.10.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "spdx-exceptions@2.1.0",
+                "pkgId": "spdx-exceptions@2.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "spdx-license-ids@3.0.3",
+                "pkgId": "spdx-license-ids@3.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "spdx-exceptions@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "spdx-license-ids@3.0.3",
+                  },
+                ],
+                "nodeId": "spdx-expression-parse@3.0.0",
+                "pkgId": "spdx-expression-parse@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "spdx-expression-parse@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "spdx-license-ids@3.0.3",
+                  },
+                ],
+                "nodeId": "spdx-correct@3.0.0",
+                "pkgId": "spdx-correct@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "spdx-correct@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "spdx-expression-parse@3.0.0",
+                  },
+                ],
+                "nodeId": "validate-npm-package-license@3.0.4",
+                "pkgId": "validate-npm-package-license@3.0.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "hosted-git-info@2.8.8",
+                  },
+                  Object {
+                    "nodeId": "resolve@1.10.0",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "validate-npm-package-license@3.0.4",
+                  },
+                ],
+                "nodeId": "normalize-package-data@2.5.0",
+                "pkgId": "normalize-package-data@2.5.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "glob@7.1.6",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "json-parse-better-errors@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "normalize-package-data@2.5.0",
+                  },
+                  Object {
+                    "nodeId": "npm-normalize-package-bin@1.0.1",
+                  },
+                ],
+                "nodeId": "read-package-json@2.1.1",
+                "pkgId": "read-package-json@2.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "glob@7.1.6",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "promzard@0.3.0",
+                  },
+                  Object {
+                    "nodeId": "read@1.0.7",
+                  },
+                  Object {
+                    "nodeId": "read-package-json@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "validate-npm-package-license@3.0.4",
+                  },
+                  Object {
+                    "nodeId": "validate-npm-package-name@3.0.0",
+                  },
+                ],
+                "nodeId": "init-package-json@1.10.3",
+                "pkgId": "init-package-json@1.10.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ip-regex@2.1.0",
+                "pkgId": "ip-regex@2.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ip-regex@2.1.0",
+                  },
+                ],
+                "nodeId": "cidr-regex@2.0.10",
+                "pkgId": "cidr-regex@2.0.10",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "cidr-regex@2.0.10",
+                  },
+                ],
+                "nodeId": "is-cidr@3.0.0",
+                "pkgId": "is-cidr@3.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "isexe@2.0.0",
+                "pkgId": "isexe@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lazy-property@1.0.0",
+                "pkgId": "lazy-property@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                ],
+                "nodeId": "lock-verify@2.1.0",
+                "pkgId": "lock-verify@2.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "byline@5.0.0",
+                "pkgId": "byline@5.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "env-paths@2.2.0",
+                "pkgId": "env-paths@2.2.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "abbrev@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "osenv@0.1.5",
+                  },
+                ],
+                "nodeId": "nopt@4.0.3",
+                "pkgId": "nopt@4.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "delegates@1.0.0",
+                "pkgId": "delegates@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "delegates@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                ],
+                "nodeId": "are-we-there-yet@1.1.4",
+                "pkgId": "are-we-there-yet@1.1.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "console-control-strings@1.1.0",
+                "pkgId": "console-control-strings@1.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "code-point-at@1.1.0",
+                "pkgId": "code-point-at@1.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "number-is-nan@1.0.1",
+                "pkgId": "number-is-nan@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "number-is-nan@1.0.1",
+                  },
+                ],
+                "nodeId": "is-fullwidth-code-point@1.0.0",
+                "pkgId": "is-fullwidth-code-point@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "code-point-at@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "is-fullwidth-code-point@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "strip-ansi@3.0.1",
+                  },
+                ],
+                "nodeId": "string-width@1.0.2",
+                "pkgId": "string-width@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "string-width@1.0.2",
+                  },
+                ],
+                "nodeId": "wide-align@1.1.2",
+                "pkgId": "wide-align@1.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "console-control-strings@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "has-unicode@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "object-assign@4.1.1",
+                  },
+                  Object {
+                    "nodeId": "signal-exit@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "string-width@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "strip-ansi@3.0.1",
+                  },
+                  Object {
+                    "nodeId": "wide-align@1.1.2",
+                  },
+                ],
+                "nodeId": "gauge@2.7.4",
+                "pkgId": "gauge@2.7.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "set-blocking@2.0.0",
+                "pkgId": "set-blocking@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "are-we-there-yet@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "console-control-strings@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "gauge@2.7.4",
+                  },
+                  Object {
+                    "nodeId": "set-blocking@2.0.0",
+                  },
+                ],
+                "nodeId": "npmlog@4.1.2",
+                "pkgId": "npmlog@4.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "aws-sign2@0.7.0",
+                "pkgId": "aws-sign2@0.7.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "aws4@1.8.0",
+                "pkgId": "aws4@1.8.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "caseless@0.12.0",
+                "pkgId": "caseless@0.12.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "delayed-stream@1.0.0",
+                "pkgId": "delayed-stream@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "delayed-stream@1.0.0",
+                  },
+                ],
+                "nodeId": "combined-stream@1.0.6",
+                "pkgId": "combined-stream@1.0.6",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "extend@3.0.2",
+                "pkgId": "extend@3.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "forever-agent@0.6.1",
+                "pkgId": "forever-agent@0.6.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "asynckit@0.4.0",
+                "pkgId": "asynckit@0.4.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "mime-db@1.35.0",
+                "pkgId": "mime-db@1.35.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "mime-db@1.35.0",
+                  },
+                ],
+                "nodeId": "mime-types@2.1.19",
+                "pkgId": "mime-types@2.1.19",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "asynckit@0.4.0",
+                  },
+                  Object {
+                    "nodeId": "combined-stream@1.0.6",
+                  },
+                  Object {
+                    "nodeId": "mime-types@2.1.19",
+                  },
+                ],
+                "nodeId": "form-data@2.3.2",
+                "pkgId": "form-data@2.3.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "co@4.6.0",
+                "pkgId": "co@4.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "fast-deep-equal@1.1.0",
+                "pkgId": "fast-deep-equal@1.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "fast-json-stable-stringify@2.0.0",
+                "pkgId": "fast-json-stable-stringify@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "json-schema-traverse@0.3.1",
+                "pkgId": "json-schema-traverse@0.3.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "co@4.6.0",
+                  },
+                  Object {
+                    "nodeId": "fast-deep-equal@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "fast-json-stable-stringify@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "json-schema-traverse@0.3.1",
+                  },
+                ],
+                "nodeId": "ajv@5.5.2",
+                "pkgId": "ajv@5.5.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "har-schema@2.0.0",
+                "pkgId": "har-schema@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ajv@5.5.2",
+                  },
+                  Object {
+                    "nodeId": "har-schema@2.0.0",
+                  },
+                ],
+                "nodeId": "har-validator@5.1.0",
+                "pkgId": "har-validator@5.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "assert-plus@1.0.0",
+                "pkgId": "assert-plus@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "extsprintf@1.3.0",
+                "pkgId": "extsprintf@1.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "json-schema@0.2.3",
+                "pkgId": "json-schema@0.2.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "assert-plus@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "core-util-is@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "extsprintf@1.3.0",
+                  },
+                ],
+                "nodeId": "verror@1.10.0",
+                "pkgId": "verror@1.10.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "assert-plus@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "extsprintf@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "json-schema@0.2.3",
+                  },
+                  Object {
+                    "nodeId": "verror@1.10.0",
+                  },
+                ],
+                "nodeId": "jsprim@1.4.1",
+                "pkgId": "jsprim@1.4.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "safer-buffer@2.1.2",
+                "pkgId": "safer-buffer@2.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safer-buffer@2.1.2",
+                  },
+                ],
+                "nodeId": "asn1@0.2.4",
+                "pkgId": "asn1@0.2.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "tweetnacl@0.14.5",
+                "pkgId": "tweetnacl@0.14.5",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "tweetnacl@0.14.5",
+                  },
+                ],
+                "nodeId": "bcrypt-pbkdf@1.0.2",
+                "pkgId": "bcrypt-pbkdf@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "assert-plus@1.0.0",
+                  },
+                ],
+                "nodeId": "dashdash@1.14.1",
+                "pkgId": "dashdash@1.14.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "jsbn@0.1.1",
+                "pkgId": "jsbn@0.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "jsbn@0.1.1",
+                  },
+                  Object {
+                    "nodeId": "safer-buffer@2.1.2",
+                  },
+                ],
+                "nodeId": "ecc-jsbn@0.1.2",
+                "pkgId": "ecc-jsbn@0.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "assert-plus@1.0.0",
+                  },
+                ],
+                "nodeId": "getpass@0.1.7",
+                "pkgId": "getpass@0.1.7",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "asn1@0.2.4",
+                  },
+                  Object {
+                    "nodeId": "assert-plus@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "bcrypt-pbkdf@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "dashdash@1.14.1",
+                  },
+                  Object {
+                    "nodeId": "ecc-jsbn@0.1.2",
+                  },
+                  Object {
+                    "nodeId": "getpass@0.1.7",
+                  },
+                  Object {
+                    "nodeId": "jsbn@0.1.1",
+                  },
+                  Object {
+                    "nodeId": "safer-buffer@2.1.2",
+                  },
+                  Object {
+                    "nodeId": "tweetnacl@0.14.5",
+                  },
+                ],
+                "nodeId": "sshpk@1.14.2",
+                "pkgId": "sshpk@1.14.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "assert-plus@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "jsprim@1.4.1",
+                  },
+                  Object {
+                    "nodeId": "sshpk@1.14.2",
+                  },
+                ],
+                "nodeId": "http-signature@1.2.0",
+                "pkgId": "http-signature@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-typedarray@1.0.0",
+                "pkgId": "is-typedarray@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "isstream@0.1.2",
+                "pkgId": "isstream@0.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "json-stringify-safe@5.0.1",
+                "pkgId": "json-stringify-safe@5.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "oauth-sign@0.9.0",
+                "pkgId": "oauth-sign@0.9.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "performance-now@2.1.0",
+                "pkgId": "performance-now@2.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "qs@6.5.2",
+                "pkgId": "qs@6.5.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "psl@1.1.29",
+                "pkgId": "psl@1.1.29",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "punycode@1.4.1",
+                "pkgId": "punycode@1.4.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "psl@1.1.29",
+                  },
+                  Object {
+                    "nodeId": "punycode@1.4.1",
+                  },
+                ],
+                "nodeId": "tough-cookie@2.4.3",
+                "pkgId": "tough-cookie@2.4.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                ],
+                "nodeId": "tunnel-agent@0.6.0",
+                "pkgId": "tunnel-agent@0.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "uuid@3.3.3",
+                "pkgId": "uuid@3.3.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aws-sign2@0.7.0",
+                  },
+                  Object {
+                    "nodeId": "aws4@1.8.0",
+                  },
+                  Object {
+                    "nodeId": "caseless@0.12.0",
+                  },
+                  Object {
+                    "nodeId": "combined-stream@1.0.6",
+                  },
+                  Object {
+                    "nodeId": "extend@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "forever-agent@0.6.1",
+                  },
+                  Object {
+                    "nodeId": "form-data@2.3.2",
+                  },
+                  Object {
+                    "nodeId": "har-validator@5.1.0",
+                  },
+                  Object {
+                    "nodeId": "http-signature@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "is-typedarray@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "isstream@0.1.2",
+                  },
+                  Object {
+                    "nodeId": "json-stringify-safe@5.0.1",
+                  },
+                  Object {
+                    "nodeId": "mime-types@2.1.19",
+                  },
+                  Object {
+                    "nodeId": "oauth-sign@0.9.0",
+                  },
+                  Object {
+                    "nodeId": "performance-now@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "qs@6.5.2",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                  Object {
+                    "nodeId": "tough-cookie@2.4.3",
+                  },
+                  Object {
+                    "nodeId": "tunnel-agent@0.6.0",
+                  },
+                  Object {
+                    "nodeId": "uuid@3.3.3",
+                  },
+                ],
+                "nodeId": "request@2.88.0",
+                "pkgId": "request@2.88.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                  Object {
+                    "nodeId": "yallist@3.0.3",
+                  },
+                ],
+                "nodeId": "minipass@2.9.0",
+                "pkgId": "minipass@2.9.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "minipass@2.9.0",
+                  },
+                ],
+                "nodeId": "fs-minipass@1.2.7",
+                "pkgId": "fs-minipass@1.2.7",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "minipass@2.9.0",
+                  },
+                ],
+                "nodeId": "minizlib@1.3.3",
+                "pkgId": "minizlib@1.3.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "chownr@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "fs-minipass@1.2.7",
+                  },
+                  Object {
+                    "nodeId": "minipass@2.9.0",
+                  },
+                  Object {
+                    "nodeId": "minizlib@1.3.3",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                  Object {
+                    "nodeId": "yallist@3.0.3",
+                  },
+                ],
+                "nodeId": "tar@4.4.13",
+                "pkgId": "tar@4.4.13",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "env-paths@2.2.0",
+                  },
+                  Object {
+                    "nodeId": "glob@7.1.6",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "nopt@4.0.3",
+                  },
+                  Object {
+                    "nodeId": "npmlog@4.1.2",
+                  },
+                  Object {
+                    "nodeId": "request@2.88.0",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "tar@4.4.13",
+                  },
+                ],
+                "nodeId": "node-gyp@5.1.0",
+                "pkgId": "node-gyp@5.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "resolve-from@4.0.0",
+                "pkgId": "resolve-from@4.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "uid-number@0.0.6",
+                "pkgId": "uid-number@0.0.6",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "umask@1.1.0",
+                "pkgId": "umask@1.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "byline@5.0.0",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "node-gyp@5.1.0",
+                  },
+                  Object {
+                    "nodeId": "resolve-from@4.0.0",
+                  },
+                  Object {
+                    "nodeId": "slide@1.1.6",
+                  },
+                  Object {
+                    "nodeId": "uid-number@0.0.6",
+                  },
+                  Object {
+                    "nodeId": "umask@1.1.0",
+                  },
+                ],
+                "nodeId": "npm-lifecycle@3.1.4",
+                "pkgId": "npm-lifecycle@3.1.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "npm-logical-tree@1.2.1",
+                "pkgId": "npm-logical-tree@1.2.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "pump@3.0.0",
+                  },
+                ],
+                "nodeId": "get-stream@4.1.0",
+                "pkgId": "get-stream@4.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ms@2.1.1",
+                "pkgId": "ms@2.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ms@2.1.1",
+                  },
+                ],
+                "nodeId": "humanize-ms@1.2.1",
+                "pkgId": "humanize-ms@1.2.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "humanize-ms@1.2.1",
+                  },
+                ],
+                "nodeId": "agentkeepalive@3.5.2",
+                "pkgId": "agentkeepalive@3.5.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "http-cache-semantics@3.8.1",
+                "pkgId": "http-cache-semantics@3.8.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "es6-promise@4.2.8",
+                "pkgId": "es6-promise@4.2.8",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es6-promise@4.2.8",
+                  },
+                ],
+                "nodeId": "es6-promisify@5.0.0",
+                "pkgId": "es6-promisify@5.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es6-promisify@5.0.0",
+                  },
+                ],
+                "nodeId": "agent-base@4.3.0",
+                "pkgId": "agent-base@4.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ms@2.0.0",
+                "pkgId": "ms@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ms@2.0.0",
+                  },
+                ],
+                "nodeId": "debug@3.1.0",
+                "pkgId": "debug@3.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "agent-base@4.3.0",
+                  },
+                  Object {
+                    "nodeId": "debug@3.1.0",
+                  },
+                ],
+                "nodeId": "http-proxy-agent@2.1.0",
+                "pkgId": "http-proxy-agent@2.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "agent-base@4.3.0",
+                  },
+                  Object {
+                    "nodeId": "debug@3.1.0",
+                  },
+                ],
+                "nodeId": "https-proxy-agent@2.2.4",
+                "pkgId": "https-proxy-agent@2.2.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safer-buffer@2.1.2",
+                  },
+                ],
+                "nodeId": "iconv-lite@0.4.23",
+                "pkgId": "iconv-lite@0.4.23",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "iconv-lite@0.4.23",
+                  },
+                ],
+                "nodeId": "encoding@0.1.12",
+                "pkgId": "encoding@0.1.12",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "encoding@0.1.12",
+                  },
+                  Object {
+                    "nodeId": "json-parse-better-errors@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                ],
+                "nodeId": "node-fetch-npm@2.0.2",
+                "pkgId": "node-fetch-npm@2.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "err-code@1.1.2",
+                "pkgId": "err-code@1.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "retry@0.10.1",
+                "pkgId": "retry@0.10.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "err-code@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "retry@0.10.1",
+                  },
+                ],
+                "nodeId": "promise-retry@1.1.1",
+                "pkgId": "promise-retry@1.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es6-promisify@5.0.0",
+                  },
+                ],
+                "nodeId": "agent-base@4.2.1",
+                "pkgId": "agent-base@4.2.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ip@1.1.5",
+                "pkgId": "ip@1.1.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "smart-buffer@4.1.0",
+                "pkgId": "smart-buffer@4.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ip@1.1.5",
+                  },
+                  Object {
+                    "nodeId": "smart-buffer@4.1.0",
+                  },
+                ],
+                "nodeId": "socks@2.3.3",
+                "pkgId": "socks@2.3.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "agent-base@4.2.1",
+                  },
+                  Object {
+                    "nodeId": "socks@2.3.3",
+                  },
+                ],
+                "nodeId": "socks-proxy-agent@4.0.2",
+                "pkgId": "socks-proxy-agent@4.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "agentkeepalive@3.5.2",
+                  },
+                  Object {
+                    "nodeId": "cacache@12.0.3",
+                  },
+                  Object {
+                    "nodeId": "http-cache-semantics@3.8.1",
+                  },
+                  Object {
+                    "nodeId": "http-proxy-agent@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "https-proxy-agent@2.2.4",
+                  },
+                  Object {
+                    "nodeId": "lru-cache@5.1.1",
+                  },
+                  Object {
+                    "nodeId": "mississippi@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "node-fetch-npm@2.0.2",
+                  },
+                  Object {
+                    "nodeId": "promise-retry@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "socks-proxy-agent@4.0.2",
+                  },
+                  Object {
+                    "nodeId": "ssri@6.0.1",
+                  },
+                ],
+                "nodeId": "make-fetch-happen@5.0.2",
+                "pkgId": "make-fetch-happen@5.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "minimatch@3.0.4",
+                  },
+                ],
+                "nodeId": "ignore-walk@3.0.3",
+                "pkgId": "ignore-walk@3.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "npm-normalize-package-bin@1.0.1",
+                  },
+                ],
+                "nodeId": "npm-bundled@1.1.1",
+                "pkgId": "npm-bundled@1.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ignore-walk@3.0.3",
+                  },
+                  Object {
+                    "nodeId": "npm-bundled@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "npm-normalize-package-bin@1.0.1",
+                  },
+                ],
+                "nodeId": "npm-packlist@1.4.8",
+                "pkgId": "npm-packlist@1.4.8",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                ],
+                "nodeId": "npm-pick-manifest@3.0.2",
+                "pkgId": "npm-pick-manifest@3.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "safe-buffer@5.2.0",
+                "pkgId": "safe-buffer@5.2.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "JSONStream@1.3.5",
+                  },
+                  Object {
+                    "nodeId": "bluebird@3.5.5",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "lru-cache@5.1.1",
+                  },
+                  Object {
+                    "nodeId": "make-fetch-happen@5.0.2",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.2.0",
+                  },
+                ],
+                "nodeId": "npm-registry-fetch@4.0.4",
+                "pkgId": "npm-registry-fetch@4.0.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "genfun@5.0.0",
+                "pkgId": "genfun@5.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "genfun@5.0.0",
+                  },
+                ],
+                "nodeId": "protoduck@5.0.1",
+                "pkgId": "protoduck@5.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bluebird@3.5.5",
+                  },
+                  Object {
+                    "nodeId": "cacache@12.0.3",
+                  },
+                  Object {
+                    "nodeId": "chownr@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "get-stream@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "glob@7.1.6",
+                  },
+                  Object {
+                    "nodeId": "infer-owner@1.0.4",
+                  },
+                  Object {
+                    "nodeId": "lru-cache@5.1.1",
+                  },
+                  Object {
+                    "nodeId": "make-fetch-happen@5.0.2",
+                  },
+                  Object {
+                    "nodeId": "minimatch@3.0.4",
+                  },
+                  Object {
+                    "nodeId": "minipass@2.9.0",
+                  },
+                  Object {
+                    "nodeId": "mississippi@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "normalize-package-data@2.5.0",
+                  },
+                  Object {
+                    "nodeId": "npm-normalize-package-bin@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "npm-packlist@1.4.8",
+                  },
+                  Object {
+                    "nodeId": "npm-pick-manifest@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                  Object {
+                    "nodeId": "osenv@0.1.5",
+                  },
+                  Object {
+                    "nodeId": "promise-inflight@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "promise-retry@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "protoduck@5.0.1",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "ssri@6.0.1",
+                  },
+                  Object {
+                    "nodeId": "tar@4.4.13",
+                  },
+                  Object {
+                    "nodeId": "unique-filename@1.1.1",
+                  },
+                ],
+                "nodeId": "pacote@9.5.12",
+                "pkgId": "pacote@9.5.12",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "prr@1.0.1",
+                "pkgId": "prr@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "prr@1.0.1",
+                  },
+                ],
+                "nodeId": "errno@0.1.7",
+                "pkgId": "errno@0.1.7",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "errno@0.1.7",
+                  },
+                ],
+                "nodeId": "worker-farm@1.7.0",
+                "pkgId": "worker-farm@1.7.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bin-links@1.1.7",
+                  },
+                  Object {
+                    "nodeId": "bluebird@3.5.5",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "find-npm-prefix@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "ini@1.3.5",
+                  },
+                  Object {
+                    "nodeId": "lock-verify@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "npm-lifecycle@3.1.4",
+                  },
+                  Object {
+                    "nodeId": "npm-logical-tree@1.2.1",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "pacote@9.5.12",
+                  },
+                  Object {
+                    "nodeId": "read-package-json@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                  Object {
+                    "nodeId": "worker-farm@1.7.0",
+                  },
+                ],
+                "nodeId": "libcipm@4.0.7",
+                "pkgId": "libcipm@4.0.7",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "get-stream@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                ],
+                "nodeId": "libnpmaccess@3.0.2",
+                "pkgId": "libnpmaccess@3.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "p-try@2.2.0",
+                "pkgId": "p-try@2.2.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "p-try@2.2.0",
+                  },
+                ],
+                "nodeId": "p-limit@2.2.0",
+                "pkgId": "p-limit@2.2.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "p-limit@2.2.0",
+                  },
+                ],
+                "nodeId": "p-locate@3.0.0",
+                "pkgId": "p-locate@3.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "path-exists@3.0.0",
+                "pkgId": "path-exists@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "p-locate@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "path-exists@3.0.0",
+                  },
+                ],
+                "nodeId": "locate-path@3.0.0",
+                "pkgId": "locate-path@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "locate-path@3.0.0",
+                  },
+                ],
+                "nodeId": "find-up@3.0.0",
+                "pkgId": "find-up@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "find-up@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "ini@1.3.5",
+                  },
+                ],
+                "nodeId": "libnpmconfig@1.2.1",
+                "pkgId": "libnpmconfig@1.2.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "get-stream@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                ],
+                "nodeId": "libnpmhook@5.0.3",
+                "pkgId": "libnpmhook@5.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "get-stream@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                ],
+                "nodeId": "libnpmorg@1.0.1",
+                "pkgId": "libnpmorg@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash.clonedeep@4.5.0",
+                "pkgId": "lodash.clonedeep@4.5.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "get-stream@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "lodash.clonedeep@4.5.0",
+                  },
+                  Object {
+                    "nodeId": "normalize-package-data@2.5.0",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "ssri@6.0.1",
+                  },
+                ],
+                "nodeId": "libnpmpublish@1.1.2",
+                "pkgId": "libnpmpublish@1.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "get-stream@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                ],
+                "nodeId": "libnpmsearch@2.0.2",
+                "pkgId": "libnpmsearch@2.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "get-stream@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                ],
+                "nodeId": "libnpmteam@1.0.2",
+                "pkgId": "libnpmteam@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "aproba@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                ],
+                "nodeId": "npm-profile@4.0.4",
+                "pkgId": "npm-profile@4.0.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "stringify-package@1.0.1",
+                "pkgId": "stringify-package@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "bin-links@1.1.7",
+                  },
+                  Object {
+                    "nodeId": "bluebird@3.5.5",
+                  },
+                  Object {
+                    "nodeId": "find-npm-prefix@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "libnpmaccess@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "libnpmconfig@1.2.1",
+                  },
+                  Object {
+                    "nodeId": "libnpmhook@5.0.3",
+                  },
+                  Object {
+                    "nodeId": "libnpmorg@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "libnpmpublish@1.1.2",
+                  },
+                  Object {
+                    "nodeId": "libnpmsearch@2.0.2",
+                  },
+                  Object {
+                    "nodeId": "libnpmteam@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "lock-verify@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "npm-lifecycle@3.1.4",
+                  },
+                  Object {
+                    "nodeId": "npm-logical-tree@1.2.1",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "npm-profile@4.0.4",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                  Object {
+                    "nodeId": "npmlog@4.1.2",
+                  },
+                  Object {
+                    "nodeId": "pacote@9.5.12",
+                  },
+                  Object {
+                    "nodeId": "read-package-json@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "stringify-package@1.0.1",
+                  },
+                ],
+                "nodeId": "libnpm@3.0.1",
+                "pkgId": "libnpm@3.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "dotenv@5.0.1",
+                "pkgId": "dotenv@5.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "string-width@2.1.1",
+                  },
+                ],
+                "nodeId": "ansi-align@2.0.0",
+                "pkgId": "ansi-align@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "camelcase@4.1.0",
+                "pkgId": "camelcase@4.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "color-name@1.1.3",
+                "pkgId": "color-name@1.1.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "color-name@1.1.3",
+                  },
+                ],
+                "nodeId": "color-convert@1.9.1",
+                "pkgId": "color-convert@1.9.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "color-convert@1.9.1",
+                  },
+                ],
+                "nodeId": "ansi-styles@3.2.1",
+                "pkgId": "ansi-styles@3.2.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "escape-string-regexp@1.0.5",
+                "pkgId": "escape-string-regexp@1.0.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "has-flag@3.0.0",
+                "pkgId": "has-flag@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "has-flag@3.0.0",
+                  },
+                ],
+                "nodeId": "supports-color@5.4.0",
+                "pkgId": "supports-color@5.4.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ansi-styles@3.2.1",
+                  },
+                  Object {
+                    "nodeId": "escape-string-regexp@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "supports-color@5.4.0",
+                  },
+                ],
+                "nodeId": "chalk@2.4.1",
+                "pkgId": "chalk@2.4.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "cli-boxes@1.0.0",
+                "pkgId": "cli-boxes@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "pseudomap@1.0.2",
+                "pkgId": "pseudomap@1.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "yallist@2.1.2",
+                "pkgId": "yallist@2.1.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "pseudomap@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "yallist@2.1.2",
+                  },
+                ],
+                "nodeId": "lru-cache@4.1.5",
+                "pkgId": "lru-cache@4.1.5",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "shebang-regex@1.0.0",
+                "pkgId": "shebang-regex@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "shebang-regex@1.0.0",
+                  },
+                ],
+                "nodeId": "shebang-command@1.2.0",
+                "pkgId": "shebang-command@1.2.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "lru-cache@4.1.5",
+                  },
+                  Object {
+                    "nodeId": "shebang-command@1.2.0",
+                  },
+                ],
+                "nodeId": "cross-spawn@5.1.0",
+                "pkgId": "cross-spawn@5.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "get-stream@3.0.0",
+                "pkgId": "get-stream@3.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-stream@1.1.0",
+                "pkgId": "is-stream@1.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "path-key@2.0.1",
+                "pkgId": "path-key@2.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "path-key@2.0.1",
+                  },
+                ],
+                "nodeId": "npm-run-path@2.0.2",
+                "pkgId": "npm-run-path@2.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "p-finally@1.0.0",
+                "pkgId": "p-finally@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "strip-eof@1.0.0",
+                "pkgId": "strip-eof@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "cross-spawn@5.1.0",
+                  },
+                  Object {
+                    "nodeId": "get-stream@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "is-stream@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "npm-run-path@2.0.2",
+                  },
+                  Object {
+                    "nodeId": "p-finally@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "signal-exit@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "strip-eof@1.0.0",
+                  },
+                ],
+                "nodeId": "execa@0.7.0",
+                "pkgId": "execa@0.7.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "execa@0.7.0",
+                  },
+                ],
+                "nodeId": "term-size@1.2.0",
+                "pkgId": "term-size@1.2.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "string-width@2.1.1",
+                  },
+                ],
+                "nodeId": "widest-line@2.0.1",
+                "pkgId": "widest-line@2.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ansi-align@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "camelcase@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "chalk@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "cli-boxes@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "string-width@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "term-size@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "widest-line@2.0.1",
+                  },
+                ],
+                "nodeId": "boxen@1.3.0",
+                "pkgId": "boxen@1.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-obj@1.0.1",
+                "pkgId": "is-obj@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "is-obj@1.0.1",
+                  },
+                ],
+                "nodeId": "dot-prop@4.2.0",
+                "pkgId": "dot-prop@4.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "pify@3.0.0",
+                "pkgId": "pify@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "pify@3.0.0",
+                  },
+                ],
+                "nodeId": "make-dir@1.3.0",
+                "pkgId": "make-dir@1.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "crypto-random-string@1.0.0",
+                "pkgId": "crypto-random-string@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "crypto-random-string@1.0.0",
+                  },
+                ],
+                "nodeId": "unique-string@1.0.0",
+                "pkgId": "unique-string@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "xdg-basedir@3.0.0",
+                "pkgId": "xdg-basedir@3.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "dot-prop@4.2.0",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "make-dir@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "unique-string@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "write-file-atomic@2.4.3",
+                  },
+                  Object {
+                    "nodeId": "xdg-basedir@3.0.0",
+                  },
+                ],
+                "nodeId": "configstore@3.1.2",
+                "pkgId": "configstore@3.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "import-lazy@2.1.0",
+                "pkgId": "import-lazy@2.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "ci-info@1.6.0",
+                "pkgId": "ci-info@1.6.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ci-info@1.6.0",
+                  },
+                ],
+                "nodeId": "is-ci@1.2.1",
+                "pkgId": "is-ci@1.2.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "ini@1.3.5",
+                  },
+                ],
+                "nodeId": "global-dirs@0.1.1",
+                "pkgId": "global-dirs@0.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "path-is-inside@1.0.2",
+                  },
+                ],
+                "nodeId": "is-path-inside@1.0.1",
+                "pkgId": "is-path-inside@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "global-dirs@0.1.1",
+                  },
+                  Object {
+                    "nodeId": "is-path-inside@1.0.1",
+                  },
+                ],
+                "nodeId": "is-installed-globally@0.1.0",
+                "pkgId": "is-installed-globally@0.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-npm@1.0.0",
+                "pkgId": "is-npm@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "capture-stack-trace@1.0.0",
+                "pkgId": "capture-stack-trace@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "capture-stack-trace@1.0.0",
+                  },
+                ],
+                "nodeId": "create-error-class@3.0.2",
+                "pkgId": "create-error-class@3.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "duplexer3@0.1.4",
+                "pkgId": "duplexer3@0.1.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-redirect@1.0.0",
+                "pkgId": "is-redirect@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-retry-allowed@1.2.0",
+                "pkgId": "is-retry-allowed@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lowercase-keys@1.0.1",
+                "pkgId": "lowercase-keys@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "timed-out@4.0.1",
+                "pkgId": "timed-out@4.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "unzip-response@2.0.1",
+                "pkgId": "unzip-response@2.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "prepend-http@1.0.4",
+                "pkgId": "prepend-http@1.0.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "prepend-http@1.0.4",
+                  },
+                ],
+                "nodeId": "url-parse-lax@1.0.0",
+                "pkgId": "url-parse-lax@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "create-error-class@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "duplexer3@0.1.4",
+                  },
+                  Object {
+                    "nodeId": "get-stream@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "is-redirect@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "is-retry-allowed@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "is-stream@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "lowercase-keys@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                  Object {
+                    "nodeId": "timed-out@4.0.1",
+                  },
+                  Object {
+                    "nodeId": "unzip-response@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "url-parse-lax@1.0.0",
+                  },
+                ],
+                "nodeId": "got@6.7.1",
+                "pkgId": "got@6.7.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "deep-extend@0.6.0",
+                "pkgId": "deep-extend@0.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "strip-json-comments@2.0.1",
+                "pkgId": "strip-json-comments@2.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "deep-extend@0.6.0",
+                  },
+                  Object {
+                    "nodeId": "ini@1.3.5",
+                  },
+                  Object {
+                    "nodeId": "minimist@1.2.5",
+                  },
+                  Object {
+                    "nodeId": "strip-json-comments@2.0.1",
+                  },
+                ],
+                "nodeId": "rc@1.2.8",
+                "pkgId": "rc@1.2.8",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "rc@1.2.8",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                ],
+                "nodeId": "registry-auth-token@3.4.0",
+                "pkgId": "registry-auth-token@3.4.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "rc@1.2.8",
+                  },
+                ],
+                "nodeId": "registry-url@3.1.0",
+                "pkgId": "registry-url@3.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "got@6.7.1",
+                  },
+                  Object {
+                    "nodeId": "registry-auth-token@3.4.0",
+                  },
+                  Object {
+                    "nodeId": "registry-url@3.1.0",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                ],
+                "nodeId": "package-json@4.0.1",
+                "pkgId": "package-json@4.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "package-json@4.0.1",
+                  },
+                ],
+                "nodeId": "latest-version@3.1.0",
+                "pkgId": "latest-version@3.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                ],
+                "nodeId": "semver-diff@2.1.0",
+                "pkgId": "semver-diff@2.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "boxen@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "chalk@2.4.1",
+                  },
+                  Object {
+                    "nodeId": "configstore@3.1.2",
+                  },
+                  Object {
+                    "nodeId": "import-lazy@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "is-ci@1.2.1",
+                  },
+                  Object {
+                    "nodeId": "is-installed-globally@0.1.0",
+                  },
+                  Object {
+                    "nodeId": "is-npm@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "latest-version@3.1.0",
+                  },
+                  Object {
+                    "nodeId": "semver-diff@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "xdg-basedir@3.0.0",
+                  },
+                ],
+                "nodeId": "update-notifier@2.5.0",
+                "pkgId": "update-notifier@2.5.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "string-width@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "strip-ansi@3.0.1",
+                  },
+                ],
+                "nodeId": "wrap-ansi@2.1.0",
+                "pkgId": "wrap-ansi@2.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "string-width@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "strip-ansi@4.0.0",
+                  },
+                  Object {
+                    "nodeId": "wrap-ansi@2.1.0",
+                  },
+                ],
+                "nodeId": "cliui@4.1.0",
+                "pkgId": "cliui@4.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "decamelize@1.2.0",
+                "pkgId": "decamelize@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "p-try@1.0.0",
+                "pkgId": "p-try@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "p-try@1.0.0",
+                  },
+                ],
+                "nodeId": "p-limit@1.2.0",
+                "pkgId": "p-limit@1.2.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "p-limit@1.2.0",
+                  },
+                ],
+                "nodeId": "p-locate@2.0.0",
+                "pkgId": "p-locate@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "p-locate@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "path-exists@3.0.0",
+                  },
+                ],
+                "nodeId": "locate-path@2.0.0",
+                "pkgId": "locate-path@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "locate-path@2.0.0",
+                  },
+                ],
+                "nodeId": "find-up@2.1.0",
+                "pkgId": "find-up@2.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "get-caller-file@1.0.3",
+                "pkgId": "get-caller-file@1.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "nice-try@1.0.5",
+                "pkgId": "nice-try@1.0.5",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "nice-try@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "path-key@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "shebang-command@1.2.0",
+                  },
+                ],
+                "nodeId": "cross-spawn@6.0.5",
+                "pkgId": "cross-spawn@6.0.5",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "cross-spawn@6.0.5",
+                  },
+                  Object {
+                    "nodeId": "get-stream@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "is-stream@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "npm-run-path@2.0.2",
+                  },
+                  Object {
+                    "nodeId": "p-finally@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "signal-exit@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "strip-eof@1.0.0",
+                  },
+                ],
+                "nodeId": "execa@1.0.0",
+                "pkgId": "execa@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "invert-kv@2.0.0",
+                "pkgId": "invert-kv@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "invert-kv@2.0.0",
+                  },
+                ],
+                "nodeId": "lcid@2.0.0",
+                "pkgId": "lcid@2.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "p-defer@1.0.0",
+                "pkgId": "p-defer@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "p-defer@1.0.0",
+                  },
+                ],
+                "nodeId": "map-age-cleaner@0.1.3",
+                "pkgId": "map-age-cleaner@0.1.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "mimic-fn@2.1.0",
+                "pkgId": "mimic-fn@2.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "p-is-promise@2.1.0",
+                "pkgId": "p-is-promise@2.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "map-age-cleaner@0.1.3",
+                  },
+                  Object {
+                    "nodeId": "mimic-fn@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "p-is-promise@2.1.0",
+                  },
+                ],
+                "nodeId": "mem@4.3.0",
+                "pkgId": "mem@4.3.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "execa@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "lcid@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "mem@4.3.0",
+                  },
+                ],
+                "nodeId": "os-locale@3.1.0",
+                "pkgId": "os-locale@3.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "require-directory@2.1.1",
+                "pkgId": "require-directory@2.1.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "require-main-filename@1.0.1",
+                "pkgId": "require-main-filename@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "y18n@3.2.1",
+                "pkgId": "y18n@3.2.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "camelcase@4.1.0",
+                  },
+                ],
+                "nodeId": "yargs-parser@9.0.2",
+                "pkgId": "yargs-parser@9.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "cliui@4.1.0",
+                  },
+                  Object {
+                    "nodeId": "decamelize@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "find-up@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "get-caller-file@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "os-locale@3.1.0",
+                  },
+                  Object {
+                    "nodeId": "require-directory@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "require-main-filename@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "set-blocking@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "string-width@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "y18n@3.2.1",
+                  },
+                  Object {
+                    "nodeId": "yargs-parser@9.0.2",
+                  },
+                ],
+                "nodeId": "yargs@11.1.1",
+                "pkgId": "yargs@11.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "dotenv@5.0.1",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                  Object {
+                    "nodeId": "update-notifier@2.5.0",
+                  },
+                  Object {
+                    "nodeId": "y18n@4.0.0",
+                  },
+                  Object {
+                    "nodeId": "yargs@11.1.1",
+                  },
+                ],
+                "nodeId": "libnpx@10.2.2",
+                "pkgId": "libnpx@10.2.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "signal-exit@3.0.2",
+                  },
+                ],
+                "nodeId": "lockfile@1.0.4",
+                "pkgId": "lockfile@1.0.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash._baseindexof@3.1.0",
+                "pkgId": "lodash._baseindexof@3.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash._createset@4.0.3",
+                "pkgId": "lodash._createset@4.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash._root@3.0.1",
+                "pkgId": "lodash._root@3.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "lodash._createset@4.0.3",
+                  },
+                  Object {
+                    "nodeId": "lodash._root@3.0.1",
+                  },
+                ],
+                "nodeId": "lodash._baseuniq@4.6.0",
+                "pkgId": "lodash._baseuniq@4.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash._bindcallback@3.0.1",
+                "pkgId": "lodash._bindcallback@3.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash._cacheindexof@3.0.2",
+                "pkgId": "lodash._cacheindexof@3.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash._getnative@3.9.1",
+                "pkgId": "lodash._getnative@3.9.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "lodash._getnative@3.9.1",
+                  },
+                ],
+                "nodeId": "lodash._createcache@3.1.2",
+                "pkgId": "lodash._createcache@3.1.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash.restparam@3.6.1",
+                "pkgId": "lodash.restparam@3.6.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash.union@4.6.0",
+                "pkgId": "lodash.union@4.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash.uniq@4.5.0",
+                "pkgId": "lodash.uniq@4.5.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "lodash.without@4.4.0",
+                "pkgId": "lodash.without@4.4.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "meant@1.0.1",
+                "pkgId": "meant@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "cli-table3@0.5.1",
+                  },
+                  Object {
+                    "nodeId": "console-control-strings@1.1.0",
+                  },
+                ],
+                "nodeId": "npm-audit-report@1.3.2",
+                "pkgId": "npm-audit-report@1.3.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "npm-cache-filename@1.0.2",
+                "pkgId": "npm-cache-filename@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                ],
+                "nodeId": "npm-install-checks@3.0.2",
+                "pkgId": "npm-install-checks@3.0.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "npm-user-validate@1.0.0",
+                "pkgId": "npm-user-validate@1.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "opener@1.5.1",
+                "pkgId": "opener@1.5.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "qrcode-terminal@0.12.0",
+                "pkgId": "qrcode-terminal@0.12.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "decode-uri-component@0.2.0",
+                "pkgId": "decode-uri-component@0.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "split-on-first@1.1.0",
+                "pkgId": "split-on-first@1.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "strict-uri-encode@2.0.0",
+                "pkgId": "strict-uri-encode@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "decode-uri-component@0.2.0",
+                  },
+                  Object {
+                    "nodeId": "split-on-first@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "strict-uri-encode@2.0.0",
+                  },
+                ],
+                "nodeId": "query-string@6.8.2",
+                "pkgId": "query-string@6.8.2",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "qw@1.0.1",
+                "pkgId": "qw@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "debuglog@1.0.1",
+                "pkgId": "debuglog@1.0.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "debuglog@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "dezalgo@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "once@1.4.0",
+                  },
+                ],
+                "nodeId": "readdir-scoped-modules@1.1.0",
+                "pkgId": "readdir-scoped-modules@1.1.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "util-extend@1.0.3",
+                "pkgId": "util-extend@1.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "debuglog@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "read-package-json@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "readdir-scoped-modules@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "slide@1.1.6",
+                  },
+                  Object {
+                    "nodeId": "util-extend@1.0.3",
+                  },
+                ],
+                "nodeId": "read-installed@4.0.3",
+                "pkgId": "read-installed@4.0.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "object-keys@1.0.12",
+                "pkgId": "object-keys@1.0.12",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "object-keys@1.0.12",
+                  },
+                ],
+                "nodeId": "define-properties@1.1.3",
+                "pkgId": "define-properties@1.1.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-callable@1.1.4",
+                "pkgId": "is-callable@1.1.4",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "is-date-object@1.0.1",
+                "pkgId": "is-date-object@1.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "has-symbols@1.0.0",
+                "pkgId": "has-symbols@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "has-symbols@1.0.0",
+                  },
+                ],
+                "nodeId": "is-symbol@1.0.2",
+                "pkgId": "is-symbol@1.0.2",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "is-callable@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "is-date-object@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "is-symbol@1.0.2",
+                  },
+                ],
+                "nodeId": "es-to-primitive@1.2.0",
+                "pkgId": "es-to-primitive@1.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "function-bind@1.1.1",
+                "pkgId": "function-bind@1.1.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "function-bind@1.1.1",
+                  },
+                ],
+                "nodeId": "has@1.0.3",
+                "pkgId": "has@1.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "has@1.0.3",
+                  },
+                ],
+                "nodeId": "is-regex@1.0.4",
+                "pkgId": "is-regex@1.0.4",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "es-to-primitive@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "function-bind@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "has@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "is-callable@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "is-regex@1.0.4",
+                  },
+                ],
+                "nodeId": "es-abstract@1.12.0",
+                "pkgId": "es-abstract@1.12.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "define-properties@1.1.3",
+                  },
+                  Object {
+                    "nodeId": "es-abstract@1.12.0",
+                  },
+                ],
+                "nodeId": "object.getownpropertydescriptors@2.0.3",
+                "pkgId": "object.getownpropertydescriptors@2.0.3",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "object.getownpropertydescriptors@2.0.3",
+                  },
+                ],
+                "nodeId": "util-promisify@2.1.0",
+                "pkgId": "util-promisify@2.1.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "read-package-json@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "readdir-scoped-modules@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "util-promisify@2.1.0",
+                  },
+                ],
+                "nodeId": "read-package-tree@5.3.1",
+                "pkgId": "read-package-tree@5.3.1",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "safe-buffer@5.2.0",
+                  },
+                ],
+                "nodeId": "string_decoder@1.3.0",
+                "pkgId": "string_decoder@1.3.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "string_decoder@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "util-deprecate@1.0.2",
+                  },
+                ],
+                "nodeId": "readable-stream@3.6.0",
+                "pkgId": "readable-stream@3.6.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "retry@0.12.0",
+                "pkgId": "retry@0.12.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                ],
+                "nodeId": "sha@3.0.0",
+                "pkgId": "sha@3.0.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "sorted-object@2.0.1",
+                "pkgId": "sorted-object@2.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "isarray@0.0.1",
+                "pkgId": "isarray@0.0.1",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "string_decoder@0.10.31",
+                "pkgId": "string_decoder@0.10.31",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "core-util-is@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "isarray@0.0.1",
+                  },
+                  Object {
+                    "nodeId": "string_decoder@0.10.31",
+                  },
+                ],
+                "nodeId": "readable-stream@1.1.14",
+                "pkgId": "readable-stream@1.1.14",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@1.1.14",
+                  },
+                ],
+                "nodeId": "from2@1.3.0",
+                "pkgId": "from2@1.3.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "readable-stream@2.3.6",
+                  },
+                  Object {
+                    "nodeId": "stream-shift@1.0.0",
+                  },
+                ],
+                "nodeId": "stream-iterate@1.2.0",
+                "pkgId": "stream-iterate@1.2.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "from2@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "stream-iterate@1.2.0",
+                  },
+                ],
+                "nodeId": "sorted-union-stream@2.1.3",
+                "pkgId": "sorted-union-stream@2.1.3",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "text-table@0.2.0",
+                "pkgId": "text-table@0.2.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "tiny-relative-date@1.3.0",
+                "pkgId": "tiny-relative-date@1.3.0",
+              },
+              Object {
+                "deps": Array [],
+                "nodeId": "unpipe@1.0.0",
+                "pkgId": "unpipe@1.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "JSONStream@1.3.5",
+                  },
+                  Object {
+                    "nodeId": "abbrev@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "ansicolors@0.3.2",
+                  },
+                  Object {
+                    "nodeId": "ansistyles@0.1.3",
+                  },
+                  Object {
+                    "nodeId": "aproba@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "archy@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "bin-links@1.1.7",
+                  },
+                  Object {
+                    "nodeId": "bluebird@3.5.5",
+                  },
+                  Object {
+                    "nodeId": "byte-size@5.0.1",
+                  },
+                  Object {
+                    "nodeId": "cacache@12.0.3",
+                  },
+                  Object {
+                    "nodeId": "call-limit@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "chownr@1.1.4",
+                  },
+                  Object {
+                    "nodeId": "ci-info@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "cli-columns@3.1.2",
+                  },
+                  Object {
+                    "nodeId": "cli-table3@0.5.1",
+                  },
+                  Object {
+                    "nodeId": "cmd-shim@3.0.3",
+                  },
+                  Object {
+                    "nodeId": "columnify@1.5.4",
+                  },
+                  Object {
+                    "nodeId": "config-chain@1.1.12",
+                  },
+                  Object {
+                    "nodeId": "detect-indent@5.0.0",
+                  },
+                  Object {
+                    "nodeId": "detect-newline@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "dezalgo@1.0.3",
+                  },
+                  Object {
+                    "nodeId": "editor@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "figgy-pudding@3.5.1",
+                  },
+                  Object {
+                    "nodeId": "find-npm-prefix@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "fs-vacuum@1.2.10",
+                  },
+                  Object {
+                    "nodeId": "fs-write-stream-atomic@1.0.10",
+                  },
+                  Object {
+                    "nodeId": "gentle-fs@2.3.0",
+                  },
+                  Object {
+                    "nodeId": "glob@7.1.6",
+                  },
+                  Object {
+                    "nodeId": "graceful-fs@4.2.4",
+                  },
+                  Object {
+                    "nodeId": "has-unicode@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "hosted-git-info@2.8.8",
+                  },
+                  Object {
+                    "nodeId": "iferr@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "infer-owner@1.0.4",
+                  },
+                  Object {
+                    "nodeId": "inflight@1.0.6",
+                  },
+                  Object {
+                    "nodeId": "inherits@2.0.4",
+                  },
+                  Object {
+                    "nodeId": "ini@1.3.5",
+                  },
+                  Object {
+                    "nodeId": "init-package-json@1.10.3",
+                  },
+                  Object {
+                    "nodeId": "is-cidr@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "isexe@2.0.0",
+                  },
+                  Object {
+                    "nodeId": "json-parse-better-errors@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "lazy-property@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "libcipm@4.0.7",
+                  },
+                  Object {
+                    "nodeId": "libnpm@3.0.1",
+                  },
+                  Object {
+                    "nodeId": "libnpmaccess@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "libnpmhook@5.0.3",
+                  },
+                  Object {
+                    "nodeId": "libnpmorg@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "libnpmsearch@2.0.2",
+                  },
+                  Object {
+                    "nodeId": "libnpmteam@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "libnpx@10.2.2",
+                  },
+                  Object {
+                    "nodeId": "lock-verify@2.1.0",
+                  },
+                  Object {
+                    "nodeId": "lockfile@1.0.4",
+                  },
+                  Object {
+                    "nodeId": "lodash._baseindexof@3.1.0",
+                  },
+                  Object {
+                    "nodeId": "lodash._baseuniq@4.6.0",
+                  },
+                  Object {
+                    "nodeId": "lodash._bindcallback@3.0.1",
+                  },
+                  Object {
+                    "nodeId": "lodash._cacheindexof@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "lodash._createcache@3.1.2",
+                  },
+                  Object {
+                    "nodeId": "lodash.clonedeep@4.5.0",
+                  },
+                  Object {
+                    "nodeId": "lodash.restparam@3.6.1",
+                  },
+                  Object {
+                    "nodeId": "lodash.union@4.6.0",
+                  },
+                  Object {
+                    "nodeId": "lodash.uniq@4.5.0",
+                  },
+                  Object {
+                    "nodeId": "lodash.without@4.4.0",
+                  },
+                  Object {
+                    "nodeId": "lru-cache@5.1.1",
+                  },
+                  Object {
+                    "nodeId": "meant@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "mississippi@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "mkdirp@0.5.5",
+                  },
+                  Object {
+                    "nodeId": "move-concurrently@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "node-gyp@5.1.0",
+                  },
+                  Object {
+                    "nodeId": "nopt@4.0.3",
+                  },
+                  Object {
+                    "nodeId": "normalize-package-data@2.5.0",
+                  },
+                  Object {
+                    "nodeId": "npm-audit-report@1.3.2",
+                  },
+                  Object {
+                    "nodeId": "npm-cache-filename@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "npm-install-checks@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "npm-lifecycle@3.1.4",
+                  },
+                  Object {
+                    "nodeId": "npm-package-arg@6.1.1",
+                  },
+                  Object {
+                    "nodeId": "npm-packlist@1.4.8",
+                  },
+                  Object {
+                    "nodeId": "npm-pick-manifest@3.0.2",
+                  },
+                  Object {
+                    "nodeId": "npm-profile@4.0.4",
+                  },
+                  Object {
+                    "nodeId": "npm-registry-fetch@4.0.4",
+                  },
+                  Object {
+                    "nodeId": "npm-user-validate@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "npmlog@4.1.2",
+                  },
+                  Object {
+                    "nodeId": "once@1.4.0",
+                  },
+                  Object {
+                    "nodeId": "opener@1.5.1",
+                  },
+                  Object {
+                    "nodeId": "osenv@0.1.5",
+                  },
+                  Object {
+                    "nodeId": "pacote@9.5.12",
+                  },
+                  Object {
+                    "nodeId": "path-is-inside@1.0.2",
+                  },
+                  Object {
+                    "nodeId": "promise-inflight@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "qrcode-terminal@0.12.0",
+                  },
+                  Object {
+                    "nodeId": "query-string@6.8.2",
+                  },
+                  Object {
+                    "nodeId": "qw@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "read@1.0.7",
+                  },
+                  Object {
+                    "nodeId": "read-cmd-shim@1.0.5",
+                  },
+                  Object {
+                    "nodeId": "read-installed@4.0.3",
+                  },
+                  Object {
+                    "nodeId": "read-package-json@2.1.1",
+                  },
+                  Object {
+                    "nodeId": "read-package-tree@5.3.1",
+                  },
+                  Object {
+                    "nodeId": "readable-stream@3.6.0",
+                  },
+                  Object {
+                    "nodeId": "readdir-scoped-modules@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "request@2.88.0",
+                  },
+                  Object {
+                    "nodeId": "retry@0.12.0",
+                  },
+                  Object {
+                    "nodeId": "rimraf@2.7.1",
+                  },
+                  Object {
+                    "nodeId": "safe-buffer@5.1.2",
+                  },
+                  Object {
+                    "nodeId": "semver@5.7.1",
+                  },
+                  Object {
+                    "nodeId": "sha@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "slide@1.1.6",
+                  },
+                  Object {
+                    "nodeId": "sorted-object@2.0.1",
+                  },
+                  Object {
+                    "nodeId": "sorted-union-stream@2.1.3",
+                  },
+                  Object {
+                    "nodeId": "ssri@6.0.1",
+                  },
+                  Object {
+                    "nodeId": "stringify-package@1.0.1",
+                  },
+                  Object {
+                    "nodeId": "tar@4.4.13",
+                  },
+                  Object {
+                    "nodeId": "text-table@0.2.0",
+                  },
+                  Object {
+                    "nodeId": "tiny-relative-date@1.3.0",
+                  },
+                  Object {
+                    "nodeId": "uid-number@0.0.6",
+                  },
+                  Object {
+                    "nodeId": "umask@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "unique-filename@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "unpipe@1.0.0",
+                  },
+                  Object {
+                    "nodeId": "update-notifier@2.5.0",
+                  },
+                  Object {
+                    "nodeId": "uuid@3.3.3",
+                  },
+                  Object {
+                    "nodeId": "validate-npm-package-license@3.0.4",
+                  },
+                  Object {
+                    "nodeId": "validate-npm-package-name@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "worker-farm@1.7.0",
+                  },
+                  Object {
+                    "nodeId": "write-file-atomic@2.4.3",
+                  },
+                ],
+                "nodeId": "npm@6.14.5",
+                "pkgId": "npm@6.14.5",
+              },
+            ],
+            "rootNodeId": "root-node",
+          },
+          "pkgManager": Object {
+            "name": "npm",
+          },
+          "pkgs": Array [
+            Object {
+              "id": "lib@",
+              "info": Object {
+                "name": "lib",
+                "version": undefined,
+              },
+            },
+            Object {
+              "id": "jsonparse@1.3.1",
+              "info": Object {
+                "name": "jsonparse",
+                "version": "1.3.1",
+              },
+            },
+            Object {
+              "id": "through@2.3.8",
+              "info": Object {
+                "name": "through",
+                "version": "2.3.8",
+              },
+            },
+            Object {
+              "id": "JSONStream@1.3.5",
+              "info": Object {
+                "name": "JSONStream",
+                "version": "1.3.5",
+              },
+            },
+            Object {
+              "id": "abbrev@1.1.1",
+              "info": Object {
+                "name": "abbrev",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "ansicolors@0.3.2",
+              "info": Object {
+                "name": "ansicolors",
+                "version": "0.3.2",
+              },
+            },
+            Object {
+              "id": "ansistyles@0.1.3",
+              "info": Object {
+                "name": "ansistyles",
+                "version": "0.1.3",
+              },
+            },
+            Object {
+              "id": "aproba@2.0.0",
+              "info": Object {
+                "name": "aproba",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "archy@1.0.0",
+              "info": Object {
+                "name": "archy",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "bluebird@3.5.5",
+              "info": Object {
+                "name": "bluebird",
+                "version": "3.5.5",
+              },
+            },
+            Object {
+              "id": "graceful-fs@4.2.4",
+              "info": Object {
+                "name": "graceful-fs",
+                "version": "4.2.4",
+              },
+            },
+            Object {
+              "id": "minimist@1.2.5",
+              "info": Object {
+                "name": "minimist",
+                "version": "1.2.5",
+              },
+            },
+            Object {
+              "id": "mkdirp@0.5.5",
+              "info": Object {
+                "name": "mkdirp",
+                "version": "0.5.5",
+              },
+            },
+            Object {
+              "id": "cmd-shim@3.0.3",
+              "info": Object {
+                "name": "cmd-shim",
+                "version": "3.0.3",
+              },
+            },
+            Object {
+              "id": "aproba@1.2.0",
+              "info": Object {
+                "name": "aproba",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "chownr@1.1.4",
+              "info": Object {
+                "name": "chownr",
+                "version": "1.1.4",
+              },
+            },
+            Object {
+              "id": "path-is-inside@1.0.2",
+              "info": Object {
+                "name": "path-is-inside",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "fs.realpath@1.0.0",
+              "info": Object {
+                "name": "fs.realpath",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "wrappy@1.0.2",
+              "info": Object {
+                "name": "wrappy",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "once@1.4.0",
+              "info": Object {
+                "name": "once",
+                "version": "1.4.0",
+              },
+            },
+            Object {
+              "id": "inflight@1.0.6",
+              "info": Object {
+                "name": "inflight",
+                "version": "1.0.6",
+              },
+            },
+            Object {
+              "id": "inherits@2.0.4",
+              "info": Object {
+                "name": "inherits",
+                "version": "2.0.4",
+              },
+            },
+            Object {
+              "id": "balanced-match@1.0.0",
+              "info": Object {
+                "name": "balanced-match",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "concat-map@0.0.1",
+              "info": Object {
+                "name": "concat-map",
+                "version": "0.0.1",
+              },
+            },
+            Object {
+              "id": "brace-expansion@1.1.11",
+              "info": Object {
+                "name": "brace-expansion",
+                "version": "1.1.11",
+              },
+            },
+            Object {
+              "id": "minimatch@3.0.4",
+              "info": Object {
+                "name": "minimatch",
+                "version": "3.0.4",
+              },
+            },
+            Object {
+              "id": "path-is-absolute@1.0.1",
+              "info": Object {
+                "name": "path-is-absolute",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "glob@7.1.6",
+              "info": Object {
+                "name": "glob",
+                "version": "7.1.6",
+              },
+            },
+            Object {
+              "id": "rimraf@2.7.1",
+              "info": Object {
+                "name": "rimraf",
+                "version": "2.7.1",
+              },
+            },
+            Object {
+              "id": "fs-vacuum@1.2.10",
+              "info": Object {
+                "name": "fs-vacuum",
+                "version": "1.2.10",
+              },
+            },
+            Object {
+              "id": "iferr@0.1.5",
+              "info": Object {
+                "name": "iferr",
+                "version": "0.1.5",
+              },
+            },
+            Object {
+              "id": "infer-owner@1.0.4",
+              "info": Object {
+                "name": "infer-owner",
+                "version": "1.0.4",
+              },
+            },
+            Object {
+              "id": "read-cmd-shim@1.0.5",
+              "info": Object {
+                "name": "read-cmd-shim",
+                "version": "1.0.5",
+              },
+            },
+            Object {
+              "id": "slide@1.1.6",
+              "info": Object {
+                "name": "slide",
+                "version": "1.1.6",
+              },
+            },
+            Object {
+              "id": "gentle-fs@2.3.0",
+              "info": Object {
+                "name": "gentle-fs",
+                "version": "2.3.0",
+              },
+            },
+            Object {
+              "id": "npm-normalize-package-bin@1.0.1",
+              "info": Object {
+                "name": "npm-normalize-package-bin",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "imurmurhash@0.1.4",
+              "info": Object {
+                "name": "imurmurhash",
+                "version": "0.1.4",
+              },
+            },
+            Object {
+              "id": "signal-exit@3.0.2",
+              "info": Object {
+                "name": "signal-exit",
+                "version": "3.0.2",
+              },
+            },
+            Object {
+              "id": "write-file-atomic@2.4.3",
+              "info": Object {
+                "name": "write-file-atomic",
+                "version": "2.4.3",
+              },
+            },
+            Object {
+              "id": "bin-links@1.1.7",
+              "info": Object {
+                "name": "bin-links",
+                "version": "1.1.7",
+              },
+            },
+            Object {
+              "id": "byte-size@5.0.1",
+              "info": Object {
+                "name": "byte-size",
+                "version": "5.0.1",
+              },
+            },
+            Object {
+              "id": "figgy-pudding@3.5.1",
+              "info": Object {
+                "name": "figgy-pudding",
+                "version": "3.5.1",
+              },
+            },
+            Object {
+              "id": "yallist@3.0.3",
+              "info": Object {
+                "name": "yallist",
+                "version": "3.0.3",
+              },
+            },
+            Object {
+              "id": "lru-cache@5.1.1",
+              "info": Object {
+                "name": "lru-cache",
+                "version": "5.1.1",
+              },
+            },
+            Object {
+              "id": "buffer-from@1.0.0",
+              "info": Object {
+                "name": "buffer-from",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "core-util-is@1.0.2",
+              "info": Object {
+                "name": "core-util-is",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "isarray@1.0.0",
+              "info": Object {
+                "name": "isarray",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "process-nextick-args@2.0.0",
+              "info": Object {
+                "name": "process-nextick-args",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "safe-buffer@5.1.2",
+              "info": Object {
+                "name": "safe-buffer",
+                "version": "5.1.2",
+              },
+            },
+            Object {
+              "id": "string_decoder@1.1.1",
+              "info": Object {
+                "name": "string_decoder",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "util-deprecate@1.0.2",
+              "info": Object {
+                "name": "util-deprecate",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "readable-stream@2.3.6",
+              "info": Object {
+                "name": "readable-stream",
+                "version": "2.3.6",
+              },
+            },
+            Object {
+              "id": "typedarray@0.0.6",
+              "info": Object {
+                "name": "typedarray",
+                "version": "0.0.6",
+              },
+            },
+            Object {
+              "id": "concat-stream@1.6.2",
+              "info": Object {
+                "name": "concat-stream",
+                "version": "1.6.2",
+              },
+            },
+            Object {
+              "id": "end-of-stream@1.4.1",
+              "info": Object {
+                "name": "end-of-stream",
+                "version": "1.4.1",
+              },
+            },
+            Object {
+              "id": "stream-shift@1.0.0",
+              "info": Object {
+                "name": "stream-shift",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "duplexify@3.6.0",
+              "info": Object {
+                "name": "duplexify",
+                "version": "3.6.0",
+              },
+            },
+            Object {
+              "id": "flush-write-stream@1.0.3",
+              "info": Object {
+                "name": "flush-write-stream",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "from2@2.3.0",
+              "info": Object {
+                "name": "from2",
+                "version": "2.3.0",
+              },
+            },
+            Object {
+              "id": "cyclist@0.2.2",
+              "info": Object {
+                "name": "cyclist",
+                "version": "0.2.2",
+              },
+            },
+            Object {
+              "id": "parallel-transform@1.1.0",
+              "info": Object {
+                "name": "parallel-transform",
+                "version": "1.1.0",
+              },
+            },
+            Object {
+              "id": "pump@3.0.0",
+              "info": Object {
+                "name": "pump",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "pump@2.0.1",
+              "info": Object {
+                "name": "pump",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "pumpify@1.5.1",
+              "info": Object {
+                "name": "pumpify",
+                "version": "1.5.1",
+              },
+            },
+            Object {
+              "id": "stream-each@1.2.2",
+              "info": Object {
+                "name": "stream-each",
+                "version": "1.2.2",
+              },
+            },
+            Object {
+              "id": "xtend@4.0.1",
+              "info": Object {
+                "name": "xtend",
+                "version": "4.0.1",
+              },
+            },
+            Object {
+              "id": "through2@2.0.3",
+              "info": Object {
+                "name": "through2",
+                "version": "2.0.3",
+              },
+            },
+            Object {
+              "id": "mississippi@3.0.0",
+              "info": Object {
+                "name": "mississippi",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "fs-write-stream-atomic@1.0.10",
+              "info": Object {
+                "name": "fs-write-stream-atomic",
+                "version": "1.0.10",
+              },
+            },
+            Object {
+              "id": "run-queue@1.0.3",
+              "info": Object {
+                "name": "run-queue",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "copy-concurrently@1.0.5",
+              "info": Object {
+                "name": "copy-concurrently",
+                "version": "1.0.5",
+              },
+            },
+            Object {
+              "id": "move-concurrently@1.0.1",
+              "info": Object {
+                "name": "move-concurrently",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "promise-inflight@1.0.1",
+              "info": Object {
+                "name": "promise-inflight",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "ssri@6.0.1",
+              "info": Object {
+                "name": "ssri",
+                "version": "6.0.1",
+              },
+            },
+            Object {
+              "id": "unique-slug@2.0.0",
+              "info": Object {
+                "name": "unique-slug",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "unique-filename@1.1.1",
+              "info": Object {
+                "name": "unique-filename",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "y18n@4.0.0",
+              "info": Object {
+                "name": "y18n",
+                "version": "4.0.0",
+              },
+            },
+            Object {
+              "id": "cacache@12.0.3",
+              "info": Object {
+                "name": "cacache",
+                "version": "12.0.3",
+              },
+            },
+            Object {
+              "id": "call-limit@1.1.1",
+              "info": Object {
+                "name": "call-limit",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "ci-info@2.0.0",
+              "info": Object {
+                "name": "ci-info",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "is-fullwidth-code-point@2.0.0",
+              "info": Object {
+                "name": "is-fullwidth-code-point",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "ansi-regex@3.0.0",
+              "info": Object {
+                "name": "ansi-regex",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "strip-ansi@4.0.0",
+              "info": Object {
+                "name": "strip-ansi",
+                "version": "4.0.0",
+              },
+            },
+            Object {
+              "id": "string-width@2.1.1",
+              "info": Object {
+                "name": "string-width",
+                "version": "2.1.1",
+              },
+            },
+            Object {
+              "id": "ansi-regex@2.1.1",
+              "info": Object {
+                "name": "ansi-regex",
+                "version": "2.1.1",
+              },
+            },
+            Object {
+              "id": "strip-ansi@3.0.1",
+              "info": Object {
+                "name": "strip-ansi",
+                "version": "3.0.1",
+              },
+            },
+            Object {
+              "id": "cli-columns@3.1.2",
+              "info": Object {
+                "name": "cli-columns",
+                "version": "3.1.2",
+              },
+            },
+            Object {
+              "id": "colors@1.3.3",
+              "info": Object {
+                "name": "colors",
+                "version": "1.3.3",
+              },
+            },
+            Object {
+              "id": "object-assign@4.1.1",
+              "info": Object {
+                "name": "object-assign",
+                "version": "4.1.1",
+              },
+            },
+            Object {
+              "id": "cli-table3@0.5.1",
+              "info": Object {
+                "name": "cli-table3",
+                "version": "0.5.1",
+              },
+            },
+            Object {
+              "id": "clone@1.0.4",
+              "info": Object {
+                "name": "clone",
+                "version": "1.0.4",
+              },
+            },
+            Object {
+              "id": "defaults@1.0.3",
+              "info": Object {
+                "name": "defaults",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "wcwidth@1.0.1",
+              "info": Object {
+                "name": "wcwidth",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "columnify@1.5.4",
+              "info": Object {
+                "name": "columnify",
+                "version": "1.5.4",
+              },
+            },
+            Object {
+              "id": "ini@1.3.5",
+              "info": Object {
+                "name": "ini",
+                "version": "1.3.5",
+              },
+            },
+            Object {
+              "id": "proto-list@1.2.4",
+              "info": Object {
+                "name": "proto-list",
+                "version": "1.2.4",
+              },
+            },
+            Object {
+              "id": "config-chain@1.1.12",
+              "info": Object {
+                "name": "config-chain",
+                "version": "1.1.12",
+              },
+            },
+            Object {
+              "id": "detect-indent@5.0.0",
+              "info": Object {
+                "name": "detect-indent",
+                "version": "5.0.0",
+              },
+            },
+            Object {
+              "id": "detect-newline@2.1.0",
+              "info": Object {
+                "name": "detect-newline",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "asap@2.0.6",
+              "info": Object {
+                "name": "asap",
+                "version": "2.0.6",
+              },
+            },
+            Object {
+              "id": "dezalgo@1.0.3",
+              "info": Object {
+                "name": "dezalgo",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "editor@1.0.0",
+              "info": Object {
+                "name": "editor",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "find-npm-prefix@1.0.2",
+              "info": Object {
+                "name": "find-npm-prefix",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "has-unicode@2.0.1",
+              "info": Object {
+                "name": "has-unicode",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "hosted-git-info@2.8.8",
+              "info": Object {
+                "name": "hosted-git-info",
+                "version": "2.8.8",
+              },
+            },
+            Object {
+              "id": "iferr@1.0.2",
+              "info": Object {
+                "name": "iferr",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "os-homedir@1.0.2",
+              "info": Object {
+                "name": "os-homedir",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "os-tmpdir@1.0.2",
+              "info": Object {
+                "name": "os-tmpdir",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "osenv@0.1.5",
+              "info": Object {
+                "name": "osenv",
+                "version": "0.1.5",
+              },
+            },
+            Object {
+              "id": "semver@5.7.1",
+              "info": Object {
+                "name": "semver",
+                "version": "5.7.1",
+              },
+            },
+            Object {
+              "id": "builtins@1.0.3",
+              "info": Object {
+                "name": "builtins",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "validate-npm-package-name@3.0.0",
+              "info": Object {
+                "name": "validate-npm-package-name",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "npm-package-arg@6.1.1",
+              "info": Object {
+                "name": "npm-package-arg",
+                "version": "6.1.1",
+              },
+            },
+            Object {
+              "id": "mute-stream@0.0.7",
+              "info": Object {
+                "name": "mute-stream",
+                "version": "0.0.7",
+              },
+            },
+            Object {
+              "id": "read@1.0.7",
+              "info": Object {
+                "name": "read",
+                "version": "1.0.7",
+              },
+            },
+            Object {
+              "id": "promzard@0.3.0",
+              "info": Object {
+                "name": "promzard",
+                "version": "0.3.0",
+              },
+            },
+            Object {
+              "id": "json-parse-better-errors@1.0.2",
+              "info": Object {
+                "name": "json-parse-better-errors",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "path-parse@1.0.6",
+              "info": Object {
+                "name": "path-parse",
+                "version": "1.0.6",
+              },
+            },
+            Object {
+              "id": "resolve@1.10.0",
+              "info": Object {
+                "name": "resolve",
+                "version": "1.10.0",
+              },
+            },
+            Object {
+              "id": "spdx-exceptions@2.1.0",
+              "info": Object {
+                "name": "spdx-exceptions",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "spdx-license-ids@3.0.3",
+              "info": Object {
+                "name": "spdx-license-ids",
+                "version": "3.0.3",
+              },
+            },
+            Object {
+              "id": "spdx-expression-parse@3.0.0",
+              "info": Object {
+                "name": "spdx-expression-parse",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "spdx-correct@3.0.0",
+              "info": Object {
+                "name": "spdx-correct",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "validate-npm-package-license@3.0.4",
+              "info": Object {
+                "name": "validate-npm-package-license",
+                "version": "3.0.4",
+              },
+            },
+            Object {
+              "id": "normalize-package-data@2.5.0",
+              "info": Object {
+                "name": "normalize-package-data",
+                "version": "2.5.0",
+              },
+            },
+            Object {
+              "id": "read-package-json@2.1.1",
+              "info": Object {
+                "name": "read-package-json",
+                "version": "2.1.1",
+              },
+            },
+            Object {
+              "id": "init-package-json@1.10.3",
+              "info": Object {
+                "name": "init-package-json",
+                "version": "1.10.3",
+              },
+            },
+            Object {
+              "id": "ip-regex@2.1.0",
+              "info": Object {
+                "name": "ip-regex",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "cidr-regex@2.0.10",
+              "info": Object {
+                "name": "cidr-regex",
+                "version": "2.0.10",
+              },
+            },
+            Object {
+              "id": "is-cidr@3.0.0",
+              "info": Object {
+                "name": "is-cidr",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "isexe@2.0.0",
+              "info": Object {
+                "name": "isexe",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "lazy-property@1.0.0",
+              "info": Object {
+                "name": "lazy-property",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "lock-verify@2.1.0",
+              "info": Object {
+                "name": "lock-verify",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "byline@5.0.0",
+              "info": Object {
+                "name": "byline",
+                "version": "5.0.0",
+              },
+            },
+            Object {
+              "id": "env-paths@2.2.0",
+              "info": Object {
+                "name": "env-paths",
+                "version": "2.2.0",
+              },
+            },
+            Object {
+              "id": "nopt@4.0.3",
+              "info": Object {
+                "name": "nopt",
+                "version": "4.0.3",
+              },
+            },
+            Object {
+              "id": "delegates@1.0.0",
+              "info": Object {
+                "name": "delegates",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "are-we-there-yet@1.1.4",
+              "info": Object {
+                "name": "are-we-there-yet",
+                "version": "1.1.4",
+              },
+            },
+            Object {
+              "id": "console-control-strings@1.1.0",
+              "info": Object {
+                "name": "console-control-strings",
+                "version": "1.1.0",
+              },
+            },
+            Object {
+              "id": "code-point-at@1.1.0",
+              "info": Object {
+                "name": "code-point-at",
+                "version": "1.1.0",
+              },
+            },
+            Object {
+              "id": "number-is-nan@1.0.1",
+              "info": Object {
+                "name": "number-is-nan",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "is-fullwidth-code-point@1.0.0",
+              "info": Object {
+                "name": "is-fullwidth-code-point",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "string-width@1.0.2",
+              "info": Object {
+                "name": "string-width",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "wide-align@1.1.2",
+              "info": Object {
+                "name": "wide-align",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "gauge@2.7.4",
+              "info": Object {
+                "name": "gauge",
+                "version": "2.7.4",
+              },
+            },
+            Object {
+              "id": "set-blocking@2.0.0",
+              "info": Object {
+                "name": "set-blocking",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "npmlog@4.1.2",
+              "info": Object {
+                "name": "npmlog",
+                "version": "4.1.2",
+              },
+            },
+            Object {
+              "id": "aws-sign2@0.7.0",
+              "info": Object {
+                "name": "aws-sign2",
+                "version": "0.7.0",
+              },
+            },
+            Object {
+              "id": "aws4@1.8.0",
+              "info": Object {
+                "name": "aws4",
+                "version": "1.8.0",
+              },
+            },
+            Object {
+              "id": "caseless@0.12.0",
+              "info": Object {
+                "name": "caseless",
+                "version": "0.12.0",
+              },
+            },
+            Object {
+              "id": "delayed-stream@1.0.0",
+              "info": Object {
+                "name": "delayed-stream",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "combined-stream@1.0.6",
+              "info": Object {
+                "name": "combined-stream",
+                "version": "1.0.6",
+              },
+            },
+            Object {
+              "id": "extend@3.0.2",
+              "info": Object {
+                "name": "extend",
+                "version": "3.0.2",
+              },
+            },
+            Object {
+              "id": "forever-agent@0.6.1",
+              "info": Object {
+                "name": "forever-agent",
+                "version": "0.6.1",
+              },
+            },
+            Object {
+              "id": "asynckit@0.4.0",
+              "info": Object {
+                "name": "asynckit",
+                "version": "0.4.0",
+              },
+            },
+            Object {
+              "id": "mime-db@1.35.0",
+              "info": Object {
+                "name": "mime-db",
+                "version": "1.35.0",
+              },
+            },
+            Object {
+              "id": "mime-types@2.1.19",
+              "info": Object {
+                "name": "mime-types",
+                "version": "2.1.19",
+              },
+            },
+            Object {
+              "id": "form-data@2.3.2",
+              "info": Object {
+                "name": "form-data",
+                "version": "2.3.2",
+              },
+            },
+            Object {
+              "id": "co@4.6.0",
+              "info": Object {
+                "name": "co",
+                "version": "4.6.0",
+              },
+            },
+            Object {
+              "id": "fast-deep-equal@1.1.0",
+              "info": Object {
+                "name": "fast-deep-equal",
+                "version": "1.1.0",
+              },
+            },
+            Object {
+              "id": "fast-json-stable-stringify@2.0.0",
+              "info": Object {
+                "name": "fast-json-stable-stringify",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "json-schema-traverse@0.3.1",
+              "info": Object {
+                "name": "json-schema-traverse",
+                "version": "0.3.1",
+              },
+            },
+            Object {
+              "id": "ajv@5.5.2",
+              "info": Object {
+                "name": "ajv",
+                "version": "5.5.2",
+              },
+            },
+            Object {
+              "id": "har-schema@2.0.0",
+              "info": Object {
+                "name": "har-schema",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "har-validator@5.1.0",
+              "info": Object {
+                "name": "har-validator",
+                "version": "5.1.0",
+              },
+            },
+            Object {
+              "id": "assert-plus@1.0.0",
+              "info": Object {
+                "name": "assert-plus",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "extsprintf@1.3.0",
+              "info": Object {
+                "name": "extsprintf",
+                "version": "1.3.0",
+              },
+            },
+            Object {
+              "id": "json-schema@0.2.3",
+              "info": Object {
+                "name": "json-schema",
+                "version": "0.2.3",
+              },
+            },
+            Object {
+              "id": "verror@1.10.0",
+              "info": Object {
+                "name": "verror",
+                "version": "1.10.0",
+              },
+            },
+            Object {
+              "id": "jsprim@1.4.1",
+              "info": Object {
+                "name": "jsprim",
+                "version": "1.4.1",
+              },
+            },
+            Object {
+              "id": "safer-buffer@2.1.2",
+              "info": Object {
+                "name": "safer-buffer",
+                "version": "2.1.2",
+              },
+            },
+            Object {
+              "id": "asn1@0.2.4",
+              "info": Object {
+                "name": "asn1",
+                "version": "0.2.4",
+              },
+            },
+            Object {
+              "id": "tweetnacl@0.14.5",
+              "info": Object {
+                "name": "tweetnacl",
+                "version": "0.14.5",
+              },
+            },
+            Object {
+              "id": "bcrypt-pbkdf@1.0.2",
+              "info": Object {
+                "name": "bcrypt-pbkdf",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "dashdash@1.14.1",
+              "info": Object {
+                "name": "dashdash",
+                "version": "1.14.1",
+              },
+            },
+            Object {
+              "id": "jsbn@0.1.1",
+              "info": Object {
+                "name": "jsbn",
+                "version": "0.1.1",
+              },
+            },
+            Object {
+              "id": "ecc-jsbn@0.1.2",
+              "info": Object {
+                "name": "ecc-jsbn",
+                "version": "0.1.2",
+              },
+            },
+            Object {
+              "id": "getpass@0.1.7",
+              "info": Object {
+                "name": "getpass",
+                "version": "0.1.7",
+              },
+            },
+            Object {
+              "id": "sshpk@1.14.2",
+              "info": Object {
+                "name": "sshpk",
+                "version": "1.14.2",
+              },
+            },
+            Object {
+              "id": "http-signature@1.2.0",
+              "info": Object {
+                "name": "http-signature",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "is-typedarray@1.0.0",
+              "info": Object {
+                "name": "is-typedarray",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "isstream@0.1.2",
+              "info": Object {
+                "name": "isstream",
+                "version": "0.1.2",
+              },
+            },
+            Object {
+              "id": "json-stringify-safe@5.0.1",
+              "info": Object {
+                "name": "json-stringify-safe",
+                "version": "5.0.1",
+              },
+            },
+            Object {
+              "id": "oauth-sign@0.9.0",
+              "info": Object {
+                "name": "oauth-sign",
+                "version": "0.9.0",
+              },
+            },
+            Object {
+              "id": "performance-now@2.1.0",
+              "info": Object {
+                "name": "performance-now",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "qs@6.5.2",
+              "info": Object {
+                "name": "qs",
+                "version": "6.5.2",
+              },
+            },
+            Object {
+              "id": "psl@1.1.29",
+              "info": Object {
+                "name": "psl",
+                "version": "1.1.29",
+              },
+            },
+            Object {
+              "id": "punycode@1.4.1",
+              "info": Object {
+                "name": "punycode",
+                "version": "1.4.1",
+              },
+            },
+            Object {
+              "id": "tough-cookie@2.4.3",
+              "info": Object {
+                "name": "tough-cookie",
+                "version": "2.4.3",
+              },
+            },
+            Object {
+              "id": "tunnel-agent@0.6.0",
+              "info": Object {
+                "name": "tunnel-agent",
+                "version": "0.6.0",
+              },
+            },
+            Object {
+              "id": "uuid@3.3.3",
+              "info": Object {
+                "name": "uuid",
+                "version": "3.3.3",
+              },
+            },
+            Object {
+              "id": "request@2.88.0",
+              "info": Object {
+                "name": "request",
+                "version": "2.88.0",
+              },
+            },
+            Object {
+              "id": "minipass@2.9.0",
+              "info": Object {
+                "name": "minipass",
+                "version": "2.9.0",
+              },
+            },
+            Object {
+              "id": "fs-minipass@1.2.7",
+              "info": Object {
+                "name": "fs-minipass",
+                "version": "1.2.7",
+              },
+            },
+            Object {
+              "id": "minizlib@1.3.3",
+              "info": Object {
+                "name": "minizlib",
+                "version": "1.3.3",
+              },
+            },
+            Object {
+              "id": "tar@4.4.13",
+              "info": Object {
+                "name": "tar",
+                "version": "4.4.13",
+              },
+            },
+            Object {
+              "id": "node-gyp@5.1.0",
+              "info": Object {
+                "name": "node-gyp",
+                "version": "5.1.0",
+              },
+            },
+            Object {
+              "id": "resolve-from@4.0.0",
+              "info": Object {
+                "name": "resolve-from",
+                "version": "4.0.0",
+              },
+            },
+            Object {
+              "id": "uid-number@0.0.6",
+              "info": Object {
+                "name": "uid-number",
+                "version": "0.0.6",
+              },
+            },
+            Object {
+              "id": "umask@1.1.0",
+              "info": Object {
+                "name": "umask",
+                "version": "1.1.0",
+              },
+            },
+            Object {
+              "id": "npm-lifecycle@3.1.4",
+              "info": Object {
+                "name": "npm-lifecycle",
+                "version": "3.1.4",
+              },
+            },
+            Object {
+              "id": "npm-logical-tree@1.2.1",
+              "info": Object {
+                "name": "npm-logical-tree",
+                "version": "1.2.1",
+              },
+            },
+            Object {
+              "id": "get-stream@4.1.0",
+              "info": Object {
+                "name": "get-stream",
+                "version": "4.1.0",
+              },
+            },
+            Object {
+              "id": "ms@2.1.1",
+              "info": Object {
+                "name": "ms",
+                "version": "2.1.1",
+              },
+            },
+            Object {
+              "id": "humanize-ms@1.2.1",
+              "info": Object {
+                "name": "humanize-ms",
+                "version": "1.2.1",
+              },
+            },
+            Object {
+              "id": "agentkeepalive@3.5.2",
+              "info": Object {
+                "name": "agentkeepalive",
+                "version": "3.5.2",
+              },
+            },
+            Object {
+              "id": "http-cache-semantics@3.8.1",
+              "info": Object {
+                "name": "http-cache-semantics",
+                "version": "3.8.1",
+              },
+            },
+            Object {
+              "id": "es6-promise@4.2.8",
+              "info": Object {
+                "name": "es6-promise",
+                "version": "4.2.8",
+              },
+            },
+            Object {
+              "id": "es6-promisify@5.0.0",
+              "info": Object {
+                "name": "es6-promisify",
+                "version": "5.0.0",
+              },
+            },
+            Object {
+              "id": "agent-base@4.3.0",
+              "info": Object {
+                "name": "agent-base",
+                "version": "4.3.0",
+              },
+            },
+            Object {
+              "id": "ms@2.0.0",
+              "info": Object {
+                "name": "ms",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "debug@3.1.0",
+              "info": Object {
+                "name": "debug",
+                "version": "3.1.0",
+              },
+            },
+            Object {
+              "id": "http-proxy-agent@2.1.0",
+              "info": Object {
+                "name": "http-proxy-agent",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "https-proxy-agent@2.2.4",
+              "info": Object {
+                "name": "https-proxy-agent",
+                "version": "2.2.4",
+              },
+            },
+            Object {
+              "id": "iconv-lite@0.4.23",
+              "info": Object {
+                "name": "iconv-lite",
+                "version": "0.4.23",
+              },
+            },
+            Object {
+              "id": "encoding@0.1.12",
+              "info": Object {
+                "name": "encoding",
+                "version": "0.1.12",
+              },
+            },
+            Object {
+              "id": "node-fetch-npm@2.0.2",
+              "info": Object {
+                "name": "node-fetch-npm",
+                "version": "2.0.2",
+              },
+            },
+            Object {
+              "id": "err-code@1.1.2",
+              "info": Object {
+                "name": "err-code",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "retry@0.10.1",
+              "info": Object {
+                "name": "retry",
+                "version": "0.10.1",
+              },
+            },
+            Object {
+              "id": "promise-retry@1.1.1",
+              "info": Object {
+                "name": "promise-retry",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "agent-base@4.2.1",
+              "info": Object {
+                "name": "agent-base",
+                "version": "4.2.1",
+              },
+            },
+            Object {
+              "id": "ip@1.1.5",
+              "info": Object {
+                "name": "ip",
+                "version": "1.1.5",
+              },
+            },
+            Object {
+              "id": "smart-buffer@4.1.0",
+              "info": Object {
+                "name": "smart-buffer",
+                "version": "4.1.0",
+              },
+            },
+            Object {
+              "id": "socks@2.3.3",
+              "info": Object {
+                "name": "socks",
+                "version": "2.3.3",
+              },
+            },
+            Object {
+              "id": "socks-proxy-agent@4.0.2",
+              "info": Object {
+                "name": "socks-proxy-agent",
+                "version": "4.0.2",
+              },
+            },
+            Object {
+              "id": "make-fetch-happen@5.0.2",
+              "info": Object {
+                "name": "make-fetch-happen",
+                "version": "5.0.2",
+              },
+            },
+            Object {
+              "id": "ignore-walk@3.0.3",
+              "info": Object {
+                "name": "ignore-walk",
+                "version": "3.0.3",
+              },
+            },
+            Object {
+              "id": "npm-bundled@1.1.1",
+              "info": Object {
+                "name": "npm-bundled",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "npm-packlist@1.4.8",
+              "info": Object {
+                "name": "npm-packlist",
+                "version": "1.4.8",
+              },
+            },
+            Object {
+              "id": "npm-pick-manifest@3.0.2",
+              "info": Object {
+                "name": "npm-pick-manifest",
+                "version": "3.0.2",
+              },
+            },
+            Object {
+              "id": "safe-buffer@5.2.0",
+              "info": Object {
+                "name": "safe-buffer",
+                "version": "5.2.0",
+              },
+            },
+            Object {
+              "id": "npm-registry-fetch@4.0.4",
+              "info": Object {
+                "name": "npm-registry-fetch",
+                "version": "4.0.4",
+              },
+            },
+            Object {
+              "id": "genfun@5.0.0",
+              "info": Object {
+                "name": "genfun",
+                "version": "5.0.0",
+              },
+            },
+            Object {
+              "id": "protoduck@5.0.1",
+              "info": Object {
+                "name": "protoduck",
+                "version": "5.0.1",
+              },
+            },
+            Object {
+              "id": "pacote@9.5.12",
+              "info": Object {
+                "name": "pacote",
+                "version": "9.5.12",
+              },
+            },
+            Object {
+              "id": "prr@1.0.1",
+              "info": Object {
+                "name": "prr",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "errno@0.1.7",
+              "info": Object {
+                "name": "errno",
+                "version": "0.1.7",
+              },
+            },
+            Object {
+              "id": "worker-farm@1.7.0",
+              "info": Object {
+                "name": "worker-farm",
+                "version": "1.7.0",
+              },
+            },
+            Object {
+              "id": "libcipm@4.0.7",
+              "info": Object {
+                "name": "libcipm",
+                "version": "4.0.7",
+              },
+            },
+            Object {
+              "id": "libnpmaccess@3.0.2",
+              "info": Object {
+                "name": "libnpmaccess",
+                "version": "3.0.2",
+              },
+            },
+            Object {
+              "id": "p-try@2.2.0",
+              "info": Object {
+                "name": "p-try",
+                "version": "2.2.0",
+              },
+            },
+            Object {
+              "id": "p-limit@2.2.0",
+              "info": Object {
+                "name": "p-limit",
+                "version": "2.2.0",
+              },
+            },
+            Object {
+              "id": "p-locate@3.0.0",
+              "info": Object {
+                "name": "p-locate",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "path-exists@3.0.0",
+              "info": Object {
+                "name": "path-exists",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "locate-path@3.0.0",
+              "info": Object {
+                "name": "locate-path",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "find-up@3.0.0",
+              "info": Object {
+                "name": "find-up",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "libnpmconfig@1.2.1",
+              "info": Object {
+                "name": "libnpmconfig",
+                "version": "1.2.1",
+              },
+            },
+            Object {
+              "id": "libnpmhook@5.0.3",
+              "info": Object {
+                "name": "libnpmhook",
+                "version": "5.0.3",
+              },
+            },
+            Object {
+              "id": "libnpmorg@1.0.1",
+              "info": Object {
+                "name": "libnpmorg",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "lodash.clonedeep@4.5.0",
+              "info": Object {
+                "name": "lodash.clonedeep",
+                "version": "4.5.0",
+              },
+            },
+            Object {
+              "id": "libnpmpublish@1.1.2",
+              "info": Object {
+                "name": "libnpmpublish",
+                "version": "1.1.2",
+              },
+            },
+            Object {
+              "id": "libnpmsearch@2.0.2",
+              "info": Object {
+                "name": "libnpmsearch",
+                "version": "2.0.2",
+              },
+            },
+            Object {
+              "id": "libnpmteam@1.0.2",
+              "info": Object {
+                "name": "libnpmteam",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "npm-profile@4.0.4",
+              "info": Object {
+                "name": "npm-profile",
+                "version": "4.0.4",
+              },
+            },
+            Object {
+              "id": "stringify-package@1.0.1",
+              "info": Object {
+                "name": "stringify-package",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "libnpm@3.0.1",
+              "info": Object {
+                "name": "libnpm",
+                "version": "3.0.1",
+              },
+            },
+            Object {
+              "id": "dotenv@5.0.1",
+              "info": Object {
+                "name": "dotenv",
+                "version": "5.0.1",
+              },
+            },
+            Object {
+              "id": "ansi-align@2.0.0",
+              "info": Object {
+                "name": "ansi-align",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "camelcase@4.1.0",
+              "info": Object {
+                "name": "camelcase",
+                "version": "4.1.0",
+              },
+            },
+            Object {
+              "id": "color-name@1.1.3",
+              "info": Object {
+                "name": "color-name",
+                "version": "1.1.3",
+              },
+            },
+            Object {
+              "id": "color-convert@1.9.1",
+              "info": Object {
+                "name": "color-convert",
+                "version": "1.9.1",
+              },
+            },
+            Object {
+              "id": "ansi-styles@3.2.1",
+              "info": Object {
+                "name": "ansi-styles",
+                "version": "3.2.1",
+              },
+            },
+            Object {
+              "id": "escape-string-regexp@1.0.5",
+              "info": Object {
+                "name": "escape-string-regexp",
+                "version": "1.0.5",
+              },
+            },
+            Object {
+              "id": "has-flag@3.0.0",
+              "info": Object {
+                "name": "has-flag",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "supports-color@5.4.0",
+              "info": Object {
+                "name": "supports-color",
+                "version": "5.4.0",
+              },
+            },
+            Object {
+              "id": "chalk@2.4.1",
+              "info": Object {
+                "name": "chalk",
+                "version": "2.4.1",
+              },
+            },
+            Object {
+              "id": "cli-boxes@1.0.0",
+              "info": Object {
+                "name": "cli-boxes",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "pseudomap@1.0.2",
+              "info": Object {
+                "name": "pseudomap",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "yallist@2.1.2",
+              "info": Object {
+                "name": "yallist",
+                "version": "2.1.2",
+              },
+            },
+            Object {
+              "id": "lru-cache@4.1.5",
+              "info": Object {
+                "name": "lru-cache",
+                "version": "4.1.5",
+              },
+            },
+            Object {
+              "id": "shebang-regex@1.0.0",
+              "info": Object {
+                "name": "shebang-regex",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "shebang-command@1.2.0",
+              "info": Object {
+                "name": "shebang-command",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "cross-spawn@5.1.0",
+              "info": Object {
+                "name": "cross-spawn",
+                "version": "5.1.0",
+              },
+            },
+            Object {
+              "id": "get-stream@3.0.0",
+              "info": Object {
+                "name": "get-stream",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "is-stream@1.1.0",
+              "info": Object {
+                "name": "is-stream",
+                "version": "1.1.0",
+              },
+            },
+            Object {
+              "id": "path-key@2.0.1",
+              "info": Object {
+                "name": "path-key",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "npm-run-path@2.0.2",
+              "info": Object {
+                "name": "npm-run-path",
+                "version": "2.0.2",
+              },
+            },
+            Object {
+              "id": "p-finally@1.0.0",
+              "info": Object {
+                "name": "p-finally",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "strip-eof@1.0.0",
+              "info": Object {
+                "name": "strip-eof",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "execa@0.7.0",
+              "info": Object {
+                "name": "execa",
+                "version": "0.7.0",
+              },
+            },
+            Object {
+              "id": "term-size@1.2.0",
+              "info": Object {
+                "name": "term-size",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "widest-line@2.0.1",
+              "info": Object {
+                "name": "widest-line",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "boxen@1.3.0",
+              "info": Object {
+                "name": "boxen",
+                "version": "1.3.0",
+              },
+            },
+            Object {
+              "id": "is-obj@1.0.1",
+              "info": Object {
+                "name": "is-obj",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "dot-prop@4.2.0",
+              "info": Object {
+                "name": "dot-prop",
+                "version": "4.2.0",
+              },
+            },
+            Object {
+              "id": "pify@3.0.0",
+              "info": Object {
+                "name": "pify",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "make-dir@1.3.0",
+              "info": Object {
+                "name": "make-dir",
+                "version": "1.3.0",
+              },
+            },
+            Object {
+              "id": "crypto-random-string@1.0.0",
+              "info": Object {
+                "name": "crypto-random-string",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "unique-string@1.0.0",
+              "info": Object {
+                "name": "unique-string",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "xdg-basedir@3.0.0",
+              "info": Object {
+                "name": "xdg-basedir",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "configstore@3.1.2",
+              "info": Object {
+                "name": "configstore",
+                "version": "3.1.2",
+              },
+            },
+            Object {
+              "id": "import-lazy@2.1.0",
+              "info": Object {
+                "name": "import-lazy",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "ci-info@1.6.0",
+              "info": Object {
+                "name": "ci-info",
+                "version": "1.6.0",
+              },
+            },
+            Object {
+              "id": "is-ci@1.2.1",
+              "info": Object {
+                "name": "is-ci",
+                "version": "1.2.1",
+              },
+            },
+            Object {
+              "id": "global-dirs@0.1.1",
+              "info": Object {
+                "name": "global-dirs",
+                "version": "0.1.1",
+              },
+            },
+            Object {
+              "id": "is-path-inside@1.0.1",
+              "info": Object {
+                "name": "is-path-inside",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "is-installed-globally@0.1.0",
+              "info": Object {
+                "name": "is-installed-globally",
+                "version": "0.1.0",
+              },
+            },
+            Object {
+              "id": "is-npm@1.0.0",
+              "info": Object {
+                "name": "is-npm",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "capture-stack-trace@1.0.0",
+              "info": Object {
+                "name": "capture-stack-trace",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "create-error-class@3.0.2",
+              "info": Object {
+                "name": "create-error-class",
+                "version": "3.0.2",
+              },
+            },
+            Object {
+              "id": "duplexer3@0.1.4",
+              "info": Object {
+                "name": "duplexer3",
+                "version": "0.1.4",
+              },
+            },
+            Object {
+              "id": "is-redirect@1.0.0",
+              "info": Object {
+                "name": "is-redirect",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "is-retry-allowed@1.2.0",
+              "info": Object {
+                "name": "is-retry-allowed",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "lowercase-keys@1.0.1",
+              "info": Object {
+                "name": "lowercase-keys",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "timed-out@4.0.1",
+              "info": Object {
+                "name": "timed-out",
+                "version": "4.0.1",
+              },
+            },
+            Object {
+              "id": "unzip-response@2.0.1",
+              "info": Object {
+                "name": "unzip-response",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "prepend-http@1.0.4",
+              "info": Object {
+                "name": "prepend-http",
+                "version": "1.0.4",
+              },
+            },
+            Object {
+              "id": "url-parse-lax@1.0.0",
+              "info": Object {
+                "name": "url-parse-lax",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "got@6.7.1",
+              "info": Object {
+                "name": "got",
+                "version": "6.7.1",
+              },
+            },
+            Object {
+              "id": "deep-extend@0.6.0",
+              "info": Object {
+                "name": "deep-extend",
+                "version": "0.6.0",
+              },
+            },
+            Object {
+              "id": "strip-json-comments@2.0.1",
+              "info": Object {
+                "name": "strip-json-comments",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "rc@1.2.8",
+              "info": Object {
+                "name": "rc",
+                "version": "1.2.8",
+              },
+            },
+            Object {
+              "id": "registry-auth-token@3.4.0",
+              "info": Object {
+                "name": "registry-auth-token",
+                "version": "3.4.0",
+              },
+            },
+            Object {
+              "id": "registry-url@3.1.0",
+              "info": Object {
+                "name": "registry-url",
+                "version": "3.1.0",
+              },
+            },
+            Object {
+              "id": "package-json@4.0.1",
+              "info": Object {
+                "name": "package-json",
+                "version": "4.0.1",
+              },
+            },
+            Object {
+              "id": "latest-version@3.1.0",
+              "info": Object {
+                "name": "latest-version",
+                "version": "3.1.0",
+              },
+            },
+            Object {
+              "id": "semver-diff@2.1.0",
+              "info": Object {
+                "name": "semver-diff",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "update-notifier@2.5.0",
+              "info": Object {
+                "name": "update-notifier",
+                "version": "2.5.0",
+              },
+            },
+            Object {
+              "id": "wrap-ansi@2.1.0",
+              "info": Object {
+                "name": "wrap-ansi",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "cliui@4.1.0",
+              "info": Object {
+                "name": "cliui",
+                "version": "4.1.0",
+              },
+            },
+            Object {
+              "id": "decamelize@1.2.0",
+              "info": Object {
+                "name": "decamelize",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "p-try@1.0.0",
+              "info": Object {
+                "name": "p-try",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "p-limit@1.2.0",
+              "info": Object {
+                "name": "p-limit",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "p-locate@2.0.0",
+              "info": Object {
+                "name": "p-locate",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "locate-path@2.0.0",
+              "info": Object {
+                "name": "locate-path",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "find-up@2.1.0",
+              "info": Object {
+                "name": "find-up",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "get-caller-file@1.0.3",
+              "info": Object {
+                "name": "get-caller-file",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "nice-try@1.0.5",
+              "info": Object {
+                "name": "nice-try",
+                "version": "1.0.5",
+              },
+            },
+            Object {
+              "id": "cross-spawn@6.0.5",
+              "info": Object {
+                "name": "cross-spawn",
+                "version": "6.0.5",
+              },
+            },
+            Object {
+              "id": "execa@1.0.0",
+              "info": Object {
+                "name": "execa",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "invert-kv@2.0.0",
+              "info": Object {
+                "name": "invert-kv",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "lcid@2.0.0",
+              "info": Object {
+                "name": "lcid",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "p-defer@1.0.0",
+              "info": Object {
+                "name": "p-defer",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "map-age-cleaner@0.1.3",
+              "info": Object {
+                "name": "map-age-cleaner",
+                "version": "0.1.3",
+              },
+            },
+            Object {
+              "id": "mimic-fn@2.1.0",
+              "info": Object {
+                "name": "mimic-fn",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "p-is-promise@2.1.0",
+              "info": Object {
+                "name": "p-is-promise",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "mem@4.3.0",
+              "info": Object {
+                "name": "mem",
+                "version": "4.3.0",
+              },
+            },
+            Object {
+              "id": "os-locale@3.1.0",
+              "info": Object {
+                "name": "os-locale",
+                "version": "3.1.0",
+              },
+            },
+            Object {
+              "id": "require-directory@2.1.1",
+              "info": Object {
+                "name": "require-directory",
+                "version": "2.1.1",
+              },
+            },
+            Object {
+              "id": "require-main-filename@1.0.1",
+              "info": Object {
+                "name": "require-main-filename",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "y18n@3.2.1",
+              "info": Object {
+                "name": "y18n",
+                "version": "3.2.1",
+              },
+            },
+            Object {
+              "id": "yargs-parser@9.0.2",
+              "info": Object {
+                "name": "yargs-parser",
+                "version": "9.0.2",
+              },
+            },
+            Object {
+              "id": "yargs@11.1.1",
+              "info": Object {
+                "name": "yargs",
+                "version": "11.1.1",
+              },
+            },
+            Object {
+              "id": "libnpx@10.2.2",
+              "info": Object {
+                "name": "libnpx",
+                "version": "10.2.2",
+              },
+            },
+            Object {
+              "id": "lockfile@1.0.4",
+              "info": Object {
+                "name": "lockfile",
+                "version": "1.0.4",
+              },
+            },
+            Object {
+              "id": "lodash._baseindexof@3.1.0",
+              "info": Object {
+                "name": "lodash._baseindexof",
+                "version": "3.1.0",
+              },
+            },
+            Object {
+              "id": "lodash._createset@4.0.3",
+              "info": Object {
+                "name": "lodash._createset",
+                "version": "4.0.3",
+              },
+            },
+            Object {
+              "id": "lodash._root@3.0.1",
+              "info": Object {
+                "name": "lodash._root",
+                "version": "3.0.1",
+              },
+            },
+            Object {
+              "id": "lodash._baseuniq@4.6.0",
+              "info": Object {
+                "name": "lodash._baseuniq",
+                "version": "4.6.0",
+              },
+            },
+            Object {
+              "id": "lodash._bindcallback@3.0.1",
+              "info": Object {
+                "name": "lodash._bindcallback",
+                "version": "3.0.1",
+              },
+            },
+            Object {
+              "id": "lodash._cacheindexof@3.0.2",
+              "info": Object {
+                "name": "lodash._cacheindexof",
+                "version": "3.0.2",
+              },
+            },
+            Object {
+              "id": "lodash._getnative@3.9.1",
+              "info": Object {
+                "name": "lodash._getnative",
+                "version": "3.9.1",
+              },
+            },
+            Object {
+              "id": "lodash._createcache@3.1.2",
+              "info": Object {
+                "name": "lodash._createcache",
+                "version": "3.1.2",
+              },
+            },
+            Object {
+              "id": "lodash.restparam@3.6.1",
+              "info": Object {
+                "name": "lodash.restparam",
+                "version": "3.6.1",
+              },
+            },
+            Object {
+              "id": "lodash.union@4.6.0",
+              "info": Object {
+                "name": "lodash.union",
+                "version": "4.6.0",
+              },
+            },
+            Object {
+              "id": "lodash.uniq@4.5.0",
+              "info": Object {
+                "name": "lodash.uniq",
+                "version": "4.5.0",
+              },
+            },
+            Object {
+              "id": "lodash.without@4.4.0",
+              "info": Object {
+                "name": "lodash.without",
+                "version": "4.4.0",
+              },
+            },
+            Object {
+              "id": "meant@1.0.1",
+              "info": Object {
+                "name": "meant",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "npm-audit-report@1.3.2",
+              "info": Object {
+                "name": "npm-audit-report",
+                "version": "1.3.2",
+              },
+            },
+            Object {
+              "id": "npm-cache-filename@1.0.2",
+              "info": Object {
+                "name": "npm-cache-filename",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "npm-install-checks@3.0.2",
+              "info": Object {
+                "name": "npm-install-checks",
+                "version": "3.0.2",
+              },
+            },
+            Object {
+              "id": "npm-user-validate@1.0.0",
+              "info": Object {
+                "name": "npm-user-validate",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "opener@1.5.1",
+              "info": Object {
+                "name": "opener",
+                "version": "1.5.1",
+              },
+            },
+            Object {
+              "id": "qrcode-terminal@0.12.0",
+              "info": Object {
+                "name": "qrcode-terminal",
+                "version": "0.12.0",
+              },
+            },
+            Object {
+              "id": "decode-uri-component@0.2.0",
+              "info": Object {
+                "name": "decode-uri-component",
+                "version": "0.2.0",
+              },
+            },
+            Object {
+              "id": "split-on-first@1.1.0",
+              "info": Object {
+                "name": "split-on-first",
+                "version": "1.1.0",
+              },
+            },
+            Object {
+              "id": "strict-uri-encode@2.0.0",
+              "info": Object {
+                "name": "strict-uri-encode",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "query-string@6.8.2",
+              "info": Object {
+                "name": "query-string",
+                "version": "6.8.2",
+              },
+            },
+            Object {
+              "id": "qw@1.0.1",
+              "info": Object {
+                "name": "qw",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "debuglog@1.0.1",
+              "info": Object {
+                "name": "debuglog",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "readdir-scoped-modules@1.1.0",
+              "info": Object {
+                "name": "readdir-scoped-modules",
+                "version": "1.1.0",
+              },
+            },
+            Object {
+              "id": "util-extend@1.0.3",
+              "info": Object {
+                "name": "util-extend",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "read-installed@4.0.3",
+              "info": Object {
+                "name": "read-installed",
+                "version": "4.0.3",
+              },
+            },
+            Object {
+              "id": "object-keys@1.0.12",
+              "info": Object {
+                "name": "object-keys",
+                "version": "1.0.12",
+              },
+            },
+            Object {
+              "id": "define-properties@1.1.3",
+              "info": Object {
+                "name": "define-properties",
+                "version": "1.1.3",
+              },
+            },
+            Object {
+              "id": "is-callable@1.1.4",
+              "info": Object {
+                "name": "is-callable",
+                "version": "1.1.4",
+              },
+            },
+            Object {
+              "id": "is-date-object@1.0.1",
+              "info": Object {
+                "name": "is-date-object",
+                "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "has-symbols@1.0.0",
+              "info": Object {
+                "name": "has-symbols",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "is-symbol@1.0.2",
+              "info": Object {
+                "name": "is-symbol",
+                "version": "1.0.2",
+              },
+            },
+            Object {
+              "id": "es-to-primitive@1.2.0",
+              "info": Object {
+                "name": "es-to-primitive",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "function-bind@1.1.1",
+              "info": Object {
+                "name": "function-bind",
+                "version": "1.1.1",
+              },
+            },
+            Object {
+              "id": "has@1.0.3",
+              "info": Object {
+                "name": "has",
+                "version": "1.0.3",
+              },
+            },
+            Object {
+              "id": "is-regex@1.0.4",
+              "info": Object {
+                "name": "is-regex",
+                "version": "1.0.4",
+              },
+            },
+            Object {
+              "id": "es-abstract@1.12.0",
+              "info": Object {
+                "name": "es-abstract",
+                "version": "1.12.0",
+              },
+            },
+            Object {
+              "id": "object.getownpropertydescriptors@2.0.3",
+              "info": Object {
+                "name": "object.getownpropertydescriptors",
+                "version": "2.0.3",
+              },
+            },
+            Object {
+              "id": "util-promisify@2.1.0",
+              "info": Object {
+                "name": "util-promisify",
+                "version": "2.1.0",
+              },
+            },
+            Object {
+              "id": "read-package-tree@5.3.1",
+              "info": Object {
+                "name": "read-package-tree",
+                "version": "5.3.1",
+              },
+            },
+            Object {
+              "id": "string_decoder@1.3.0",
+              "info": Object {
+                "name": "string_decoder",
+                "version": "1.3.0",
+              },
+            },
+            Object {
+              "id": "readable-stream@3.6.0",
+              "info": Object {
+                "name": "readable-stream",
+                "version": "3.6.0",
+              },
+            },
+            Object {
+              "id": "retry@0.12.0",
+              "info": Object {
+                "name": "retry",
+                "version": "0.12.0",
+              },
+            },
+            Object {
+              "id": "sha@3.0.0",
+              "info": Object {
+                "name": "sha",
+                "version": "3.0.0",
+              },
+            },
+            Object {
+              "id": "sorted-object@2.0.1",
+              "info": Object {
+                "name": "sorted-object",
+                "version": "2.0.1",
+              },
+            },
+            Object {
+              "id": "isarray@0.0.1",
+              "info": Object {
+                "name": "isarray",
+                "version": "0.0.1",
+              },
+            },
+            Object {
+              "id": "string_decoder@0.10.31",
+              "info": Object {
+                "name": "string_decoder",
+                "version": "0.10.31",
+              },
+            },
+            Object {
+              "id": "readable-stream@1.1.14",
+              "info": Object {
+                "name": "readable-stream",
+                "version": "1.1.14",
+              },
+            },
+            Object {
+              "id": "from2@1.3.0",
+              "info": Object {
+                "name": "from2",
+                "version": "1.3.0",
+              },
+            },
+            Object {
+              "id": "stream-iterate@1.2.0",
+              "info": Object {
+                "name": "stream-iterate",
+                "version": "1.2.0",
+              },
+            },
+            Object {
+              "id": "sorted-union-stream@2.1.3",
+              "info": Object {
+                "name": "sorted-union-stream",
+                "version": "2.1.3",
+              },
+            },
+            Object {
+              "id": "text-table@0.2.0",
+              "info": Object {
+                "name": "text-table",
+                "version": "0.2.0",
+              },
+            },
+            Object {
+              "id": "tiny-relative-date@1.3.0",
+              "info": Object {
+                "name": "tiny-relative-date",
+                "version": "1.3.0",
+              },
+            },
+            Object {
+              "id": "unpipe@1.0.0",
+              "info": Object {
+                "name": "unpipe",
+                "version": "1.0.0",
+              },
+            },
+            Object {
+              "id": "npm@6.14.5",
+              "info": Object {
+                "name": "npm",
+                "version": "6.14.5",
+              },
+            },
+          ],
+          "schemaVersion": "1.3.0",
+        },
+        "type": "depGraph",
+      },
+      Object {
+        "data": "/usr/local/lib/node_modules",
+        "type": "testedFiles",
+      },
+      Object {
+        "data": "sha256:d60c3644cc5048e48a45c9de94fec3f17ee2eb72eb835434dc13ec5b9d3c532b",
+        "type": "imageId",
+      },
+    ],
+    "identity": Object {
+      "targetFile": "/usr/local/lib/node_modules",
+      "type": "npm",
+    },
+    "target": Object {
+      "image": "docker-image|multi-project-image.tar",
+    },
+  },
+]
+`;

--- a/test/system/application-scans/node.spec.ts
+++ b/test/system/application-scans/node.spec.ts
@@ -68,7 +68,7 @@ describe("node application scans", () => {
     expect(pluginResultExcludeAppVulnsTrueBoolean.scanResults).toHaveLength(1);
   });
 
-  it("ScanResult contains a npm7 depGraph generated from node modules manifest files", async () => {
+  it("should generate a scanResult that contains a npm7 depGraph generated from node modules manifest files", async () => {
     const imageWithManifestFiles = getFixture(
       "npm/npm-without-lockfiles/npm7-with-package-lock-file.tar",
     );
@@ -97,59 +97,19 @@ describe("node application scans", () => {
       pluginResultFromNodeModules.scanResults[1].facts.find(
         (fact) => fact.type === "depGraph",
       )!.data;
+
     expect(depGraphNpmFromManifestFiles.pkgManager.name).toEqual("npm");
     expect(depGraphNpmFromManifestFiles.rootPkg.name).toEqual("goof");
     expect(depGraphNpmFromManifestFiles.rootPkg.version).toBe("1.0.1");
-    expect(depGraphNpmFromManifestFiles.getPkgs().length).toEqual(65); // approximate to the number reported by snyk test --dev
+    expect(depGraphNpmFromManifestFiles.getPkgs().length).toBeGreaterThan(64);
     expect(depGraphNpmFromNodeModules.pkgManager.name).toEqual("npm");
     expect(depGraphNpmFromNodeModules.rootPkg.name).toEqual("goof");
     expect(depGraphNpmFromNodeModules.rootPkg.version).toBe("1.0.1");
     // dev dependencies are reported
-    expect(depGraphNpmFromNodeModules.getPkgs().length).toEqual(65);
+    expect(depGraphNpmFromNodeModules.getPkgs().length).toBeGreaterThan(64);
   });
 
-  it("ScanResult contains a npm7 depGraph when package.json | package-lock.json is missing from app", async () => {
-    const imageWithNodeModules = getFixture(
-      "npm/npm-without-lockfiles/npm7-with-node-modules-only.tar",
-    );
-    const imageWithoutLockFile = getFixture(
-      "npm/npm-without-lockfiles/npm7-without-package-lock-file.tar",
-    );
-    const imageWithNodeModulesNameAndTag = `docker-archive:${imageWithNodeModules}`;
-    const imageWithoutLockFileNameAndTag = `docker-archive:${imageWithoutLockFile}`;
-
-    const pluginResultFromNodeModulesImage = await scan({
-      path: imageWithNodeModulesNameAndTag,
-      "app-vulns": true,
-    });
-
-    const pluginResultWithoutLockFile = await scan({
-      path: imageWithoutLockFileNameAndTag,
-      "app-vulns": true,
-    });
-
-    const depGraphNpmFromWithoutLockFiles: DepGraph =
-      pluginResultWithoutLockFile.scanResults[1].facts.find(
-        (fact) => fact.type === "depGraph",
-      )!.data;
-
-    const depGraphNpmFromNodeModules: DepGraph =
-      pluginResultFromNodeModulesImage.scanResults[1].facts.find(
-        (fact) => fact.type === "depGraph",
-      )!.data;
-    expect(depGraphNpmFromWithoutLockFiles.pkgManager.name).toEqual("npm");
-    expect(depGraphNpmFromWithoutLockFiles.rootPkg.name).toEqual("goof");
-    expect(depGraphNpmFromWithoutLockFiles.rootPkg.version).toBe("1.0.1");
-    expect(depGraphNpmFromWithoutLockFiles.getPkgs().length).toEqual(65);
-    expect(depGraphNpmFromNodeModules.pkgManager.name).toEqual("npm");
-    // when both package.json and package-lock.json is missing root package is the name of the application dir
-    // and the version for the root package remains undefined and the dev dependencies are reported
-    expect(depGraphNpmFromNodeModules.rootPkg.name).toEqual("goof");
-    expect(depGraphNpmFromNodeModules.rootPkg.version).toBe(undefined);
-    expect(depGraphNpmFromNodeModules.getPkgs().length).toEqual(65);
-  });
-
-  it("Scan result contains a yarn depgraph generated from node modules manifest files", async () => {
+  it("should generate a scanResult that contains a yarn depgraph generated from node modules manifest files", async () => {
     const imageWithManifestFiles = getFixture(
       "npm/npm-without-lockfiles/yarn-with-lock-file.tar",
     );
@@ -181,53 +141,24 @@ describe("node application scans", () => {
     expect(depGraphNpmFromManifestFiles.pkgManager.name).toEqual("yarn");
     expect(depGraphNpmFromManifestFiles.rootPkg.name).toEqual("goof");
     expect(depGraphNpmFromManifestFiles.rootPkg.version).toBe("1.0.1");
-    expect(depGraphNpmFromManifestFiles.getPkgs().length).toEqual(65); // approximate to the number reported by snyk test --dev
+    expect(depGraphNpmFromManifestFiles.getPkgs().length).toBeGreaterThan(64);
     expect(depGraphNpmFromNodeModules.pkgManager.name).toEqual("npm");
     expect(depGraphNpmFromNodeModules.rootPkg.name).toEqual("goof");
     expect(depGraphNpmFromNodeModules.rootPkg.version).toBe("1.0.1");
     // dev dependencies are reported
-    expect(depGraphNpmFromNodeModules.getPkgs().length).toEqual(65);
+    expect(depGraphNpmFromNodeModules.getPkgs().length).toBeGreaterThan(64);
   });
 
-  it("ScanResult contains a yarn depGraph package.json | package-lock.json is missing from the app", async () => {
-    const imageWithNodeModules = getFixture(
-      "npm/npm-without-lockfiles/yarn-with-node-modules-only.tar",
-    );
-    const imageWithoutLockFile = getFixture(
-      "npm/npm-without-lockfiles/yarn-without-lock-file.tar",
-    );
-    const imageWithNodeModulesNameAndTag = `docker-archive:${imageWithNodeModules}`;
+  it("should generate a scanResult for a multi-project-image", async () => {
+    const imageWithoutLockFile = getFixture("npm/multi-project-image.tar");
     const imageWithoutLockFileNameAndTag = `docker-archive:${imageWithoutLockFile}`;
 
-    const pluginResultFromNodeModulesImage = await scan({
-      path: imageWithNodeModulesNameAndTag,
-      "app-vulns": true,
-    });
-
-    const pluginResultWithoutLockFile = await scan({
+    const { scanResults } = await scan({
       path: imageWithoutLockFileNameAndTag,
-      "app-vulns": true,
     });
 
-    const depGraphNpmFromWithoutLockFiles: DepGraph =
-      pluginResultWithoutLockFile.scanResults[1].facts.find(
-        (fact) => fact.type === "depGraph",
-      )!.data;
-
-    const depGraphNpmFromNodeModules: DepGraph =
-      pluginResultFromNodeModulesImage.scanResults[1].facts.find(
-        (fact) => fact.type === "depGraph",
-      )!.data;
-    expect(depGraphNpmFromWithoutLockFiles.pkgManager.name).toEqual("npm");
-    expect(depGraphNpmFromWithoutLockFiles.rootPkg.name).toEqual("goof");
-    expect(depGraphNpmFromWithoutLockFiles.rootPkg.version).toBe("1.0.1");
-    expect(depGraphNpmFromWithoutLockFiles.getPkgs().length).toEqual(65);
-    expect(depGraphNpmFromNodeModules.pkgManager.name).toEqual("npm");
-    // when both package.json and package-lock.json is missing root package is the name of the application dir
-    // and the version for the root package remains undefined and the dev dependencies are reported
-    expect(depGraphNpmFromNodeModules.rootPkg.name).toEqual("goof");
-    expect(depGraphNpmFromNodeModules.rootPkg.version).toBe(undefined);
-    expect(depGraphNpmFromNodeModules.getPkgs().length).toEqual(65);
+    expect(scanResults).toMatchSnapshot();
+    expect(scanResults.length).toEqual(5);
   });
 
   it("resolveDeps should return a depGraph constructed from node_modules when the application dir doesn't contain the package.json file", async () => {

--- a/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
@@ -6112,6 +6112,9949 @@ Object {
         "image": "docker-image|registry.access.redhat.com/ubi8/nodejs-10",
       },
     },
+    Object {
+      "facts": Array [
+        Object {
+          "data": Object {
+            "graph": Object {
+              "nodes": Array [
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "nodemon@0.0.0-development",
+                    },
+                    Object {
+                      "nodeId": "npm@6.14.4",
+                    },
+                  ],
+                  "nodeId": "root-node",
+                  "pkgId": "lib@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "arr-diff@4.0.0",
+                  "pkgId": "arr-diff@4.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "array-unique@0.3.2",
+                  "pkgId": "array-unique@0.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "arr-flatten@1.1.0",
+                  "pkgId": "arr-flatten@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-extendable@0.1.1",
+                  "pkgId": "is-extendable@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-extendable@0.1.1",
+                    },
+                  ],
+                  "nodeId": "extend-shallow@2.0.1",
+                  "pkgId": "extend-shallow@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-buffer@1.1.6",
+                  "pkgId": "is-buffer@1.1.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-buffer@1.1.6",
+                    },
+                  ],
+                  "nodeId": "kind-of@3.2.2",
+                  "pkgId": "kind-of@3.2.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "kind-of@3.2.2",
+                    },
+                  ],
+                  "nodeId": "is-number@3.0.0",
+                  "pkgId": "is-number@3.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "repeat-string@1.6.1",
+                  "pkgId": "repeat-string@1.6.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-number@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "repeat-string@1.6.1",
+                    },
+                  ],
+                  "nodeId": "to-regex-range@2.1.1",
+                  "pkgId": "to-regex-range@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "extend-shallow@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "is-number@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "repeat-string@1.6.1",
+                    },
+                    Object {
+                      "nodeId": "to-regex-range@2.1.1",
+                    },
+                  ],
+                  "nodeId": "fill-range@4.0.0",
+                  "pkgId": "fill-range@4.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isobject@3.0.1",
+                  "pkgId": "isobject@3.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "repeat-element@1.1.2",
+                  "pkgId": "repeat-element@1.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                  ],
+                  "nodeId": "object-visit@1.0.1",
+                  "pkgId": "object-visit@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "object-visit@1.0.1",
+                    },
+                  ],
+                  "nodeId": "map-visit@1.0.0",
+                  "pkgId": "map-visit@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "map-visit@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "object-visit@1.0.1",
+                    },
+                  ],
+                  "nodeId": "collection-visit@1.0.0",
+                  "pkgId": "collection-visit@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "component-emitter@1.2.1",
+                  "pkgId": "component-emitter@1.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "get-value@2.0.6",
+                  "pkgId": "get-value@2.0.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-buffer@1.1.6",
+                    },
+                  ],
+                  "nodeId": "kind-of@4.0.0",
+                  "pkgId": "kind-of@4.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-number@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "kind-of@4.0.0",
+                    },
+                  ],
+                  "nodeId": "has-values@1.0.0",
+                  "pkgId": "has-values@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "get-value@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "has-values@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                  ],
+                  "nodeId": "has-value@1.0.0",
+                  "pkgId": "has-value@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                  ],
+                  "nodeId": "is-plain-object@2.0.4",
+                  "pkgId": "is-plain-object@2.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "assign-symbols@1.0.0",
+                  "pkgId": "assign-symbols@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-plain-object@2.0.4",
+                    },
+                  ],
+                  "nodeId": "is-extendable@1.0.1",
+                  "pkgId": "is-extendable@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assign-symbols@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-extendable@1.0.1",
+                    },
+                  ],
+                  "nodeId": "extend-shallow@3.0.2",
+                  "pkgId": "extend-shallow@3.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "extend-shallow@3.0.2",
+                    },
+                  ],
+                  "nodeId": "split-string@3.1.0",
+                  "pkgId": "split-string@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "extend-shallow@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "is-extendable@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "is-plain-object@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "split-string@3.1.0",
+                    },
+                  ],
+                  "nodeId": "set-value@2.0.0",
+                  "pkgId": "set-value@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "kind-of@3.2.2",
+                    },
+                  ],
+                  "nodeId": "to-object-path@0.3.0",
+                  "pkgId": "to-object-path@0.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "arr-union@3.1.0",
+                  "pkgId": "arr-union@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "extend-shallow@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "is-extendable@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "is-plain-object@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "to-object-path@0.3.0",
+                    },
+                  ],
+                  "nodeId": "set-value@0.4.3",
+                  "pkgId": "set-value@0.4.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "arr-union@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "get-value@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "is-extendable@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "set-value@0.4.3",
+                    },
+                  ],
+                  "nodeId": "union-value@1.0.0",
+                  "pkgId": "union-value@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-values@0.1.4",
+                  "pkgId": "has-values@0.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isarray@1.0.0",
+                  "pkgId": "isarray@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "isarray@1.0.0",
+                    },
+                  ],
+                  "nodeId": "isobject@2.1.0",
+                  "pkgId": "isobject@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "get-value@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "has-values@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "isobject@2.1.0",
+                    },
+                  ],
+                  "nodeId": "has-value@0.3.1",
+                  "pkgId": "has-value@0.3.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "has-value@0.3.1",
+                    },
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                  ],
+                  "nodeId": "unset-value@1.0.0",
+                  "pkgId": "unset-value@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "collection-visit@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "component-emitter@1.2.1",
+                    },
+                    Object {
+                      "nodeId": "get-value@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "has-value@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "set-value@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "to-object-path@0.3.0",
+                    },
+                    Object {
+                      "nodeId": "union-value@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "unset-value@1.0.0",
+                    },
+                  ],
+                  "nodeId": "cache-base@1.0.1",
+                  "pkgId": "cache-base@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "kind-of@3.2.2",
+                    },
+                  ],
+                  "nodeId": "is-accessor-descriptor@0.1.6",
+                  "pkgId": "is-accessor-descriptor@0.1.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "kind-of@3.2.2",
+                    },
+                  ],
+                  "nodeId": "is-data-descriptor@0.1.4",
+                  "pkgId": "is-data-descriptor@0.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "kind-of@5.1.0",
+                  "pkgId": "kind-of@5.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-accessor-descriptor@0.1.6",
+                    },
+                    Object {
+                      "nodeId": "is-data-descriptor@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "kind-of@5.1.0",
+                    },
+                  ],
+                  "nodeId": "is-descriptor@0.1.6",
+                  "pkgId": "is-descriptor@0.1.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-descriptor@0.1.6",
+                    },
+                  ],
+                  "nodeId": "define-property@0.2.5",
+                  "pkgId": "define-property@0.2.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "copy-descriptor@0.1.1",
+                  "pkgId": "copy-descriptor@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "copy-descriptor@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "define-property@0.2.5",
+                    },
+                    Object {
+                      "nodeId": "kind-of@3.2.2",
+                    },
+                  ],
+                  "nodeId": "object-copy@0.1.0",
+                  "pkgId": "object-copy@0.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "define-property@0.2.5",
+                    },
+                    Object {
+                      "nodeId": "object-copy@0.1.0",
+                    },
+                  ],
+                  "nodeId": "static-extend@0.1.2",
+                  "pkgId": "static-extend@0.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "arr-union@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "define-property@0.2.5",
+                    },
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "static-extend@0.1.2",
+                    },
+                  ],
+                  "nodeId": "class-utils@0.3.6",
+                  "pkgId": "class-utils@0.3.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "kind-of@6.0.2",
+                  "pkgId": "kind-of@6.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "kind-of@6.0.2",
+                    },
+                  ],
+                  "nodeId": "is-accessor-descriptor@1.0.0",
+                  "pkgId": "is-accessor-descriptor@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "kind-of@6.0.2",
+                    },
+                  ],
+                  "nodeId": "is-data-descriptor@1.0.0",
+                  "pkgId": "is-data-descriptor@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-accessor-descriptor@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-data-descriptor@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "kind-of@6.0.2",
+                    },
+                  ],
+                  "nodeId": "is-descriptor@1.0.2",
+                  "pkgId": "is-descriptor@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-descriptor@1.0.2",
+                    },
+                  ],
+                  "nodeId": "define-property@1.0.0",
+                  "pkgId": "define-property@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "for-in@1.0.2",
+                  "pkgId": "for-in@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "for-in@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "is-extendable@1.0.1",
+                    },
+                  ],
+                  "nodeId": "mixin-deep@1.3.1",
+                  "pkgId": "mixin-deep@1.3.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pascalcase@0.1.1",
+                  "pkgId": "pascalcase@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cache-base@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "class-utils@0.3.6",
+                    },
+                    Object {
+                      "nodeId": "component-emitter@1.2.1",
+                    },
+                    Object {
+                      "nodeId": "define-property@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "mixin-deep@1.3.1",
+                    },
+                    Object {
+                      "nodeId": "pascalcase@0.1.1",
+                    },
+                  ],
+                  "nodeId": "base@0.11.2",
+                  "pkgId": "base@0.11.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ms@2.0.0",
+                  "pkgId": "ms@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ms@2.0.0",
+                    },
+                  ],
+                  "nodeId": "debug@2.6.9",
+                  "pkgId": "debug@2.6.9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "map-cache@0.2.2",
+                  "pkgId": "map-cache@0.2.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "source-map@0.5.7",
+                  "pkgId": "source-map@0.5.7",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "atob@2.1.1",
+                  "pkgId": "atob@2.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "decode-uri-component@0.2.0",
+                  "pkgId": "decode-uri-component@0.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "resolve-url@0.2.1",
+                  "pkgId": "resolve-url@0.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "source-map-url@0.4.0",
+                  "pkgId": "source-map-url@0.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "urix@0.1.0",
+                  "pkgId": "urix@0.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "atob@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "decode-uri-component@0.2.0",
+                    },
+                    Object {
+                      "nodeId": "resolve-url@0.2.1",
+                    },
+                    Object {
+                      "nodeId": "source-map-url@0.4.0",
+                    },
+                    Object {
+                      "nodeId": "urix@0.1.0",
+                    },
+                  ],
+                  "nodeId": "source-map-resolve@0.5.1",
+                  "pkgId": "source-map-resolve@0.5.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "kind-of@6.0.2",
+                    },
+                  ],
+                  "nodeId": "use@3.1.0",
+                  "pkgId": "use@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "base@0.11.2",
+                    },
+                    Object {
+                      "nodeId": "debug@2.6.9",
+                    },
+                    Object {
+                      "nodeId": "define-property@0.2.5",
+                    },
+                    Object {
+                      "nodeId": "extend-shallow@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "map-cache@0.2.2",
+                    },
+                    Object {
+                      "nodeId": "source-map@0.5.7",
+                    },
+                    Object {
+                      "nodeId": "source-map-resolve@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "use@3.1.0",
+                    },
+                  ],
+                  "nodeId": "snapdragon@0.8.2",
+                  "pkgId": "snapdragon@0.8.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "kind-of@3.2.2",
+                    },
+                  ],
+                  "nodeId": "snapdragon-util@3.0.1",
+                  "pkgId": "snapdragon-util@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "define-property@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "snapdragon-util@3.0.1",
+                    },
+                  ],
+                  "nodeId": "snapdragon-node@2.1.1",
+                  "pkgId": "snapdragon-node@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-descriptor@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                  ],
+                  "nodeId": "define-property@2.0.2",
+                  "pkgId": "define-property@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ret@0.1.15",
+                  "pkgId": "ret@0.1.15",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ret@0.1.15",
+                    },
+                  ],
+                  "nodeId": "safe-regex@1.1.0",
+                  "pkgId": "safe-regex@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "extend-shallow@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "safe-regex@1.1.0",
+                    },
+                  ],
+                  "nodeId": "regex-not@1.0.2",
+                  "pkgId": "regex-not@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "define-property@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "extend-shallow@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "regex-not@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "safe-regex@1.1.0",
+                    },
+                  ],
+                  "nodeId": "to-regex@3.0.2",
+                  "pkgId": "to-regex@3.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "arr-flatten@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "array-unique@0.3.2",
+                    },
+                    Object {
+                      "nodeId": "extend-shallow@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "fill-range@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "repeat-element@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "snapdragon@0.8.2",
+                    },
+                    Object {
+                      "nodeId": "snapdragon-node@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "split-string@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "to-regex@3.0.2",
+                    },
+                  ],
+                  "nodeId": "braces@2.3.2",
+                  "pkgId": "braces@2.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "posix-character-classes@0.1.1",
+                  "pkgId": "posix-character-classes@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debug@2.6.9",
+                    },
+                    Object {
+                      "nodeId": "define-property@0.2.5",
+                    },
+                    Object {
+                      "nodeId": "extend-shallow@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "posix-character-classes@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "regex-not@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "snapdragon@0.8.2",
+                    },
+                    Object {
+                      "nodeId": "to-regex@3.0.2",
+                    },
+                  ],
+                  "nodeId": "expand-brackets@2.1.4",
+                  "pkgId": "expand-brackets@2.1.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "map-cache@0.2.2",
+                    },
+                  ],
+                  "nodeId": "fragment-cache@0.2.1",
+                  "pkgId": "fragment-cache@0.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "array-unique@0.3.2",
+                    },
+                    Object {
+                      "nodeId": "define-property@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "expand-brackets@2.1.4",
+                    },
+                    Object {
+                      "nodeId": "extend-shallow@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "fragment-cache@0.2.1",
+                    },
+                    Object {
+                      "nodeId": "regex-not@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "snapdragon@0.8.2",
+                    },
+                    Object {
+                      "nodeId": "to-regex@3.0.2",
+                    },
+                  ],
+                  "nodeId": "extglob@2.0.4",
+                  "pkgId": "extglob@2.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-number@4.0.0",
+                  "pkgId": "is-number@4.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-number@4.0.0",
+                    },
+                  ],
+                  "nodeId": "is-odd@2.0.0",
+                  "pkgId": "is-odd@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-windows@1.0.2",
+                  "pkgId": "is-windows@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "isobject@3.0.1",
+                    },
+                  ],
+                  "nodeId": "object.pick@1.3.0",
+                  "pkgId": "object.pick@1.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "arr-diff@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "array-unique@0.3.2",
+                    },
+                    Object {
+                      "nodeId": "define-property@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "extend-shallow@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "fragment-cache@0.2.1",
+                    },
+                    Object {
+                      "nodeId": "is-odd@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-windows@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "kind-of@6.0.2",
+                    },
+                    Object {
+                      "nodeId": "object.pick@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "regex-not@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "snapdragon@0.8.2",
+                    },
+                    Object {
+                      "nodeId": "to-regex@3.0.2",
+                    },
+                  ],
+                  "nodeId": "nanomatch@1.2.9",
+                  "pkgId": "nanomatch@1.2.9",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "arr-diff@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "array-unique@0.3.2",
+                    },
+                    Object {
+                      "nodeId": "braces@2.3.2",
+                    },
+                    Object {
+                      "nodeId": "define-property@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "extend-shallow@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "extglob@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "fragment-cache@0.2.1",
+                    },
+                    Object {
+                      "nodeId": "kind-of@6.0.2",
+                    },
+                    Object {
+                      "nodeId": "nanomatch@1.2.9",
+                    },
+                    Object {
+                      "nodeId": "object.pick@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "regex-not@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "snapdragon@0.8.2",
+                    },
+                    Object {
+                      "nodeId": "to-regex@3.0.2",
+                    },
+                  ],
+                  "nodeId": "micromatch@3.1.10",
+                  "pkgId": "micromatch@3.1.10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "remove-trailing-separator@1.1.0",
+                  "pkgId": "remove-trailing-separator@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "remove-trailing-separator@1.1.0",
+                    },
+                  ],
+                  "nodeId": "normalize-path@2.1.1",
+                  "pkgId": "normalize-path@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "micromatch@3.1.10",
+                    },
+                    Object {
+                      "nodeId": "normalize-path@2.1.1",
+                    },
+                  ],
+                  "nodeId": "anymatch@2.0.0",
+                  "pkgId": "anymatch@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "async-each@1.0.1",
+                  "pkgId": "async-each@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-extglob@2.1.1",
+                  "pkgId": "is-extglob@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-extglob@2.1.1",
+                    },
+                  ],
+                  "nodeId": "is-glob@3.1.0",
+                  "pkgId": "is-glob@3.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-dirname@1.0.2",
+                  "pkgId": "path-dirname@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-glob@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "path-dirname@1.0.2",
+                    },
+                  ],
+                  "nodeId": "glob-parent@3.1.0",
+                  "pkgId": "glob-parent@3.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "inherits@2.0.3",
+                  "pkgId": "inherits@2.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "binary-extensions@1.11.0",
+                  "pkgId": "binary-extensions@1.11.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "binary-extensions@1.11.0",
+                    },
+                  ],
+                  "nodeId": "is-binary-path@1.0.1",
+                  "pkgId": "is-binary-path@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-extglob@2.1.1",
+                    },
+                  ],
+                  "nodeId": "is-glob@4.0.0",
+                  "pkgId": "is-glob@4.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-is-absolute@1.0.1",
+                  "pkgId": "path-is-absolute@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "graceful-fs@4.1.11",
+                  "pkgId": "graceful-fs@4.1.11",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "balanced-match@1.0.0",
+                  "pkgId": "balanced-match@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "concat-map@0.0.1",
+                  "pkgId": "concat-map@0.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "balanced-match@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "concat-map@0.0.1",
+                    },
+                  ],
+                  "nodeId": "brace-expansion@1.1.8",
+                  "pkgId": "brace-expansion@1.1.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "brace-expansion@1.1.8",
+                    },
+                  ],
+                  "nodeId": "minimatch@3.0.4|1",
+                  "pkgId": "minimatch@3.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "brace-expansion@1.1.11",
+                    },
+                  ],
+                  "nodeId": "minimatch@3.0.4|2",
+                  "pkgId": "minimatch@3.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "core-util-is@1.0.2",
+                  "pkgId": "core-util-is@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "process-nextick-args@1.0.7",
+                  "pkgId": "process-nextick-args@1.0.7",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "safe-buffer@5.1.1",
+                  "pkgId": "safe-buffer@5.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.1",
+                    },
+                  ],
+                  "nodeId": "string_decoder@1.0.3",
+                  "pkgId": "string_decoder@1.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-deprecate@1.0.2",
+                  "pkgId": "util-deprecate@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "isarray@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "process-nextick-args@1.0.7",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.1",
+                    },
+                    Object {
+                      "nodeId": "string_decoder@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "util-deprecate@1.0.2",
+                    },
+                  ],
+                  "nodeId": "readable-stream@2.3.3",
+                  "pkgId": "readable-stream@2.3.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "set-immediate-shim@1.0.1",
+                  "pkgId": "set-immediate-shim@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.11",
+                    },
+                    Object {
+                      "nodeId": "minimatch@3.0.4|1",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.3",
+                    },
+                    Object {
+                      "nodeId": "set-immediate-shim@1.0.1",
+                    },
+                  ],
+                  "nodeId": "readdirp@2.1.0",
+                  "pkgId": "readdirp@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "upath@1.0.5",
+                  "pkgId": "upath@1.0.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "anymatch@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "async-each@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "braces@2.3.2",
+                    },
+                    Object {
+                      "nodeId": "glob-parent@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "is-binary-path@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "is-glob@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "normalize-path@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "path-is-absolute@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "readdirp@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "upath@1.0.5",
+                    },
+                  ],
+                  "nodeId": "chokidar@2.0.2",
+                  "pkgId": "chokidar@2.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ms@2.0.0",
+                    },
+                  ],
+                  "nodeId": "debug@3.1.0",
+                  "pkgId": "debug@3.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ignore-by-default@1.0.1",
+                  "pkgId": "ignore-by-default@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isexe@2.0.0",
+                  "pkgId": "isexe@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "duplexer@0.1.1",
+                  "pkgId": "duplexer@0.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "from@0.1.7",
+                  "pkgId": "from@0.1.7",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "map-stream@0.1.0",
+                  "pkgId": "map-stream@0.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "through@2.3.8",
+                  "pkgId": "through@2.3.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "through@2.3.8",
+                    },
+                  ],
+                  "nodeId": "pause-stream@0.0.11",
+                  "pkgId": "pause-stream@0.0.11",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "through@2.3.8",
+                    },
+                  ],
+                  "nodeId": "split@0.3.3",
+                  "pkgId": "split@0.3.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "duplexer@0.1.1",
+                    },
+                  ],
+                  "nodeId": "stream-combiner@0.0.4",
+                  "pkgId": "stream-combiner@0.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "duplexer@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "from@0.1.7",
+                    },
+                    Object {
+                      "nodeId": "map-stream@0.1.0",
+                    },
+                    Object {
+                      "nodeId": "pause-stream@0.0.11",
+                    },
+                    Object {
+                      "nodeId": "split@0.3.3",
+                    },
+                    Object {
+                      "nodeId": "stream-combiner@0.0.4",
+                    },
+                    Object {
+                      "nodeId": "through@2.3.8",
+                    },
+                  ],
+                  "nodeId": "event-stream@3.3.4",
+                  "pkgId": "event-stream@3.3.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "event-stream@3.3.4",
+                    },
+                  ],
+                  "nodeId": "ps-tree@1.1.0",
+                  "pkgId": "ps-tree@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ps-tree@1.1.0",
+                    },
+                  ],
+                  "nodeId": "pstree.remy@1.1.0",
+                  "pkgId": "pstree.remy@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "semver@5.5.0",
+                  "pkgId": "semver@5.5.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-flag@3.0.0",
+                  "pkgId": "has-flag@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "has-flag@3.0.0",
+                    },
+                  ],
+                  "nodeId": "supports-color@5.2.0",
+                  "pkgId": "supports-color@5.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "abbrev@1.1.1",
+                  "pkgId": "abbrev@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                  ],
+                  "nodeId": "nopt@1.0.10",
+                  "pkgId": "nopt@1.0.10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "nopt@1.0.10",
+                    },
+                  ],
+                  "nodeId": "touch@3.1.0",
+                  "pkgId": "touch@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debug@2.6.9",
+                    },
+                  ],
+                  "nodeId": "undefsafe@2.0.2",
+                  "pkgId": "undefsafe@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-fullwidth-code-point@2.0.0",
+                  "pkgId": "is-fullwidth-code-point@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansi-regex@3.0.0",
+                  "pkgId": "ansi-regex@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-regex@3.0.0",
+                    },
+                  ],
+                  "nodeId": "strip-ansi@4.0.0",
+                  "pkgId": "strip-ansi@4.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-fullwidth-code-point@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@4.0.0",
+                    },
+                  ],
+                  "nodeId": "string-width@2.1.1",
+                  "pkgId": "string-width@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "ansi-align@2.0.0",
+                  "pkgId": "ansi-align@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "camelcase@4.1.0",
+                  "pkgId": "camelcase@4.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "color-name@1.1.3",
+                  "pkgId": "color-name@1.1.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "color-name@1.1.3",
+                    },
+                  ],
+                  "nodeId": "color-convert@1.9.1",
+                  "pkgId": "color-convert@1.9.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "color-convert@1.9.1",
+                    },
+                  ],
+                  "nodeId": "ansi-styles@3.2.0",
+                  "pkgId": "ansi-styles@3.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "escape-string-regexp@1.0.5",
+                  "pkgId": "escape-string-regexp@1.0.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-flag@2.0.0",
+                  "pkgId": "has-flag@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "has-flag@2.0.0",
+                    },
+                  ],
+                  "nodeId": "supports-color@4.5.0",
+                  "pkgId": "supports-color@4.5.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-styles@3.2.0",
+                    },
+                    Object {
+                      "nodeId": "escape-string-regexp@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "supports-color@4.5.0",
+                    },
+                  ],
+                  "nodeId": "chalk@2.3.0",
+                  "pkgId": "chalk@2.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "cli-boxes@1.0.0",
+                  "pkgId": "cli-boxes@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pseudomap@1.0.2",
+                  "pkgId": "pseudomap@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "yallist@2.1.2",
+                  "pkgId": "yallist@2.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pseudomap@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@2.1.2",
+                    },
+                  ],
+                  "nodeId": "lru-cache@4.1.1",
+                  "pkgId": "lru-cache@4.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "shebang-regex@1.0.0",
+                  "pkgId": "shebang-regex@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "shebang-regex@1.0.0",
+                    },
+                  ],
+                  "nodeId": "shebang-command@1.2.0",
+                  "pkgId": "shebang-command@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lru-cache@4.1.1",
+                    },
+                    Object {
+                      "nodeId": "shebang-command@1.2.0",
+                    },
+                  ],
+                  "nodeId": "cross-spawn@5.1.0|1",
+                  "pkgId": "cross-spawn@5.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lru-cache@4.1.5",
+                    },
+                    Object {
+                      "nodeId": "shebang-command@1.2.0",
+                    },
+                  ],
+                  "nodeId": "cross-spawn@5.1.0|2",
+                  "pkgId": "cross-spawn@5.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "get-stream@3.0.0",
+                  "pkgId": "get-stream@3.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-stream@1.1.0",
+                  "pkgId": "is-stream@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-key@2.0.1",
+                  "pkgId": "path-key@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "path-key@2.0.1",
+                    },
+                  ],
+                  "nodeId": "npm-run-path@2.0.2",
+                  "pkgId": "npm-run-path@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-finally@1.0.0",
+                  "pkgId": "p-finally@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "signal-exit@3.0.2",
+                  "pkgId": "signal-exit@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strip-eof@1.0.0",
+                  "pkgId": "strip-eof@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cross-spawn@5.1.0|1",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-run-path@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "p-finally@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-eof@1.0.0",
+                    },
+                  ],
+                  "nodeId": "execa@0.7.0|1",
+                  "pkgId": "execa@0.7.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cross-spawn@5.1.0|2",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-run-path@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "p-finally@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-eof@1.0.0",
+                    },
+                  ],
+                  "nodeId": "execa@0.7.0|2",
+                  "pkgId": "execa@0.7.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "execa@0.7.0|1",
+                    },
+                  ],
+                  "nodeId": "term-size@1.2.0|1",
+                  "pkgId": "term-size@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "execa@0.7.0|2",
+                    },
+                  ],
+                  "nodeId": "term-size@1.2.0|2",
+                  "pkgId": "term-size@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "widest-line@2.0.0",
+                  "pkgId": "widest-line@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-align@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "camelcase@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "chalk@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "cli-boxes@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "term-size@1.2.0|1",
+                    },
+                    Object {
+                      "nodeId": "widest-line@2.0.0",
+                    },
+                  ],
+                  "nodeId": "boxen@1.3.0|1",
+                  "pkgId": "boxen@1.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-align@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "camelcase@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "chalk@2.4.1",
+                    },
+                    Object {
+                      "nodeId": "cli-boxes@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "term-size@1.2.0|2",
+                    },
+                    Object {
+                      "nodeId": "widest-line@2.0.1",
+                    },
+                  ],
+                  "nodeId": "boxen@1.3.0|2",
+                  "pkgId": "boxen@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-obj@1.0.1",
+                  "pkgId": "is-obj@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-obj@1.0.1",
+                    },
+                  ],
+                  "nodeId": "dot-prop@4.2.0",
+                  "pkgId": "dot-prop@4.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pify@3.0.0",
+                  "pkgId": "pify@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pify@3.0.0",
+                    },
+                  ],
+                  "nodeId": "make-dir@1.1.0",
+                  "pkgId": "make-dir@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "crypto-random-string@1.0.0",
+                  "pkgId": "crypto-random-string@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "crypto-random-string@1.0.0",
+                    },
+                  ],
+                  "nodeId": "unique-string@1.0.0",
+                  "pkgId": "unique-string@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "imurmurhash@0.1.4",
+                  "pkgId": "imurmurhash@0.1.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.11",
+                    },
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                  ],
+                  "nodeId": "write-file-atomic@2.3.0",
+                  "pkgId": "write-file-atomic@2.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xdg-basedir@3.0.0",
+                  "pkgId": "xdg-basedir@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "dot-prop@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.11",
+                    },
+                    Object {
+                      "nodeId": "make-dir@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "unique-string@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "xdg-basedir@3.0.0",
+                    },
+                  ],
+                  "nodeId": "configstore@3.1.1",
+                  "pkgId": "configstore@3.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "import-lazy@2.1.0",
+                  "pkgId": "import-lazy@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ini@1.3.5",
+                  "pkgId": "ini@1.3.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                  ],
+                  "nodeId": "global-dirs@0.1.1",
+                  "pkgId": "global-dirs@0.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-is-inside@1.0.2",
+                  "pkgId": "path-is-inside@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                  ],
+                  "nodeId": "is-path-inside@1.0.1",
+                  "pkgId": "is-path-inside@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "global-dirs@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "is-path-inside@1.0.1",
+                    },
+                  ],
+                  "nodeId": "is-installed-globally@0.1.0",
+                  "pkgId": "is-installed-globally@0.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-npm@1.0.0",
+                  "pkgId": "is-npm@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "capture-stack-trace@1.0.0",
+                  "pkgId": "capture-stack-trace@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "capture-stack-trace@1.0.0",
+                    },
+                  ],
+                  "nodeId": "create-error-class@3.0.2",
+                  "pkgId": "create-error-class@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "duplexer3@0.1.4",
+                  "pkgId": "duplexer3@0.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-redirect@1.0.0",
+                  "pkgId": "is-redirect@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-retry-allowed@1.1.0",
+                  "pkgId": "is-retry-allowed@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lowercase-keys@1.0.0",
+                  "pkgId": "lowercase-keys@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "timed-out@4.0.1",
+                  "pkgId": "timed-out@4.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "unzip-response@2.0.1",
+                  "pkgId": "unzip-response@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "prepend-http@1.0.4",
+                  "pkgId": "prepend-http@1.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "prepend-http@1.0.4",
+                    },
+                  ],
+                  "nodeId": "url-parse-lax@1.0.0",
+                  "pkgId": "url-parse-lax@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "create-error-class@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "duplexer3@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-redirect@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-retry-allowed@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "lowercase-keys@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.1",
+                    },
+                    Object {
+                      "nodeId": "timed-out@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "unzip-response@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "url-parse-lax@1.0.0",
+                    },
+                  ],
+                  "nodeId": "got@6.7.1|1",
+                  "pkgId": "got@6.7.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "create-error-class@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "duplexer3@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-redirect@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-retry-allowed@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "lowercase-keys@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "timed-out@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "unzip-response@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "url-parse-lax@1.0.0",
+                    },
+                  ],
+                  "nodeId": "got@6.7.1|2",
+                  "pkgId": "got@6.7.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "deep-extend@0.4.2",
+                  "pkgId": "deep-extend@0.4.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "minimist@1.2.0",
+                  "pkgId": "minimist@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strip-json-comments@2.0.1",
+                  "pkgId": "strip-json-comments@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "deep-extend@0.4.2",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "minimist@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "strip-json-comments@2.0.1",
+                    },
+                  ],
+                  "nodeId": "rc@1.2.2",
+                  "pkgId": "rc@1.2.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "rc@1.2.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.1",
+                    },
+                  ],
+                  "nodeId": "registry-auth-token@3.3.1",
+                  "pkgId": "registry-auth-token@3.3.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "rc@1.2.2",
+                    },
+                  ],
+                  "nodeId": "registry-url@3.1.0|1",
+                  "pkgId": "registry-url@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "rc@1.2.8",
+                    },
+                  ],
+                  "nodeId": "registry-url@3.1.0|2",
+                  "pkgId": "registry-url@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "got@6.7.1|1",
+                    },
+                    Object {
+                      "nodeId": "registry-auth-token@3.3.1",
+                    },
+                    Object {
+                      "nodeId": "registry-url@3.1.0|1",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.0",
+                    },
+                  ],
+                  "nodeId": "package-json@4.0.1|1",
+                  "pkgId": "package-json@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "got@6.7.1|2",
+                    },
+                    Object {
+                      "nodeId": "registry-auth-token@3.4.0",
+                    },
+                    Object {
+                      "nodeId": "registry-url@3.1.0|2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                  ],
+                  "nodeId": "package-json@4.0.1|2",
+                  "pkgId": "package-json@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "package-json@4.0.1|1",
+                    },
+                  ],
+                  "nodeId": "latest-version@3.1.0|1",
+                  "pkgId": "latest-version@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "package-json@4.0.1|2",
+                    },
+                  ],
+                  "nodeId": "latest-version@3.1.0|2",
+                  "pkgId": "latest-version@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "semver@5.5.0",
+                    },
+                  ],
+                  "nodeId": "semver-diff@2.1.0|1",
+                  "pkgId": "semver-diff@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                  ],
+                  "nodeId": "semver-diff@2.1.0|2",
+                  "pkgId": "semver-diff@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "boxen@1.3.0|1",
+                    },
+                    Object {
+                      "nodeId": "chalk@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "configstore@3.1.1",
+                    },
+                    Object {
+                      "nodeId": "import-lazy@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-installed-globally@0.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-npm@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "latest-version@3.1.0|1",
+                    },
+                    Object {
+                      "nodeId": "semver-diff@2.1.0|1",
+                    },
+                    Object {
+                      "nodeId": "xdg-basedir@3.0.0",
+                    },
+                  ],
+                  "nodeId": "update-notifier@2.3.0",
+                  "pkgId": "update-notifier@2.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "chokidar@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "debug@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "ignore-by-default@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "isexe@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "minimatch@3.0.4|1",
+                    },
+                    Object {
+                      "nodeId": "pstree.remy@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.0",
+                    },
+                    Object {
+                      "nodeId": "supports-color@5.2.0",
+                    },
+                    Object {
+                      "nodeId": "touch@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "undefsafe@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "update-notifier@2.3.0",
+                    },
+                  ],
+                  "nodeId": "nodemon@0.0.0-development",
+                  "pkgId": "nodemon@0.0.0-development",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "jsonparse@1.3.1",
+                  "pkgId": "jsonparse@1.3.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "jsonparse@1.3.1",
+                    },
+                    Object {
+                      "nodeId": "through@2.3.8",
+                    },
+                  ],
+                  "nodeId": "JSONStream@1.3.5",
+                  "pkgId": "JSONStream@1.3.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansicolors@0.3.2",
+                  "pkgId": "ansicolors@0.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansistyles@0.1.3",
+                  "pkgId": "ansistyles@0.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aproba@2.0.0",
+                  "pkgId": "aproba@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "archy@1.0.0",
+                  "pkgId": "archy@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "bluebird@3.5.5",
+                  "pkgId": "bluebird@3.5.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "graceful-fs@4.2.3",
+                  "pkgId": "graceful-fs@4.2.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "minimist@1.2.5",
+                  "pkgId": "minimist@1.2.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minimist@1.2.5",
+                    },
+                  ],
+                  "nodeId": "mkdirp@0.5.4",
+                  "pkgId": "mkdirp@0.5.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                  ],
+                  "nodeId": "cmd-shim@3.0.3",
+                  "pkgId": "cmd-shim@3.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aproba@1.2.0",
+                  "pkgId": "aproba@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "chownr@1.1.4",
+                  "pkgId": "chownr@1.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fs.realpath@1.0.0",
+                  "pkgId": "fs.realpath@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "wrappy@1.0.2",
+                  "pkgId": "wrappy@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "once@1.4.0",
+                  "pkgId": "once@1.4.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "inflight@1.0.6",
+                  "pkgId": "inflight@1.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "inherits@2.0.4",
+                  "pkgId": "inherits@2.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "balanced-match@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "concat-map@0.0.1",
+                    },
+                  ],
+                  "nodeId": "brace-expansion@1.1.11",
+                  "pkgId": "brace-expansion@1.1.11",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "fs.realpath@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "inflight@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "minimatch@3.0.4|2",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "path-is-absolute@1.0.1",
+                    },
+                  ],
+                  "nodeId": "glob@7.1.6",
+                  "pkgId": "glob@7.1.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.6",
+                    },
+                  ],
+                  "nodeId": "rimraf@2.7.1",
+                  "pkgId": "rimraf@2.7.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                  ],
+                  "nodeId": "fs-vacuum@1.2.10",
+                  "pkgId": "fs-vacuum@1.2.10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "iferr@0.1.5",
+                  "pkgId": "iferr@0.1.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "infer-owner@1.0.4",
+                  "pkgId": "infer-owner@1.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                  ],
+                  "nodeId": "read-cmd-shim@1.0.5",
+                  "pkgId": "read-cmd-shim@1.0.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "slide@1.1.6",
+                  "pkgId": "slide@1.1.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "cmd-shim@3.0.3",
+                    },
+                    Object {
+                      "nodeId": "fs-vacuum@1.2.10",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "infer-owner@1.0.4",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "read-cmd-shim@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                  ],
+                  "nodeId": "gentle-fs@2.3.0",
+                  "pkgId": "gentle-fs@2.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-normalize-package-bin@1.0.1",
+                  "pkgId": "npm-normalize-package-bin@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                  ],
+                  "nodeId": "write-file-atomic@2.4.3",
+                  "pkgId": "write-file-atomic@2.4.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.5",
+                    },
+                    Object {
+                      "nodeId": "cmd-shim@3.0.3",
+                    },
+                    Object {
+                      "nodeId": "gentle-fs@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "npm-normalize-package-bin@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.4.3",
+                    },
+                  ],
+                  "nodeId": "bin-links@1.1.7",
+                  "pkgId": "bin-links@1.1.7",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "byte-size@5.0.1",
+                  "pkgId": "byte-size@5.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "figgy-pudding@3.5.1",
+                  "pkgId": "figgy-pudding@3.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "yallist@3.0.3",
+                  "pkgId": "yallist@3.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "yallist@3.0.3",
+                    },
+                  ],
+                  "nodeId": "lru-cache@5.1.1",
+                  "pkgId": "lru-cache@5.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "buffer-from@1.0.0",
+                  "pkgId": "buffer-from@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "process-nextick-args@2.0.0",
+                  "pkgId": "process-nextick-args@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "safe-buffer@5.1.2",
+                  "pkgId": "safe-buffer@5.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "string_decoder@1.1.1",
+                  "pkgId": "string_decoder@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "isarray@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "process-nextick-args@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "string_decoder@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "util-deprecate@1.0.2",
+                    },
+                  ],
+                  "nodeId": "readable-stream@2.3.6",
+                  "pkgId": "readable-stream@2.3.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "typedarray@0.0.6",
+                  "pkgId": "typedarray@0.0.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "buffer-from@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "typedarray@0.0.6",
+                    },
+                  ],
+                  "nodeId": "concat-stream@1.6.2",
+                  "pkgId": "concat-stream@1.6.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "end-of-stream@1.4.1",
+                  "pkgId": "end-of-stream@1.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stream-shift@1.0.0",
+                  "pkgId": "stream-shift@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "duplexify@3.6.0",
+                  "pkgId": "duplexify@3.6.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "flush-write-stream@1.0.3",
+                  "pkgId": "flush-write-stream@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "from2@2.3.0",
+                  "pkgId": "from2@2.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "cyclist@0.2.2",
+                  "pkgId": "cyclist@0.2.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cyclist@0.2.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "parallel-transform@1.1.0",
+                  "pkgId": "parallel-transform@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "pump@3.0.0",
+                  "pkgId": "pump@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "pump@2.0.1",
+                  "pkgId": "pump@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "duplexify@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "pump@2.0.1",
+                    },
+                  ],
+                  "nodeId": "pumpify@1.5.1",
+                  "pkgId": "pumpify@1.5.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "stream-each@1.2.2",
+                  "pkgId": "stream-each@1.2.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xtend@4.0.1",
+                  "pkgId": "xtend@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "xtend@4.0.1",
+                    },
+                  ],
+                  "nodeId": "through2@2.0.3",
+                  "pkgId": "through2@2.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "concat-stream@1.6.2",
+                    },
+                    Object {
+                      "nodeId": "duplexify@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "flush-write-stream@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "from2@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "parallel-transform@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "pump@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "pumpify@1.5.1",
+                    },
+                    Object {
+                      "nodeId": "stream-each@1.2.2",
+                    },
+                    Object {
+                      "nodeId": "through2@2.0.3",
+                    },
+                  ],
+                  "nodeId": "mississippi@3.0.0",
+                  "pkgId": "mississippi@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "fs-write-stream-atomic@1.0.10",
+                  "pkgId": "fs-write-stream-atomic@1.0.10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                  ],
+                  "nodeId": "run-queue@1.0.3",
+                  "pkgId": "run-queue@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "run-queue@1.0.3",
+                    },
+                  ],
+                  "nodeId": "copy-concurrently@1.0.5",
+                  "pkgId": "copy-concurrently@1.0.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "copy-concurrently@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "run-queue@1.0.3",
+                    },
+                  ],
+                  "nodeId": "move-concurrently@1.0.1",
+                  "pkgId": "move-concurrently@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "promise-inflight@1.0.1",
+                  "pkgId": "promise-inflight@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                  ],
+                  "nodeId": "ssri@6.0.1",
+                  "pkgId": "ssri@6.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                  ],
+                  "nodeId": "unique-slug@2.0.0",
+                  "pkgId": "unique-slug@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "unique-slug@2.0.0",
+                    },
+                  ],
+                  "nodeId": "unique-filename@1.1.1",
+                  "pkgId": "unique-filename@1.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "y18n@4.0.0",
+                  "pkgId": "y18n@4.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.5",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.6",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "infer-owner@1.0.4",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@5.1.1",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "move-concurrently@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "y18n@4.0.0",
+                    },
+                  ],
+                  "nodeId": "cacache@12.0.3",
+                  "pkgId": "cacache@12.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "call-limit@1.1.1",
+                  "pkgId": "call-limit@1.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ci-info@2.0.0",
+                  "pkgId": "ci-info@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansi-regex@2.1.1",
+                  "pkgId": "ansi-regex@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-regex@2.1.1",
+                    },
+                  ],
+                  "nodeId": "strip-ansi@3.0.1",
+                  "pkgId": "strip-ansi@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "cli-columns@3.1.2",
+                  "pkgId": "cli-columns@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "colors@1.3.3",
+                  "pkgId": "colors@1.3.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "object-assign@4.1.1",
+                  "pkgId": "object-assign@4.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "colors@1.3.3",
+                    },
+                    Object {
+                      "nodeId": "object-assign@4.1.1",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "cli-table3@0.5.1",
+                  "pkgId": "cli-table3@0.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "clone@1.0.4",
+                  "pkgId": "clone@1.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "clone@1.0.4",
+                    },
+                  ],
+                  "nodeId": "defaults@1.0.3",
+                  "pkgId": "defaults@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "defaults@1.0.3",
+                    },
+                  ],
+                  "nodeId": "wcwidth@1.0.1",
+                  "pkgId": "wcwidth@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "wcwidth@1.0.1",
+                    },
+                  ],
+                  "nodeId": "columnify@1.5.4",
+                  "pkgId": "columnify@1.5.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "proto-list@1.2.4",
+                  "pkgId": "proto-list@1.2.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "proto-list@1.2.4",
+                    },
+                  ],
+                  "nodeId": "config-chain@1.1.12",
+                  "pkgId": "config-chain@1.1.12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "detect-indent@5.0.0",
+                  "pkgId": "detect-indent@5.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "detect-newline@2.1.0",
+                  "pkgId": "detect-newline@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "asap@2.0.6",
+                  "pkgId": "asap@2.0.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asap@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "dezalgo@1.0.3",
+                  "pkgId": "dezalgo@1.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "editor@1.0.0",
+                  "pkgId": "editor@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "find-npm-prefix@1.0.2",
+                  "pkgId": "find-npm-prefix@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-unicode@2.0.1",
+                  "pkgId": "has-unicode@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "hosted-git-info@2.8.8",
+                  "pkgId": "hosted-git-info@2.8.8",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "iferr@1.0.2",
+                  "pkgId": "iferr@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "os-homedir@1.0.2",
+                  "pkgId": "os-homedir@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "os-tmpdir@1.0.2",
+                  "pkgId": "os-tmpdir@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "os-homedir@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "os-tmpdir@1.0.2",
+                    },
+                  ],
+                  "nodeId": "osenv@0.1.5",
+                  "pkgId": "osenv@0.1.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "semver@5.7.1",
+                  "pkgId": "semver@5.7.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "builtins@1.0.3",
+                  "pkgId": "builtins@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "builtins@1.0.3",
+                    },
+                  ],
+                  "nodeId": "validate-npm-package-name@3.0.0",
+                  "pkgId": "validate-npm-package-name@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "hosted-git-info@2.8.8",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                  ],
+                  "nodeId": "npm-package-arg@6.1.1",
+                  "pkgId": "npm-package-arg@6.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mute-stream@0.0.7",
+                  "pkgId": "mute-stream@0.0.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mute-stream@0.0.7",
+                    },
+                  ],
+                  "nodeId": "read@1.0.7",
+                  "pkgId": "read@1.0.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                  ],
+                  "nodeId": "promzard@0.3.0",
+                  "pkgId": "promzard@0.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-parse-better-errors@1.0.2",
+                  "pkgId": "json-parse-better-errors@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-parse@1.0.6",
+                  "pkgId": "path-parse@1.0.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "path-parse@1.0.6",
+                    },
+                  ],
+                  "nodeId": "resolve@1.10.0",
+                  "pkgId": "resolve@1.10.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "spdx-exceptions@2.1.0",
+                  "pkgId": "spdx-exceptions@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "spdx-license-ids@3.0.3",
+                  "pkgId": "spdx-license-ids@3.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-exceptions@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-license-ids@3.0.3",
+                    },
+                  ],
+                  "nodeId": "spdx-expression-parse@3.0.0",
+                  "pkgId": "spdx-expression-parse@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-expression-parse@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-license-ids@3.0.3",
+                    },
+                  ],
+                  "nodeId": "spdx-correct@3.0.0",
+                  "pkgId": "spdx-correct@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-correct@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-expression-parse@3.0.0",
+                    },
+                  ],
+                  "nodeId": "validate-npm-package-license@3.0.4",
+                  "pkgId": "validate-npm-package-license@3.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "hosted-git-info@2.8.8",
+                    },
+                    Object {
+                      "nodeId": "resolve@1.10.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                  ],
+                  "nodeId": "normalize-package-data@2.5.0",
+                  "pkgId": "normalize-package-data@2.5.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.6",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "npm-normalize-package-bin@1.0.1",
+                    },
+                  ],
+                  "nodeId": "read-package-json@2.1.1",
+                  "pkgId": "read-package-json@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.6",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "promzard@0.3.0",
+                    },
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                  ],
+                  "nodeId": "init-package-json@1.10.3",
+                  "pkgId": "init-package-json@1.10.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ip-regex@2.1.0",
+                  "pkgId": "ip-regex@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ip-regex@2.1.0",
+                    },
+                  ],
+                  "nodeId": "cidr-regex@2.0.10",
+                  "pkgId": "cidr-regex@2.0.10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cidr-regex@2.0.10",
+                    },
+                  ],
+                  "nodeId": "is-cidr@3.0.0",
+                  "pkgId": "is-cidr@3.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lazy-property@1.0.0",
+                  "pkgId": "lazy-property@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                  ],
+                  "nodeId": "lock-verify@2.1.0",
+                  "pkgId": "lock-verify@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "byline@5.0.0",
+                  "pkgId": "byline@5.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "env-paths@2.2.0",
+                  "pkgId": "env-paths@2.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                  ],
+                  "nodeId": "nopt@4.0.1",
+                  "pkgId": "nopt@4.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "delegates@1.0.0",
+                  "pkgId": "delegates@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "delegates@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "are-we-there-yet@1.1.4",
+                  "pkgId": "are-we-there-yet@1.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "console-control-strings@1.1.0",
+                  "pkgId": "console-control-strings@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "code-point-at@1.1.0",
+                  "pkgId": "code-point-at@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "number-is-nan@1.0.1",
+                  "pkgId": "number-is-nan@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "number-is-nan@1.0.1",
+                    },
+                  ],
+                  "nodeId": "is-fullwidth-code-point@1.0.0",
+                  "pkgId": "is-fullwidth-code-point@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "code-point-at@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-fullwidth-code-point@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "string-width@1.0.2",
+                  "pkgId": "string-width@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                  ],
+                  "nodeId": "wide-align@1.1.2",
+                  "pkgId": "wide-align@1.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "has-unicode@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "object-assign@4.1.1",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "wide-align@1.1.2",
+                    },
+                  ],
+                  "nodeId": "gauge@2.7.4",
+                  "pkgId": "gauge@2.7.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "set-blocking@2.0.0",
+                  "pkgId": "set-blocking@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "are-we-there-yet@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "gauge@2.7.4",
+                    },
+                    Object {
+                      "nodeId": "set-blocking@2.0.0",
+                    },
+                  ],
+                  "nodeId": "npmlog@4.1.2",
+                  "pkgId": "npmlog@4.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aws-sign2@0.7.0",
+                  "pkgId": "aws-sign2@0.7.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aws4@1.8.0",
+                  "pkgId": "aws4@1.8.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "caseless@0.12.0",
+                  "pkgId": "caseless@0.12.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "delayed-stream@1.0.0",
+                  "pkgId": "delayed-stream@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "delayed-stream@1.0.0",
+                    },
+                  ],
+                  "nodeId": "combined-stream@1.0.6",
+                  "pkgId": "combined-stream@1.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "extend@3.0.2",
+                  "pkgId": "extend@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "forever-agent@0.6.1",
+                  "pkgId": "forever-agent@0.6.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "asynckit@0.4.0",
+                  "pkgId": "asynckit@0.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mime-db@1.35.0",
+                  "pkgId": "mime-db@1.35.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mime-db@1.35.0",
+                    },
+                  ],
+                  "nodeId": "mime-types@2.1.19",
+                  "pkgId": "mime-types@2.1.19",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asynckit@0.4.0",
+                    },
+                    Object {
+                      "nodeId": "combined-stream@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "mime-types@2.1.19",
+                    },
+                  ],
+                  "nodeId": "form-data@2.3.2",
+                  "pkgId": "form-data@2.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "co@4.6.0",
+                  "pkgId": "co@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fast-deep-equal@1.1.0",
+                  "pkgId": "fast-deep-equal@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fast-json-stable-stringify@2.0.0",
+                  "pkgId": "fast-json-stable-stringify@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-schema-traverse@0.3.1",
+                  "pkgId": "json-schema-traverse@0.3.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "co@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "fast-deep-equal@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "fast-json-stable-stringify@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "json-schema-traverse@0.3.1",
+                    },
+                  ],
+                  "nodeId": "ajv@5.5.2",
+                  "pkgId": "ajv@5.5.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "har-schema@2.0.0",
+                  "pkgId": "har-schema@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ajv@5.5.2",
+                    },
+                    Object {
+                      "nodeId": "har-schema@2.0.0",
+                    },
+                  ],
+                  "nodeId": "har-validator@5.1.0",
+                  "pkgId": "har-validator@5.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "assert-plus@1.0.0",
+                  "pkgId": "assert-plus@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "extsprintf@1.3.0",
+                  "pkgId": "extsprintf@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-schema@0.2.3",
+                  "pkgId": "json-schema@0.2.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "extsprintf@1.3.0",
+                    },
+                  ],
+                  "nodeId": "verror@1.10.0",
+                  "pkgId": "verror@1.10.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "extsprintf@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "json-schema@0.2.3",
+                    },
+                    Object {
+                      "nodeId": "verror@1.10.0",
+                    },
+                  ],
+                  "nodeId": "jsprim@1.4.1",
+                  "pkgId": "jsprim@1.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "safer-buffer@2.1.2",
+                  "pkgId": "safer-buffer@2.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "asn1@0.2.4",
+                  "pkgId": "asn1@0.2.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tweetnacl@0.14.5",
+                  "pkgId": "tweetnacl@0.14.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "tweetnacl@0.14.5",
+                    },
+                  ],
+                  "nodeId": "bcrypt-pbkdf@1.0.2",
+                  "pkgId": "bcrypt-pbkdf@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                  ],
+                  "nodeId": "dashdash@1.14.1",
+                  "pkgId": "dashdash@1.14.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "jsbn@0.1.1",
+                  "pkgId": "jsbn@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "jsbn@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "ecc-jsbn@0.1.2",
+                  "pkgId": "ecc-jsbn@0.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                  ],
+                  "nodeId": "getpass@0.1.7",
+                  "pkgId": "getpass@0.1.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asn1@0.2.4",
+                    },
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "bcrypt-pbkdf@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "dashdash@1.14.1",
+                    },
+                    Object {
+                      "nodeId": "ecc-jsbn@0.1.2",
+                    },
+                    Object {
+                      "nodeId": "getpass@0.1.7",
+                    },
+                    Object {
+                      "nodeId": "jsbn@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                    Object {
+                      "nodeId": "tweetnacl@0.14.5",
+                    },
+                  ],
+                  "nodeId": "sshpk@1.14.2",
+                  "pkgId": "sshpk@1.14.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "jsprim@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "sshpk@1.14.2",
+                    },
+                  ],
+                  "nodeId": "http-signature@1.2.0",
+                  "pkgId": "http-signature@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-typedarray@1.0.0",
+                  "pkgId": "is-typedarray@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isstream@0.1.2",
+                  "pkgId": "isstream@0.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-stringify-safe@5.0.1",
+                  "pkgId": "json-stringify-safe@5.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "oauth-sign@0.9.0",
+                  "pkgId": "oauth-sign@0.9.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "performance-now@2.1.0",
+                  "pkgId": "performance-now@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qs@6.5.2",
+                  "pkgId": "qs@6.5.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "psl@1.1.29",
+                  "pkgId": "psl@1.1.29",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "punycode@1.4.1",
+                  "pkgId": "punycode@1.4.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "psl@1.1.29",
+                    },
+                    Object {
+                      "nodeId": "punycode@1.4.1",
+                    },
+                  ],
+                  "nodeId": "tough-cookie@2.4.3",
+                  "pkgId": "tough-cookie@2.4.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "tunnel-agent@0.6.0",
+                  "pkgId": "tunnel-agent@0.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "uuid@3.3.3",
+                  "pkgId": "uuid@3.3.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aws-sign2@0.7.0",
+                    },
+                    Object {
+                      "nodeId": "aws4@1.8.0",
+                    },
+                    Object {
+                      "nodeId": "caseless@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "combined-stream@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "extend@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "forever-agent@0.6.1",
+                    },
+                    Object {
+                      "nodeId": "form-data@2.3.2",
+                    },
+                    Object {
+                      "nodeId": "har-validator@5.1.0",
+                    },
+                    Object {
+                      "nodeId": "http-signature@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "is-typedarray@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "isstream@0.1.2",
+                    },
+                    Object {
+                      "nodeId": "json-stringify-safe@5.0.1",
+                    },
+                    Object {
+                      "nodeId": "mime-types@2.1.19",
+                    },
+                    Object {
+                      "nodeId": "oauth-sign@0.9.0",
+                    },
+                    Object {
+                      "nodeId": "performance-now@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "qs@6.5.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "tough-cookie@2.4.3",
+                    },
+                    Object {
+                      "nodeId": "tunnel-agent@0.6.0",
+                    },
+                    Object {
+                      "nodeId": "uuid@3.3.3",
+                    },
+                  ],
+                  "nodeId": "request@2.88.0",
+                  "pkgId": "request@2.88.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@3.0.3",
+                    },
+                  ],
+                  "nodeId": "minipass@2.9.0",
+                  "pkgId": "minipass@2.9.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minipass@2.9.0",
+                    },
+                  ],
+                  "nodeId": "fs-minipass@1.2.7",
+                  "pkgId": "fs-minipass@1.2.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minipass@2.9.0",
+                    },
+                  ],
+                  "nodeId": "minizlib@1.3.3",
+                  "pkgId": "minizlib@1.3.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "chownr@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "fs-minipass@1.2.7",
+                    },
+                    Object {
+                      "nodeId": "minipass@2.9.0",
+                    },
+                    Object {
+                      "nodeId": "minizlib@1.3.3",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@3.0.3",
+                    },
+                  ],
+                  "nodeId": "tar@4.4.13",
+                  "pkgId": "tar@4.4.13",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "env-paths@2.2.0",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.6",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "nopt@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "request@2.88.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "tar@4.4.13",
+                    },
+                  ],
+                  "nodeId": "node-gyp@5.1.0",
+                  "pkgId": "node-gyp@5.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "resolve-from@4.0.0",
+                  "pkgId": "resolve-from@4.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "uid-number@0.0.6",
+                  "pkgId": "uid-number@0.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "umask@1.1.0",
+                  "pkgId": "umask@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "byline@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "node-gyp@5.1.0",
+                    },
+                    Object {
+                      "nodeId": "resolve-from@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "uid-number@0.0.6",
+                    },
+                    Object {
+                      "nodeId": "umask@1.1.0",
+                    },
+                  ],
+                  "nodeId": "npm-lifecycle@3.1.4",
+                  "pkgId": "npm-lifecycle@3.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-logical-tree@1.2.1",
+                  "pkgId": "npm-logical-tree@1.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pump@3.0.0",
+                    },
+                  ],
+                  "nodeId": "get-stream@4.1.0",
+                  "pkgId": "get-stream@4.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ms@2.1.1",
+                  "pkgId": "ms@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ms@2.1.1",
+                    },
+                  ],
+                  "nodeId": "humanize-ms@1.2.1",
+                  "pkgId": "humanize-ms@1.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "humanize-ms@1.2.1",
+                    },
+                  ],
+                  "nodeId": "agentkeepalive@3.5.2",
+                  "pkgId": "agentkeepalive@3.5.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "http-cache-semantics@3.8.1",
+                  "pkgId": "http-cache-semantics@3.8.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "es6-promise@4.2.8",
+                  "pkgId": "es6-promise@4.2.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "es6-promise@4.2.8",
+                    },
+                  ],
+                  "nodeId": "es6-promisify@5.0.0",
+                  "pkgId": "es6-promisify@5.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "es6-promisify@5.0.0",
+                    },
+                  ],
+                  "nodeId": "agent-base@4.3.0",
+                  "pkgId": "agent-base@4.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.3.0",
+                    },
+                    Object {
+                      "nodeId": "debug@3.1.0",
+                    },
+                  ],
+                  "nodeId": "http-proxy-agent@2.1.0",
+                  "pkgId": "http-proxy-agent@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.3.0",
+                    },
+                    Object {
+                      "nodeId": "debug@3.1.0",
+                    },
+                  ],
+                  "nodeId": "https-proxy-agent@2.2.4",
+                  "pkgId": "https-proxy-agent@2.2.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "iconv-lite@0.4.23",
+                  "pkgId": "iconv-lite@0.4.23",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "iconv-lite@0.4.23",
+                    },
+                  ],
+                  "nodeId": "encoding@0.1.12",
+                  "pkgId": "encoding@0.1.12",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "encoding@0.1.12",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "node-fetch-npm@2.0.2",
+                  "pkgId": "node-fetch-npm@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "err-code@1.1.2",
+                  "pkgId": "err-code@1.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "retry@0.10.1",
+                  "pkgId": "retry@0.10.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "err-code@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "retry@0.10.1",
+                    },
+                  ],
+                  "nodeId": "promise-retry@1.1.1",
+                  "pkgId": "promise-retry@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "es6-promisify@5.0.0",
+                    },
+                  ],
+                  "nodeId": "agent-base@4.2.1",
+                  "pkgId": "agent-base@4.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ip@1.1.5",
+                  "pkgId": "ip@1.1.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "smart-buffer@4.1.0",
+                  "pkgId": "smart-buffer@4.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ip@1.1.5",
+                    },
+                    Object {
+                      "nodeId": "smart-buffer@4.1.0",
+                    },
+                  ],
+                  "nodeId": "socks@2.3.3",
+                  "pkgId": "socks@2.3.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.1",
+                    },
+                    Object {
+                      "nodeId": "socks@2.3.3",
+                    },
+                  ],
+                  "nodeId": "socks-proxy-agent@4.0.2",
+                  "pkgId": "socks-proxy-agent@4.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agentkeepalive@3.5.2",
+                    },
+                    Object {
+                      "nodeId": "cacache@12.0.3",
+                    },
+                    Object {
+                      "nodeId": "http-cache-semantics@3.8.1",
+                    },
+                    Object {
+                      "nodeId": "http-proxy-agent@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "https-proxy-agent@2.2.4",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@5.1.1",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "node-fetch-npm@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "promise-retry@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "socks-proxy-agent@4.0.2",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                  ],
+                  "nodeId": "make-fetch-happen@5.0.2",
+                  "pkgId": "make-fetch-happen@5.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minimatch@3.0.4|2",
+                    },
+                  ],
+                  "nodeId": "ignore-walk@3.0.3",
+                  "pkgId": "ignore-walk@3.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "npm-normalize-package-bin@1.0.1",
+                    },
+                  ],
+                  "nodeId": "npm-bundled@1.1.1",
+                  "pkgId": "npm-bundled@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ignore-walk@3.0.3",
+                    },
+                    Object {
+                      "nodeId": "npm-bundled@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "npm-normalize-package-bin@1.0.1",
+                    },
+                  ],
+                  "nodeId": "npm-packlist@1.4.8",
+                  "pkgId": "npm-packlist@1.4.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                  ],
+                  "nodeId": "npm-pick-manifest@3.0.2",
+                  "pkgId": "npm-pick-manifest@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "safe-buffer@5.2.0",
+                  "pkgId": "safe-buffer@5.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "JSONStream@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "bluebird@3.5.5",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@5.1.1",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@5.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.2.0",
+                    },
+                  ],
+                  "nodeId": "npm-registry-fetch@4.0.3",
+                  "pkgId": "npm-registry-fetch@4.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "genfun@5.0.0",
+                  "pkgId": "genfun@5.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "genfun@5.0.0",
+                    },
+                  ],
+                  "nodeId": "protoduck@5.0.1",
+                  "pkgId": "protoduck@5.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.5",
+                    },
+                    Object {
+                      "nodeId": "cacache@12.0.3",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "get-stream@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.6",
+                    },
+                    Object {
+                      "nodeId": "infer-owner@1.0.4",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@5.1.1",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@5.0.2",
+                    },
+                    Object {
+                      "nodeId": "minimatch@3.0.4|2",
+                    },
+                    Object {
+                      "nodeId": "minipass@2.9.0",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "npm-normalize-package-bin@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "npm-packlist@1.4.8",
+                    },
+                    Object {
+                      "nodeId": "npm-pick-manifest@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "promise-retry@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "protoduck@5.0.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "tar@4.4.13",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.1",
+                    },
+                  ],
+                  "nodeId": "pacote@9.5.12",
+                  "pkgId": "pacote@9.5.12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "prr@1.0.1",
+                  "pkgId": "prr@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "prr@1.0.1",
+                    },
+                  ],
+                  "nodeId": "errno@0.1.7",
+                  "pkgId": "errno@0.1.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "errno@0.1.7",
+                    },
+                  ],
+                  "nodeId": "worker-farm@1.7.0",
+                  "pkgId": "worker-farm@1.7.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bin-links@1.1.7",
+                    },
+                    Object {
+                      "nodeId": "bluebird@3.5.5",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "find-npm-prefix@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "lock-verify@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "npm-lifecycle@3.1.4",
+                    },
+                    Object {
+                      "nodeId": "npm-logical-tree@1.2.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "pacote@9.5.12",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "worker-farm@1.7.0",
+                    },
+                  ],
+                  "nodeId": "libcipm@4.0.7",
+                  "pkgId": "libcipm@4.0.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "get-stream@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                  ],
+                  "nodeId": "libnpmaccess@3.0.2",
+                  "pkgId": "libnpmaccess@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-try@2.2.0",
+                  "pkgId": "p-try@2.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-try@2.2.0",
+                    },
+                  ],
+                  "nodeId": "p-limit@2.2.0",
+                  "pkgId": "p-limit@2.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-limit@2.2.0",
+                    },
+                  ],
+                  "nodeId": "p-locate@3.0.0",
+                  "pkgId": "p-locate@3.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-exists@3.0.0",
+                  "pkgId": "path-exists@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-locate@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "path-exists@3.0.0",
+                    },
+                  ],
+                  "nodeId": "locate-path@3.0.0",
+                  "pkgId": "locate-path@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "locate-path@3.0.0",
+                    },
+                  ],
+                  "nodeId": "find-up@3.0.0",
+                  "pkgId": "find-up@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "find-up@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                  ],
+                  "nodeId": "libnpmconfig@1.2.1",
+                  "pkgId": "libnpmconfig@1.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "get-stream@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                  ],
+                  "nodeId": "libnpmhook@5.0.3",
+                  "pkgId": "libnpmhook@5.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "get-stream@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                  ],
+                  "nodeId": "libnpmorg@1.0.1",
+                  "pkgId": "libnpmorg@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.clonedeep@4.5.0",
+                  "pkgId": "lodash.clonedeep@4.5.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "get-stream@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.clonedeep@4.5.0",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                  ],
+                  "nodeId": "libnpmpublish@1.1.2",
+                  "pkgId": "libnpmpublish@1.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "get-stream@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                  ],
+                  "nodeId": "libnpmsearch@2.0.2",
+                  "pkgId": "libnpmsearch@2.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "get-stream@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                  ],
+                  "nodeId": "libnpmteam@1.0.2",
+                  "pkgId": "libnpmteam@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                  ],
+                  "nodeId": "npm-profile@4.0.4",
+                  "pkgId": "npm-profile@4.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stringify-package@1.0.1",
+                  "pkgId": "stringify-package@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bin-links@1.1.7",
+                    },
+                    Object {
+                      "nodeId": "bluebird@3.5.5",
+                    },
+                    Object {
+                      "nodeId": "find-npm-prefix@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "libnpmaccess@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "libnpmconfig@1.2.1",
+                    },
+                    Object {
+                      "nodeId": "libnpmhook@5.0.3",
+                    },
+                    Object {
+                      "nodeId": "libnpmorg@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "libnpmpublish@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "libnpmsearch@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "libnpmteam@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "lock-verify@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-lifecycle@3.1.4",
+                    },
+                    Object {
+                      "nodeId": "npm-logical-tree@1.2.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "npm-profile@4.0.4",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "pacote@9.5.12",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "stringify-package@1.0.1",
+                    },
+                  ],
+                  "nodeId": "libnpm@3.0.1",
+                  "pkgId": "libnpm@3.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dotenv@5.0.1",
+                  "pkgId": "dotenv@5.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "color-convert@1.9.1",
+                    },
+                  ],
+                  "nodeId": "ansi-styles@3.2.1",
+                  "pkgId": "ansi-styles@3.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "has-flag@3.0.0",
+                    },
+                  ],
+                  "nodeId": "supports-color@5.4.0",
+                  "pkgId": "supports-color@5.4.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-styles@3.2.1",
+                    },
+                    Object {
+                      "nodeId": "escape-string-regexp@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "supports-color@5.4.0",
+                    },
+                  ],
+                  "nodeId": "chalk@2.4.1",
+                  "pkgId": "chalk@2.4.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pseudomap@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@2.1.2",
+                    },
+                  ],
+                  "nodeId": "lru-cache@4.1.5",
+                  "pkgId": "lru-cache@4.1.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "widest-line@2.0.1",
+                  "pkgId": "widest-line@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pify@3.0.0",
+                    },
+                  ],
+                  "nodeId": "make-dir@1.3.0",
+                  "pkgId": "make-dir@1.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "dot-prop@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "make-dir@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "unique-string@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.4.3",
+                    },
+                    Object {
+                      "nodeId": "xdg-basedir@3.0.0",
+                    },
+                  ],
+                  "nodeId": "configstore@3.1.2",
+                  "pkgId": "configstore@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ci-info@1.6.0",
+                  "pkgId": "ci-info@1.6.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ci-info@1.6.0",
+                    },
+                  ],
+                  "nodeId": "is-ci@1.2.1",
+                  "pkgId": "is-ci@1.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-retry-allowed@1.2.0",
+                  "pkgId": "is-retry-allowed@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lowercase-keys@1.0.1",
+                  "pkgId": "lowercase-keys@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "deep-extend@0.6.0",
+                  "pkgId": "deep-extend@0.6.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "deep-extend@0.6.0",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "minimist@1.2.5",
+                    },
+                    Object {
+                      "nodeId": "strip-json-comments@2.0.1",
+                    },
+                  ],
+                  "nodeId": "rc@1.2.8",
+                  "pkgId": "rc@1.2.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "rc@1.2.8",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "registry-auth-token@3.4.0",
+                  "pkgId": "registry-auth-token@3.4.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "boxen@1.3.0|2",
+                    },
+                    Object {
+                      "nodeId": "chalk@2.4.1",
+                    },
+                    Object {
+                      "nodeId": "configstore@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "import-lazy@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-ci@1.2.1",
+                    },
+                    Object {
+                      "nodeId": "is-installed-globally@0.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-npm@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "latest-version@3.1.0|2",
+                    },
+                    Object {
+                      "nodeId": "semver-diff@2.1.0|2",
+                    },
+                    Object {
+                      "nodeId": "xdg-basedir@3.0.0",
+                    },
+                  ],
+                  "nodeId": "update-notifier@2.5.0",
+                  "pkgId": "update-notifier@2.5.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "wrap-ansi@2.1.0",
+                  "pkgId": "wrap-ansi@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "wrap-ansi@2.1.0",
+                    },
+                  ],
+                  "nodeId": "cliui@4.1.0",
+                  "pkgId": "cliui@4.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "decamelize@1.2.0",
+                  "pkgId": "decamelize@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-try@1.0.0",
+                  "pkgId": "p-try@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-try@1.0.0",
+                    },
+                  ],
+                  "nodeId": "p-limit@1.2.0",
+                  "pkgId": "p-limit@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-limit@1.2.0",
+                    },
+                  ],
+                  "nodeId": "p-locate@2.0.0",
+                  "pkgId": "p-locate@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-locate@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "path-exists@3.0.0",
+                    },
+                  ],
+                  "nodeId": "locate-path@2.0.0",
+                  "pkgId": "locate-path@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "locate-path@2.0.0",
+                    },
+                  ],
+                  "nodeId": "find-up@2.1.0",
+                  "pkgId": "find-up@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "get-caller-file@1.0.3",
+                  "pkgId": "get-caller-file@1.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "nice-try@1.0.5",
+                  "pkgId": "nice-try@1.0.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "nice-try@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "path-key@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "shebang-command@1.2.0",
+                    },
+                  ],
+                  "nodeId": "cross-spawn@6.0.5",
+                  "pkgId": "cross-spawn@6.0.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cross-spawn@6.0.5",
+                    },
+                    Object {
+                      "nodeId": "get-stream@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-run-path@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "p-finally@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-eof@1.0.0",
+                    },
+                  ],
+                  "nodeId": "execa@1.0.0",
+                  "pkgId": "execa@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "invert-kv@2.0.0",
+                  "pkgId": "invert-kv@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "invert-kv@2.0.0",
+                    },
+                  ],
+                  "nodeId": "lcid@2.0.0",
+                  "pkgId": "lcid@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-defer@1.0.0",
+                  "pkgId": "p-defer@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-defer@1.0.0",
+                    },
+                  ],
+                  "nodeId": "map-age-cleaner@0.1.3",
+                  "pkgId": "map-age-cleaner@0.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mimic-fn@2.1.0",
+                  "pkgId": "mimic-fn@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-is-promise@2.1.0",
+                  "pkgId": "p-is-promise@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "map-age-cleaner@0.1.3",
+                    },
+                    Object {
+                      "nodeId": "mimic-fn@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "p-is-promise@2.1.0",
+                    },
+                  ],
+                  "nodeId": "mem@4.3.0",
+                  "pkgId": "mem@4.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "execa@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "lcid@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "mem@4.3.0",
+                    },
+                  ],
+                  "nodeId": "os-locale@3.1.0",
+                  "pkgId": "os-locale@3.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "require-directory@2.1.1",
+                  "pkgId": "require-directory@2.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "require-main-filename@1.0.1",
+                  "pkgId": "require-main-filename@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "y18n@3.2.1",
+                  "pkgId": "y18n@3.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "camelcase@4.1.0",
+                    },
+                  ],
+                  "nodeId": "yargs-parser@9.0.2",
+                  "pkgId": "yargs-parser@9.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cliui@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "decamelize@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "find-up@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "get-caller-file@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "os-locale@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "require-directory@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "require-main-filename@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "set-blocking@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "y18n@3.2.1",
+                    },
+                    Object {
+                      "nodeId": "yargs-parser@9.0.2",
+                    },
+                  ],
+                  "nodeId": "yargs@11.1.1",
+                  "pkgId": "yargs@11.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "dotenv@5.0.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "y18n@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "yargs@11.1.1",
+                    },
+                  ],
+                  "nodeId": "libnpx@10.2.2",
+                  "pkgId": "libnpx@10.2.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                  ],
+                  "nodeId": "lockfile@1.0.4",
+                  "pkgId": "lockfile@1.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._baseindexof@3.1.0",
+                  "pkgId": "lodash._baseindexof@3.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._createset@4.0.3",
+                  "pkgId": "lodash._createset@4.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._root@3.0.1",
+                  "pkgId": "lodash._root@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lodash._createset@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "lodash._root@3.0.1",
+                    },
+                  ],
+                  "nodeId": "lodash._baseuniq@4.6.0",
+                  "pkgId": "lodash._baseuniq@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._bindcallback@3.0.1",
+                  "pkgId": "lodash._bindcallback@3.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._cacheindexof@3.0.2",
+                  "pkgId": "lodash._cacheindexof@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._getnative@3.9.1",
+                  "pkgId": "lodash._getnative@3.9.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lodash._getnative@3.9.1",
+                    },
+                  ],
+                  "nodeId": "lodash._createcache@3.1.2",
+                  "pkgId": "lodash._createcache@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.restparam@3.6.1",
+                  "pkgId": "lodash.restparam@3.6.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.union@4.6.0",
+                  "pkgId": "lodash.union@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.uniq@4.5.0",
+                  "pkgId": "lodash.uniq@4.5.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.without@4.4.0",
+                  "pkgId": "lodash.without@4.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "meant@1.0.1",
+                  "pkgId": "meant@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cli-table3@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                  ],
+                  "nodeId": "npm-audit-report@1.3.2",
+                  "pkgId": "npm-audit-report@1.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-cache-filename@1.0.2",
+                  "pkgId": "npm-cache-filename@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                  ],
+                  "nodeId": "npm-install-checks@3.0.2",
+                  "pkgId": "npm-install-checks@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-user-validate@1.0.0",
+                  "pkgId": "npm-user-validate@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "opener@1.5.1",
+                  "pkgId": "opener@1.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qrcode-terminal@0.12.0",
+                  "pkgId": "qrcode-terminal@0.12.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "split-on-first@1.1.0",
+                  "pkgId": "split-on-first@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strict-uri-encode@2.0.0",
+                  "pkgId": "strict-uri-encode@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "decode-uri-component@0.2.0",
+                    },
+                    Object {
+                      "nodeId": "split-on-first@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "strict-uri-encode@2.0.0",
+                    },
+                  ],
+                  "nodeId": "query-string@6.8.2",
+                  "pkgId": "query-string@6.8.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qw@1.0.1",
+                  "pkgId": "qw@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "debuglog@1.0.1",
+                  "pkgId": "debuglog@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debuglog@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "dezalgo@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "readdir-scoped-modules@1.1.0",
+                  "pkgId": "readdir-scoped-modules@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-extend@1.0.3",
+                  "pkgId": "util-extend@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debuglog@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "readdir-scoped-modules@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "util-extend@1.0.3",
+                    },
+                  ],
+                  "nodeId": "read-installed@4.0.3",
+                  "pkgId": "read-installed@4.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "object-keys@1.0.12",
+                  "pkgId": "object-keys@1.0.12",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "object-keys@1.0.12",
+                    },
+                  ],
+                  "nodeId": "define-properties@1.1.3",
+                  "pkgId": "define-properties@1.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-callable@1.1.4",
+                  "pkgId": "is-callable@1.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-date-object@1.0.1",
+                  "pkgId": "is-date-object@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-symbols@1.0.0",
+                  "pkgId": "has-symbols@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "has-symbols@1.0.0",
+                    },
+                  ],
+                  "nodeId": "is-symbol@1.0.2",
+                  "pkgId": "is-symbol@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-callable@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "is-date-object@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "is-symbol@1.0.2",
+                    },
+                  ],
+                  "nodeId": "es-to-primitive@1.2.0",
+                  "pkgId": "es-to-primitive@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "function-bind@1.1.1",
+                  "pkgId": "function-bind@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "function-bind@1.1.1",
+                    },
+                  ],
+                  "nodeId": "has@1.0.3",
+                  "pkgId": "has@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "has@1.0.3",
+                    },
+                  ],
+                  "nodeId": "is-regex@1.0.4",
+                  "pkgId": "is-regex@1.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "es-to-primitive@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "function-bind@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "has@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "is-callable@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "is-regex@1.0.4",
+                    },
+                  ],
+                  "nodeId": "es-abstract@1.12.0",
+                  "pkgId": "es-abstract@1.12.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "define-properties@1.1.3",
+                    },
+                    Object {
+                      "nodeId": "es-abstract@1.12.0",
+                    },
+                  ],
+                  "nodeId": "object.getownpropertydescriptors@2.0.3",
+                  "pkgId": "object.getownpropertydescriptors@2.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "object.getownpropertydescriptors@2.0.3",
+                    },
+                  ],
+                  "nodeId": "util-promisify@2.1.0",
+                  "pkgId": "util-promisify@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "read-package-json@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "readdir-scoped-modules@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "util-promisify@2.1.0",
+                    },
+                  ],
+                  "nodeId": "read-package-tree@5.3.1",
+                  "pkgId": "read-package-tree@5.3.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.2.0",
+                    },
+                  ],
+                  "nodeId": "string_decoder@1.3.0",
+                  "pkgId": "string_decoder@1.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "string_decoder@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "util-deprecate@1.0.2",
+                    },
+                  ],
+                  "nodeId": "readable-stream@3.6.0",
+                  "pkgId": "readable-stream@3.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "retry@0.12.0",
+                  "pkgId": "retry@0.12.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                  ],
+                  "nodeId": "sha@3.0.0",
+                  "pkgId": "sha@3.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "sorted-object@2.0.1",
+                  "pkgId": "sorted-object@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isarray@0.0.1",
+                  "pkgId": "isarray@0.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "string_decoder@0.10.31",
+                  "pkgId": "string_decoder@0.10.31",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "isarray@0.0.1",
+                    },
+                    Object {
+                      "nodeId": "string_decoder@0.10.31",
+                    },
+                  ],
+                  "nodeId": "readable-stream@1.1.14",
+                  "pkgId": "readable-stream@1.1.14",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@1.1.14",
+                    },
+                  ],
+                  "nodeId": "from2@1.3.0",
+                  "pkgId": "from2@1.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "stream-iterate@1.2.0",
+                  "pkgId": "stream-iterate@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "from2@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "stream-iterate@1.2.0",
+                    },
+                  ],
+                  "nodeId": "sorted-union-stream@2.1.3",
+                  "pkgId": "sorted-union-stream@2.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "text-table@0.2.0",
+                  "pkgId": "text-table@0.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tiny-relative-date@1.3.0",
+                  "pkgId": "tiny-relative-date@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "unpipe@1.0.0",
+                  "pkgId": "unpipe@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "JSONStream@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "ansicolors@0.3.2",
+                    },
+                    Object {
+                      "nodeId": "ansistyles@0.1.3",
+                    },
+                    Object {
+                      "nodeId": "aproba@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "archy@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "bin-links@1.1.7",
+                    },
+                    Object {
+                      "nodeId": "bluebird@3.5.5",
+                    },
+                    Object {
+                      "nodeId": "byte-size@5.0.1",
+                    },
+                    Object {
+                      "nodeId": "cacache@12.0.3",
+                    },
+                    Object {
+                      "nodeId": "call-limit@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "ci-info@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "cli-columns@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "cli-table3@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "cmd-shim@3.0.3",
+                    },
+                    Object {
+                      "nodeId": "columnify@1.5.4",
+                    },
+                    Object {
+                      "nodeId": "config-chain@1.1.12",
+                    },
+                    Object {
+                      "nodeId": "detect-indent@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "detect-newline@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "dezalgo@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "editor@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "find-npm-prefix@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "fs-vacuum@1.2.10",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "gentle-fs@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.6",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.2.3",
+                    },
+                    Object {
+                      "nodeId": "has-unicode@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "hosted-git-info@2.8.8",
+                    },
+                    Object {
+                      "nodeId": "iferr@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "infer-owner@1.0.4",
+                    },
+                    Object {
+                      "nodeId": "inflight@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.4",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "init-package-json@1.10.3",
+                    },
+                    Object {
+                      "nodeId": "is-cidr@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "isexe@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "lazy-property@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "libcipm@4.0.7",
+                    },
+                    Object {
+                      "nodeId": "libnpm@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "libnpmaccess@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "libnpmhook@5.0.3",
+                    },
+                    Object {
+                      "nodeId": "libnpmorg@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "libnpmsearch@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "libnpmteam@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "libnpx@10.2.2",
+                    },
+                    Object {
+                      "nodeId": "lock-verify@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "lockfile@1.0.4",
+                    },
+                    Object {
+                      "nodeId": "lodash._baseindexof@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "lodash._baseuniq@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "lodash._bindcallback@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "lodash._cacheindexof@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "lodash._createcache@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "lodash.clonedeep@4.5.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.restparam@3.6.1",
+                    },
+                    Object {
+                      "nodeId": "lodash.union@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.uniq@4.5.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.without@4.4.0",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@5.1.1",
+                    },
+                    Object {
+                      "nodeId": "meant@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.4",
+                    },
+                    Object {
+                      "nodeId": "move-concurrently@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "node-gyp@5.1.0",
+                    },
+                    Object {
+                      "nodeId": "nopt@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "npm-audit-report@1.3.2",
+                    },
+                    Object {
+                      "nodeId": "npm-cache-filename@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-install-checks@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-lifecycle@3.1.4",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.1",
+                    },
+                    Object {
+                      "nodeId": "npm-packlist@1.4.8",
+                    },
+                    Object {
+                      "nodeId": "npm-pick-manifest@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-profile@4.0.4",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "npm-user-validate@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "opener@1.5.1",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "pacote@9.5.12",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "qrcode-terminal@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "query-string@6.8.2",
+                    },
+                    Object {
+                      "nodeId": "qw@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                    Object {
+                      "nodeId": "read-cmd-shim@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "read-installed@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "read-package-tree@5.3.1",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "readdir-scoped-modules@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "request@2.88.0",
+                    },
+                    Object {
+                      "nodeId": "retry@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.7.1",
+                    },
+                    Object {
+                      "nodeId": "sha@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "sorted-object@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "sorted-union-stream@2.1.3",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "stringify-package@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "tar@4.4.13",
+                    },
+                    Object {
+                      "nodeId": "text-table@0.2.0",
+                    },
+                    Object {
+                      "nodeId": "tiny-relative-date@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "uid-number@0.0.6",
+                    },
+                    Object {
+                      "nodeId": "umask@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "unpipe@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "uuid@3.3.3",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "worker-farm@1.7.0",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.4.3",
+                    },
+                  ],
+                  "nodeId": "npm@6.14.4",
+                  "pkgId": "npm@6.14.4",
+                },
+              ],
+              "rootNodeId": "root-node",
+            },
+            "pkgManager": Object {
+              "name": "npm",
+            },
+            "pkgs": Array [
+              Object {
+                "id": "lib@",
+                "info": Object {
+                  "name": "lib",
+                  "version": undefined,
+                },
+              },
+              Object {
+                "id": "arr-diff@4.0.0",
+                "info": Object {
+                  "name": "arr-diff",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "array-unique@0.3.2",
+                "info": Object {
+                  "name": "array-unique",
+                  "version": "0.3.2",
+                },
+              },
+              Object {
+                "id": "arr-flatten@1.1.0",
+                "info": Object {
+                  "name": "arr-flatten",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "is-extendable@0.1.1",
+                "info": Object {
+                  "name": "is-extendable",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "extend-shallow@2.0.1",
+                "info": Object {
+                  "name": "extend-shallow",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "is-buffer@1.1.6",
+                "info": Object {
+                  "name": "is-buffer",
+                  "version": "1.1.6",
+                },
+              },
+              Object {
+                "id": "kind-of@3.2.2",
+                "info": Object {
+                  "name": "kind-of",
+                  "version": "3.2.2",
+                },
+              },
+              Object {
+                "id": "is-number@3.0.0",
+                "info": Object {
+                  "name": "is-number",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "repeat-string@1.6.1",
+                "info": Object {
+                  "name": "repeat-string",
+                  "version": "1.6.1",
+                },
+              },
+              Object {
+                "id": "to-regex-range@2.1.1",
+                "info": Object {
+                  "name": "to-regex-range",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "fill-range@4.0.0",
+                "info": Object {
+                  "name": "fill-range",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "isobject@3.0.1",
+                "info": Object {
+                  "name": "isobject",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "repeat-element@1.1.2",
+                "info": Object {
+                  "name": "repeat-element",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "object-visit@1.0.1",
+                "info": Object {
+                  "name": "object-visit",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "map-visit@1.0.0",
+                "info": Object {
+                  "name": "map-visit",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "collection-visit@1.0.0",
+                "info": Object {
+                  "name": "collection-visit",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "component-emitter@1.2.1",
+                "info": Object {
+                  "name": "component-emitter",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "get-value@2.0.6",
+                "info": Object {
+                  "name": "get-value",
+                  "version": "2.0.6",
+                },
+              },
+              Object {
+                "id": "kind-of@4.0.0",
+                "info": Object {
+                  "name": "kind-of",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "has-values@1.0.0",
+                "info": Object {
+                  "name": "has-values",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "has-value@1.0.0",
+                "info": Object {
+                  "name": "has-value",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "is-plain-object@2.0.4",
+                "info": Object {
+                  "name": "is-plain-object",
+                  "version": "2.0.4",
+                },
+              },
+              Object {
+                "id": "assign-symbols@1.0.0",
+                "info": Object {
+                  "name": "assign-symbols",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "is-extendable@1.0.1",
+                "info": Object {
+                  "name": "is-extendable",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "extend-shallow@3.0.2",
+                "info": Object {
+                  "name": "extend-shallow",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "split-string@3.1.0",
+                "info": Object {
+                  "name": "split-string",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "set-value@2.0.0",
+                "info": Object {
+                  "name": "set-value",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "to-object-path@0.3.0",
+                "info": Object {
+                  "name": "to-object-path",
+                  "version": "0.3.0",
+                },
+              },
+              Object {
+                "id": "arr-union@3.1.0",
+                "info": Object {
+                  "name": "arr-union",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "set-value@0.4.3",
+                "info": Object {
+                  "name": "set-value",
+                  "version": "0.4.3",
+                },
+              },
+              Object {
+                "id": "union-value@1.0.0",
+                "info": Object {
+                  "name": "union-value",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "has-values@0.1.4",
+                "info": Object {
+                  "name": "has-values",
+                  "version": "0.1.4",
+                },
+              },
+              Object {
+                "id": "isarray@1.0.0",
+                "info": Object {
+                  "name": "isarray",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "isobject@2.1.0",
+                "info": Object {
+                  "name": "isobject",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "has-value@0.3.1",
+                "info": Object {
+                  "name": "has-value",
+                  "version": "0.3.1",
+                },
+              },
+              Object {
+                "id": "unset-value@1.0.0",
+                "info": Object {
+                  "name": "unset-value",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "cache-base@1.0.1",
+                "info": Object {
+                  "name": "cache-base",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-accessor-descriptor@0.1.6",
+                "info": Object {
+                  "name": "is-accessor-descriptor",
+                  "version": "0.1.6",
+                },
+              },
+              Object {
+                "id": "is-data-descriptor@0.1.4",
+                "info": Object {
+                  "name": "is-data-descriptor",
+                  "version": "0.1.4",
+                },
+              },
+              Object {
+                "id": "kind-of@5.1.0",
+                "info": Object {
+                  "name": "kind-of",
+                  "version": "5.1.0",
+                },
+              },
+              Object {
+                "id": "is-descriptor@0.1.6",
+                "info": Object {
+                  "name": "is-descriptor",
+                  "version": "0.1.6",
+                },
+              },
+              Object {
+                "id": "define-property@0.2.5",
+                "info": Object {
+                  "name": "define-property",
+                  "version": "0.2.5",
+                },
+              },
+              Object {
+                "id": "copy-descriptor@0.1.1",
+                "info": Object {
+                  "name": "copy-descriptor",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "object-copy@0.1.0",
+                "info": Object {
+                  "name": "object-copy",
+                  "version": "0.1.0",
+                },
+              },
+              Object {
+                "id": "static-extend@0.1.2",
+                "info": Object {
+                  "name": "static-extend",
+                  "version": "0.1.2",
+                },
+              },
+              Object {
+                "id": "class-utils@0.3.6",
+                "info": Object {
+                  "name": "class-utils",
+                  "version": "0.3.6",
+                },
+              },
+              Object {
+                "id": "kind-of@6.0.2",
+                "info": Object {
+                  "name": "kind-of",
+                  "version": "6.0.2",
+                },
+              },
+              Object {
+                "id": "is-accessor-descriptor@1.0.0",
+                "info": Object {
+                  "name": "is-accessor-descriptor",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "is-data-descriptor@1.0.0",
+                "info": Object {
+                  "name": "is-data-descriptor",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "is-descriptor@1.0.2",
+                "info": Object {
+                  "name": "is-descriptor",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "define-property@1.0.0",
+                "info": Object {
+                  "name": "define-property",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "for-in@1.0.2",
+                "info": Object {
+                  "name": "for-in",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "mixin-deep@1.3.1",
+                "info": Object {
+                  "name": "mixin-deep",
+                  "version": "1.3.1",
+                },
+              },
+              Object {
+                "id": "pascalcase@0.1.1",
+                "info": Object {
+                  "name": "pascalcase",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "base@0.11.2",
+                "info": Object {
+                  "name": "base",
+                  "version": "0.11.2",
+                },
+              },
+              Object {
+                "id": "ms@2.0.0",
+                "info": Object {
+                  "name": "ms",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "debug@2.6.9",
+                "info": Object {
+                  "name": "debug",
+                  "version": "2.6.9",
+                },
+              },
+              Object {
+                "id": "map-cache@0.2.2",
+                "info": Object {
+                  "name": "map-cache",
+                  "version": "0.2.2",
+                },
+              },
+              Object {
+                "id": "source-map@0.5.7",
+                "info": Object {
+                  "name": "source-map",
+                  "version": "0.5.7",
+                },
+              },
+              Object {
+                "id": "atob@2.1.1",
+                "info": Object {
+                  "name": "atob",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "decode-uri-component@0.2.0",
+                "info": Object {
+                  "name": "decode-uri-component",
+                  "version": "0.2.0",
+                },
+              },
+              Object {
+                "id": "resolve-url@0.2.1",
+                "info": Object {
+                  "name": "resolve-url",
+                  "version": "0.2.1",
+                },
+              },
+              Object {
+                "id": "source-map-url@0.4.0",
+                "info": Object {
+                  "name": "source-map-url",
+                  "version": "0.4.0",
+                },
+              },
+              Object {
+                "id": "urix@0.1.0",
+                "info": Object {
+                  "name": "urix",
+                  "version": "0.1.0",
+                },
+              },
+              Object {
+                "id": "source-map-resolve@0.5.1",
+                "info": Object {
+                  "name": "source-map-resolve",
+                  "version": "0.5.1",
+                },
+              },
+              Object {
+                "id": "use@3.1.0",
+                "info": Object {
+                  "name": "use",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "snapdragon@0.8.2",
+                "info": Object {
+                  "name": "snapdragon",
+                  "version": "0.8.2",
+                },
+              },
+              Object {
+                "id": "snapdragon-util@3.0.1",
+                "info": Object {
+                  "name": "snapdragon-util",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "snapdragon-node@2.1.1",
+                "info": Object {
+                  "name": "snapdragon-node",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "define-property@2.0.2",
+                "info": Object {
+                  "name": "define-property",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "ret@0.1.15",
+                "info": Object {
+                  "name": "ret",
+                  "version": "0.1.15",
+                },
+              },
+              Object {
+                "id": "safe-regex@1.1.0",
+                "info": Object {
+                  "name": "safe-regex",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "regex-not@1.0.2",
+                "info": Object {
+                  "name": "regex-not",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "to-regex@3.0.2",
+                "info": Object {
+                  "name": "to-regex",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "braces@2.3.2",
+                "info": Object {
+                  "name": "braces",
+                  "version": "2.3.2",
+                },
+              },
+              Object {
+                "id": "posix-character-classes@0.1.1",
+                "info": Object {
+                  "name": "posix-character-classes",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "expand-brackets@2.1.4",
+                "info": Object {
+                  "name": "expand-brackets",
+                  "version": "2.1.4",
+                },
+              },
+              Object {
+                "id": "fragment-cache@0.2.1",
+                "info": Object {
+                  "name": "fragment-cache",
+                  "version": "0.2.1",
+                },
+              },
+              Object {
+                "id": "extglob@2.0.4",
+                "info": Object {
+                  "name": "extglob",
+                  "version": "2.0.4",
+                },
+              },
+              Object {
+                "id": "is-number@4.0.0",
+                "info": Object {
+                  "name": "is-number",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "is-odd@2.0.0",
+                "info": Object {
+                  "name": "is-odd",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "is-windows@1.0.2",
+                "info": Object {
+                  "name": "is-windows",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "object.pick@1.3.0",
+                "info": Object {
+                  "name": "object.pick",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "nanomatch@1.2.9",
+                "info": Object {
+                  "name": "nanomatch",
+                  "version": "1.2.9",
+                },
+              },
+              Object {
+                "id": "micromatch@3.1.10",
+                "info": Object {
+                  "name": "micromatch",
+                  "version": "3.1.10",
+                },
+              },
+              Object {
+                "id": "remove-trailing-separator@1.1.0",
+                "info": Object {
+                  "name": "remove-trailing-separator",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "normalize-path@2.1.1",
+                "info": Object {
+                  "name": "normalize-path",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "anymatch@2.0.0",
+                "info": Object {
+                  "name": "anymatch",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "async-each@1.0.1",
+                "info": Object {
+                  "name": "async-each",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-extglob@2.1.1",
+                "info": Object {
+                  "name": "is-extglob",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "is-glob@3.1.0",
+                "info": Object {
+                  "name": "is-glob",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "path-dirname@1.0.2",
+                "info": Object {
+                  "name": "path-dirname",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "glob-parent@3.1.0",
+                "info": Object {
+                  "name": "glob-parent",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "inherits@2.0.3",
+                "info": Object {
+                  "name": "inherits",
+                  "version": "2.0.3",
+                },
+              },
+              Object {
+                "id": "binary-extensions@1.11.0",
+                "info": Object {
+                  "name": "binary-extensions",
+                  "version": "1.11.0",
+                },
+              },
+              Object {
+                "id": "is-binary-path@1.0.1",
+                "info": Object {
+                  "name": "is-binary-path",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-glob@4.0.0",
+                "info": Object {
+                  "name": "is-glob",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "path-is-absolute@1.0.1",
+                "info": Object {
+                  "name": "path-is-absolute",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "graceful-fs@4.1.11",
+                "info": Object {
+                  "name": "graceful-fs",
+                  "version": "4.1.11",
+                },
+              },
+              Object {
+                "id": "balanced-match@1.0.0",
+                "info": Object {
+                  "name": "balanced-match",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "concat-map@0.0.1",
+                "info": Object {
+                  "name": "concat-map",
+                  "version": "0.0.1",
+                },
+              },
+              Object {
+                "id": "brace-expansion@1.1.8",
+                "info": Object {
+                  "name": "brace-expansion",
+                  "version": "1.1.8",
+                },
+              },
+              Object {
+                "id": "minimatch@3.0.4",
+                "info": Object {
+                  "name": "minimatch",
+                  "version": "3.0.4",
+                },
+              },
+              Object {
+                "id": "core-util-is@1.0.2",
+                "info": Object {
+                  "name": "core-util-is",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "process-nextick-args@1.0.7",
+                "info": Object {
+                  "name": "process-nextick-args",
+                  "version": "1.0.7",
+                },
+              },
+              Object {
+                "id": "safe-buffer@5.1.1",
+                "info": Object {
+                  "name": "safe-buffer",
+                  "version": "5.1.1",
+                },
+              },
+              Object {
+                "id": "string_decoder@1.0.3",
+                "info": Object {
+                  "name": "string_decoder",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "util-deprecate@1.0.2",
+                "info": Object {
+                  "name": "util-deprecate",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "readable-stream@2.3.3",
+                "info": Object {
+                  "name": "readable-stream",
+                  "version": "2.3.3",
+                },
+              },
+              Object {
+                "id": "set-immediate-shim@1.0.1",
+                "info": Object {
+                  "name": "set-immediate-shim",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "readdirp@2.1.0",
+                "info": Object {
+                  "name": "readdirp",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "upath@1.0.5",
+                "info": Object {
+                  "name": "upath",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "chokidar@2.0.2",
+                "info": Object {
+                  "name": "chokidar",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "debug@3.1.0",
+                "info": Object {
+                  "name": "debug",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "ignore-by-default@1.0.1",
+                "info": Object {
+                  "name": "ignore-by-default",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "isexe@2.0.0",
+                "info": Object {
+                  "name": "isexe",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "duplexer@0.1.1",
+                "info": Object {
+                  "name": "duplexer",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "from@0.1.7",
+                "info": Object {
+                  "name": "from",
+                  "version": "0.1.7",
+                },
+              },
+              Object {
+                "id": "map-stream@0.1.0",
+                "info": Object {
+                  "name": "map-stream",
+                  "version": "0.1.0",
+                },
+              },
+              Object {
+                "id": "through@2.3.8",
+                "info": Object {
+                  "name": "through",
+                  "version": "2.3.8",
+                },
+              },
+              Object {
+                "id": "pause-stream@0.0.11",
+                "info": Object {
+                  "name": "pause-stream",
+                  "version": "0.0.11",
+                },
+              },
+              Object {
+                "id": "split@0.3.3",
+                "info": Object {
+                  "name": "split",
+                  "version": "0.3.3",
+                },
+              },
+              Object {
+                "id": "stream-combiner@0.0.4",
+                "info": Object {
+                  "name": "stream-combiner",
+                  "version": "0.0.4",
+                },
+              },
+              Object {
+                "id": "event-stream@3.3.4",
+                "info": Object {
+                  "name": "event-stream",
+                  "version": "3.3.4",
+                },
+              },
+              Object {
+                "id": "ps-tree@1.1.0",
+                "info": Object {
+                  "name": "ps-tree",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "pstree.remy@1.1.0",
+                "info": Object {
+                  "name": "pstree.remy",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "semver@5.5.0",
+                "info": Object {
+                  "name": "semver",
+                  "version": "5.5.0",
+                },
+              },
+              Object {
+                "id": "has-flag@3.0.0",
+                "info": Object {
+                  "name": "has-flag",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "supports-color@5.2.0",
+                "info": Object {
+                  "name": "supports-color",
+                  "version": "5.2.0",
+                },
+              },
+              Object {
+                "id": "abbrev@1.1.1",
+                "info": Object {
+                  "name": "abbrev",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "nopt@1.0.10",
+                "info": Object {
+                  "name": "nopt",
+                  "version": "1.0.10",
+                },
+              },
+              Object {
+                "id": "touch@3.1.0",
+                "info": Object {
+                  "name": "touch",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "undefsafe@2.0.2",
+                "info": Object {
+                  "name": "undefsafe",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "is-fullwidth-code-point@2.0.0",
+                "info": Object {
+                  "name": "is-fullwidth-code-point",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "ansi-regex@3.0.0",
+                "info": Object {
+                  "name": "ansi-regex",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "strip-ansi@4.0.0",
+                "info": Object {
+                  "name": "strip-ansi",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "string-width@2.1.1",
+                "info": Object {
+                  "name": "string-width",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "ansi-align@2.0.0",
+                "info": Object {
+                  "name": "ansi-align",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "camelcase@4.1.0",
+                "info": Object {
+                  "name": "camelcase",
+                  "version": "4.1.0",
+                },
+              },
+              Object {
+                "id": "color-name@1.1.3",
+                "info": Object {
+                  "name": "color-name",
+                  "version": "1.1.3",
+                },
+              },
+              Object {
+                "id": "color-convert@1.9.1",
+                "info": Object {
+                  "name": "color-convert",
+                  "version": "1.9.1",
+                },
+              },
+              Object {
+                "id": "ansi-styles@3.2.0",
+                "info": Object {
+                  "name": "ansi-styles",
+                  "version": "3.2.0",
+                },
+              },
+              Object {
+                "id": "escape-string-regexp@1.0.5",
+                "info": Object {
+                  "name": "escape-string-regexp",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "has-flag@2.0.0",
+                "info": Object {
+                  "name": "has-flag",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "supports-color@4.5.0",
+                "info": Object {
+                  "name": "supports-color",
+                  "version": "4.5.0",
+                },
+              },
+              Object {
+                "id": "chalk@2.3.0",
+                "info": Object {
+                  "name": "chalk",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "cli-boxes@1.0.0",
+                "info": Object {
+                  "name": "cli-boxes",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "pseudomap@1.0.2",
+                "info": Object {
+                  "name": "pseudomap",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "yallist@2.1.2",
+                "info": Object {
+                  "name": "yallist",
+                  "version": "2.1.2",
+                },
+              },
+              Object {
+                "id": "lru-cache@4.1.1",
+                "info": Object {
+                  "name": "lru-cache",
+                  "version": "4.1.1",
+                },
+              },
+              Object {
+                "id": "shebang-regex@1.0.0",
+                "info": Object {
+                  "name": "shebang-regex",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "shebang-command@1.2.0",
+                "info": Object {
+                  "name": "shebang-command",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "cross-spawn@5.1.0",
+                "info": Object {
+                  "name": "cross-spawn",
+                  "version": "5.1.0",
+                },
+              },
+              Object {
+                "id": "get-stream@3.0.0",
+                "info": Object {
+                  "name": "get-stream",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "is-stream@1.1.0",
+                "info": Object {
+                  "name": "is-stream",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "path-key@2.0.1",
+                "info": Object {
+                  "name": "path-key",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "npm-run-path@2.0.2",
+                "info": Object {
+                  "name": "npm-run-path",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "p-finally@1.0.0",
+                "info": Object {
+                  "name": "p-finally",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "signal-exit@3.0.2",
+                "info": Object {
+                  "name": "signal-exit",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "strip-eof@1.0.0",
+                "info": Object {
+                  "name": "strip-eof",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "execa@0.7.0",
+                "info": Object {
+                  "name": "execa",
+                  "version": "0.7.0",
+                },
+              },
+              Object {
+                "id": "term-size@1.2.0",
+                "info": Object {
+                  "name": "term-size",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "widest-line@2.0.0",
+                "info": Object {
+                  "name": "widest-line",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "boxen@1.3.0",
+                "info": Object {
+                  "name": "boxen",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "is-obj@1.0.1",
+                "info": Object {
+                  "name": "is-obj",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "dot-prop@4.2.0",
+                "info": Object {
+                  "name": "dot-prop",
+                  "version": "4.2.0",
+                },
+              },
+              Object {
+                "id": "pify@3.0.0",
+                "info": Object {
+                  "name": "pify",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "make-dir@1.1.0",
+                "info": Object {
+                  "name": "make-dir",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "crypto-random-string@1.0.0",
+                "info": Object {
+                  "name": "crypto-random-string",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "unique-string@1.0.0",
+                "info": Object {
+                  "name": "unique-string",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "imurmurhash@0.1.4",
+                "info": Object {
+                  "name": "imurmurhash",
+                  "version": "0.1.4",
+                },
+              },
+              Object {
+                "id": "write-file-atomic@2.3.0",
+                "info": Object {
+                  "name": "write-file-atomic",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "xdg-basedir@3.0.0",
+                "info": Object {
+                  "name": "xdg-basedir",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "configstore@3.1.1",
+                "info": Object {
+                  "name": "configstore",
+                  "version": "3.1.1",
+                },
+              },
+              Object {
+                "id": "import-lazy@2.1.0",
+                "info": Object {
+                  "name": "import-lazy",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "ini@1.3.5",
+                "info": Object {
+                  "name": "ini",
+                  "version": "1.3.5",
+                },
+              },
+              Object {
+                "id": "global-dirs@0.1.1",
+                "info": Object {
+                  "name": "global-dirs",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "path-is-inside@1.0.2",
+                "info": Object {
+                  "name": "path-is-inside",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "is-path-inside@1.0.1",
+                "info": Object {
+                  "name": "is-path-inside",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-installed-globally@0.1.0",
+                "info": Object {
+                  "name": "is-installed-globally",
+                  "version": "0.1.0",
+                },
+              },
+              Object {
+                "id": "is-npm@1.0.0",
+                "info": Object {
+                  "name": "is-npm",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "capture-stack-trace@1.0.0",
+                "info": Object {
+                  "name": "capture-stack-trace",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "create-error-class@3.0.2",
+                "info": Object {
+                  "name": "create-error-class",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "duplexer3@0.1.4",
+                "info": Object {
+                  "name": "duplexer3",
+                  "version": "0.1.4",
+                },
+              },
+              Object {
+                "id": "is-redirect@1.0.0",
+                "info": Object {
+                  "name": "is-redirect",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "is-retry-allowed@1.1.0",
+                "info": Object {
+                  "name": "is-retry-allowed",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "lowercase-keys@1.0.0",
+                "info": Object {
+                  "name": "lowercase-keys",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "timed-out@4.0.1",
+                "info": Object {
+                  "name": "timed-out",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "unzip-response@2.0.1",
+                "info": Object {
+                  "name": "unzip-response",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "prepend-http@1.0.4",
+                "info": Object {
+                  "name": "prepend-http",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "url-parse-lax@1.0.0",
+                "info": Object {
+                  "name": "url-parse-lax",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "got@6.7.1",
+                "info": Object {
+                  "name": "got",
+                  "version": "6.7.1",
+                },
+              },
+              Object {
+                "id": "deep-extend@0.4.2",
+                "info": Object {
+                  "name": "deep-extend",
+                  "version": "0.4.2",
+                },
+              },
+              Object {
+                "id": "minimist@1.2.0",
+                "info": Object {
+                  "name": "minimist",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "strip-json-comments@2.0.1",
+                "info": Object {
+                  "name": "strip-json-comments",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "rc@1.2.2",
+                "info": Object {
+                  "name": "rc",
+                  "version": "1.2.2",
+                },
+              },
+              Object {
+                "id": "registry-auth-token@3.3.1",
+                "info": Object {
+                  "name": "registry-auth-token",
+                  "version": "3.3.1",
+                },
+              },
+              Object {
+                "id": "registry-url@3.1.0",
+                "info": Object {
+                  "name": "registry-url",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "package-json@4.0.1",
+                "info": Object {
+                  "name": "package-json",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "latest-version@3.1.0",
+                "info": Object {
+                  "name": "latest-version",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "semver-diff@2.1.0",
+                "info": Object {
+                  "name": "semver-diff",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "update-notifier@2.3.0",
+                "info": Object {
+                  "name": "update-notifier",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "nodemon@0.0.0-development",
+                "info": Object {
+                  "name": "nodemon",
+                  "version": "0.0.0-development",
+                },
+              },
+              Object {
+                "id": "jsonparse@1.3.1",
+                "info": Object {
+                  "name": "jsonparse",
+                  "version": "1.3.1",
+                },
+              },
+              Object {
+                "id": "JSONStream@1.3.5",
+                "info": Object {
+                  "name": "JSONStream",
+                  "version": "1.3.5",
+                },
+              },
+              Object {
+                "id": "ansicolors@0.3.2",
+                "info": Object {
+                  "name": "ansicolors",
+                  "version": "0.3.2",
+                },
+              },
+              Object {
+                "id": "ansistyles@0.1.3",
+                "info": Object {
+                  "name": "ansistyles",
+                  "version": "0.1.3",
+                },
+              },
+              Object {
+                "id": "aproba@2.0.0",
+                "info": Object {
+                  "name": "aproba",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "archy@1.0.0",
+                "info": Object {
+                  "name": "archy",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "bluebird@3.5.5",
+                "info": Object {
+                  "name": "bluebird",
+                  "version": "3.5.5",
+                },
+              },
+              Object {
+                "id": "graceful-fs@4.2.3",
+                "info": Object {
+                  "name": "graceful-fs",
+                  "version": "4.2.3",
+                },
+              },
+              Object {
+                "id": "minimist@1.2.5",
+                "info": Object {
+                  "name": "minimist",
+                  "version": "1.2.5",
+                },
+              },
+              Object {
+                "id": "mkdirp@0.5.4",
+                "info": Object {
+                  "name": "mkdirp",
+                  "version": "0.5.4",
+                },
+              },
+              Object {
+                "id": "cmd-shim@3.0.3",
+                "info": Object {
+                  "name": "cmd-shim",
+                  "version": "3.0.3",
+                },
+              },
+              Object {
+                "id": "aproba@1.2.0",
+                "info": Object {
+                  "name": "aproba",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "chownr@1.1.4",
+                "info": Object {
+                  "name": "chownr",
+                  "version": "1.1.4",
+                },
+              },
+              Object {
+                "id": "fs.realpath@1.0.0",
+                "info": Object {
+                  "name": "fs.realpath",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "wrappy@1.0.2",
+                "info": Object {
+                  "name": "wrappy",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "once@1.4.0",
+                "info": Object {
+                  "name": "once",
+                  "version": "1.4.0",
+                },
+              },
+              Object {
+                "id": "inflight@1.0.6",
+                "info": Object {
+                  "name": "inflight",
+                  "version": "1.0.6",
+                },
+              },
+              Object {
+                "id": "inherits@2.0.4",
+                "info": Object {
+                  "name": "inherits",
+                  "version": "2.0.4",
+                },
+              },
+              Object {
+                "id": "brace-expansion@1.1.11",
+                "info": Object {
+                  "name": "brace-expansion",
+                  "version": "1.1.11",
+                },
+              },
+              Object {
+                "id": "glob@7.1.6",
+                "info": Object {
+                  "name": "glob",
+                  "version": "7.1.6",
+                },
+              },
+              Object {
+                "id": "rimraf@2.7.1",
+                "info": Object {
+                  "name": "rimraf",
+                  "version": "2.7.1",
+                },
+              },
+              Object {
+                "id": "fs-vacuum@1.2.10",
+                "info": Object {
+                  "name": "fs-vacuum",
+                  "version": "1.2.10",
+                },
+              },
+              Object {
+                "id": "iferr@0.1.5",
+                "info": Object {
+                  "name": "iferr",
+                  "version": "0.1.5",
+                },
+              },
+              Object {
+                "id": "infer-owner@1.0.4",
+                "info": Object {
+                  "name": "infer-owner",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "read-cmd-shim@1.0.5",
+                "info": Object {
+                  "name": "read-cmd-shim",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "slide@1.1.6",
+                "info": Object {
+                  "name": "slide",
+                  "version": "1.1.6",
+                },
+              },
+              Object {
+                "id": "gentle-fs@2.3.0",
+                "info": Object {
+                  "name": "gentle-fs",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "npm-normalize-package-bin@1.0.1",
+                "info": Object {
+                  "name": "npm-normalize-package-bin",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "write-file-atomic@2.4.3",
+                "info": Object {
+                  "name": "write-file-atomic",
+                  "version": "2.4.3",
+                },
+              },
+              Object {
+                "id": "bin-links@1.1.7",
+                "info": Object {
+                  "name": "bin-links",
+                  "version": "1.1.7",
+                },
+              },
+              Object {
+                "id": "byte-size@5.0.1",
+                "info": Object {
+                  "name": "byte-size",
+                  "version": "5.0.1",
+                },
+              },
+              Object {
+                "id": "figgy-pudding@3.5.1",
+                "info": Object {
+                  "name": "figgy-pudding",
+                  "version": "3.5.1",
+                },
+              },
+              Object {
+                "id": "yallist@3.0.3",
+                "info": Object {
+                  "name": "yallist",
+                  "version": "3.0.3",
+                },
+              },
+              Object {
+                "id": "lru-cache@5.1.1",
+                "info": Object {
+                  "name": "lru-cache",
+                  "version": "5.1.1",
+                },
+              },
+              Object {
+                "id": "buffer-from@1.0.0",
+                "info": Object {
+                  "name": "buffer-from",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "process-nextick-args@2.0.0",
+                "info": Object {
+                  "name": "process-nextick-args",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "safe-buffer@5.1.2",
+                "info": Object {
+                  "name": "safe-buffer",
+                  "version": "5.1.2",
+                },
+              },
+              Object {
+                "id": "string_decoder@1.1.1",
+                "info": Object {
+                  "name": "string_decoder",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "readable-stream@2.3.6",
+                "info": Object {
+                  "name": "readable-stream",
+                  "version": "2.3.6",
+                },
+              },
+              Object {
+                "id": "typedarray@0.0.6",
+                "info": Object {
+                  "name": "typedarray",
+                  "version": "0.0.6",
+                },
+              },
+              Object {
+                "id": "concat-stream@1.6.2",
+                "info": Object {
+                  "name": "concat-stream",
+                  "version": "1.6.2",
+                },
+              },
+              Object {
+                "id": "end-of-stream@1.4.1",
+                "info": Object {
+                  "name": "end-of-stream",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "stream-shift@1.0.0",
+                "info": Object {
+                  "name": "stream-shift",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "duplexify@3.6.0",
+                "info": Object {
+                  "name": "duplexify",
+                  "version": "3.6.0",
+                },
+              },
+              Object {
+                "id": "flush-write-stream@1.0.3",
+                "info": Object {
+                  "name": "flush-write-stream",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "from2@2.3.0",
+                "info": Object {
+                  "name": "from2",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "cyclist@0.2.2",
+                "info": Object {
+                  "name": "cyclist",
+                  "version": "0.2.2",
+                },
+              },
+              Object {
+                "id": "parallel-transform@1.1.0",
+                "info": Object {
+                  "name": "parallel-transform",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "pump@3.0.0",
+                "info": Object {
+                  "name": "pump",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "pump@2.0.1",
+                "info": Object {
+                  "name": "pump",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "pumpify@1.5.1",
+                "info": Object {
+                  "name": "pumpify",
+                  "version": "1.5.1",
+                },
+              },
+              Object {
+                "id": "stream-each@1.2.2",
+                "info": Object {
+                  "name": "stream-each",
+                  "version": "1.2.2",
+                },
+              },
+              Object {
+                "id": "xtend@4.0.1",
+                "info": Object {
+                  "name": "xtend",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "through2@2.0.3",
+                "info": Object {
+                  "name": "through2",
+                  "version": "2.0.3",
+                },
+              },
+              Object {
+                "id": "mississippi@3.0.0",
+                "info": Object {
+                  "name": "mississippi",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "fs-write-stream-atomic@1.0.10",
+                "info": Object {
+                  "name": "fs-write-stream-atomic",
+                  "version": "1.0.10",
+                },
+              },
+              Object {
+                "id": "run-queue@1.0.3",
+                "info": Object {
+                  "name": "run-queue",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "copy-concurrently@1.0.5",
+                "info": Object {
+                  "name": "copy-concurrently",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "move-concurrently@1.0.1",
+                "info": Object {
+                  "name": "move-concurrently",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "promise-inflight@1.0.1",
+                "info": Object {
+                  "name": "promise-inflight",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "ssri@6.0.1",
+                "info": Object {
+                  "name": "ssri",
+                  "version": "6.0.1",
+                },
+              },
+              Object {
+                "id": "unique-slug@2.0.0",
+                "info": Object {
+                  "name": "unique-slug",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "unique-filename@1.1.1",
+                "info": Object {
+                  "name": "unique-filename",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "y18n@4.0.0",
+                "info": Object {
+                  "name": "y18n",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "cacache@12.0.3",
+                "info": Object {
+                  "name": "cacache",
+                  "version": "12.0.3",
+                },
+              },
+              Object {
+                "id": "call-limit@1.1.1",
+                "info": Object {
+                  "name": "call-limit",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "ci-info@2.0.0",
+                "info": Object {
+                  "name": "ci-info",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "ansi-regex@2.1.1",
+                "info": Object {
+                  "name": "ansi-regex",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "strip-ansi@3.0.1",
+                "info": Object {
+                  "name": "strip-ansi",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "cli-columns@3.1.2",
+                "info": Object {
+                  "name": "cli-columns",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "colors@1.3.3",
+                "info": Object {
+                  "name": "colors",
+                  "version": "1.3.3",
+                },
+              },
+              Object {
+                "id": "object-assign@4.1.1",
+                "info": Object {
+                  "name": "object-assign",
+                  "version": "4.1.1",
+                },
+              },
+              Object {
+                "id": "cli-table3@0.5.1",
+                "info": Object {
+                  "name": "cli-table3",
+                  "version": "0.5.1",
+                },
+              },
+              Object {
+                "id": "clone@1.0.4",
+                "info": Object {
+                  "name": "clone",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "defaults@1.0.3",
+                "info": Object {
+                  "name": "defaults",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "wcwidth@1.0.1",
+                "info": Object {
+                  "name": "wcwidth",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "columnify@1.5.4",
+                "info": Object {
+                  "name": "columnify",
+                  "version": "1.5.4",
+                },
+              },
+              Object {
+                "id": "proto-list@1.2.4",
+                "info": Object {
+                  "name": "proto-list",
+                  "version": "1.2.4",
+                },
+              },
+              Object {
+                "id": "config-chain@1.1.12",
+                "info": Object {
+                  "name": "config-chain",
+                  "version": "1.1.12",
+                },
+              },
+              Object {
+                "id": "detect-indent@5.0.0",
+                "info": Object {
+                  "name": "detect-indent",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "detect-newline@2.1.0",
+                "info": Object {
+                  "name": "detect-newline",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "asap@2.0.6",
+                "info": Object {
+                  "name": "asap",
+                  "version": "2.0.6",
+                },
+              },
+              Object {
+                "id": "dezalgo@1.0.3",
+                "info": Object {
+                  "name": "dezalgo",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "editor@1.0.0",
+                "info": Object {
+                  "name": "editor",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "find-npm-prefix@1.0.2",
+                "info": Object {
+                  "name": "find-npm-prefix",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "has-unicode@2.0.1",
+                "info": Object {
+                  "name": "has-unicode",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "hosted-git-info@2.8.8",
+                "info": Object {
+                  "name": "hosted-git-info",
+                  "version": "2.8.8",
+                },
+              },
+              Object {
+                "id": "iferr@1.0.2",
+                "info": Object {
+                  "name": "iferr",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "os-homedir@1.0.2",
+                "info": Object {
+                  "name": "os-homedir",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "os-tmpdir@1.0.2",
+                "info": Object {
+                  "name": "os-tmpdir",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "osenv@0.1.5",
+                "info": Object {
+                  "name": "osenv",
+                  "version": "0.1.5",
+                },
+              },
+              Object {
+                "id": "semver@5.7.1",
+                "info": Object {
+                  "name": "semver",
+                  "version": "5.7.1",
+                },
+              },
+              Object {
+                "id": "builtins@1.0.3",
+                "info": Object {
+                  "name": "builtins",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "validate-npm-package-name@3.0.0",
+                "info": Object {
+                  "name": "validate-npm-package-name",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "npm-package-arg@6.1.1",
+                "info": Object {
+                  "name": "npm-package-arg",
+                  "version": "6.1.1",
+                },
+              },
+              Object {
+                "id": "mute-stream@0.0.7",
+                "info": Object {
+                  "name": "mute-stream",
+                  "version": "0.0.7",
+                },
+              },
+              Object {
+                "id": "read@1.0.7",
+                "info": Object {
+                  "name": "read",
+                  "version": "1.0.7",
+                },
+              },
+              Object {
+                "id": "promzard@0.3.0",
+                "info": Object {
+                  "name": "promzard",
+                  "version": "0.3.0",
+                },
+              },
+              Object {
+                "id": "json-parse-better-errors@1.0.2",
+                "info": Object {
+                  "name": "json-parse-better-errors",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "path-parse@1.0.6",
+                "info": Object {
+                  "name": "path-parse",
+                  "version": "1.0.6",
+                },
+              },
+              Object {
+                "id": "resolve@1.10.0",
+                "info": Object {
+                  "name": "resolve",
+                  "version": "1.10.0",
+                },
+              },
+              Object {
+                "id": "spdx-exceptions@2.1.0",
+                "info": Object {
+                  "name": "spdx-exceptions",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "spdx-license-ids@3.0.3",
+                "info": Object {
+                  "name": "spdx-license-ids",
+                  "version": "3.0.3",
+                },
+              },
+              Object {
+                "id": "spdx-expression-parse@3.0.0",
+                "info": Object {
+                  "name": "spdx-expression-parse",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "spdx-correct@3.0.0",
+                "info": Object {
+                  "name": "spdx-correct",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "validate-npm-package-license@3.0.4",
+                "info": Object {
+                  "name": "validate-npm-package-license",
+                  "version": "3.0.4",
+                },
+              },
+              Object {
+                "id": "normalize-package-data@2.5.0",
+                "info": Object {
+                  "name": "normalize-package-data",
+                  "version": "2.5.0",
+                },
+              },
+              Object {
+                "id": "read-package-json@2.1.1",
+                "info": Object {
+                  "name": "read-package-json",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "init-package-json@1.10.3",
+                "info": Object {
+                  "name": "init-package-json",
+                  "version": "1.10.3",
+                },
+              },
+              Object {
+                "id": "ip-regex@2.1.0",
+                "info": Object {
+                  "name": "ip-regex",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "cidr-regex@2.0.10",
+                "info": Object {
+                  "name": "cidr-regex",
+                  "version": "2.0.10",
+                },
+              },
+              Object {
+                "id": "is-cidr@3.0.0",
+                "info": Object {
+                  "name": "is-cidr",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "lazy-property@1.0.0",
+                "info": Object {
+                  "name": "lazy-property",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "lock-verify@2.1.0",
+                "info": Object {
+                  "name": "lock-verify",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "byline@5.0.0",
+                "info": Object {
+                  "name": "byline",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "env-paths@2.2.0",
+                "info": Object {
+                  "name": "env-paths",
+                  "version": "2.2.0",
+                },
+              },
+              Object {
+                "id": "nopt@4.0.1",
+                "info": Object {
+                  "name": "nopt",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "delegates@1.0.0",
+                "info": Object {
+                  "name": "delegates",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "are-we-there-yet@1.1.4",
+                "info": Object {
+                  "name": "are-we-there-yet",
+                  "version": "1.1.4",
+                },
+              },
+              Object {
+                "id": "console-control-strings@1.1.0",
+                "info": Object {
+                  "name": "console-control-strings",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "code-point-at@1.1.0",
+                "info": Object {
+                  "name": "code-point-at",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "number-is-nan@1.0.1",
+                "info": Object {
+                  "name": "number-is-nan",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-fullwidth-code-point@1.0.0",
+                "info": Object {
+                  "name": "is-fullwidth-code-point",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "string-width@1.0.2",
+                "info": Object {
+                  "name": "string-width",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "wide-align@1.1.2",
+                "info": Object {
+                  "name": "wide-align",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "gauge@2.7.4",
+                "info": Object {
+                  "name": "gauge",
+                  "version": "2.7.4",
+                },
+              },
+              Object {
+                "id": "set-blocking@2.0.0",
+                "info": Object {
+                  "name": "set-blocking",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "npmlog@4.1.2",
+                "info": Object {
+                  "name": "npmlog",
+                  "version": "4.1.2",
+                },
+              },
+              Object {
+                "id": "aws-sign2@0.7.0",
+                "info": Object {
+                  "name": "aws-sign2",
+                  "version": "0.7.0",
+                },
+              },
+              Object {
+                "id": "aws4@1.8.0",
+                "info": Object {
+                  "name": "aws4",
+                  "version": "1.8.0",
+                },
+              },
+              Object {
+                "id": "caseless@0.12.0",
+                "info": Object {
+                  "name": "caseless",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "delayed-stream@1.0.0",
+                "info": Object {
+                  "name": "delayed-stream",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "combined-stream@1.0.6",
+                "info": Object {
+                  "name": "combined-stream",
+                  "version": "1.0.6",
+                },
+              },
+              Object {
+                "id": "extend@3.0.2",
+                "info": Object {
+                  "name": "extend",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "forever-agent@0.6.1",
+                "info": Object {
+                  "name": "forever-agent",
+                  "version": "0.6.1",
+                },
+              },
+              Object {
+                "id": "asynckit@0.4.0",
+                "info": Object {
+                  "name": "asynckit",
+                  "version": "0.4.0",
+                },
+              },
+              Object {
+                "id": "mime-db@1.35.0",
+                "info": Object {
+                  "name": "mime-db",
+                  "version": "1.35.0",
+                },
+              },
+              Object {
+                "id": "mime-types@2.1.19",
+                "info": Object {
+                  "name": "mime-types",
+                  "version": "2.1.19",
+                },
+              },
+              Object {
+                "id": "form-data@2.3.2",
+                "info": Object {
+                  "name": "form-data",
+                  "version": "2.3.2",
+                },
+              },
+              Object {
+                "id": "co@4.6.0",
+                "info": Object {
+                  "name": "co",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "fast-deep-equal@1.1.0",
+                "info": Object {
+                  "name": "fast-deep-equal",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "fast-json-stable-stringify@2.0.0",
+                "info": Object {
+                  "name": "fast-json-stable-stringify",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "json-schema-traverse@0.3.1",
+                "info": Object {
+                  "name": "json-schema-traverse",
+                  "version": "0.3.1",
+                },
+              },
+              Object {
+                "id": "ajv@5.5.2",
+                "info": Object {
+                  "name": "ajv",
+                  "version": "5.5.2",
+                },
+              },
+              Object {
+                "id": "har-schema@2.0.0",
+                "info": Object {
+                  "name": "har-schema",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "har-validator@5.1.0",
+                "info": Object {
+                  "name": "har-validator",
+                  "version": "5.1.0",
+                },
+              },
+              Object {
+                "id": "assert-plus@1.0.0",
+                "info": Object {
+                  "name": "assert-plus",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "extsprintf@1.3.0",
+                "info": Object {
+                  "name": "extsprintf",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "json-schema@0.2.3",
+                "info": Object {
+                  "name": "json-schema",
+                  "version": "0.2.3",
+                },
+              },
+              Object {
+                "id": "verror@1.10.0",
+                "info": Object {
+                  "name": "verror",
+                  "version": "1.10.0",
+                },
+              },
+              Object {
+                "id": "jsprim@1.4.1",
+                "info": Object {
+                  "name": "jsprim",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "safer-buffer@2.1.2",
+                "info": Object {
+                  "name": "safer-buffer",
+                  "version": "2.1.2",
+                },
+              },
+              Object {
+                "id": "asn1@0.2.4",
+                "info": Object {
+                  "name": "asn1",
+                  "version": "0.2.4",
+                },
+              },
+              Object {
+                "id": "tweetnacl@0.14.5",
+                "info": Object {
+                  "name": "tweetnacl",
+                  "version": "0.14.5",
+                },
+              },
+              Object {
+                "id": "bcrypt-pbkdf@1.0.2",
+                "info": Object {
+                  "name": "bcrypt-pbkdf",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "dashdash@1.14.1",
+                "info": Object {
+                  "name": "dashdash",
+                  "version": "1.14.1",
+                },
+              },
+              Object {
+                "id": "jsbn@0.1.1",
+                "info": Object {
+                  "name": "jsbn",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "ecc-jsbn@0.1.2",
+                "info": Object {
+                  "name": "ecc-jsbn",
+                  "version": "0.1.2",
+                },
+              },
+              Object {
+                "id": "getpass@0.1.7",
+                "info": Object {
+                  "name": "getpass",
+                  "version": "0.1.7",
+                },
+              },
+              Object {
+                "id": "sshpk@1.14.2",
+                "info": Object {
+                  "name": "sshpk",
+                  "version": "1.14.2",
+                },
+              },
+              Object {
+                "id": "http-signature@1.2.0",
+                "info": Object {
+                  "name": "http-signature",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "is-typedarray@1.0.0",
+                "info": Object {
+                  "name": "is-typedarray",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "isstream@0.1.2",
+                "info": Object {
+                  "name": "isstream",
+                  "version": "0.1.2",
+                },
+              },
+              Object {
+                "id": "json-stringify-safe@5.0.1",
+                "info": Object {
+                  "name": "json-stringify-safe",
+                  "version": "5.0.1",
+                },
+              },
+              Object {
+                "id": "oauth-sign@0.9.0",
+                "info": Object {
+                  "name": "oauth-sign",
+                  "version": "0.9.0",
+                },
+              },
+              Object {
+                "id": "performance-now@2.1.0",
+                "info": Object {
+                  "name": "performance-now",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "qs@6.5.2",
+                "info": Object {
+                  "name": "qs",
+                  "version": "6.5.2",
+                },
+              },
+              Object {
+                "id": "psl@1.1.29",
+                "info": Object {
+                  "name": "psl",
+                  "version": "1.1.29",
+                },
+              },
+              Object {
+                "id": "punycode@1.4.1",
+                "info": Object {
+                  "name": "punycode",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "tough-cookie@2.4.3",
+                "info": Object {
+                  "name": "tough-cookie",
+                  "version": "2.4.3",
+                },
+              },
+              Object {
+                "id": "tunnel-agent@0.6.0",
+                "info": Object {
+                  "name": "tunnel-agent",
+                  "version": "0.6.0",
+                },
+              },
+              Object {
+                "id": "uuid@3.3.3",
+                "info": Object {
+                  "name": "uuid",
+                  "version": "3.3.3",
+                },
+              },
+              Object {
+                "id": "request@2.88.0",
+                "info": Object {
+                  "name": "request",
+                  "version": "2.88.0",
+                },
+              },
+              Object {
+                "id": "minipass@2.9.0",
+                "info": Object {
+                  "name": "minipass",
+                  "version": "2.9.0",
+                },
+              },
+              Object {
+                "id": "fs-minipass@1.2.7",
+                "info": Object {
+                  "name": "fs-minipass",
+                  "version": "1.2.7",
+                },
+              },
+              Object {
+                "id": "minizlib@1.3.3",
+                "info": Object {
+                  "name": "minizlib",
+                  "version": "1.3.3",
+                },
+              },
+              Object {
+                "id": "tar@4.4.13",
+                "info": Object {
+                  "name": "tar",
+                  "version": "4.4.13",
+                },
+              },
+              Object {
+                "id": "node-gyp@5.1.0",
+                "info": Object {
+                  "name": "node-gyp",
+                  "version": "5.1.0",
+                },
+              },
+              Object {
+                "id": "resolve-from@4.0.0",
+                "info": Object {
+                  "name": "resolve-from",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "uid-number@0.0.6",
+                "info": Object {
+                  "name": "uid-number",
+                  "version": "0.0.6",
+                },
+              },
+              Object {
+                "id": "umask@1.1.0",
+                "info": Object {
+                  "name": "umask",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "npm-lifecycle@3.1.4",
+                "info": Object {
+                  "name": "npm-lifecycle",
+                  "version": "3.1.4",
+                },
+              },
+              Object {
+                "id": "npm-logical-tree@1.2.1",
+                "info": Object {
+                  "name": "npm-logical-tree",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "get-stream@4.1.0",
+                "info": Object {
+                  "name": "get-stream",
+                  "version": "4.1.0",
+                },
+              },
+              Object {
+                "id": "ms@2.1.1",
+                "info": Object {
+                  "name": "ms",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "humanize-ms@1.2.1",
+                "info": Object {
+                  "name": "humanize-ms",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "agentkeepalive@3.5.2",
+                "info": Object {
+                  "name": "agentkeepalive",
+                  "version": "3.5.2",
+                },
+              },
+              Object {
+                "id": "http-cache-semantics@3.8.1",
+                "info": Object {
+                  "name": "http-cache-semantics",
+                  "version": "3.8.1",
+                },
+              },
+              Object {
+                "id": "es6-promise@4.2.8",
+                "info": Object {
+                  "name": "es6-promise",
+                  "version": "4.2.8",
+                },
+              },
+              Object {
+                "id": "es6-promisify@5.0.0",
+                "info": Object {
+                  "name": "es6-promisify",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "agent-base@4.3.0",
+                "info": Object {
+                  "name": "agent-base",
+                  "version": "4.3.0",
+                },
+              },
+              Object {
+                "id": "http-proxy-agent@2.1.0",
+                "info": Object {
+                  "name": "http-proxy-agent",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "https-proxy-agent@2.2.4",
+                "info": Object {
+                  "name": "https-proxy-agent",
+                  "version": "2.2.4",
+                },
+              },
+              Object {
+                "id": "iconv-lite@0.4.23",
+                "info": Object {
+                  "name": "iconv-lite",
+                  "version": "0.4.23",
+                },
+              },
+              Object {
+                "id": "encoding@0.1.12",
+                "info": Object {
+                  "name": "encoding",
+                  "version": "0.1.12",
+                },
+              },
+              Object {
+                "id": "node-fetch-npm@2.0.2",
+                "info": Object {
+                  "name": "node-fetch-npm",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "err-code@1.1.2",
+                "info": Object {
+                  "name": "err-code",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "retry@0.10.1",
+                "info": Object {
+                  "name": "retry",
+                  "version": "0.10.1",
+                },
+              },
+              Object {
+                "id": "promise-retry@1.1.1",
+                "info": Object {
+                  "name": "promise-retry",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "agent-base@4.2.1",
+                "info": Object {
+                  "name": "agent-base",
+                  "version": "4.2.1",
+                },
+              },
+              Object {
+                "id": "ip@1.1.5",
+                "info": Object {
+                  "name": "ip",
+                  "version": "1.1.5",
+                },
+              },
+              Object {
+                "id": "smart-buffer@4.1.0",
+                "info": Object {
+                  "name": "smart-buffer",
+                  "version": "4.1.0",
+                },
+              },
+              Object {
+                "id": "socks@2.3.3",
+                "info": Object {
+                  "name": "socks",
+                  "version": "2.3.3",
+                },
+              },
+              Object {
+                "id": "socks-proxy-agent@4.0.2",
+                "info": Object {
+                  "name": "socks-proxy-agent",
+                  "version": "4.0.2",
+                },
+              },
+              Object {
+                "id": "make-fetch-happen@5.0.2",
+                "info": Object {
+                  "name": "make-fetch-happen",
+                  "version": "5.0.2",
+                },
+              },
+              Object {
+                "id": "ignore-walk@3.0.3",
+                "info": Object {
+                  "name": "ignore-walk",
+                  "version": "3.0.3",
+                },
+              },
+              Object {
+                "id": "npm-bundled@1.1.1",
+                "info": Object {
+                  "name": "npm-bundled",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "npm-packlist@1.4.8",
+                "info": Object {
+                  "name": "npm-packlist",
+                  "version": "1.4.8",
+                },
+              },
+              Object {
+                "id": "npm-pick-manifest@3.0.2",
+                "info": Object {
+                  "name": "npm-pick-manifest",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "safe-buffer@5.2.0",
+                "info": Object {
+                  "name": "safe-buffer",
+                  "version": "5.2.0",
+                },
+              },
+              Object {
+                "id": "npm-registry-fetch@4.0.3",
+                "info": Object {
+                  "name": "npm-registry-fetch",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "genfun@5.0.0",
+                "info": Object {
+                  "name": "genfun",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "protoduck@5.0.1",
+                "info": Object {
+                  "name": "protoduck",
+                  "version": "5.0.1",
+                },
+              },
+              Object {
+                "id": "pacote@9.5.12",
+                "info": Object {
+                  "name": "pacote",
+                  "version": "9.5.12",
+                },
+              },
+              Object {
+                "id": "prr@1.0.1",
+                "info": Object {
+                  "name": "prr",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "errno@0.1.7",
+                "info": Object {
+                  "name": "errno",
+                  "version": "0.1.7",
+                },
+              },
+              Object {
+                "id": "worker-farm@1.7.0",
+                "info": Object {
+                  "name": "worker-farm",
+                  "version": "1.7.0",
+                },
+              },
+              Object {
+                "id": "libcipm@4.0.7",
+                "info": Object {
+                  "name": "libcipm",
+                  "version": "4.0.7",
+                },
+              },
+              Object {
+                "id": "libnpmaccess@3.0.2",
+                "info": Object {
+                  "name": "libnpmaccess",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "p-try@2.2.0",
+                "info": Object {
+                  "name": "p-try",
+                  "version": "2.2.0",
+                },
+              },
+              Object {
+                "id": "p-limit@2.2.0",
+                "info": Object {
+                  "name": "p-limit",
+                  "version": "2.2.0",
+                },
+              },
+              Object {
+                "id": "p-locate@3.0.0",
+                "info": Object {
+                  "name": "p-locate",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "path-exists@3.0.0",
+                "info": Object {
+                  "name": "path-exists",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "locate-path@3.0.0",
+                "info": Object {
+                  "name": "locate-path",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "find-up@3.0.0",
+                "info": Object {
+                  "name": "find-up",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "libnpmconfig@1.2.1",
+                "info": Object {
+                  "name": "libnpmconfig",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "libnpmhook@5.0.3",
+                "info": Object {
+                  "name": "libnpmhook",
+                  "version": "5.0.3",
+                },
+              },
+              Object {
+                "id": "libnpmorg@1.0.1",
+                "info": Object {
+                  "name": "libnpmorg",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "lodash.clonedeep@4.5.0",
+                "info": Object {
+                  "name": "lodash.clonedeep",
+                  "version": "4.5.0",
+                },
+              },
+              Object {
+                "id": "libnpmpublish@1.1.2",
+                "info": Object {
+                  "name": "libnpmpublish",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "libnpmsearch@2.0.2",
+                "info": Object {
+                  "name": "libnpmsearch",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "libnpmteam@1.0.2",
+                "info": Object {
+                  "name": "libnpmteam",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "npm-profile@4.0.4",
+                "info": Object {
+                  "name": "npm-profile",
+                  "version": "4.0.4",
+                },
+              },
+              Object {
+                "id": "stringify-package@1.0.1",
+                "info": Object {
+                  "name": "stringify-package",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "libnpm@3.0.1",
+                "info": Object {
+                  "name": "libnpm",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "dotenv@5.0.1",
+                "info": Object {
+                  "name": "dotenv",
+                  "version": "5.0.1",
+                },
+              },
+              Object {
+                "id": "ansi-styles@3.2.1",
+                "info": Object {
+                  "name": "ansi-styles",
+                  "version": "3.2.1",
+                },
+              },
+              Object {
+                "id": "supports-color@5.4.0",
+                "info": Object {
+                  "name": "supports-color",
+                  "version": "5.4.0",
+                },
+              },
+              Object {
+                "id": "chalk@2.4.1",
+                "info": Object {
+                  "name": "chalk",
+                  "version": "2.4.1",
+                },
+              },
+              Object {
+                "id": "lru-cache@4.1.5",
+                "info": Object {
+                  "name": "lru-cache",
+                  "version": "4.1.5",
+                },
+              },
+              Object {
+                "id": "widest-line@2.0.1",
+                "info": Object {
+                  "name": "widest-line",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "make-dir@1.3.0",
+                "info": Object {
+                  "name": "make-dir",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "configstore@3.1.2",
+                "info": Object {
+                  "name": "configstore",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "ci-info@1.6.0",
+                "info": Object {
+                  "name": "ci-info",
+                  "version": "1.6.0",
+                },
+              },
+              Object {
+                "id": "is-ci@1.2.1",
+                "info": Object {
+                  "name": "is-ci",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "is-retry-allowed@1.2.0",
+                "info": Object {
+                  "name": "is-retry-allowed",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "lowercase-keys@1.0.1",
+                "info": Object {
+                  "name": "lowercase-keys",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "deep-extend@0.6.0",
+                "info": Object {
+                  "name": "deep-extend",
+                  "version": "0.6.0",
+                },
+              },
+              Object {
+                "id": "rc@1.2.8",
+                "info": Object {
+                  "name": "rc",
+                  "version": "1.2.8",
+                },
+              },
+              Object {
+                "id": "registry-auth-token@3.4.0",
+                "info": Object {
+                  "name": "registry-auth-token",
+                  "version": "3.4.0",
+                },
+              },
+              Object {
+                "id": "update-notifier@2.5.0",
+                "info": Object {
+                  "name": "update-notifier",
+                  "version": "2.5.0",
+                },
+              },
+              Object {
+                "id": "wrap-ansi@2.1.0",
+                "info": Object {
+                  "name": "wrap-ansi",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "cliui@4.1.0",
+                "info": Object {
+                  "name": "cliui",
+                  "version": "4.1.0",
+                },
+              },
+              Object {
+                "id": "decamelize@1.2.0",
+                "info": Object {
+                  "name": "decamelize",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "p-try@1.0.0",
+                "info": Object {
+                  "name": "p-try",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "p-limit@1.2.0",
+                "info": Object {
+                  "name": "p-limit",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "p-locate@2.0.0",
+                "info": Object {
+                  "name": "p-locate",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "locate-path@2.0.0",
+                "info": Object {
+                  "name": "locate-path",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "find-up@2.1.0",
+                "info": Object {
+                  "name": "find-up",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "get-caller-file@1.0.3",
+                "info": Object {
+                  "name": "get-caller-file",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "nice-try@1.0.5",
+                "info": Object {
+                  "name": "nice-try",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "cross-spawn@6.0.5",
+                "info": Object {
+                  "name": "cross-spawn",
+                  "version": "6.0.5",
+                },
+              },
+              Object {
+                "id": "execa@1.0.0",
+                "info": Object {
+                  "name": "execa",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "invert-kv@2.0.0",
+                "info": Object {
+                  "name": "invert-kv",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "lcid@2.0.0",
+                "info": Object {
+                  "name": "lcid",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "p-defer@1.0.0",
+                "info": Object {
+                  "name": "p-defer",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "map-age-cleaner@0.1.3",
+                "info": Object {
+                  "name": "map-age-cleaner",
+                  "version": "0.1.3",
+                },
+              },
+              Object {
+                "id": "mimic-fn@2.1.0",
+                "info": Object {
+                  "name": "mimic-fn",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "p-is-promise@2.1.0",
+                "info": Object {
+                  "name": "p-is-promise",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "mem@4.3.0",
+                "info": Object {
+                  "name": "mem",
+                  "version": "4.3.0",
+                },
+              },
+              Object {
+                "id": "os-locale@3.1.0",
+                "info": Object {
+                  "name": "os-locale",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "require-directory@2.1.1",
+                "info": Object {
+                  "name": "require-directory",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "require-main-filename@1.0.1",
+                "info": Object {
+                  "name": "require-main-filename",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "y18n@3.2.1",
+                "info": Object {
+                  "name": "y18n",
+                  "version": "3.2.1",
+                },
+              },
+              Object {
+                "id": "yargs-parser@9.0.2",
+                "info": Object {
+                  "name": "yargs-parser",
+                  "version": "9.0.2",
+                },
+              },
+              Object {
+                "id": "yargs@11.1.1",
+                "info": Object {
+                  "name": "yargs",
+                  "version": "11.1.1",
+                },
+              },
+              Object {
+                "id": "libnpx@10.2.2",
+                "info": Object {
+                  "name": "libnpx",
+                  "version": "10.2.2",
+                },
+              },
+              Object {
+                "id": "lockfile@1.0.4",
+                "info": Object {
+                  "name": "lockfile",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "lodash._baseindexof@3.1.0",
+                "info": Object {
+                  "name": "lodash._baseindexof",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "lodash._createset@4.0.3",
+                "info": Object {
+                  "name": "lodash._createset",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "lodash._root@3.0.1",
+                "info": Object {
+                  "name": "lodash._root",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "lodash._baseuniq@4.6.0",
+                "info": Object {
+                  "name": "lodash._baseuniq",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "lodash._bindcallback@3.0.1",
+                "info": Object {
+                  "name": "lodash._bindcallback",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "lodash._cacheindexof@3.0.2",
+                "info": Object {
+                  "name": "lodash._cacheindexof",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "lodash._getnative@3.9.1",
+                "info": Object {
+                  "name": "lodash._getnative",
+                  "version": "3.9.1",
+                },
+              },
+              Object {
+                "id": "lodash._createcache@3.1.2",
+                "info": Object {
+                  "name": "lodash._createcache",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "lodash.restparam@3.6.1",
+                "info": Object {
+                  "name": "lodash.restparam",
+                  "version": "3.6.1",
+                },
+              },
+              Object {
+                "id": "lodash.union@4.6.0",
+                "info": Object {
+                  "name": "lodash.union",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "lodash.uniq@4.5.0",
+                "info": Object {
+                  "name": "lodash.uniq",
+                  "version": "4.5.0",
+                },
+              },
+              Object {
+                "id": "lodash.without@4.4.0",
+                "info": Object {
+                  "name": "lodash.without",
+                  "version": "4.4.0",
+                },
+              },
+              Object {
+                "id": "meant@1.0.1",
+                "info": Object {
+                  "name": "meant",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "npm-audit-report@1.3.2",
+                "info": Object {
+                  "name": "npm-audit-report",
+                  "version": "1.3.2",
+                },
+              },
+              Object {
+                "id": "npm-cache-filename@1.0.2",
+                "info": Object {
+                  "name": "npm-cache-filename",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "npm-install-checks@3.0.2",
+                "info": Object {
+                  "name": "npm-install-checks",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "npm-user-validate@1.0.0",
+                "info": Object {
+                  "name": "npm-user-validate",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "opener@1.5.1",
+                "info": Object {
+                  "name": "opener",
+                  "version": "1.5.1",
+                },
+              },
+              Object {
+                "id": "qrcode-terminal@0.12.0",
+                "info": Object {
+                  "name": "qrcode-terminal",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "split-on-first@1.1.0",
+                "info": Object {
+                  "name": "split-on-first",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "strict-uri-encode@2.0.0",
+                "info": Object {
+                  "name": "strict-uri-encode",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "query-string@6.8.2",
+                "info": Object {
+                  "name": "query-string",
+                  "version": "6.8.2",
+                },
+              },
+              Object {
+                "id": "qw@1.0.1",
+                "info": Object {
+                  "name": "qw",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "debuglog@1.0.1",
+                "info": Object {
+                  "name": "debuglog",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "readdir-scoped-modules@1.1.0",
+                "info": Object {
+                  "name": "readdir-scoped-modules",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "util-extend@1.0.3",
+                "info": Object {
+                  "name": "util-extend",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "read-installed@4.0.3",
+                "info": Object {
+                  "name": "read-installed",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "object-keys@1.0.12",
+                "info": Object {
+                  "name": "object-keys",
+                  "version": "1.0.12",
+                },
+              },
+              Object {
+                "id": "define-properties@1.1.3",
+                "info": Object {
+                  "name": "define-properties",
+                  "version": "1.1.3",
+                },
+              },
+              Object {
+                "id": "is-callable@1.1.4",
+                "info": Object {
+                  "name": "is-callable",
+                  "version": "1.1.4",
+                },
+              },
+              Object {
+                "id": "is-date-object@1.0.1",
+                "info": Object {
+                  "name": "is-date-object",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "has-symbols@1.0.0",
+                "info": Object {
+                  "name": "has-symbols",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "is-symbol@1.0.2",
+                "info": Object {
+                  "name": "is-symbol",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "es-to-primitive@1.2.0",
+                "info": Object {
+                  "name": "es-to-primitive",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "function-bind@1.1.1",
+                "info": Object {
+                  "name": "function-bind",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "has@1.0.3",
+                "info": Object {
+                  "name": "has",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "is-regex@1.0.4",
+                "info": Object {
+                  "name": "is-regex",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "es-abstract@1.12.0",
+                "info": Object {
+                  "name": "es-abstract",
+                  "version": "1.12.0",
+                },
+              },
+              Object {
+                "id": "object.getownpropertydescriptors@2.0.3",
+                "info": Object {
+                  "name": "object.getownpropertydescriptors",
+                  "version": "2.0.3",
+                },
+              },
+              Object {
+                "id": "util-promisify@2.1.0",
+                "info": Object {
+                  "name": "util-promisify",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "read-package-tree@5.3.1",
+                "info": Object {
+                  "name": "read-package-tree",
+                  "version": "5.3.1",
+                },
+              },
+              Object {
+                "id": "string_decoder@1.3.0",
+                "info": Object {
+                  "name": "string_decoder",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "readable-stream@3.6.0",
+                "info": Object {
+                  "name": "readable-stream",
+                  "version": "3.6.0",
+                },
+              },
+              Object {
+                "id": "retry@0.12.0",
+                "info": Object {
+                  "name": "retry",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "sha@3.0.0",
+                "info": Object {
+                  "name": "sha",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "sorted-object@2.0.1",
+                "info": Object {
+                  "name": "sorted-object",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "isarray@0.0.1",
+                "info": Object {
+                  "name": "isarray",
+                  "version": "0.0.1",
+                },
+              },
+              Object {
+                "id": "string_decoder@0.10.31",
+                "info": Object {
+                  "name": "string_decoder",
+                  "version": "0.10.31",
+                },
+              },
+              Object {
+                "id": "readable-stream@1.1.14",
+                "info": Object {
+                  "name": "readable-stream",
+                  "version": "1.1.14",
+                },
+              },
+              Object {
+                "id": "from2@1.3.0",
+                "info": Object {
+                  "name": "from2",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "stream-iterate@1.2.0",
+                "info": Object {
+                  "name": "stream-iterate",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "sorted-union-stream@2.1.3",
+                "info": Object {
+                  "name": "sorted-union-stream",
+                  "version": "2.1.3",
+                },
+              },
+              Object {
+                "id": "text-table@0.2.0",
+                "info": Object {
+                  "name": "text-table",
+                  "version": "0.2.0",
+                },
+              },
+              Object {
+                "id": "tiny-relative-date@1.3.0",
+                "info": Object {
+                  "name": "tiny-relative-date",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "unpipe@1.0.0",
+                "info": Object {
+                  "name": "unpipe",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "npm@6.14.4",
+                "info": Object {
+                  "name": "npm",
+                  "version": "6.14.4",
+                },
+              },
+            ],
+            "schemaVersion": "1.3.0",
+          },
+          "type": "depGraph",
+        },
+        Object {
+          "data": "/usr/lib/node_modules",
+          "type": "testedFiles",
+        },
+        Object {
+          "data": "sha256:bd9170226033c453a1bf655548bf9f418e48b9f054bc86695acaec25934caa61",
+          "type": "imageId",
+        },
+      ],
+      "identity": Object {
+        "targetFile": "/usr/lib/node_modules",
+        "type": "npm",
+      },
+      "target": Object {
+        "image": "docker-image|registry.access.redhat.com/ubi8/nodejs-10",
+      },
+    },
   ],
 }
 `;

--- a/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
+++ b/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
@@ -511,6 +511,6874 @@ Object {
         "image": "docker-image|snykgoof/dockerhub-goof",
       },
     },
+    Object {
+      "facts": Array [
+        Object {
+          "data": Object {
+            "graph": Object {
+              "nodes": Array [
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "npm@6.5.0",
+                    },
+                  ],
+                  "nodeId": "root-node",
+                  "pkgId": "lib@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "jsonparse@1.3.1",
+                  "pkgId": "jsonparse@1.3.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "through@2.3.8",
+                  "pkgId": "through@2.3.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "jsonparse@1.3.1",
+                    },
+                    Object {
+                      "nodeId": "through@2.3.8",
+                    },
+                  ],
+                  "nodeId": "JSONStream@1.3.4",
+                  "pkgId": "JSONStream@1.3.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "abbrev@1.1.1",
+                  "pkgId": "abbrev@1.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansicolors@0.3.2",
+                  "pkgId": "ansicolors@0.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansistyles@0.1.3",
+                  "pkgId": "ansistyles@0.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aproba@1.2.0",
+                  "pkgId": "aproba@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "archy@1.0.0",
+                  "pkgId": "archy@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "bluebird@3.5.3",
+                  "pkgId": "bluebird@3.5.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "graceful-fs@4.1.15",
+                  "pkgId": "graceful-fs@4.1.15",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "minimist@0.0.8",
+                  "pkgId": "minimist@0.0.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minimist@0.0.8",
+                    },
+                  ],
+                  "nodeId": "mkdirp@0.5.1",
+                  "pkgId": "mkdirp@0.5.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                  ],
+                  "nodeId": "cmd-shim@2.0.2",
+                  "pkgId": "cmd-shim@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-is-inside@1.0.2",
+                  "pkgId": "path-is-inside@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fs.realpath@1.0.0",
+                  "pkgId": "fs.realpath@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "wrappy@1.0.2",
+                  "pkgId": "wrappy@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "once@1.4.0",
+                  "pkgId": "once@1.4.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "inflight@1.0.6",
+                  "pkgId": "inflight@1.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "inherits@2.0.3",
+                  "pkgId": "inherits@2.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "balanced-match@1.0.0",
+                  "pkgId": "balanced-match@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "concat-map@0.0.1",
+                  "pkgId": "concat-map@0.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "balanced-match@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "concat-map@0.0.1",
+                    },
+                  ],
+                  "nodeId": "brace-expansion@1.1.11",
+                  "pkgId": "brace-expansion@1.1.11",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "brace-expansion@1.1.11",
+                    },
+                  ],
+                  "nodeId": "minimatch@3.0.4",
+                  "pkgId": "minimatch@3.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-is-absolute@1.0.1",
+                  "pkgId": "path-is-absolute@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "fs.realpath@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "inflight@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "minimatch@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "path-is-absolute@1.0.1",
+                    },
+                  ],
+                  "nodeId": "glob@7.1.3",
+                  "pkgId": "glob@7.1.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                  ],
+                  "nodeId": "rimraf@2.6.2",
+                  "pkgId": "rimraf@2.6.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                  ],
+                  "nodeId": "fs-vacuum@1.2.10",
+                  "pkgId": "fs-vacuum@1.2.10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "iferr@0.1.5",
+                  "pkgId": "iferr@0.1.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                  ],
+                  "nodeId": "read-cmd-shim@1.0.1",
+                  "pkgId": "read-cmd-shim@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "slide@1.1.6",
+                  "pkgId": "slide@1.1.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "fs-vacuum@1.2.10",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "read-cmd-shim@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                  ],
+                  "nodeId": "gentle-fs@2.0.1",
+                  "pkgId": "gentle-fs@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "imurmurhash@0.1.4",
+                  "pkgId": "imurmurhash@0.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "signal-exit@3.0.2",
+                  "pkgId": "signal-exit@3.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                  ],
+                  "nodeId": "write-file-atomic@2.3.0",
+                  "pkgId": "write-file-atomic@2.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "cmd-shim@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "gentle-fs@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.3.0",
+                    },
+                  ],
+                  "nodeId": "bin-links@1.1.2",
+                  "pkgId": "bin-links@1.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "byte-size@4.0.3",
+                  "pkgId": "byte-size@4.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "chownr@1.0.1",
+                  "pkgId": "chownr@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "figgy-pudding@3.5.1",
+                  "pkgId": "figgy-pudding@3.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pseudomap@1.0.2",
+                  "pkgId": "pseudomap@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "yallist@2.1.2",
+                  "pkgId": "yallist@2.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pseudomap@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@2.1.2",
+                    },
+                  ],
+                  "nodeId": "lru-cache@4.1.3",
+                  "pkgId": "lru-cache@4.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "buffer-from@1.0.0",
+                  "pkgId": "buffer-from@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "core-util-is@1.0.2",
+                  "pkgId": "core-util-is@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isarray@1.0.0",
+                  "pkgId": "isarray@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "process-nextick-args@2.0.0",
+                  "pkgId": "process-nextick-args@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "safe-buffer@5.1.2",
+                  "pkgId": "safe-buffer@5.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "string_decoder@1.1.1",
+                  "pkgId": "string_decoder@1.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-deprecate@1.0.2",
+                  "pkgId": "util-deprecate@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "isarray@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "process-nextick-args@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "string_decoder@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "util-deprecate@1.0.2",
+                    },
+                  ],
+                  "nodeId": "readable-stream@2.3.6",
+                  "pkgId": "readable-stream@2.3.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "typedarray@0.0.6",
+                  "pkgId": "typedarray@0.0.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "buffer-from@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "typedarray@0.0.6",
+                    },
+                  ],
+                  "nodeId": "concat-stream@1.6.2",
+                  "pkgId": "concat-stream@1.6.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "end-of-stream@1.4.1",
+                  "pkgId": "end-of-stream@1.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stream-shift@1.0.0",
+                  "pkgId": "stream-shift@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "duplexify@3.6.0",
+                  "pkgId": "duplexify@3.6.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "flush-write-stream@1.0.3",
+                  "pkgId": "flush-write-stream@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "from2@2.3.0",
+                  "pkgId": "from2@2.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "cyclist@0.2.2",
+                  "pkgId": "cyclist@0.2.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cyclist@0.2.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "parallel-transform@1.1.0",
+                  "pkgId": "parallel-transform@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "pump@3.0.0",
+                  "pkgId": "pump@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "pump@2.0.1",
+                  "pkgId": "pump@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "duplexify@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "pump@2.0.1",
+                    },
+                  ],
+                  "nodeId": "pumpify@1.5.1",
+                  "pkgId": "pumpify@1.5.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "stream-each@1.2.2",
+                  "pkgId": "stream-each@1.2.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xtend@4.0.1",
+                  "pkgId": "xtend@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "xtend@4.0.1",
+                    },
+                  ],
+                  "nodeId": "through2@2.0.3",
+                  "pkgId": "through2@2.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "concat-stream@1.6.2",
+                    },
+                    Object {
+                      "nodeId": "duplexify@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "flush-write-stream@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "from2@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "parallel-transform@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "pump@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "pumpify@1.5.1",
+                    },
+                    Object {
+                      "nodeId": "stream-each@1.2.2",
+                    },
+                    Object {
+                      "nodeId": "through2@2.0.3",
+                    },
+                  ],
+                  "nodeId": "mississippi@3.0.0",
+                  "pkgId": "mississippi@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "fs-write-stream-atomic@1.0.10",
+                  "pkgId": "fs-write-stream-atomic@1.0.10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                  ],
+                  "nodeId": "run-queue@1.0.3",
+                  "pkgId": "run-queue@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "run-queue@1.0.3",
+                    },
+                  ],
+                  "nodeId": "copy-concurrently@1.0.5",
+                  "pkgId": "copy-concurrently@1.0.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "copy-concurrently@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "run-queue@1.0.3",
+                    },
+                  ],
+                  "nodeId": "move-concurrently@1.0.1",
+                  "pkgId": "move-concurrently@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "promise-inflight@1.0.1",
+                  "pkgId": "promise-inflight@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                  ],
+                  "nodeId": "ssri@6.0.1",
+                  "pkgId": "ssri@6.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                  ],
+                  "nodeId": "unique-slug@2.0.0",
+                  "pkgId": "unique-slug@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "unique-slug@2.0.0",
+                    },
+                  ],
+                  "nodeId": "unique-filename@1.1.0",
+                  "pkgId": "unique-filename@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "y18n@4.0.0",
+                  "pkgId": "y18n@4.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "move-concurrently@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "y18n@4.0.0",
+                    },
+                  ],
+                  "nodeId": "cacache@11.2.0",
+                  "pkgId": "cacache@11.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "call-limit@1.1.0",
+                  "pkgId": "call-limit@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ci-info@1.6.0",
+                  "pkgId": "ci-info@1.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-fullwidth-code-point@2.0.0",
+                  "pkgId": "is-fullwidth-code-point@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansi-regex@3.0.0",
+                  "pkgId": "ansi-regex@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-regex@3.0.0",
+                    },
+                  ],
+                  "nodeId": "strip-ansi@4.0.0",
+                  "pkgId": "strip-ansi@4.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-fullwidth-code-point@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@4.0.0",
+                    },
+                  ],
+                  "nodeId": "string-width@2.1.1",
+                  "pkgId": "string-width@2.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansi-regex@2.1.1",
+                  "pkgId": "ansi-regex@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-regex@2.1.1",
+                    },
+                  ],
+                  "nodeId": "strip-ansi@3.0.1",
+                  "pkgId": "strip-ansi@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "cli-columns@3.1.2",
+                  "pkgId": "cli-columns@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "colors@1.1.2",
+                  "pkgId": "colors@1.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "object-assign@4.1.1",
+                  "pkgId": "object-assign@4.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "colors@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "object-assign@4.1.1",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "cli-table3@0.5.0",
+                  "pkgId": "cli-table3@0.5.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "clone@1.0.4",
+                  "pkgId": "clone@1.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "clone@1.0.4",
+                    },
+                  ],
+                  "nodeId": "defaults@1.0.3",
+                  "pkgId": "defaults@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "defaults@1.0.3",
+                    },
+                  ],
+                  "nodeId": "wcwidth@1.0.1",
+                  "pkgId": "wcwidth@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "wcwidth@1.0.1",
+                    },
+                  ],
+                  "nodeId": "columnify@1.5.4",
+                  "pkgId": "columnify@1.5.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ini@1.3.5",
+                  "pkgId": "ini@1.3.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "proto-list@1.2.4",
+                  "pkgId": "proto-list@1.2.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "proto-list@1.2.4",
+                    },
+                  ],
+                  "nodeId": "config-chain@1.1.12",
+                  "pkgId": "config-chain@1.1.12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "detect-indent@5.0.0",
+                  "pkgId": "detect-indent@5.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "detect-newline@2.1.0",
+                  "pkgId": "detect-newline@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "asap@2.0.6",
+                  "pkgId": "asap@2.0.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asap@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "dezalgo@1.0.3",
+                  "pkgId": "dezalgo@1.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "editor@1.0.0",
+                  "pkgId": "editor@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "find-npm-prefix@1.0.2",
+                  "pkgId": "find-npm-prefix@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-unicode@2.0.1",
+                  "pkgId": "has-unicode@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "hosted-git-info@2.7.1",
+                  "pkgId": "hosted-git-info@2.7.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "iferr@1.0.2",
+                  "pkgId": "iferr@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "os-homedir@1.0.2",
+                  "pkgId": "os-homedir@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "os-tmpdir@1.0.2",
+                  "pkgId": "os-tmpdir@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "os-homedir@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "os-tmpdir@1.0.2",
+                    },
+                  ],
+                  "nodeId": "osenv@0.1.5",
+                  "pkgId": "osenv@0.1.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "semver@5.5.1",
+                  "pkgId": "semver@5.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "builtins@1.0.3",
+                  "pkgId": "builtins@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "builtins@1.0.3",
+                    },
+                  ],
+                  "nodeId": "validate-npm-package-name@3.0.0",
+                  "pkgId": "validate-npm-package-name@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "hosted-git-info@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                  ],
+                  "nodeId": "npm-package-arg@6.1.0",
+                  "pkgId": "npm-package-arg@6.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mute-stream@0.0.7",
+                  "pkgId": "mute-stream@0.0.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mute-stream@0.0.7",
+                    },
+                  ],
+                  "nodeId": "read@1.0.7",
+                  "pkgId": "read@1.0.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                  ],
+                  "nodeId": "promzard@0.3.0",
+                  "pkgId": "promzard@0.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-parse-better-errors@1.0.2",
+                  "pkgId": "json-parse-better-errors@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "builtin-modules@1.1.1",
+                  "pkgId": "builtin-modules@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "builtin-modules@1.1.1",
+                    },
+                  ],
+                  "nodeId": "is-builtin-module@1.0.0",
+                  "pkgId": "is-builtin-module@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "spdx-exceptions@2.1.0",
+                  "pkgId": "spdx-exceptions@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "spdx-license-ids@3.0.0",
+                  "pkgId": "spdx-license-ids@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-exceptions@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-license-ids@3.0.0",
+                    },
+                  ],
+                  "nodeId": "spdx-expression-parse@3.0.0",
+                  "pkgId": "spdx-expression-parse@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-expression-parse@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-license-ids@3.0.0",
+                    },
+                  ],
+                  "nodeId": "spdx-correct@3.0.0",
+                  "pkgId": "spdx-correct@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-correct@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-expression-parse@3.0.0",
+                    },
+                  ],
+                  "nodeId": "validate-npm-package-license@3.0.4",
+                  "pkgId": "validate-npm-package-license@3.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "hosted-git-info@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "is-builtin-module@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                  ],
+                  "nodeId": "normalize-package-data@2.4.0",
+                  "pkgId": "normalize-package-data@2.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "slash@1.0.0",
+                  "pkgId": "slash@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.4.0",
+                    },
+                    Object {
+                      "nodeId": "slash@1.0.0",
+                    },
+                  ],
+                  "nodeId": "read-package-json@2.0.13",
+                  "pkgId": "read-package-json@2.0.13",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "promzard@0.3.0",
+                    },
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                  ],
+                  "nodeId": "init-package-json@1.10.3",
+                  "pkgId": "init-package-json@1.10.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ip-regex@2.1.0",
+                  "pkgId": "ip-regex@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ip-regex@2.1.0",
+                    },
+                  ],
+                  "nodeId": "cidr-regex@2.0.9",
+                  "pkgId": "cidr-regex@2.0.9",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cidr-regex@2.0.9",
+                    },
+                  ],
+                  "nodeId": "is-cidr@2.0.6",
+                  "pkgId": "is-cidr@2.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isexe@2.0.0",
+                  "pkgId": "isexe@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lazy-property@1.0.0",
+                  "pkgId": "lazy-property@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "lock-verify@2.0.2",
+                  "pkgId": "lock-verify@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "byline@5.0.0",
+                  "pkgId": "byline@5.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                  ],
+                  "nodeId": "fstream@1.0.11",
+                  "pkgId": "fstream@1.0.11",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                  ],
+                  "nodeId": "nopt@3.0.6",
+                  "pkgId": "nopt@3.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "delegates@1.0.0",
+                  "pkgId": "delegates@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "delegates@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "are-we-there-yet@1.1.4",
+                  "pkgId": "are-we-there-yet@1.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "console-control-strings@1.1.0",
+                  "pkgId": "console-control-strings@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "code-point-at@1.1.0",
+                  "pkgId": "code-point-at@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "number-is-nan@1.0.1",
+                  "pkgId": "number-is-nan@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "number-is-nan@1.0.1",
+                    },
+                  ],
+                  "nodeId": "is-fullwidth-code-point@1.0.0",
+                  "pkgId": "is-fullwidth-code-point@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "code-point-at@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-fullwidth-code-point@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "string-width@1.0.2",
+                  "pkgId": "string-width@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                  ],
+                  "nodeId": "wide-align@1.1.2",
+                  "pkgId": "wide-align@1.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "has-unicode@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "object-assign@4.1.1",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "wide-align@1.1.2",
+                    },
+                  ],
+                  "nodeId": "gauge@2.7.4",
+                  "pkgId": "gauge@2.7.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "set-blocking@2.0.0",
+                  "pkgId": "set-blocking@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "are-we-there-yet@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "gauge@2.7.4",
+                    },
+                    Object {
+                      "nodeId": "set-blocking@2.0.0",
+                    },
+                  ],
+                  "nodeId": "npmlog@4.1.2",
+                  "pkgId": "npmlog@4.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aws-sign2@0.7.0",
+                  "pkgId": "aws-sign2@0.7.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aws4@1.8.0",
+                  "pkgId": "aws4@1.8.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "caseless@0.12.0",
+                  "pkgId": "caseless@0.12.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "delayed-stream@1.0.0",
+                  "pkgId": "delayed-stream@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "delayed-stream@1.0.0",
+                    },
+                  ],
+                  "nodeId": "combined-stream@1.0.6",
+                  "pkgId": "combined-stream@1.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "extend@3.0.2",
+                  "pkgId": "extend@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "forever-agent@0.6.1",
+                  "pkgId": "forever-agent@0.6.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "asynckit@0.4.0",
+                  "pkgId": "asynckit@0.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mime-db@1.35.0",
+                  "pkgId": "mime-db@1.35.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mime-db@1.35.0",
+                    },
+                  ],
+                  "nodeId": "mime-types@2.1.19",
+                  "pkgId": "mime-types@2.1.19",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asynckit@0.4.0",
+                    },
+                    Object {
+                      "nodeId": "combined-stream@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "mime-types@2.1.19",
+                    },
+                  ],
+                  "nodeId": "form-data@2.3.2",
+                  "pkgId": "form-data@2.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "co@4.6.0",
+                  "pkgId": "co@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fast-deep-equal@1.1.0",
+                  "pkgId": "fast-deep-equal@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fast-json-stable-stringify@2.0.0",
+                  "pkgId": "fast-json-stable-stringify@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-schema-traverse@0.3.1",
+                  "pkgId": "json-schema-traverse@0.3.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "co@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "fast-deep-equal@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "fast-json-stable-stringify@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "json-schema-traverse@0.3.1",
+                    },
+                  ],
+                  "nodeId": "ajv@5.5.2",
+                  "pkgId": "ajv@5.5.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "har-schema@2.0.0",
+                  "pkgId": "har-schema@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ajv@5.5.2",
+                    },
+                    Object {
+                      "nodeId": "har-schema@2.0.0",
+                    },
+                  ],
+                  "nodeId": "har-validator@5.1.0",
+                  "pkgId": "har-validator@5.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "assert-plus@1.0.0",
+                  "pkgId": "assert-plus@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "extsprintf@1.3.0",
+                  "pkgId": "extsprintf@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-schema@0.2.3",
+                  "pkgId": "json-schema@0.2.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "extsprintf@1.3.0",
+                    },
+                  ],
+                  "nodeId": "verror@1.10.0",
+                  "pkgId": "verror@1.10.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "extsprintf@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "json-schema@0.2.3",
+                    },
+                    Object {
+                      "nodeId": "verror@1.10.0",
+                    },
+                  ],
+                  "nodeId": "jsprim@1.4.1",
+                  "pkgId": "jsprim@1.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "safer-buffer@2.1.2",
+                  "pkgId": "safer-buffer@2.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "asn1@0.2.4",
+                  "pkgId": "asn1@0.2.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tweetnacl@0.14.5",
+                  "pkgId": "tweetnacl@0.14.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "tweetnacl@0.14.5",
+                    },
+                  ],
+                  "nodeId": "bcrypt-pbkdf@1.0.2",
+                  "pkgId": "bcrypt-pbkdf@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                  ],
+                  "nodeId": "dashdash@1.14.1",
+                  "pkgId": "dashdash@1.14.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "jsbn@0.1.1",
+                  "pkgId": "jsbn@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "jsbn@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "ecc-jsbn@0.1.2",
+                  "pkgId": "ecc-jsbn@0.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                  ],
+                  "nodeId": "getpass@0.1.7",
+                  "pkgId": "getpass@0.1.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asn1@0.2.4",
+                    },
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "bcrypt-pbkdf@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "dashdash@1.14.1",
+                    },
+                    Object {
+                      "nodeId": "ecc-jsbn@0.1.2",
+                    },
+                    Object {
+                      "nodeId": "getpass@0.1.7",
+                    },
+                    Object {
+                      "nodeId": "jsbn@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                    Object {
+                      "nodeId": "tweetnacl@0.14.5",
+                    },
+                  ],
+                  "nodeId": "sshpk@1.14.2",
+                  "pkgId": "sshpk@1.14.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "jsprim@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "sshpk@1.14.2",
+                    },
+                  ],
+                  "nodeId": "http-signature@1.2.0",
+                  "pkgId": "http-signature@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-typedarray@1.0.0",
+                  "pkgId": "is-typedarray@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isstream@0.1.2",
+                  "pkgId": "isstream@0.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-stringify-safe@5.0.1",
+                  "pkgId": "json-stringify-safe@5.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "oauth-sign@0.9.0",
+                  "pkgId": "oauth-sign@0.9.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "performance-now@2.1.0",
+                  "pkgId": "performance-now@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qs@6.5.2",
+                  "pkgId": "qs@6.5.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "psl@1.1.29",
+                  "pkgId": "psl@1.1.29",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "punycode@1.4.1",
+                  "pkgId": "punycode@1.4.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "psl@1.1.29",
+                    },
+                    Object {
+                      "nodeId": "punycode@1.4.1",
+                    },
+                  ],
+                  "nodeId": "tough-cookie@2.4.3",
+                  "pkgId": "tough-cookie@2.4.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "tunnel-agent@0.6.0",
+                  "pkgId": "tunnel-agent@0.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "uuid@3.3.2",
+                  "pkgId": "uuid@3.3.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aws-sign2@0.7.0",
+                    },
+                    Object {
+                      "nodeId": "aws4@1.8.0",
+                    },
+                    Object {
+                      "nodeId": "caseless@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "combined-stream@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "extend@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "forever-agent@0.6.1",
+                    },
+                    Object {
+                      "nodeId": "form-data@2.3.2",
+                    },
+                    Object {
+                      "nodeId": "har-validator@5.1.0",
+                    },
+                    Object {
+                      "nodeId": "http-signature@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "is-typedarray@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "isstream@0.1.2",
+                    },
+                    Object {
+                      "nodeId": "json-stringify-safe@5.0.1",
+                    },
+                    Object {
+                      "nodeId": "mime-types@2.1.19",
+                    },
+                    Object {
+                      "nodeId": "oauth-sign@0.9.0",
+                    },
+                    Object {
+                      "nodeId": "performance-now@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "qs@6.5.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "tough-cookie@2.4.3",
+                    },
+                    Object {
+                      "nodeId": "tunnel-agent@0.6.0",
+                    },
+                    Object {
+                      "nodeId": "uuid@3.3.2",
+                    },
+                  ],
+                  "nodeId": "request@2.88.0",
+                  "pkgId": "request@2.88.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "semver@5.3.0",
+                  "pkgId": "semver@5.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                  ],
+                  "nodeId": "block-stream@0.0.9",
+                  "pkgId": "block-stream@0.0.9",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "block-stream@0.0.9",
+                    },
+                    Object {
+                      "nodeId": "fstream@1.0.11",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                  ],
+                  "nodeId": "tar@2.2.1",
+                  "pkgId": "tar@2.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "fstream@1.0.11",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "nopt@3.0.6",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "request@2.88.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.3.0",
+                    },
+                    Object {
+                      "nodeId": "tar@2.2.1",
+                    },
+                  ],
+                  "nodeId": "node-gyp@3.8.0",
+                  "pkgId": "node-gyp@3.8.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "resolve-from@4.0.0",
+                  "pkgId": "resolve-from@4.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "uid-number@0.0.6",
+                  "pkgId": "uid-number@0.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "umask@1.1.0",
+                  "pkgId": "umask@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "byline@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "node-gyp@3.8.0",
+                    },
+                    Object {
+                      "nodeId": "resolve-from@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "uid-number@0.0.6",
+                    },
+                    Object {
+                      "nodeId": "umask@1.1.0",
+                    },
+                  ],
+                  "nodeId": "npm-lifecycle@2.1.0",
+                  "pkgId": "npm-lifecycle@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-logical-tree@1.2.1",
+                  "pkgId": "npm-logical-tree@1.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "get-stream@3.0.0",
+                  "pkgId": "get-stream@3.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ms@2.1.1",
+                  "pkgId": "ms@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ms@2.1.1",
+                    },
+                  ],
+                  "nodeId": "humanize-ms@1.2.1",
+                  "pkgId": "humanize-ms@1.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "humanize-ms@1.2.1",
+                    },
+                  ],
+                  "nodeId": "agentkeepalive@3.4.1",
+                  "pkgId": "agentkeepalive@3.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "http-cache-semantics@3.8.1",
+                  "pkgId": "http-cache-semantics@3.8.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "es6-promise@4.2.4",
+                  "pkgId": "es6-promise@4.2.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "es6-promise@4.2.4",
+                    },
+                  ],
+                  "nodeId": "es6-promisify@5.0.0",
+                  "pkgId": "es6-promisify@5.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "es6-promisify@5.0.0",
+                    },
+                  ],
+                  "nodeId": "agent-base@4.2.0",
+                  "pkgId": "agent-base@4.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ms@2.0.0",
+                  "pkgId": "ms@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ms@2.0.0",
+                    },
+                  ],
+                  "nodeId": "debug@3.1.0",
+                  "pkgId": "debug@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "debug@3.1.0",
+                    },
+                  ],
+                  "nodeId": "http-proxy-agent@2.1.0",
+                  "pkgId": "http-proxy-agent@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "debug@3.1.0",
+                    },
+                  ],
+                  "nodeId": "https-proxy-agent@2.2.1",
+                  "pkgId": "https-proxy-agent@2.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "iconv-lite@0.4.23",
+                  "pkgId": "iconv-lite@0.4.23",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "iconv-lite@0.4.23",
+                    },
+                  ],
+                  "nodeId": "encoding@0.1.12",
+                  "pkgId": "encoding@0.1.12",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "encoding@0.1.12",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "node-fetch-npm@2.0.2",
+                  "pkgId": "node-fetch-npm@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "err-code@1.1.2",
+                  "pkgId": "err-code@1.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "retry@0.10.1",
+                  "pkgId": "retry@0.10.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "err-code@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "retry@0.10.1",
+                    },
+                  ],
+                  "nodeId": "promise-retry@1.1.1",
+                  "pkgId": "promise-retry@1.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ip@1.1.5",
+                  "pkgId": "ip@1.1.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "smart-buffer@4.0.1",
+                  "pkgId": "smart-buffer@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ip@1.1.5",
+                    },
+                    Object {
+                      "nodeId": "smart-buffer@4.0.1",
+                    },
+                  ],
+                  "nodeId": "socks@2.2.0",
+                  "pkgId": "socks@2.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "socks@2.2.0",
+                    },
+                  ],
+                  "nodeId": "socks-proxy-agent@4.0.1",
+                  "pkgId": "socks-proxy-agent@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agentkeepalive@3.4.1",
+                    },
+                    Object {
+                      "nodeId": "cacache@11.2.0",
+                    },
+                    Object {
+                      "nodeId": "http-cache-semantics@3.8.1",
+                    },
+                    Object {
+                      "nodeId": "http-proxy-agent@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "https-proxy-agent@2.2.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "node-fetch-npm@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "promise-retry@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "socks-proxy-agent@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                  ],
+                  "nodeId": "make-fetch-happen@4.0.1",
+                  "pkgId": "make-fetch-happen@4.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "yallist@3.0.2",
+                  "pkgId": "yallist@3.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@3.0.2",
+                    },
+                  ],
+                  "nodeId": "minipass@2.3.3",
+                  "pkgId": "minipass@2.3.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minimatch@3.0.4",
+                    },
+                  ],
+                  "nodeId": "ignore-walk@3.0.1",
+                  "pkgId": "ignore-walk@3.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-bundled@1.0.5",
+                  "pkgId": "npm-bundled@1.0.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ignore-walk@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "npm-bundled@1.0.5",
+                    },
+                  ],
+                  "nodeId": "npm-packlist@1.1.12",
+                  "pkgId": "npm-packlist@1.1.12",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "npm-pick-manifest@2.1.0",
+                  "pkgId": "npm-pick-manifest@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "genfun@4.0.1",
+                  "pkgId": "genfun@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "genfun@4.0.1",
+                    },
+                  ],
+                  "nodeId": "protoduck@5.0.0",
+                  "pkgId": "protoduck@5.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "chownr@1.1.1",
+                  "pkgId": "chownr@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minipass@2.3.3",
+                    },
+                  ],
+                  "nodeId": "fs-minipass@1.2.5",
+                  "pkgId": "fs-minipass@1.2.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "yallist@3.0.3",
+                  "pkgId": "yallist@3.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@3.0.3",
+                    },
+                  ],
+                  "nodeId": "minipass@2.3.5",
+                  "pkgId": "minipass@2.3.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minipass@2.3.3",
+                    },
+                  ],
+                  "nodeId": "minizlib@1.1.1",
+                  "pkgId": "minizlib@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "chownr@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "fs-minipass@1.2.5",
+                    },
+                    Object {
+                      "nodeId": "minipass@2.3.5",
+                    },
+                    Object {
+                      "nodeId": "minizlib@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@3.0.3",
+                    },
+                  ],
+                  "nodeId": "tar@4.4.8",
+                  "pkgId": "tar@4.4.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "cacache@11.2.0",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "minimatch@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "minipass@2.3.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.4.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-packlist@1.1.12",
+                    },
+                    Object {
+                      "nodeId": "npm-pick-manifest@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "promise-retry@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "protoduck@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "tar@4.4.8",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.0",
+                    },
+                  ],
+                  "nodeId": "pacote@8.1.6",
+                  "pkgId": "pacote@8.1.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "prr@1.0.1",
+                  "pkgId": "prr@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "prr@1.0.1",
+                    },
+                  ],
+                  "nodeId": "errno@0.1.7",
+                  "pkgId": "errno@0.1.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "errno@0.1.7",
+                    },
+                  ],
+                  "nodeId": "worker-farm@1.6.0",
+                  "pkgId": "worker-farm@1.6.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bin-links@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "find-npm-prefix@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "lock-verify@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "npm-lifecycle@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-logical-tree@1.2.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "pacote@8.1.6",
+                    },
+                    Object {
+                      "nodeId": "protoduck@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "worker-farm@1.6.0",
+                    },
+                  ],
+                  "nodeId": "libcipm@2.0.2",
+                  "pkgId": "libcipm@2.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                  ],
+                  "nodeId": "npm-registry-fetch@3.1.1",
+                  "pkgId": "npm-registry-fetch@3.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@3.1.1",
+                    },
+                  ],
+                  "nodeId": "libnpmhook@4.0.1",
+                  "pkgId": "libnpmhook@4.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dotenv@5.0.1",
+                  "pkgId": "dotenv@5.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "ansi-align@2.0.0",
+                  "pkgId": "ansi-align@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "camelcase@4.1.0",
+                  "pkgId": "camelcase@4.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "color-name@1.1.3",
+                  "pkgId": "color-name@1.1.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "color-name@1.1.3",
+                    },
+                  ],
+                  "nodeId": "color-convert@1.9.1",
+                  "pkgId": "color-convert@1.9.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "color-convert@1.9.1",
+                    },
+                  ],
+                  "nodeId": "ansi-styles@3.2.1",
+                  "pkgId": "ansi-styles@3.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "escape-string-regexp@1.0.5",
+                  "pkgId": "escape-string-regexp@1.0.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-flag@3.0.0",
+                  "pkgId": "has-flag@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "has-flag@3.0.0",
+                    },
+                  ],
+                  "nodeId": "supports-color@5.4.0",
+                  "pkgId": "supports-color@5.4.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-styles@3.2.1",
+                    },
+                    Object {
+                      "nodeId": "escape-string-regexp@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "supports-color@5.4.0",
+                    },
+                  ],
+                  "nodeId": "chalk@2.4.1",
+                  "pkgId": "chalk@2.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "cli-boxes@1.0.0",
+                  "pkgId": "cli-boxes@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "shebang-regex@1.0.0",
+                  "pkgId": "shebang-regex@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "shebang-regex@1.0.0",
+                    },
+                  ],
+                  "nodeId": "shebang-command@1.2.0",
+                  "pkgId": "shebang-command@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "shebang-command@1.2.0",
+                    },
+                  ],
+                  "nodeId": "cross-spawn@5.1.0",
+                  "pkgId": "cross-spawn@5.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-stream@1.1.0",
+                  "pkgId": "is-stream@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-key@2.0.1",
+                  "pkgId": "path-key@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "path-key@2.0.1",
+                    },
+                  ],
+                  "nodeId": "npm-run-path@2.0.2",
+                  "pkgId": "npm-run-path@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-finally@1.0.0",
+                  "pkgId": "p-finally@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strip-eof@1.0.0",
+                  "pkgId": "strip-eof@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cross-spawn@5.1.0",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-run-path@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "p-finally@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-eof@1.0.0",
+                    },
+                  ],
+                  "nodeId": "execa@0.7.0",
+                  "pkgId": "execa@0.7.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "execa@0.7.0",
+                    },
+                  ],
+                  "nodeId": "term-size@1.2.0",
+                  "pkgId": "term-size@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "widest-line@2.0.0",
+                  "pkgId": "widest-line@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-align@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "camelcase@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "chalk@2.4.1",
+                    },
+                    Object {
+                      "nodeId": "cli-boxes@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "term-size@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "widest-line@2.0.0",
+                    },
+                  ],
+                  "nodeId": "boxen@1.3.0",
+                  "pkgId": "boxen@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-obj@1.0.1",
+                  "pkgId": "is-obj@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-obj@1.0.1",
+                    },
+                  ],
+                  "nodeId": "dot-prop@4.2.0",
+                  "pkgId": "dot-prop@4.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pify@3.0.0",
+                  "pkgId": "pify@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pify@3.0.0",
+                    },
+                  ],
+                  "nodeId": "make-dir@1.3.0",
+                  "pkgId": "make-dir@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "crypto-random-string@1.0.0",
+                  "pkgId": "crypto-random-string@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "crypto-random-string@1.0.0",
+                    },
+                  ],
+                  "nodeId": "unique-string@1.0.0",
+                  "pkgId": "unique-string@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xdg-basedir@3.0.0",
+                  "pkgId": "xdg-basedir@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "dot-prop@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "make-dir@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "unique-string@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "xdg-basedir@3.0.0",
+                    },
+                  ],
+                  "nodeId": "configstore@3.1.2",
+                  "pkgId": "configstore@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "import-lazy@2.1.0",
+                  "pkgId": "import-lazy@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ci-info@1.6.0",
+                    },
+                  ],
+                  "nodeId": "is-ci@1.1.0",
+                  "pkgId": "is-ci@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                  ],
+                  "nodeId": "global-dirs@0.1.1",
+                  "pkgId": "global-dirs@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                  ],
+                  "nodeId": "is-path-inside@1.0.1",
+                  "pkgId": "is-path-inside@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "global-dirs@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "is-path-inside@1.0.1",
+                    },
+                  ],
+                  "nodeId": "is-installed-globally@0.1.0",
+                  "pkgId": "is-installed-globally@0.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-npm@1.0.0",
+                  "pkgId": "is-npm@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "capture-stack-trace@1.0.0",
+                  "pkgId": "capture-stack-trace@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "capture-stack-trace@1.0.0",
+                    },
+                  ],
+                  "nodeId": "create-error-class@3.0.2",
+                  "pkgId": "create-error-class@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "duplexer3@0.1.4",
+                  "pkgId": "duplexer3@0.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-redirect@1.0.0",
+                  "pkgId": "is-redirect@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-retry-allowed@1.1.0",
+                  "pkgId": "is-retry-allowed@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lowercase-keys@1.0.1",
+                  "pkgId": "lowercase-keys@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "timed-out@4.0.1",
+                  "pkgId": "timed-out@4.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "unzip-response@2.0.1",
+                  "pkgId": "unzip-response@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "prepend-http@1.0.4",
+                  "pkgId": "prepend-http@1.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "prepend-http@1.0.4",
+                    },
+                  ],
+                  "nodeId": "url-parse-lax@1.0.0",
+                  "pkgId": "url-parse-lax@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "create-error-class@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "duplexer3@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-redirect@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-retry-allowed@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "lowercase-keys@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "timed-out@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "unzip-response@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "url-parse-lax@1.0.0",
+                    },
+                  ],
+                  "nodeId": "got@6.7.1",
+                  "pkgId": "got@6.7.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "deep-extend@0.5.1",
+                  "pkgId": "deep-extend@0.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "minimist@1.2.0",
+                  "pkgId": "minimist@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strip-json-comments@2.0.1",
+                  "pkgId": "strip-json-comments@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "deep-extend@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "minimist@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "strip-json-comments@2.0.1",
+                    },
+                  ],
+                  "nodeId": "rc@1.2.7",
+                  "pkgId": "rc@1.2.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "rc@1.2.7",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "registry-auth-token@3.3.2",
+                  "pkgId": "registry-auth-token@3.3.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "rc@1.2.7",
+                    },
+                  ],
+                  "nodeId": "registry-url@3.1.0",
+                  "pkgId": "registry-url@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "got@6.7.1",
+                    },
+                    Object {
+                      "nodeId": "registry-auth-token@3.3.2",
+                    },
+                    Object {
+                      "nodeId": "registry-url@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "package-json@4.0.1",
+                  "pkgId": "package-json@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "package-json@4.0.1",
+                    },
+                  ],
+                  "nodeId": "latest-version@3.1.0",
+                  "pkgId": "latest-version@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "semver-diff@2.1.0",
+                  "pkgId": "semver-diff@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "boxen@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "chalk@2.4.1",
+                    },
+                    Object {
+                      "nodeId": "configstore@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "import-lazy@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-ci@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-installed-globally@0.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-npm@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "latest-version@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver-diff@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "xdg-basedir@3.0.0",
+                    },
+                  ],
+                  "nodeId": "update-notifier@2.5.0",
+                  "pkgId": "update-notifier@2.5.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "wrap-ansi@2.1.0",
+                  "pkgId": "wrap-ansi@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "wrap-ansi@2.1.0",
+                    },
+                  ],
+                  "nodeId": "cliui@4.1.0",
+                  "pkgId": "cliui@4.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "decamelize@1.2.0",
+                  "pkgId": "decamelize@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-try@1.0.0",
+                  "pkgId": "p-try@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-try@1.0.0",
+                    },
+                  ],
+                  "nodeId": "p-limit@1.2.0",
+                  "pkgId": "p-limit@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-limit@1.2.0",
+                    },
+                  ],
+                  "nodeId": "p-locate@2.0.0",
+                  "pkgId": "p-locate@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-exists@3.0.0",
+                  "pkgId": "path-exists@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-locate@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "path-exists@3.0.0",
+                    },
+                  ],
+                  "nodeId": "locate-path@2.0.0",
+                  "pkgId": "locate-path@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "locate-path@2.0.0",
+                    },
+                  ],
+                  "nodeId": "find-up@2.1.0",
+                  "pkgId": "find-up@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "get-caller-file@1.0.2",
+                  "pkgId": "get-caller-file@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "invert-kv@1.0.0",
+                  "pkgId": "invert-kv@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "invert-kv@1.0.0",
+                    },
+                  ],
+                  "nodeId": "lcid@1.0.0",
+                  "pkgId": "lcid@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mimic-fn@1.2.0",
+                  "pkgId": "mimic-fn@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mimic-fn@1.2.0",
+                    },
+                  ],
+                  "nodeId": "mem@1.1.0",
+                  "pkgId": "mem@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "execa@0.7.0",
+                    },
+                    Object {
+                      "nodeId": "lcid@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "mem@1.1.0",
+                    },
+                  ],
+                  "nodeId": "os-locale@2.1.0",
+                  "pkgId": "os-locale@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "require-directory@2.1.1",
+                  "pkgId": "require-directory@2.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "require-main-filename@1.0.1",
+                  "pkgId": "require-main-filename@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "y18n@3.2.1",
+                  "pkgId": "y18n@3.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "camelcase@4.1.0",
+                    },
+                  ],
+                  "nodeId": "yargs-parser@9.0.2",
+                  "pkgId": "yargs-parser@9.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cliui@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "decamelize@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "find-up@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "get-caller-file@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "os-locale@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "require-directory@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "require-main-filename@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "set-blocking@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "y18n@3.2.1",
+                    },
+                    Object {
+                      "nodeId": "yargs-parser@9.0.2",
+                    },
+                  ],
+                  "nodeId": "yargs@11.0.0",
+                  "pkgId": "yargs@11.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "dotenv@5.0.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "y18n@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "yargs@11.0.0",
+                    },
+                  ],
+                  "nodeId": "libnpx@10.2.0",
+                  "pkgId": "libnpx@10.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                  ],
+                  "nodeId": "lockfile@1.0.4",
+                  "pkgId": "lockfile@1.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._baseindexof@3.1.0",
+                  "pkgId": "lodash._baseindexof@3.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._createset@4.0.3",
+                  "pkgId": "lodash._createset@4.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._root@3.0.1",
+                  "pkgId": "lodash._root@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lodash._createset@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "lodash._root@3.0.1",
+                    },
+                  ],
+                  "nodeId": "lodash._baseuniq@4.6.0",
+                  "pkgId": "lodash._baseuniq@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._bindcallback@3.0.1",
+                  "pkgId": "lodash._bindcallback@3.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._cacheindexof@3.0.2",
+                  "pkgId": "lodash._cacheindexof@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._getnative@3.9.1",
+                  "pkgId": "lodash._getnative@3.9.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lodash._getnative@3.9.1",
+                    },
+                  ],
+                  "nodeId": "lodash._createcache@3.1.2",
+                  "pkgId": "lodash._createcache@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.clonedeep@4.5.0",
+                  "pkgId": "lodash.clonedeep@4.5.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.restparam@3.6.1",
+                  "pkgId": "lodash.restparam@3.6.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.union@4.6.0",
+                  "pkgId": "lodash.union@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.uniq@4.5.0",
+                  "pkgId": "lodash.uniq@4.5.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.without@4.4.0",
+                  "pkgId": "lodash.without@4.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "meant@1.0.1",
+                  "pkgId": "meant@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                  ],
+                  "nodeId": "nopt@4.0.1",
+                  "pkgId": "nopt@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cli-table3@0.5.0",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                  ],
+                  "nodeId": "npm-audit-report@1.3.1",
+                  "pkgId": "npm-audit-report@1.3.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-cache-filename@1.0.2",
+                  "pkgId": "npm-cache-filename@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "npm-install-checks@3.0.0",
+                  "pkgId": "npm-install-checks@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@4.0.1",
+                    },
+                  ],
+                  "nodeId": "npm-profile@3.0.2",
+                  "pkgId": "npm-profile@3.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "ssri@5.3.0",
+                  "pkgId": "ssri@5.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "concat-stream@1.6.2",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.4.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "request@2.88.0",
+                    },
+                    Object {
+                      "nodeId": "retry@0.10.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "ssri@5.3.0",
+                    },
+                  ],
+                  "nodeId": "npm-registry-client@8.6.0",
+                  "pkgId": "npm-registry-client@8.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "figgy-pudding@2.0.1",
+                  "pkgId": "figgy-pudding@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "concat-stream@1.6.2",
+                    },
+                    Object {
+                      "nodeId": "duplexify@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "flush-write-stream@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "from2@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "parallel-transform@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "pump@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "pumpify@1.5.1",
+                    },
+                    Object {
+                      "nodeId": "stream-each@1.2.2",
+                    },
+                    Object {
+                      "nodeId": "through2@2.0.3",
+                    },
+                  ],
+                  "nodeId": "mississippi@2.0.0",
+                  "pkgId": "mississippi@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "move-concurrently@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "ssri@5.3.0",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "y18n@4.0.0",
+                    },
+                  ],
+                  "nodeId": "cacache@10.0.4",
+                  "pkgId": "cacache@10.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "smart-buffer@1.1.15",
+                  "pkgId": "smart-buffer@1.1.15",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ip@1.1.5",
+                    },
+                    Object {
+                      "nodeId": "smart-buffer@1.1.15",
+                    },
+                  ],
+                  "nodeId": "socks@1.1.10",
+                  "pkgId": "socks@1.1.10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "socks@1.1.10",
+                    },
+                  ],
+                  "nodeId": "socks-proxy-agent@3.0.1",
+                  "pkgId": "socks-proxy-agent@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agentkeepalive@3.4.1",
+                    },
+                    Object {
+                      "nodeId": "cacache@10.0.4",
+                    },
+                    Object {
+                      "nodeId": "http-cache-semantics@3.8.1",
+                    },
+                    Object {
+                      "nodeId": "http-proxy-agent@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "https-proxy-agent@2.2.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "node-fetch-npm@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "promise-retry@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "socks-proxy-agent@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@5.3.0",
+                    },
+                  ],
+                  "nodeId": "make-fetch-happen@3.0.0",
+                  "pkgId": "make-fetch-happen@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "npm-registry-fetch@1.1.0",
+                  "pkgId": "npm-registry-fetch@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-user-validate@1.0.0",
+                  "pkgId": "npm-user-validate@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "opener@1.5.1",
+                  "pkgId": "opener@1.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qrcode-terminal@0.12.0",
+                  "pkgId": "qrcode-terminal@0.12.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "decode-uri-component@0.2.0",
+                  "pkgId": "decode-uri-component@0.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strict-uri-encode@2.0.0",
+                  "pkgId": "strict-uri-encode@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "decode-uri-component@0.2.0",
+                    },
+                    Object {
+                      "nodeId": "strict-uri-encode@2.0.0",
+                    },
+                  ],
+                  "nodeId": "query-string@6.1.0",
+                  "pkgId": "query-string@6.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qw@1.0.1",
+                  "pkgId": "qw@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "debuglog@1.0.1",
+                  "pkgId": "debuglog@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debuglog@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "dezalgo@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "readdir-scoped-modules@1.0.2",
+                  "pkgId": "readdir-scoped-modules@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-extend@1.0.3",
+                  "pkgId": "util-extend@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debuglog@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "readdir-scoped-modules@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "util-extend@1.0.3",
+                    },
+                  ],
+                  "nodeId": "read-installed@4.0.3",
+                  "pkgId": "read-installed@4.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debuglog@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "dezalgo@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "readdir-scoped-modules@1.0.2",
+                    },
+                  ],
+                  "nodeId": "read-package-tree@5.2.1",
+                  "pkgId": "read-package-tree@5.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "retry@0.12.0",
+                  "pkgId": "retry@0.12.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "sha@2.0.1",
+                  "pkgId": "sha@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "sorted-object@2.0.1",
+                  "pkgId": "sorted-object@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isarray@0.0.1",
+                  "pkgId": "isarray@0.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "string_decoder@0.10.31",
+                  "pkgId": "string_decoder@0.10.31",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "isarray@0.0.1",
+                    },
+                    Object {
+                      "nodeId": "string_decoder@0.10.31",
+                    },
+                  ],
+                  "nodeId": "readable-stream@1.1.14",
+                  "pkgId": "readable-stream@1.1.14",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@1.1.14",
+                    },
+                  ],
+                  "nodeId": "from2@1.3.0",
+                  "pkgId": "from2@1.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "stream-iterate@1.2.0",
+                  "pkgId": "stream-iterate@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "from2@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "stream-iterate@1.2.0",
+                    },
+                  ],
+                  "nodeId": "sorted-union-stream@2.1.3",
+                  "pkgId": "sorted-union-stream@2.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stringify-package@1.0.0",
+                  "pkgId": "stringify-package@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "text-table@0.2.0",
+                  "pkgId": "text-table@0.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tiny-relative-date@1.3.0",
+                  "pkgId": "tiny-relative-date@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "unpipe@1.0.0",
+                  "pkgId": "unpipe@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "JSONStream@1.3.4",
+                    },
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "ansicolors@0.3.2",
+                    },
+                    Object {
+                      "nodeId": "ansistyles@0.1.3",
+                    },
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "archy@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "bin-links@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "byte-size@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "cacache@11.2.0",
+                    },
+                    Object {
+                      "nodeId": "call-limit@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "ci-info@1.6.0",
+                    },
+                    Object {
+                      "nodeId": "cli-columns@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "cli-table3@0.5.0",
+                    },
+                    Object {
+                      "nodeId": "cmd-shim@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "columnify@1.5.4",
+                    },
+                    Object {
+                      "nodeId": "config-chain@1.1.12",
+                    },
+                    Object {
+                      "nodeId": "detect-indent@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "detect-newline@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "dezalgo@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "editor@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "find-npm-prefix@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "fs-vacuum@1.2.10",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "gentle-fs@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "has-unicode@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "hosted-git-info@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "iferr@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inflight@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "init-package-json@1.10.3",
+                    },
+                    Object {
+                      "nodeId": "is-cidr@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "isexe@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "lazy-property@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "libcipm@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "libnpmhook@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "libnpx@10.2.0",
+                    },
+                    Object {
+                      "nodeId": "lock-verify@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "lockfile@1.0.4",
+                    },
+                    Object {
+                      "nodeId": "lodash._baseindexof@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "lodash._baseuniq@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "lodash._bindcallback@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "lodash._cacheindexof@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "lodash._createcache@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "lodash.clonedeep@4.5.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.restparam@3.6.1",
+                    },
+                    Object {
+                      "nodeId": "lodash.union@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.uniq@4.5.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.without@4.4.0",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "meant@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "move-concurrently@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "node-gyp@3.8.0",
+                    },
+                    Object {
+                      "nodeId": "nopt@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.4.0",
+                    },
+                    Object {
+                      "nodeId": "npm-audit-report@1.3.1",
+                    },
+                    Object {
+                      "nodeId": "npm-cache-filename@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-install-checks@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "npm-lifecycle@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-packlist@1.1.12",
+                    },
+                    Object {
+                      "nodeId": "npm-pick-manifest@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-profile@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-client@8.6.0",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-user-validate@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "opener@1.5.1",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "pacote@8.1.6",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "qrcode-terminal@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "query-string@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "qw@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                    Object {
+                      "nodeId": "read-cmd-shim@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "read-installed@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "read-package-tree@5.2.1",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "request@2.88.0",
+                    },
+                    Object {
+                      "nodeId": "retry@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "sha@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "sorted-object@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "sorted-union-stream@2.1.3",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "stringify-package@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "tar@4.4.8",
+                    },
+                    Object {
+                      "nodeId": "text-table@0.2.0",
+                    },
+                    Object {
+                      "nodeId": "tiny-relative-date@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "uid-number@0.0.6",
+                    },
+                    Object {
+                      "nodeId": "umask@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "unpipe@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "uuid@3.3.2",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "worker-farm@1.6.0",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.3.0",
+                    },
+                  ],
+                  "nodeId": "npm@6.5.0",
+                  "pkgId": "npm@6.5.0",
+                },
+              ],
+              "rootNodeId": "root-node",
+            },
+            "pkgManager": Object {
+              "name": "npm",
+            },
+            "pkgs": Array [
+              Object {
+                "id": "lib@",
+                "info": Object {
+                  "name": "lib",
+                  "version": undefined,
+                },
+              },
+              Object {
+                "id": "jsonparse@1.3.1",
+                "info": Object {
+                  "name": "jsonparse",
+                  "version": "1.3.1",
+                },
+              },
+              Object {
+                "id": "through@2.3.8",
+                "info": Object {
+                  "name": "through",
+                  "version": "2.3.8",
+                },
+              },
+              Object {
+                "id": "JSONStream@1.3.4",
+                "info": Object {
+                  "name": "JSONStream",
+                  "version": "1.3.4",
+                },
+              },
+              Object {
+                "id": "abbrev@1.1.1",
+                "info": Object {
+                  "name": "abbrev",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "ansicolors@0.3.2",
+                "info": Object {
+                  "name": "ansicolors",
+                  "version": "0.3.2",
+                },
+              },
+              Object {
+                "id": "ansistyles@0.1.3",
+                "info": Object {
+                  "name": "ansistyles",
+                  "version": "0.1.3",
+                },
+              },
+              Object {
+                "id": "aproba@1.2.0",
+                "info": Object {
+                  "name": "aproba",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "archy@1.0.0",
+                "info": Object {
+                  "name": "archy",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "bluebird@3.5.3",
+                "info": Object {
+                  "name": "bluebird",
+                  "version": "3.5.3",
+                },
+              },
+              Object {
+                "id": "graceful-fs@4.1.15",
+                "info": Object {
+                  "name": "graceful-fs",
+                  "version": "4.1.15",
+                },
+              },
+              Object {
+                "id": "minimist@0.0.8",
+                "info": Object {
+                  "name": "minimist",
+                  "version": "0.0.8",
+                },
+              },
+              Object {
+                "id": "mkdirp@0.5.1",
+                "info": Object {
+                  "name": "mkdirp",
+                  "version": "0.5.1",
+                },
+              },
+              Object {
+                "id": "cmd-shim@2.0.2",
+                "info": Object {
+                  "name": "cmd-shim",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "path-is-inside@1.0.2",
+                "info": Object {
+                  "name": "path-is-inside",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "fs.realpath@1.0.0",
+                "info": Object {
+                  "name": "fs.realpath",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "wrappy@1.0.2",
+                "info": Object {
+                  "name": "wrappy",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "once@1.4.0",
+                "info": Object {
+                  "name": "once",
+                  "version": "1.4.0",
+                },
+              },
+              Object {
+                "id": "inflight@1.0.6",
+                "info": Object {
+                  "name": "inflight",
+                  "version": "1.0.6",
+                },
+              },
+              Object {
+                "id": "inherits@2.0.3",
+                "info": Object {
+                  "name": "inherits",
+                  "version": "2.0.3",
+                },
+              },
+              Object {
+                "id": "balanced-match@1.0.0",
+                "info": Object {
+                  "name": "balanced-match",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "concat-map@0.0.1",
+                "info": Object {
+                  "name": "concat-map",
+                  "version": "0.0.1",
+                },
+              },
+              Object {
+                "id": "brace-expansion@1.1.11",
+                "info": Object {
+                  "name": "brace-expansion",
+                  "version": "1.1.11",
+                },
+              },
+              Object {
+                "id": "minimatch@3.0.4",
+                "info": Object {
+                  "name": "minimatch",
+                  "version": "3.0.4",
+                },
+              },
+              Object {
+                "id": "path-is-absolute@1.0.1",
+                "info": Object {
+                  "name": "path-is-absolute",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "glob@7.1.3",
+                "info": Object {
+                  "name": "glob",
+                  "version": "7.1.3",
+                },
+              },
+              Object {
+                "id": "rimraf@2.6.2",
+                "info": Object {
+                  "name": "rimraf",
+                  "version": "2.6.2",
+                },
+              },
+              Object {
+                "id": "fs-vacuum@1.2.10",
+                "info": Object {
+                  "name": "fs-vacuum",
+                  "version": "1.2.10",
+                },
+              },
+              Object {
+                "id": "iferr@0.1.5",
+                "info": Object {
+                  "name": "iferr",
+                  "version": "0.1.5",
+                },
+              },
+              Object {
+                "id": "read-cmd-shim@1.0.1",
+                "info": Object {
+                  "name": "read-cmd-shim",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "slide@1.1.6",
+                "info": Object {
+                  "name": "slide",
+                  "version": "1.1.6",
+                },
+              },
+              Object {
+                "id": "gentle-fs@2.0.1",
+                "info": Object {
+                  "name": "gentle-fs",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "imurmurhash@0.1.4",
+                "info": Object {
+                  "name": "imurmurhash",
+                  "version": "0.1.4",
+                },
+              },
+              Object {
+                "id": "signal-exit@3.0.2",
+                "info": Object {
+                  "name": "signal-exit",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "write-file-atomic@2.3.0",
+                "info": Object {
+                  "name": "write-file-atomic",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "bin-links@1.1.2",
+                "info": Object {
+                  "name": "bin-links",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "byte-size@4.0.3",
+                "info": Object {
+                  "name": "byte-size",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "chownr@1.0.1",
+                "info": Object {
+                  "name": "chownr",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "figgy-pudding@3.5.1",
+                "info": Object {
+                  "name": "figgy-pudding",
+                  "version": "3.5.1",
+                },
+              },
+              Object {
+                "id": "pseudomap@1.0.2",
+                "info": Object {
+                  "name": "pseudomap",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "yallist@2.1.2",
+                "info": Object {
+                  "name": "yallist",
+                  "version": "2.1.2",
+                },
+              },
+              Object {
+                "id": "lru-cache@4.1.3",
+                "info": Object {
+                  "name": "lru-cache",
+                  "version": "4.1.3",
+                },
+              },
+              Object {
+                "id": "buffer-from@1.0.0",
+                "info": Object {
+                  "name": "buffer-from",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "core-util-is@1.0.2",
+                "info": Object {
+                  "name": "core-util-is",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "isarray@1.0.0",
+                "info": Object {
+                  "name": "isarray",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "process-nextick-args@2.0.0",
+                "info": Object {
+                  "name": "process-nextick-args",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "safe-buffer@5.1.2",
+                "info": Object {
+                  "name": "safe-buffer",
+                  "version": "5.1.2",
+                },
+              },
+              Object {
+                "id": "string_decoder@1.1.1",
+                "info": Object {
+                  "name": "string_decoder",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "util-deprecate@1.0.2",
+                "info": Object {
+                  "name": "util-deprecate",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "readable-stream@2.3.6",
+                "info": Object {
+                  "name": "readable-stream",
+                  "version": "2.3.6",
+                },
+              },
+              Object {
+                "id": "typedarray@0.0.6",
+                "info": Object {
+                  "name": "typedarray",
+                  "version": "0.0.6",
+                },
+              },
+              Object {
+                "id": "concat-stream@1.6.2",
+                "info": Object {
+                  "name": "concat-stream",
+                  "version": "1.6.2",
+                },
+              },
+              Object {
+                "id": "end-of-stream@1.4.1",
+                "info": Object {
+                  "name": "end-of-stream",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "stream-shift@1.0.0",
+                "info": Object {
+                  "name": "stream-shift",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "duplexify@3.6.0",
+                "info": Object {
+                  "name": "duplexify",
+                  "version": "3.6.0",
+                },
+              },
+              Object {
+                "id": "flush-write-stream@1.0.3",
+                "info": Object {
+                  "name": "flush-write-stream",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "from2@2.3.0",
+                "info": Object {
+                  "name": "from2",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "cyclist@0.2.2",
+                "info": Object {
+                  "name": "cyclist",
+                  "version": "0.2.2",
+                },
+              },
+              Object {
+                "id": "parallel-transform@1.1.0",
+                "info": Object {
+                  "name": "parallel-transform",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "pump@3.0.0",
+                "info": Object {
+                  "name": "pump",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "pump@2.0.1",
+                "info": Object {
+                  "name": "pump",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "pumpify@1.5.1",
+                "info": Object {
+                  "name": "pumpify",
+                  "version": "1.5.1",
+                },
+              },
+              Object {
+                "id": "stream-each@1.2.2",
+                "info": Object {
+                  "name": "stream-each",
+                  "version": "1.2.2",
+                },
+              },
+              Object {
+                "id": "xtend@4.0.1",
+                "info": Object {
+                  "name": "xtend",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "through2@2.0.3",
+                "info": Object {
+                  "name": "through2",
+                  "version": "2.0.3",
+                },
+              },
+              Object {
+                "id": "mississippi@3.0.0",
+                "info": Object {
+                  "name": "mississippi",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "fs-write-stream-atomic@1.0.10",
+                "info": Object {
+                  "name": "fs-write-stream-atomic",
+                  "version": "1.0.10",
+                },
+              },
+              Object {
+                "id": "run-queue@1.0.3",
+                "info": Object {
+                  "name": "run-queue",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "copy-concurrently@1.0.5",
+                "info": Object {
+                  "name": "copy-concurrently",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "move-concurrently@1.0.1",
+                "info": Object {
+                  "name": "move-concurrently",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "promise-inflight@1.0.1",
+                "info": Object {
+                  "name": "promise-inflight",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "ssri@6.0.1",
+                "info": Object {
+                  "name": "ssri",
+                  "version": "6.0.1",
+                },
+              },
+              Object {
+                "id": "unique-slug@2.0.0",
+                "info": Object {
+                  "name": "unique-slug",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "unique-filename@1.1.0",
+                "info": Object {
+                  "name": "unique-filename",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "y18n@4.0.0",
+                "info": Object {
+                  "name": "y18n",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "cacache@11.2.0",
+                "info": Object {
+                  "name": "cacache",
+                  "version": "11.2.0",
+                },
+              },
+              Object {
+                "id": "call-limit@1.1.0",
+                "info": Object {
+                  "name": "call-limit",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "ci-info@1.6.0",
+                "info": Object {
+                  "name": "ci-info",
+                  "version": "1.6.0",
+                },
+              },
+              Object {
+                "id": "is-fullwidth-code-point@2.0.0",
+                "info": Object {
+                  "name": "is-fullwidth-code-point",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "ansi-regex@3.0.0",
+                "info": Object {
+                  "name": "ansi-regex",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "strip-ansi@4.0.0",
+                "info": Object {
+                  "name": "strip-ansi",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "string-width@2.1.1",
+                "info": Object {
+                  "name": "string-width",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "ansi-regex@2.1.1",
+                "info": Object {
+                  "name": "ansi-regex",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "strip-ansi@3.0.1",
+                "info": Object {
+                  "name": "strip-ansi",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "cli-columns@3.1.2",
+                "info": Object {
+                  "name": "cli-columns",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "colors@1.1.2",
+                "info": Object {
+                  "name": "colors",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "object-assign@4.1.1",
+                "info": Object {
+                  "name": "object-assign",
+                  "version": "4.1.1",
+                },
+              },
+              Object {
+                "id": "cli-table3@0.5.0",
+                "info": Object {
+                  "name": "cli-table3",
+                  "version": "0.5.0",
+                },
+              },
+              Object {
+                "id": "clone@1.0.4",
+                "info": Object {
+                  "name": "clone",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "defaults@1.0.3",
+                "info": Object {
+                  "name": "defaults",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "wcwidth@1.0.1",
+                "info": Object {
+                  "name": "wcwidth",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "columnify@1.5.4",
+                "info": Object {
+                  "name": "columnify",
+                  "version": "1.5.4",
+                },
+              },
+              Object {
+                "id": "ini@1.3.5",
+                "info": Object {
+                  "name": "ini",
+                  "version": "1.3.5",
+                },
+              },
+              Object {
+                "id": "proto-list@1.2.4",
+                "info": Object {
+                  "name": "proto-list",
+                  "version": "1.2.4",
+                },
+              },
+              Object {
+                "id": "config-chain@1.1.12",
+                "info": Object {
+                  "name": "config-chain",
+                  "version": "1.1.12",
+                },
+              },
+              Object {
+                "id": "detect-indent@5.0.0",
+                "info": Object {
+                  "name": "detect-indent",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "detect-newline@2.1.0",
+                "info": Object {
+                  "name": "detect-newline",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "asap@2.0.6",
+                "info": Object {
+                  "name": "asap",
+                  "version": "2.0.6",
+                },
+              },
+              Object {
+                "id": "dezalgo@1.0.3",
+                "info": Object {
+                  "name": "dezalgo",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "editor@1.0.0",
+                "info": Object {
+                  "name": "editor",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "find-npm-prefix@1.0.2",
+                "info": Object {
+                  "name": "find-npm-prefix",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "has-unicode@2.0.1",
+                "info": Object {
+                  "name": "has-unicode",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "hosted-git-info@2.7.1",
+                "info": Object {
+                  "name": "hosted-git-info",
+                  "version": "2.7.1",
+                },
+              },
+              Object {
+                "id": "iferr@1.0.2",
+                "info": Object {
+                  "name": "iferr",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "os-homedir@1.0.2",
+                "info": Object {
+                  "name": "os-homedir",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "os-tmpdir@1.0.2",
+                "info": Object {
+                  "name": "os-tmpdir",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "osenv@0.1.5",
+                "info": Object {
+                  "name": "osenv",
+                  "version": "0.1.5",
+                },
+              },
+              Object {
+                "id": "semver@5.5.1",
+                "info": Object {
+                  "name": "semver",
+                  "version": "5.5.1",
+                },
+              },
+              Object {
+                "id": "builtins@1.0.3",
+                "info": Object {
+                  "name": "builtins",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "validate-npm-package-name@3.0.0",
+                "info": Object {
+                  "name": "validate-npm-package-name",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "npm-package-arg@6.1.0",
+                "info": Object {
+                  "name": "npm-package-arg",
+                  "version": "6.1.0",
+                },
+              },
+              Object {
+                "id": "mute-stream@0.0.7",
+                "info": Object {
+                  "name": "mute-stream",
+                  "version": "0.0.7",
+                },
+              },
+              Object {
+                "id": "read@1.0.7",
+                "info": Object {
+                  "name": "read",
+                  "version": "1.0.7",
+                },
+              },
+              Object {
+                "id": "promzard@0.3.0",
+                "info": Object {
+                  "name": "promzard",
+                  "version": "0.3.0",
+                },
+              },
+              Object {
+                "id": "json-parse-better-errors@1.0.2",
+                "info": Object {
+                  "name": "json-parse-better-errors",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "builtin-modules@1.1.1",
+                "info": Object {
+                  "name": "builtin-modules",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "is-builtin-module@1.0.0",
+                "info": Object {
+                  "name": "is-builtin-module",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "spdx-exceptions@2.1.0",
+                "info": Object {
+                  "name": "spdx-exceptions",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "spdx-license-ids@3.0.0",
+                "info": Object {
+                  "name": "spdx-license-ids",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "spdx-expression-parse@3.0.0",
+                "info": Object {
+                  "name": "spdx-expression-parse",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "spdx-correct@3.0.0",
+                "info": Object {
+                  "name": "spdx-correct",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "validate-npm-package-license@3.0.4",
+                "info": Object {
+                  "name": "validate-npm-package-license",
+                  "version": "3.0.4",
+                },
+              },
+              Object {
+                "id": "normalize-package-data@2.4.0",
+                "info": Object {
+                  "name": "normalize-package-data",
+                  "version": "2.4.0",
+                },
+              },
+              Object {
+                "id": "slash@1.0.0",
+                "info": Object {
+                  "name": "slash",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "read-package-json@2.0.13",
+                "info": Object {
+                  "name": "read-package-json",
+                  "version": "2.0.13",
+                },
+              },
+              Object {
+                "id": "init-package-json@1.10.3",
+                "info": Object {
+                  "name": "init-package-json",
+                  "version": "1.10.3",
+                },
+              },
+              Object {
+                "id": "ip-regex@2.1.0",
+                "info": Object {
+                  "name": "ip-regex",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "cidr-regex@2.0.9",
+                "info": Object {
+                  "name": "cidr-regex",
+                  "version": "2.0.9",
+                },
+              },
+              Object {
+                "id": "is-cidr@2.0.6",
+                "info": Object {
+                  "name": "is-cidr",
+                  "version": "2.0.6",
+                },
+              },
+              Object {
+                "id": "isexe@2.0.0",
+                "info": Object {
+                  "name": "isexe",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "lazy-property@1.0.0",
+                "info": Object {
+                  "name": "lazy-property",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "lock-verify@2.0.2",
+                "info": Object {
+                  "name": "lock-verify",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "byline@5.0.0",
+                "info": Object {
+                  "name": "byline",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "fstream@1.0.11",
+                "info": Object {
+                  "name": "fstream",
+                  "version": "1.0.11",
+                },
+              },
+              Object {
+                "id": "nopt@3.0.6",
+                "info": Object {
+                  "name": "nopt",
+                  "version": "3.0.6",
+                },
+              },
+              Object {
+                "id": "delegates@1.0.0",
+                "info": Object {
+                  "name": "delegates",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "are-we-there-yet@1.1.4",
+                "info": Object {
+                  "name": "are-we-there-yet",
+                  "version": "1.1.4",
+                },
+              },
+              Object {
+                "id": "console-control-strings@1.1.0",
+                "info": Object {
+                  "name": "console-control-strings",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "code-point-at@1.1.0",
+                "info": Object {
+                  "name": "code-point-at",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "number-is-nan@1.0.1",
+                "info": Object {
+                  "name": "number-is-nan",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-fullwidth-code-point@1.0.0",
+                "info": Object {
+                  "name": "is-fullwidth-code-point",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "string-width@1.0.2",
+                "info": Object {
+                  "name": "string-width",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "wide-align@1.1.2",
+                "info": Object {
+                  "name": "wide-align",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "gauge@2.7.4",
+                "info": Object {
+                  "name": "gauge",
+                  "version": "2.7.4",
+                },
+              },
+              Object {
+                "id": "set-blocking@2.0.0",
+                "info": Object {
+                  "name": "set-blocking",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "npmlog@4.1.2",
+                "info": Object {
+                  "name": "npmlog",
+                  "version": "4.1.2",
+                },
+              },
+              Object {
+                "id": "aws-sign2@0.7.0",
+                "info": Object {
+                  "name": "aws-sign2",
+                  "version": "0.7.0",
+                },
+              },
+              Object {
+                "id": "aws4@1.8.0",
+                "info": Object {
+                  "name": "aws4",
+                  "version": "1.8.0",
+                },
+              },
+              Object {
+                "id": "caseless@0.12.0",
+                "info": Object {
+                  "name": "caseless",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "delayed-stream@1.0.0",
+                "info": Object {
+                  "name": "delayed-stream",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "combined-stream@1.0.6",
+                "info": Object {
+                  "name": "combined-stream",
+                  "version": "1.0.6",
+                },
+              },
+              Object {
+                "id": "extend@3.0.2",
+                "info": Object {
+                  "name": "extend",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "forever-agent@0.6.1",
+                "info": Object {
+                  "name": "forever-agent",
+                  "version": "0.6.1",
+                },
+              },
+              Object {
+                "id": "asynckit@0.4.0",
+                "info": Object {
+                  "name": "asynckit",
+                  "version": "0.4.0",
+                },
+              },
+              Object {
+                "id": "mime-db@1.35.0",
+                "info": Object {
+                  "name": "mime-db",
+                  "version": "1.35.0",
+                },
+              },
+              Object {
+                "id": "mime-types@2.1.19",
+                "info": Object {
+                  "name": "mime-types",
+                  "version": "2.1.19",
+                },
+              },
+              Object {
+                "id": "form-data@2.3.2",
+                "info": Object {
+                  "name": "form-data",
+                  "version": "2.3.2",
+                },
+              },
+              Object {
+                "id": "co@4.6.0",
+                "info": Object {
+                  "name": "co",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "fast-deep-equal@1.1.0",
+                "info": Object {
+                  "name": "fast-deep-equal",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "fast-json-stable-stringify@2.0.0",
+                "info": Object {
+                  "name": "fast-json-stable-stringify",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "json-schema-traverse@0.3.1",
+                "info": Object {
+                  "name": "json-schema-traverse",
+                  "version": "0.3.1",
+                },
+              },
+              Object {
+                "id": "ajv@5.5.2",
+                "info": Object {
+                  "name": "ajv",
+                  "version": "5.5.2",
+                },
+              },
+              Object {
+                "id": "har-schema@2.0.0",
+                "info": Object {
+                  "name": "har-schema",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "har-validator@5.1.0",
+                "info": Object {
+                  "name": "har-validator",
+                  "version": "5.1.0",
+                },
+              },
+              Object {
+                "id": "assert-plus@1.0.0",
+                "info": Object {
+                  "name": "assert-plus",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "extsprintf@1.3.0",
+                "info": Object {
+                  "name": "extsprintf",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "json-schema@0.2.3",
+                "info": Object {
+                  "name": "json-schema",
+                  "version": "0.2.3",
+                },
+              },
+              Object {
+                "id": "verror@1.10.0",
+                "info": Object {
+                  "name": "verror",
+                  "version": "1.10.0",
+                },
+              },
+              Object {
+                "id": "jsprim@1.4.1",
+                "info": Object {
+                  "name": "jsprim",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "safer-buffer@2.1.2",
+                "info": Object {
+                  "name": "safer-buffer",
+                  "version": "2.1.2",
+                },
+              },
+              Object {
+                "id": "asn1@0.2.4",
+                "info": Object {
+                  "name": "asn1",
+                  "version": "0.2.4",
+                },
+              },
+              Object {
+                "id": "tweetnacl@0.14.5",
+                "info": Object {
+                  "name": "tweetnacl",
+                  "version": "0.14.5",
+                },
+              },
+              Object {
+                "id": "bcrypt-pbkdf@1.0.2",
+                "info": Object {
+                  "name": "bcrypt-pbkdf",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "dashdash@1.14.1",
+                "info": Object {
+                  "name": "dashdash",
+                  "version": "1.14.1",
+                },
+              },
+              Object {
+                "id": "jsbn@0.1.1",
+                "info": Object {
+                  "name": "jsbn",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "ecc-jsbn@0.1.2",
+                "info": Object {
+                  "name": "ecc-jsbn",
+                  "version": "0.1.2",
+                },
+              },
+              Object {
+                "id": "getpass@0.1.7",
+                "info": Object {
+                  "name": "getpass",
+                  "version": "0.1.7",
+                },
+              },
+              Object {
+                "id": "sshpk@1.14.2",
+                "info": Object {
+                  "name": "sshpk",
+                  "version": "1.14.2",
+                },
+              },
+              Object {
+                "id": "http-signature@1.2.0",
+                "info": Object {
+                  "name": "http-signature",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "is-typedarray@1.0.0",
+                "info": Object {
+                  "name": "is-typedarray",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "isstream@0.1.2",
+                "info": Object {
+                  "name": "isstream",
+                  "version": "0.1.2",
+                },
+              },
+              Object {
+                "id": "json-stringify-safe@5.0.1",
+                "info": Object {
+                  "name": "json-stringify-safe",
+                  "version": "5.0.1",
+                },
+              },
+              Object {
+                "id": "oauth-sign@0.9.0",
+                "info": Object {
+                  "name": "oauth-sign",
+                  "version": "0.9.0",
+                },
+              },
+              Object {
+                "id": "performance-now@2.1.0",
+                "info": Object {
+                  "name": "performance-now",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "qs@6.5.2",
+                "info": Object {
+                  "name": "qs",
+                  "version": "6.5.2",
+                },
+              },
+              Object {
+                "id": "psl@1.1.29",
+                "info": Object {
+                  "name": "psl",
+                  "version": "1.1.29",
+                },
+              },
+              Object {
+                "id": "punycode@1.4.1",
+                "info": Object {
+                  "name": "punycode",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "tough-cookie@2.4.3",
+                "info": Object {
+                  "name": "tough-cookie",
+                  "version": "2.4.3",
+                },
+              },
+              Object {
+                "id": "tunnel-agent@0.6.0",
+                "info": Object {
+                  "name": "tunnel-agent",
+                  "version": "0.6.0",
+                },
+              },
+              Object {
+                "id": "uuid@3.3.2",
+                "info": Object {
+                  "name": "uuid",
+                  "version": "3.3.2",
+                },
+              },
+              Object {
+                "id": "request@2.88.0",
+                "info": Object {
+                  "name": "request",
+                  "version": "2.88.0",
+                },
+              },
+              Object {
+                "id": "semver@5.3.0",
+                "info": Object {
+                  "name": "semver",
+                  "version": "5.3.0",
+                },
+              },
+              Object {
+                "id": "block-stream@0.0.9",
+                "info": Object {
+                  "name": "block-stream",
+                  "version": "0.0.9",
+                },
+              },
+              Object {
+                "id": "tar@2.2.1",
+                "info": Object {
+                  "name": "tar",
+                  "version": "2.2.1",
+                },
+              },
+              Object {
+                "id": "node-gyp@3.8.0",
+                "info": Object {
+                  "name": "node-gyp",
+                  "version": "3.8.0",
+                },
+              },
+              Object {
+                "id": "resolve-from@4.0.0",
+                "info": Object {
+                  "name": "resolve-from",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "uid-number@0.0.6",
+                "info": Object {
+                  "name": "uid-number",
+                  "version": "0.0.6",
+                },
+              },
+              Object {
+                "id": "umask@1.1.0",
+                "info": Object {
+                  "name": "umask",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "npm-lifecycle@2.1.0",
+                "info": Object {
+                  "name": "npm-lifecycle",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "npm-logical-tree@1.2.1",
+                "info": Object {
+                  "name": "npm-logical-tree",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "get-stream@3.0.0",
+                "info": Object {
+                  "name": "get-stream",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "ms@2.1.1",
+                "info": Object {
+                  "name": "ms",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "humanize-ms@1.2.1",
+                "info": Object {
+                  "name": "humanize-ms",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "agentkeepalive@3.4.1",
+                "info": Object {
+                  "name": "agentkeepalive",
+                  "version": "3.4.1",
+                },
+              },
+              Object {
+                "id": "http-cache-semantics@3.8.1",
+                "info": Object {
+                  "name": "http-cache-semantics",
+                  "version": "3.8.1",
+                },
+              },
+              Object {
+                "id": "es6-promise@4.2.4",
+                "info": Object {
+                  "name": "es6-promise",
+                  "version": "4.2.4",
+                },
+              },
+              Object {
+                "id": "es6-promisify@5.0.0",
+                "info": Object {
+                  "name": "es6-promisify",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "agent-base@4.2.0",
+                "info": Object {
+                  "name": "agent-base",
+                  "version": "4.2.0",
+                },
+              },
+              Object {
+                "id": "ms@2.0.0",
+                "info": Object {
+                  "name": "ms",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "debug@3.1.0",
+                "info": Object {
+                  "name": "debug",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "http-proxy-agent@2.1.0",
+                "info": Object {
+                  "name": "http-proxy-agent",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "https-proxy-agent@2.2.1",
+                "info": Object {
+                  "name": "https-proxy-agent",
+                  "version": "2.2.1",
+                },
+              },
+              Object {
+                "id": "iconv-lite@0.4.23",
+                "info": Object {
+                  "name": "iconv-lite",
+                  "version": "0.4.23",
+                },
+              },
+              Object {
+                "id": "encoding@0.1.12",
+                "info": Object {
+                  "name": "encoding",
+                  "version": "0.1.12",
+                },
+              },
+              Object {
+                "id": "node-fetch-npm@2.0.2",
+                "info": Object {
+                  "name": "node-fetch-npm",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "err-code@1.1.2",
+                "info": Object {
+                  "name": "err-code",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "retry@0.10.1",
+                "info": Object {
+                  "name": "retry",
+                  "version": "0.10.1",
+                },
+              },
+              Object {
+                "id": "promise-retry@1.1.1",
+                "info": Object {
+                  "name": "promise-retry",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "ip@1.1.5",
+                "info": Object {
+                  "name": "ip",
+                  "version": "1.1.5",
+                },
+              },
+              Object {
+                "id": "smart-buffer@4.0.1",
+                "info": Object {
+                  "name": "smart-buffer",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "socks@2.2.0",
+                "info": Object {
+                  "name": "socks",
+                  "version": "2.2.0",
+                },
+              },
+              Object {
+                "id": "socks-proxy-agent@4.0.1",
+                "info": Object {
+                  "name": "socks-proxy-agent",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "make-fetch-happen@4.0.1",
+                "info": Object {
+                  "name": "make-fetch-happen",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "yallist@3.0.2",
+                "info": Object {
+                  "name": "yallist",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "minipass@2.3.3",
+                "info": Object {
+                  "name": "minipass",
+                  "version": "2.3.3",
+                },
+              },
+              Object {
+                "id": "ignore-walk@3.0.1",
+                "info": Object {
+                  "name": "ignore-walk",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "npm-bundled@1.0.5",
+                "info": Object {
+                  "name": "npm-bundled",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "npm-packlist@1.1.12",
+                "info": Object {
+                  "name": "npm-packlist",
+                  "version": "1.1.12",
+                },
+              },
+              Object {
+                "id": "npm-pick-manifest@2.1.0",
+                "info": Object {
+                  "name": "npm-pick-manifest",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "genfun@4.0.1",
+                "info": Object {
+                  "name": "genfun",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "protoduck@5.0.0",
+                "info": Object {
+                  "name": "protoduck",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "chownr@1.1.1",
+                "info": Object {
+                  "name": "chownr",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "fs-minipass@1.2.5",
+                "info": Object {
+                  "name": "fs-minipass",
+                  "version": "1.2.5",
+                },
+              },
+              Object {
+                "id": "yallist@3.0.3",
+                "info": Object {
+                  "name": "yallist",
+                  "version": "3.0.3",
+                },
+              },
+              Object {
+                "id": "minipass@2.3.5",
+                "info": Object {
+                  "name": "minipass",
+                  "version": "2.3.5",
+                },
+              },
+              Object {
+                "id": "minizlib@1.1.1",
+                "info": Object {
+                  "name": "minizlib",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "tar@4.4.8",
+                "info": Object {
+                  "name": "tar",
+                  "version": "4.4.8",
+                },
+              },
+              Object {
+                "id": "pacote@8.1.6",
+                "info": Object {
+                  "name": "pacote",
+                  "version": "8.1.6",
+                },
+              },
+              Object {
+                "id": "prr@1.0.1",
+                "info": Object {
+                  "name": "prr",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "errno@0.1.7",
+                "info": Object {
+                  "name": "errno",
+                  "version": "0.1.7",
+                },
+              },
+              Object {
+                "id": "worker-farm@1.6.0",
+                "info": Object {
+                  "name": "worker-farm",
+                  "version": "1.6.0",
+                },
+              },
+              Object {
+                "id": "libcipm@2.0.2",
+                "info": Object {
+                  "name": "libcipm",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "npm-registry-fetch@3.1.1",
+                "info": Object {
+                  "name": "npm-registry-fetch",
+                  "version": "3.1.1",
+                },
+              },
+              Object {
+                "id": "libnpmhook@4.0.1",
+                "info": Object {
+                  "name": "libnpmhook",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "dotenv@5.0.1",
+                "info": Object {
+                  "name": "dotenv",
+                  "version": "5.0.1",
+                },
+              },
+              Object {
+                "id": "ansi-align@2.0.0",
+                "info": Object {
+                  "name": "ansi-align",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "camelcase@4.1.0",
+                "info": Object {
+                  "name": "camelcase",
+                  "version": "4.1.0",
+                },
+              },
+              Object {
+                "id": "color-name@1.1.3",
+                "info": Object {
+                  "name": "color-name",
+                  "version": "1.1.3",
+                },
+              },
+              Object {
+                "id": "color-convert@1.9.1",
+                "info": Object {
+                  "name": "color-convert",
+                  "version": "1.9.1",
+                },
+              },
+              Object {
+                "id": "ansi-styles@3.2.1",
+                "info": Object {
+                  "name": "ansi-styles",
+                  "version": "3.2.1",
+                },
+              },
+              Object {
+                "id": "escape-string-regexp@1.0.5",
+                "info": Object {
+                  "name": "escape-string-regexp",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "has-flag@3.0.0",
+                "info": Object {
+                  "name": "has-flag",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "supports-color@5.4.0",
+                "info": Object {
+                  "name": "supports-color",
+                  "version": "5.4.0",
+                },
+              },
+              Object {
+                "id": "chalk@2.4.1",
+                "info": Object {
+                  "name": "chalk",
+                  "version": "2.4.1",
+                },
+              },
+              Object {
+                "id": "cli-boxes@1.0.0",
+                "info": Object {
+                  "name": "cli-boxes",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "shebang-regex@1.0.0",
+                "info": Object {
+                  "name": "shebang-regex",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "shebang-command@1.2.0",
+                "info": Object {
+                  "name": "shebang-command",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "cross-spawn@5.1.0",
+                "info": Object {
+                  "name": "cross-spawn",
+                  "version": "5.1.0",
+                },
+              },
+              Object {
+                "id": "is-stream@1.1.0",
+                "info": Object {
+                  "name": "is-stream",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "path-key@2.0.1",
+                "info": Object {
+                  "name": "path-key",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "npm-run-path@2.0.2",
+                "info": Object {
+                  "name": "npm-run-path",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "p-finally@1.0.0",
+                "info": Object {
+                  "name": "p-finally",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "strip-eof@1.0.0",
+                "info": Object {
+                  "name": "strip-eof",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "execa@0.7.0",
+                "info": Object {
+                  "name": "execa",
+                  "version": "0.7.0",
+                },
+              },
+              Object {
+                "id": "term-size@1.2.0",
+                "info": Object {
+                  "name": "term-size",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "widest-line@2.0.0",
+                "info": Object {
+                  "name": "widest-line",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "boxen@1.3.0",
+                "info": Object {
+                  "name": "boxen",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "is-obj@1.0.1",
+                "info": Object {
+                  "name": "is-obj",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "dot-prop@4.2.0",
+                "info": Object {
+                  "name": "dot-prop",
+                  "version": "4.2.0",
+                },
+              },
+              Object {
+                "id": "pify@3.0.0",
+                "info": Object {
+                  "name": "pify",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "make-dir@1.3.0",
+                "info": Object {
+                  "name": "make-dir",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "crypto-random-string@1.0.0",
+                "info": Object {
+                  "name": "crypto-random-string",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "unique-string@1.0.0",
+                "info": Object {
+                  "name": "unique-string",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "xdg-basedir@3.0.0",
+                "info": Object {
+                  "name": "xdg-basedir",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "configstore@3.1.2",
+                "info": Object {
+                  "name": "configstore",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "import-lazy@2.1.0",
+                "info": Object {
+                  "name": "import-lazy",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "is-ci@1.1.0",
+                "info": Object {
+                  "name": "is-ci",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "global-dirs@0.1.1",
+                "info": Object {
+                  "name": "global-dirs",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "is-path-inside@1.0.1",
+                "info": Object {
+                  "name": "is-path-inside",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-installed-globally@0.1.0",
+                "info": Object {
+                  "name": "is-installed-globally",
+                  "version": "0.1.0",
+                },
+              },
+              Object {
+                "id": "is-npm@1.0.0",
+                "info": Object {
+                  "name": "is-npm",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "capture-stack-trace@1.0.0",
+                "info": Object {
+                  "name": "capture-stack-trace",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "create-error-class@3.0.2",
+                "info": Object {
+                  "name": "create-error-class",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "duplexer3@0.1.4",
+                "info": Object {
+                  "name": "duplexer3",
+                  "version": "0.1.4",
+                },
+              },
+              Object {
+                "id": "is-redirect@1.0.0",
+                "info": Object {
+                  "name": "is-redirect",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "is-retry-allowed@1.1.0",
+                "info": Object {
+                  "name": "is-retry-allowed",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "lowercase-keys@1.0.1",
+                "info": Object {
+                  "name": "lowercase-keys",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "timed-out@4.0.1",
+                "info": Object {
+                  "name": "timed-out",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "unzip-response@2.0.1",
+                "info": Object {
+                  "name": "unzip-response",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "prepend-http@1.0.4",
+                "info": Object {
+                  "name": "prepend-http",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "url-parse-lax@1.0.0",
+                "info": Object {
+                  "name": "url-parse-lax",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "got@6.7.1",
+                "info": Object {
+                  "name": "got",
+                  "version": "6.7.1",
+                },
+              },
+              Object {
+                "id": "deep-extend@0.5.1",
+                "info": Object {
+                  "name": "deep-extend",
+                  "version": "0.5.1",
+                },
+              },
+              Object {
+                "id": "minimist@1.2.0",
+                "info": Object {
+                  "name": "minimist",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "strip-json-comments@2.0.1",
+                "info": Object {
+                  "name": "strip-json-comments",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "rc@1.2.7",
+                "info": Object {
+                  "name": "rc",
+                  "version": "1.2.7",
+                },
+              },
+              Object {
+                "id": "registry-auth-token@3.3.2",
+                "info": Object {
+                  "name": "registry-auth-token",
+                  "version": "3.3.2",
+                },
+              },
+              Object {
+                "id": "registry-url@3.1.0",
+                "info": Object {
+                  "name": "registry-url",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "package-json@4.0.1",
+                "info": Object {
+                  "name": "package-json",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "latest-version@3.1.0",
+                "info": Object {
+                  "name": "latest-version",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "semver-diff@2.1.0",
+                "info": Object {
+                  "name": "semver-diff",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "update-notifier@2.5.0",
+                "info": Object {
+                  "name": "update-notifier",
+                  "version": "2.5.0",
+                },
+              },
+              Object {
+                "id": "wrap-ansi@2.1.0",
+                "info": Object {
+                  "name": "wrap-ansi",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "cliui@4.1.0",
+                "info": Object {
+                  "name": "cliui",
+                  "version": "4.1.0",
+                },
+              },
+              Object {
+                "id": "decamelize@1.2.0",
+                "info": Object {
+                  "name": "decamelize",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "p-try@1.0.0",
+                "info": Object {
+                  "name": "p-try",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "p-limit@1.2.0",
+                "info": Object {
+                  "name": "p-limit",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "p-locate@2.0.0",
+                "info": Object {
+                  "name": "p-locate",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "path-exists@3.0.0",
+                "info": Object {
+                  "name": "path-exists",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "locate-path@2.0.0",
+                "info": Object {
+                  "name": "locate-path",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "find-up@2.1.0",
+                "info": Object {
+                  "name": "find-up",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "get-caller-file@1.0.2",
+                "info": Object {
+                  "name": "get-caller-file",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "invert-kv@1.0.0",
+                "info": Object {
+                  "name": "invert-kv",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "lcid@1.0.0",
+                "info": Object {
+                  "name": "lcid",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "mimic-fn@1.2.0",
+                "info": Object {
+                  "name": "mimic-fn",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "mem@1.1.0",
+                "info": Object {
+                  "name": "mem",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "os-locale@2.1.0",
+                "info": Object {
+                  "name": "os-locale",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "require-directory@2.1.1",
+                "info": Object {
+                  "name": "require-directory",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "require-main-filename@1.0.1",
+                "info": Object {
+                  "name": "require-main-filename",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "y18n@3.2.1",
+                "info": Object {
+                  "name": "y18n",
+                  "version": "3.2.1",
+                },
+              },
+              Object {
+                "id": "yargs-parser@9.0.2",
+                "info": Object {
+                  "name": "yargs-parser",
+                  "version": "9.0.2",
+                },
+              },
+              Object {
+                "id": "yargs@11.0.0",
+                "info": Object {
+                  "name": "yargs",
+                  "version": "11.0.0",
+                },
+              },
+              Object {
+                "id": "libnpx@10.2.0",
+                "info": Object {
+                  "name": "libnpx",
+                  "version": "10.2.0",
+                },
+              },
+              Object {
+                "id": "lockfile@1.0.4",
+                "info": Object {
+                  "name": "lockfile",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "lodash._baseindexof@3.1.0",
+                "info": Object {
+                  "name": "lodash._baseindexof",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "lodash._createset@4.0.3",
+                "info": Object {
+                  "name": "lodash._createset",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "lodash._root@3.0.1",
+                "info": Object {
+                  "name": "lodash._root",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "lodash._baseuniq@4.6.0",
+                "info": Object {
+                  "name": "lodash._baseuniq",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "lodash._bindcallback@3.0.1",
+                "info": Object {
+                  "name": "lodash._bindcallback",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "lodash._cacheindexof@3.0.2",
+                "info": Object {
+                  "name": "lodash._cacheindexof",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "lodash._getnative@3.9.1",
+                "info": Object {
+                  "name": "lodash._getnative",
+                  "version": "3.9.1",
+                },
+              },
+              Object {
+                "id": "lodash._createcache@3.1.2",
+                "info": Object {
+                  "name": "lodash._createcache",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "lodash.clonedeep@4.5.0",
+                "info": Object {
+                  "name": "lodash.clonedeep",
+                  "version": "4.5.0",
+                },
+              },
+              Object {
+                "id": "lodash.restparam@3.6.1",
+                "info": Object {
+                  "name": "lodash.restparam",
+                  "version": "3.6.1",
+                },
+              },
+              Object {
+                "id": "lodash.union@4.6.0",
+                "info": Object {
+                  "name": "lodash.union",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "lodash.uniq@4.5.0",
+                "info": Object {
+                  "name": "lodash.uniq",
+                  "version": "4.5.0",
+                },
+              },
+              Object {
+                "id": "lodash.without@4.4.0",
+                "info": Object {
+                  "name": "lodash.without",
+                  "version": "4.4.0",
+                },
+              },
+              Object {
+                "id": "meant@1.0.1",
+                "info": Object {
+                  "name": "meant",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "nopt@4.0.1",
+                "info": Object {
+                  "name": "nopt",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "npm-audit-report@1.3.1",
+                "info": Object {
+                  "name": "npm-audit-report",
+                  "version": "1.3.1",
+                },
+              },
+              Object {
+                "id": "npm-cache-filename@1.0.2",
+                "info": Object {
+                  "name": "npm-cache-filename",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "npm-install-checks@3.0.0",
+                "info": Object {
+                  "name": "npm-install-checks",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "npm-profile@3.0.2",
+                "info": Object {
+                  "name": "npm-profile",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "ssri@5.3.0",
+                "info": Object {
+                  "name": "ssri",
+                  "version": "5.3.0",
+                },
+              },
+              Object {
+                "id": "npm-registry-client@8.6.0",
+                "info": Object {
+                  "name": "npm-registry-client",
+                  "version": "8.6.0",
+                },
+              },
+              Object {
+                "id": "figgy-pudding@2.0.1",
+                "info": Object {
+                  "name": "figgy-pudding",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "mississippi@2.0.0",
+                "info": Object {
+                  "name": "mississippi",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "cacache@10.0.4",
+                "info": Object {
+                  "name": "cacache",
+                  "version": "10.0.4",
+                },
+              },
+              Object {
+                "id": "smart-buffer@1.1.15",
+                "info": Object {
+                  "name": "smart-buffer",
+                  "version": "1.1.15",
+                },
+              },
+              Object {
+                "id": "socks@1.1.10",
+                "info": Object {
+                  "name": "socks",
+                  "version": "1.1.10",
+                },
+              },
+              Object {
+                "id": "socks-proxy-agent@3.0.1",
+                "info": Object {
+                  "name": "socks-proxy-agent",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "make-fetch-happen@3.0.0",
+                "info": Object {
+                  "name": "make-fetch-happen",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "npm-registry-fetch@1.1.0",
+                "info": Object {
+                  "name": "npm-registry-fetch",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "npm-user-validate@1.0.0",
+                "info": Object {
+                  "name": "npm-user-validate",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "opener@1.5.1",
+                "info": Object {
+                  "name": "opener",
+                  "version": "1.5.1",
+                },
+              },
+              Object {
+                "id": "qrcode-terminal@0.12.0",
+                "info": Object {
+                  "name": "qrcode-terminal",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "decode-uri-component@0.2.0",
+                "info": Object {
+                  "name": "decode-uri-component",
+                  "version": "0.2.0",
+                },
+              },
+              Object {
+                "id": "strict-uri-encode@2.0.0",
+                "info": Object {
+                  "name": "strict-uri-encode",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "query-string@6.1.0",
+                "info": Object {
+                  "name": "query-string",
+                  "version": "6.1.0",
+                },
+              },
+              Object {
+                "id": "qw@1.0.1",
+                "info": Object {
+                  "name": "qw",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "debuglog@1.0.1",
+                "info": Object {
+                  "name": "debuglog",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "readdir-scoped-modules@1.0.2",
+                "info": Object {
+                  "name": "readdir-scoped-modules",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "util-extend@1.0.3",
+                "info": Object {
+                  "name": "util-extend",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "read-installed@4.0.3",
+                "info": Object {
+                  "name": "read-installed",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "read-package-tree@5.2.1",
+                "info": Object {
+                  "name": "read-package-tree",
+                  "version": "5.2.1",
+                },
+              },
+              Object {
+                "id": "retry@0.12.0",
+                "info": Object {
+                  "name": "retry",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "sha@2.0.1",
+                "info": Object {
+                  "name": "sha",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "sorted-object@2.0.1",
+                "info": Object {
+                  "name": "sorted-object",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "isarray@0.0.1",
+                "info": Object {
+                  "name": "isarray",
+                  "version": "0.0.1",
+                },
+              },
+              Object {
+                "id": "string_decoder@0.10.31",
+                "info": Object {
+                  "name": "string_decoder",
+                  "version": "0.10.31",
+                },
+              },
+              Object {
+                "id": "readable-stream@1.1.14",
+                "info": Object {
+                  "name": "readable-stream",
+                  "version": "1.1.14",
+                },
+              },
+              Object {
+                "id": "from2@1.3.0",
+                "info": Object {
+                  "name": "from2",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "stream-iterate@1.2.0",
+                "info": Object {
+                  "name": "stream-iterate",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "sorted-union-stream@2.1.3",
+                "info": Object {
+                  "name": "sorted-union-stream",
+                  "version": "2.1.3",
+                },
+              },
+              Object {
+                "id": "stringify-package@1.0.0",
+                "info": Object {
+                  "name": "stringify-package",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "text-table@0.2.0",
+                "info": Object {
+                  "name": "text-table",
+                  "version": "0.2.0",
+                },
+              },
+              Object {
+                "id": "tiny-relative-date@1.3.0",
+                "info": Object {
+                  "name": "tiny-relative-date",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "unpipe@1.0.0",
+                "info": Object {
+                  "name": "unpipe",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "npm@6.5.0",
+                "info": Object {
+                  "name": "npm",
+                  "version": "6.5.0",
+                },
+              },
+            ],
+            "schemaVersion": "1.3.0",
+          },
+          "type": "depGraph",
+        },
+        Object {
+          "data": "/usr/local/lib/node_modules",
+          "type": "testedFiles",
+        },
+        Object {
+          "data": "sha256:ebbf98230a821f1795b10c4df40ce81b1905e47d625cb9b4b0c7c617acb85e53",
+          "type": "imageId",
+        },
+      ],
+      "identity": Object {
+        "targetFile": "/usr/local/lib/node_modules",
+        "type": "npm",
+      },
+      "target": Object {
+        "image": "docker-image|snykgoof/dockerhub-goof",
+      },
+    },
   ],
 }
 `;
@@ -1021,6 +7889,6874 @@ Object {
           "platform": "linux/amd64",
         },
         "type": "apk",
+      },
+      "target": Object {
+        "image": "docker-image|snykgoof/dockerhub-goof",
+      },
+    },
+    Object {
+      "facts": Array [
+        Object {
+          "data": Object {
+            "graph": Object {
+              "nodes": Array [
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "npm@6.5.0",
+                    },
+                  ],
+                  "nodeId": "root-node",
+                  "pkgId": "lib@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "jsonparse@1.3.1",
+                  "pkgId": "jsonparse@1.3.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "through@2.3.8",
+                  "pkgId": "through@2.3.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "jsonparse@1.3.1",
+                    },
+                    Object {
+                      "nodeId": "through@2.3.8",
+                    },
+                  ],
+                  "nodeId": "JSONStream@1.3.4",
+                  "pkgId": "JSONStream@1.3.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "abbrev@1.1.1",
+                  "pkgId": "abbrev@1.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansicolors@0.3.2",
+                  "pkgId": "ansicolors@0.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansistyles@0.1.3",
+                  "pkgId": "ansistyles@0.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aproba@1.2.0",
+                  "pkgId": "aproba@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "archy@1.0.0",
+                  "pkgId": "archy@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "bluebird@3.5.3",
+                  "pkgId": "bluebird@3.5.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "graceful-fs@4.1.15",
+                  "pkgId": "graceful-fs@4.1.15",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "minimist@0.0.8",
+                  "pkgId": "minimist@0.0.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minimist@0.0.8",
+                    },
+                  ],
+                  "nodeId": "mkdirp@0.5.1",
+                  "pkgId": "mkdirp@0.5.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                  ],
+                  "nodeId": "cmd-shim@2.0.2",
+                  "pkgId": "cmd-shim@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-is-inside@1.0.2",
+                  "pkgId": "path-is-inside@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fs.realpath@1.0.0",
+                  "pkgId": "fs.realpath@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "wrappy@1.0.2",
+                  "pkgId": "wrappy@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "once@1.4.0",
+                  "pkgId": "once@1.4.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "inflight@1.0.6",
+                  "pkgId": "inflight@1.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "inherits@2.0.3",
+                  "pkgId": "inherits@2.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "balanced-match@1.0.0",
+                  "pkgId": "balanced-match@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "concat-map@0.0.1",
+                  "pkgId": "concat-map@0.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "balanced-match@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "concat-map@0.0.1",
+                    },
+                  ],
+                  "nodeId": "brace-expansion@1.1.11",
+                  "pkgId": "brace-expansion@1.1.11",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "brace-expansion@1.1.11",
+                    },
+                  ],
+                  "nodeId": "minimatch@3.0.4",
+                  "pkgId": "minimatch@3.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-is-absolute@1.0.1",
+                  "pkgId": "path-is-absolute@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "fs.realpath@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "inflight@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "minimatch@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "path-is-absolute@1.0.1",
+                    },
+                  ],
+                  "nodeId": "glob@7.1.3",
+                  "pkgId": "glob@7.1.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                  ],
+                  "nodeId": "rimraf@2.6.2",
+                  "pkgId": "rimraf@2.6.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                  ],
+                  "nodeId": "fs-vacuum@1.2.10",
+                  "pkgId": "fs-vacuum@1.2.10",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "iferr@0.1.5",
+                  "pkgId": "iferr@0.1.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                  ],
+                  "nodeId": "read-cmd-shim@1.0.1",
+                  "pkgId": "read-cmd-shim@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "slide@1.1.6",
+                  "pkgId": "slide@1.1.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "fs-vacuum@1.2.10",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "read-cmd-shim@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                  ],
+                  "nodeId": "gentle-fs@2.0.1",
+                  "pkgId": "gentle-fs@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "imurmurhash@0.1.4",
+                  "pkgId": "imurmurhash@0.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "signal-exit@3.0.2",
+                  "pkgId": "signal-exit@3.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                  ],
+                  "nodeId": "write-file-atomic@2.3.0",
+                  "pkgId": "write-file-atomic@2.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "cmd-shim@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "gentle-fs@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.3.0",
+                    },
+                  ],
+                  "nodeId": "bin-links@1.1.2",
+                  "pkgId": "bin-links@1.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "byte-size@4.0.3",
+                  "pkgId": "byte-size@4.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "chownr@1.0.1",
+                  "pkgId": "chownr@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "figgy-pudding@3.5.1",
+                  "pkgId": "figgy-pudding@3.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pseudomap@1.0.2",
+                  "pkgId": "pseudomap@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "yallist@2.1.2",
+                  "pkgId": "yallist@2.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pseudomap@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@2.1.2",
+                    },
+                  ],
+                  "nodeId": "lru-cache@4.1.3",
+                  "pkgId": "lru-cache@4.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "buffer-from@1.0.0",
+                  "pkgId": "buffer-from@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "core-util-is@1.0.2",
+                  "pkgId": "core-util-is@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isarray@1.0.0",
+                  "pkgId": "isarray@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "process-nextick-args@2.0.0",
+                  "pkgId": "process-nextick-args@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "safe-buffer@5.1.2",
+                  "pkgId": "safe-buffer@5.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "string_decoder@1.1.1",
+                  "pkgId": "string_decoder@1.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-deprecate@1.0.2",
+                  "pkgId": "util-deprecate@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "isarray@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "process-nextick-args@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "string_decoder@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "util-deprecate@1.0.2",
+                    },
+                  ],
+                  "nodeId": "readable-stream@2.3.6",
+                  "pkgId": "readable-stream@2.3.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "typedarray@0.0.6",
+                  "pkgId": "typedarray@0.0.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "buffer-from@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "typedarray@0.0.6",
+                    },
+                  ],
+                  "nodeId": "concat-stream@1.6.2",
+                  "pkgId": "concat-stream@1.6.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "end-of-stream@1.4.1",
+                  "pkgId": "end-of-stream@1.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stream-shift@1.0.0",
+                  "pkgId": "stream-shift@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "duplexify@3.6.0",
+                  "pkgId": "duplexify@3.6.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "flush-write-stream@1.0.3",
+                  "pkgId": "flush-write-stream@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "from2@2.3.0",
+                  "pkgId": "from2@2.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "cyclist@0.2.2",
+                  "pkgId": "cyclist@0.2.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cyclist@0.2.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "parallel-transform@1.1.0",
+                  "pkgId": "parallel-transform@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "pump@3.0.0",
+                  "pkgId": "pump@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "pump@2.0.1",
+                  "pkgId": "pump@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "duplexify@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "pump@2.0.1",
+                    },
+                  ],
+                  "nodeId": "pumpify@1.5.1",
+                  "pkgId": "pumpify@1.5.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "stream-each@1.2.2",
+                  "pkgId": "stream-each@1.2.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xtend@4.0.1",
+                  "pkgId": "xtend@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "xtend@4.0.1",
+                    },
+                  ],
+                  "nodeId": "through2@2.0.3",
+                  "pkgId": "through2@2.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "concat-stream@1.6.2",
+                    },
+                    Object {
+                      "nodeId": "duplexify@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "flush-write-stream@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "from2@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "parallel-transform@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "pump@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "pumpify@1.5.1",
+                    },
+                    Object {
+                      "nodeId": "stream-each@1.2.2",
+                    },
+                    Object {
+                      "nodeId": "through2@2.0.3",
+                    },
+                  ],
+                  "nodeId": "mississippi@3.0.0",
+                  "pkgId": "mississippi@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "fs-write-stream-atomic@1.0.10",
+                  "pkgId": "fs-write-stream-atomic@1.0.10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                  ],
+                  "nodeId": "run-queue@1.0.3",
+                  "pkgId": "run-queue@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "iferr@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "run-queue@1.0.3",
+                    },
+                  ],
+                  "nodeId": "copy-concurrently@1.0.5",
+                  "pkgId": "copy-concurrently@1.0.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "copy-concurrently@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "run-queue@1.0.3",
+                    },
+                  ],
+                  "nodeId": "move-concurrently@1.0.1",
+                  "pkgId": "move-concurrently@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "promise-inflight@1.0.1",
+                  "pkgId": "promise-inflight@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                  ],
+                  "nodeId": "ssri@6.0.1",
+                  "pkgId": "ssri@6.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "imurmurhash@0.1.4",
+                    },
+                  ],
+                  "nodeId": "unique-slug@2.0.0",
+                  "pkgId": "unique-slug@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "unique-slug@2.0.0",
+                    },
+                  ],
+                  "nodeId": "unique-filename@1.1.0",
+                  "pkgId": "unique-filename@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "y18n@4.0.0",
+                  "pkgId": "y18n@4.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "move-concurrently@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "y18n@4.0.0",
+                    },
+                  ],
+                  "nodeId": "cacache@11.2.0",
+                  "pkgId": "cacache@11.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "call-limit@1.1.0",
+                  "pkgId": "call-limit@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ci-info@1.6.0",
+                  "pkgId": "ci-info@1.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-fullwidth-code-point@2.0.0",
+                  "pkgId": "is-fullwidth-code-point@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansi-regex@3.0.0",
+                  "pkgId": "ansi-regex@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-regex@3.0.0",
+                    },
+                  ],
+                  "nodeId": "strip-ansi@4.0.0",
+                  "pkgId": "strip-ansi@4.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-fullwidth-code-point@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@4.0.0",
+                    },
+                  ],
+                  "nodeId": "string-width@2.1.1",
+                  "pkgId": "string-width@2.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ansi-regex@2.1.1",
+                  "pkgId": "ansi-regex@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-regex@2.1.1",
+                    },
+                  ],
+                  "nodeId": "strip-ansi@3.0.1",
+                  "pkgId": "strip-ansi@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "cli-columns@3.1.2",
+                  "pkgId": "cli-columns@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "colors@1.1.2",
+                  "pkgId": "colors@1.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "object-assign@4.1.1",
+                  "pkgId": "object-assign@4.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "colors@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "object-assign@4.1.1",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "cli-table3@0.5.0",
+                  "pkgId": "cli-table3@0.5.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "clone@1.0.4",
+                  "pkgId": "clone@1.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "clone@1.0.4",
+                    },
+                  ],
+                  "nodeId": "defaults@1.0.3",
+                  "pkgId": "defaults@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "defaults@1.0.3",
+                    },
+                  ],
+                  "nodeId": "wcwidth@1.0.1",
+                  "pkgId": "wcwidth@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "wcwidth@1.0.1",
+                    },
+                  ],
+                  "nodeId": "columnify@1.5.4",
+                  "pkgId": "columnify@1.5.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ini@1.3.5",
+                  "pkgId": "ini@1.3.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "proto-list@1.2.4",
+                  "pkgId": "proto-list@1.2.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "proto-list@1.2.4",
+                    },
+                  ],
+                  "nodeId": "config-chain@1.1.12",
+                  "pkgId": "config-chain@1.1.12",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "detect-indent@5.0.0",
+                  "pkgId": "detect-indent@5.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "detect-newline@2.1.0",
+                  "pkgId": "detect-newline@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "asap@2.0.6",
+                  "pkgId": "asap@2.0.6",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asap@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "wrappy@1.0.2",
+                    },
+                  ],
+                  "nodeId": "dezalgo@1.0.3",
+                  "pkgId": "dezalgo@1.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "editor@1.0.0",
+                  "pkgId": "editor@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "find-npm-prefix@1.0.2",
+                  "pkgId": "find-npm-prefix@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-unicode@2.0.1",
+                  "pkgId": "has-unicode@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "hosted-git-info@2.7.1",
+                  "pkgId": "hosted-git-info@2.7.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "iferr@1.0.2",
+                  "pkgId": "iferr@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "os-homedir@1.0.2",
+                  "pkgId": "os-homedir@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "os-tmpdir@1.0.2",
+                  "pkgId": "os-tmpdir@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "os-homedir@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "os-tmpdir@1.0.2",
+                    },
+                  ],
+                  "nodeId": "osenv@0.1.5",
+                  "pkgId": "osenv@0.1.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "semver@5.5.1",
+                  "pkgId": "semver@5.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "builtins@1.0.3",
+                  "pkgId": "builtins@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "builtins@1.0.3",
+                    },
+                  ],
+                  "nodeId": "validate-npm-package-name@3.0.0",
+                  "pkgId": "validate-npm-package-name@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "hosted-git-info@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                  ],
+                  "nodeId": "npm-package-arg@6.1.0",
+                  "pkgId": "npm-package-arg@6.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mute-stream@0.0.7",
+                  "pkgId": "mute-stream@0.0.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mute-stream@0.0.7",
+                    },
+                  ],
+                  "nodeId": "read@1.0.7",
+                  "pkgId": "read@1.0.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                  ],
+                  "nodeId": "promzard@0.3.0",
+                  "pkgId": "promzard@0.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-parse-better-errors@1.0.2",
+                  "pkgId": "json-parse-better-errors@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "builtin-modules@1.1.1",
+                  "pkgId": "builtin-modules@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "builtin-modules@1.1.1",
+                    },
+                  ],
+                  "nodeId": "is-builtin-module@1.0.0",
+                  "pkgId": "is-builtin-module@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "spdx-exceptions@2.1.0",
+                  "pkgId": "spdx-exceptions@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "spdx-license-ids@3.0.0",
+                  "pkgId": "spdx-license-ids@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-exceptions@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-license-ids@3.0.0",
+                    },
+                  ],
+                  "nodeId": "spdx-expression-parse@3.0.0",
+                  "pkgId": "spdx-expression-parse@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-expression-parse@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-license-ids@3.0.0",
+                    },
+                  ],
+                  "nodeId": "spdx-correct@3.0.0",
+                  "pkgId": "spdx-correct@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "spdx-correct@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "spdx-expression-parse@3.0.0",
+                    },
+                  ],
+                  "nodeId": "validate-npm-package-license@3.0.4",
+                  "pkgId": "validate-npm-package-license@3.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "hosted-git-info@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "is-builtin-module@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                  ],
+                  "nodeId": "normalize-package-data@2.4.0",
+                  "pkgId": "normalize-package-data@2.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "slash@1.0.0",
+                  "pkgId": "slash@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.4.0",
+                    },
+                    Object {
+                      "nodeId": "slash@1.0.0",
+                    },
+                  ],
+                  "nodeId": "read-package-json@2.0.13",
+                  "pkgId": "read-package-json@2.0.13",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "promzard@0.3.0",
+                    },
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                  ],
+                  "nodeId": "init-package-json@1.10.3",
+                  "pkgId": "init-package-json@1.10.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ip-regex@2.1.0",
+                  "pkgId": "ip-regex@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ip-regex@2.1.0",
+                    },
+                  ],
+                  "nodeId": "cidr-regex@2.0.9",
+                  "pkgId": "cidr-regex@2.0.9",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cidr-regex@2.0.9",
+                    },
+                  ],
+                  "nodeId": "is-cidr@2.0.6",
+                  "pkgId": "is-cidr@2.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isexe@2.0.0",
+                  "pkgId": "isexe@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lazy-property@1.0.0",
+                  "pkgId": "lazy-property@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "lock-verify@2.0.2",
+                  "pkgId": "lock-verify@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "byline@5.0.0",
+                  "pkgId": "byline@5.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                  ],
+                  "nodeId": "fstream@1.0.11",
+                  "pkgId": "fstream@1.0.11",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                  ],
+                  "nodeId": "nopt@3.0.6",
+                  "pkgId": "nopt@3.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "delegates@1.0.0",
+                  "pkgId": "delegates@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "delegates@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "are-we-there-yet@1.1.4",
+                  "pkgId": "are-we-there-yet@1.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "console-control-strings@1.1.0",
+                  "pkgId": "console-control-strings@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "code-point-at@1.1.0",
+                  "pkgId": "code-point-at@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "number-is-nan@1.0.1",
+                  "pkgId": "number-is-nan@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "number-is-nan@1.0.1",
+                    },
+                  ],
+                  "nodeId": "is-fullwidth-code-point@1.0.0",
+                  "pkgId": "is-fullwidth-code-point@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "code-point-at@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-fullwidth-code-point@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "string-width@1.0.2",
+                  "pkgId": "string-width@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                  ],
+                  "nodeId": "wide-align@1.1.2",
+                  "pkgId": "wide-align@1.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "has-unicode@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "object-assign@4.1.1",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "wide-align@1.1.2",
+                    },
+                  ],
+                  "nodeId": "gauge@2.7.4",
+                  "pkgId": "gauge@2.7.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "set-blocking@2.0.0",
+                  "pkgId": "set-blocking@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "are-we-there-yet@1.1.4",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "gauge@2.7.4",
+                    },
+                    Object {
+                      "nodeId": "set-blocking@2.0.0",
+                    },
+                  ],
+                  "nodeId": "npmlog@4.1.2",
+                  "pkgId": "npmlog@4.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aws-sign2@0.7.0",
+                  "pkgId": "aws-sign2@0.7.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "aws4@1.8.0",
+                  "pkgId": "aws4@1.8.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "caseless@0.12.0",
+                  "pkgId": "caseless@0.12.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "delayed-stream@1.0.0",
+                  "pkgId": "delayed-stream@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "delayed-stream@1.0.0",
+                    },
+                  ],
+                  "nodeId": "combined-stream@1.0.6",
+                  "pkgId": "combined-stream@1.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "extend@3.0.2",
+                  "pkgId": "extend@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "forever-agent@0.6.1",
+                  "pkgId": "forever-agent@0.6.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "asynckit@0.4.0",
+                  "pkgId": "asynckit@0.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mime-db@1.35.0",
+                  "pkgId": "mime-db@1.35.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mime-db@1.35.0",
+                    },
+                  ],
+                  "nodeId": "mime-types@2.1.19",
+                  "pkgId": "mime-types@2.1.19",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asynckit@0.4.0",
+                    },
+                    Object {
+                      "nodeId": "combined-stream@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "mime-types@2.1.19",
+                    },
+                  ],
+                  "nodeId": "form-data@2.3.2",
+                  "pkgId": "form-data@2.3.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "co@4.6.0",
+                  "pkgId": "co@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fast-deep-equal@1.1.0",
+                  "pkgId": "fast-deep-equal@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "fast-json-stable-stringify@2.0.0",
+                  "pkgId": "fast-json-stable-stringify@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-schema-traverse@0.3.1",
+                  "pkgId": "json-schema-traverse@0.3.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "co@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "fast-deep-equal@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "fast-json-stable-stringify@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "json-schema-traverse@0.3.1",
+                    },
+                  ],
+                  "nodeId": "ajv@5.5.2",
+                  "pkgId": "ajv@5.5.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "har-schema@2.0.0",
+                  "pkgId": "har-schema@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ajv@5.5.2",
+                    },
+                    Object {
+                      "nodeId": "har-schema@2.0.0",
+                    },
+                  ],
+                  "nodeId": "har-validator@5.1.0",
+                  "pkgId": "har-validator@5.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "assert-plus@1.0.0",
+                  "pkgId": "assert-plus@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "extsprintf@1.3.0",
+                  "pkgId": "extsprintf@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-schema@0.2.3",
+                  "pkgId": "json-schema@0.2.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "extsprintf@1.3.0",
+                    },
+                  ],
+                  "nodeId": "verror@1.10.0",
+                  "pkgId": "verror@1.10.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "extsprintf@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "json-schema@0.2.3",
+                    },
+                    Object {
+                      "nodeId": "verror@1.10.0",
+                    },
+                  ],
+                  "nodeId": "jsprim@1.4.1",
+                  "pkgId": "jsprim@1.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "safer-buffer@2.1.2",
+                  "pkgId": "safer-buffer@2.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "asn1@0.2.4",
+                  "pkgId": "asn1@0.2.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tweetnacl@0.14.5",
+                  "pkgId": "tweetnacl@0.14.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "tweetnacl@0.14.5",
+                    },
+                  ],
+                  "nodeId": "bcrypt-pbkdf@1.0.2",
+                  "pkgId": "bcrypt-pbkdf@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                  ],
+                  "nodeId": "dashdash@1.14.1",
+                  "pkgId": "dashdash@1.14.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "jsbn@0.1.1",
+                  "pkgId": "jsbn@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "jsbn@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "ecc-jsbn@0.1.2",
+                  "pkgId": "ecc-jsbn@0.1.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                  ],
+                  "nodeId": "getpass@0.1.7",
+                  "pkgId": "getpass@0.1.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "asn1@0.2.4",
+                    },
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "bcrypt-pbkdf@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "dashdash@1.14.1",
+                    },
+                    Object {
+                      "nodeId": "ecc-jsbn@0.1.2",
+                    },
+                    Object {
+                      "nodeId": "getpass@0.1.7",
+                    },
+                    Object {
+                      "nodeId": "jsbn@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                    Object {
+                      "nodeId": "tweetnacl@0.14.5",
+                    },
+                  ],
+                  "nodeId": "sshpk@1.14.2",
+                  "pkgId": "sshpk@1.14.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "assert-plus@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "jsprim@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "sshpk@1.14.2",
+                    },
+                  ],
+                  "nodeId": "http-signature@1.2.0",
+                  "pkgId": "http-signature@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-typedarray@1.0.0",
+                  "pkgId": "is-typedarray@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isstream@0.1.2",
+                  "pkgId": "isstream@0.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "json-stringify-safe@5.0.1",
+                  "pkgId": "json-stringify-safe@5.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "oauth-sign@0.9.0",
+                  "pkgId": "oauth-sign@0.9.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "performance-now@2.1.0",
+                  "pkgId": "performance-now@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qs@6.5.2",
+                  "pkgId": "qs@6.5.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "psl@1.1.29",
+                  "pkgId": "psl@1.1.29",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "punycode@1.4.1",
+                  "pkgId": "punycode@1.4.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "psl@1.1.29",
+                    },
+                    Object {
+                      "nodeId": "punycode@1.4.1",
+                    },
+                  ],
+                  "nodeId": "tough-cookie@2.4.3",
+                  "pkgId": "tough-cookie@2.4.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "tunnel-agent@0.6.0",
+                  "pkgId": "tunnel-agent@0.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "uuid@3.3.2",
+                  "pkgId": "uuid@3.3.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aws-sign2@0.7.0",
+                    },
+                    Object {
+                      "nodeId": "aws4@1.8.0",
+                    },
+                    Object {
+                      "nodeId": "caseless@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "combined-stream@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "extend@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "forever-agent@0.6.1",
+                    },
+                    Object {
+                      "nodeId": "form-data@2.3.2",
+                    },
+                    Object {
+                      "nodeId": "har-validator@5.1.0",
+                    },
+                    Object {
+                      "nodeId": "http-signature@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "is-typedarray@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "isstream@0.1.2",
+                    },
+                    Object {
+                      "nodeId": "json-stringify-safe@5.0.1",
+                    },
+                    Object {
+                      "nodeId": "mime-types@2.1.19",
+                    },
+                    Object {
+                      "nodeId": "oauth-sign@0.9.0",
+                    },
+                    Object {
+                      "nodeId": "performance-now@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "qs@6.5.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "tough-cookie@2.4.3",
+                    },
+                    Object {
+                      "nodeId": "tunnel-agent@0.6.0",
+                    },
+                    Object {
+                      "nodeId": "uuid@3.3.2",
+                    },
+                  ],
+                  "nodeId": "request@2.88.0",
+                  "pkgId": "request@2.88.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "semver@5.3.0",
+                  "pkgId": "semver@5.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                  ],
+                  "nodeId": "block-stream@0.0.9",
+                  "pkgId": "block-stream@0.0.9",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "block-stream@0.0.9",
+                    },
+                    Object {
+                      "nodeId": "fstream@1.0.11",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                  ],
+                  "nodeId": "tar@2.2.1",
+                  "pkgId": "tar@2.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "fstream@1.0.11",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "nopt@3.0.6",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "request@2.88.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.3.0",
+                    },
+                    Object {
+                      "nodeId": "tar@2.2.1",
+                    },
+                  ],
+                  "nodeId": "node-gyp@3.8.0",
+                  "pkgId": "node-gyp@3.8.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "resolve-from@4.0.0",
+                  "pkgId": "resolve-from@4.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "uid-number@0.0.6",
+                  "pkgId": "uid-number@0.0.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "umask@1.1.0",
+                  "pkgId": "umask@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "byline@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "node-gyp@3.8.0",
+                    },
+                    Object {
+                      "nodeId": "resolve-from@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "uid-number@0.0.6",
+                    },
+                    Object {
+                      "nodeId": "umask@1.1.0",
+                    },
+                  ],
+                  "nodeId": "npm-lifecycle@2.1.0",
+                  "pkgId": "npm-lifecycle@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-logical-tree@1.2.1",
+                  "pkgId": "npm-logical-tree@1.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "get-stream@3.0.0",
+                  "pkgId": "get-stream@3.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ms@2.1.1",
+                  "pkgId": "ms@2.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ms@2.1.1",
+                    },
+                  ],
+                  "nodeId": "humanize-ms@1.2.1",
+                  "pkgId": "humanize-ms@1.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "humanize-ms@1.2.1",
+                    },
+                  ],
+                  "nodeId": "agentkeepalive@3.4.1",
+                  "pkgId": "agentkeepalive@3.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "http-cache-semantics@3.8.1",
+                  "pkgId": "http-cache-semantics@3.8.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "es6-promise@4.2.4",
+                  "pkgId": "es6-promise@4.2.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "es6-promise@4.2.4",
+                    },
+                  ],
+                  "nodeId": "es6-promisify@5.0.0",
+                  "pkgId": "es6-promisify@5.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "es6-promisify@5.0.0",
+                    },
+                  ],
+                  "nodeId": "agent-base@4.2.0",
+                  "pkgId": "agent-base@4.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ms@2.0.0",
+                  "pkgId": "ms@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ms@2.0.0",
+                    },
+                  ],
+                  "nodeId": "debug@3.1.0",
+                  "pkgId": "debug@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "debug@3.1.0",
+                    },
+                  ],
+                  "nodeId": "http-proxy-agent@2.1.0",
+                  "pkgId": "http-proxy-agent@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "debug@3.1.0",
+                    },
+                  ],
+                  "nodeId": "https-proxy-agent@2.2.1",
+                  "pkgId": "https-proxy-agent@2.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safer-buffer@2.1.2",
+                    },
+                  ],
+                  "nodeId": "iconv-lite@0.4.23",
+                  "pkgId": "iconv-lite@0.4.23",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "iconv-lite@0.4.23",
+                    },
+                  ],
+                  "nodeId": "encoding@0.1.12",
+                  "pkgId": "encoding@0.1.12",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "encoding@0.1.12",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "node-fetch-npm@2.0.2",
+                  "pkgId": "node-fetch-npm@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "err-code@1.1.2",
+                  "pkgId": "err-code@1.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "retry@0.10.1",
+                  "pkgId": "retry@0.10.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "err-code@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "retry@0.10.1",
+                    },
+                  ],
+                  "nodeId": "promise-retry@1.1.1",
+                  "pkgId": "promise-retry@1.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ip@1.1.5",
+                  "pkgId": "ip@1.1.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "smart-buffer@4.0.1",
+                  "pkgId": "smart-buffer@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ip@1.1.5",
+                    },
+                    Object {
+                      "nodeId": "smart-buffer@4.0.1",
+                    },
+                  ],
+                  "nodeId": "socks@2.2.0",
+                  "pkgId": "socks@2.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "socks@2.2.0",
+                    },
+                  ],
+                  "nodeId": "socks-proxy-agent@4.0.1",
+                  "pkgId": "socks-proxy-agent@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agentkeepalive@3.4.1",
+                    },
+                    Object {
+                      "nodeId": "cacache@11.2.0",
+                    },
+                    Object {
+                      "nodeId": "http-cache-semantics@3.8.1",
+                    },
+                    Object {
+                      "nodeId": "http-proxy-agent@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "https-proxy-agent@2.2.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "node-fetch-npm@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "promise-retry@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "socks-proxy-agent@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                  ],
+                  "nodeId": "make-fetch-happen@4.0.1",
+                  "pkgId": "make-fetch-happen@4.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "yallist@3.0.2",
+                  "pkgId": "yallist@3.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@3.0.2",
+                    },
+                  ],
+                  "nodeId": "minipass@2.3.3",
+                  "pkgId": "minipass@2.3.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minimatch@3.0.4",
+                    },
+                  ],
+                  "nodeId": "ignore-walk@3.0.1",
+                  "pkgId": "ignore-walk@3.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-bundled@1.0.5",
+                  "pkgId": "npm-bundled@1.0.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ignore-walk@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "npm-bundled@1.0.5",
+                    },
+                  ],
+                  "nodeId": "npm-packlist@1.1.12",
+                  "pkgId": "npm-packlist@1.1.12",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "npm-pick-manifest@2.1.0",
+                  "pkgId": "npm-pick-manifest@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "genfun@4.0.1",
+                  "pkgId": "genfun@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "genfun@4.0.1",
+                    },
+                  ],
+                  "nodeId": "protoduck@5.0.0",
+                  "pkgId": "protoduck@5.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "chownr@1.1.1",
+                  "pkgId": "chownr@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minipass@2.3.3",
+                    },
+                  ],
+                  "nodeId": "fs-minipass@1.2.5",
+                  "pkgId": "fs-minipass@1.2.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "yallist@3.0.3",
+                  "pkgId": "yallist@3.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@3.0.3",
+                    },
+                  ],
+                  "nodeId": "minipass@2.3.5",
+                  "pkgId": "minipass@2.3.5",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "minipass@2.3.3",
+                    },
+                  ],
+                  "nodeId": "minizlib@1.1.1",
+                  "pkgId": "minizlib@1.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "chownr@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "fs-minipass@1.2.5",
+                    },
+                    Object {
+                      "nodeId": "minipass@2.3.5",
+                    },
+                    Object {
+                      "nodeId": "minizlib@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "yallist@3.0.3",
+                    },
+                  ],
+                  "nodeId": "tar@4.4.8",
+                  "pkgId": "tar@4.4.8",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "cacache@11.2.0",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "minimatch@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "minipass@2.3.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.4.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-packlist@1.1.12",
+                    },
+                    Object {
+                      "nodeId": "npm-pick-manifest@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "promise-retry@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "protoduck@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "tar@4.4.8",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.0",
+                    },
+                  ],
+                  "nodeId": "pacote@8.1.6",
+                  "pkgId": "pacote@8.1.6",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "prr@1.0.1",
+                  "pkgId": "prr@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "prr@1.0.1",
+                    },
+                  ],
+                  "nodeId": "errno@0.1.7",
+                  "pkgId": "errno@0.1.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "errno@0.1.7",
+                    },
+                  ],
+                  "nodeId": "worker-farm@1.6.0",
+                  "pkgId": "worker-farm@1.6.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bin-links@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "find-npm-prefix@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "lock-verify@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "npm-lifecycle@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-logical-tree@1.2.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "pacote@8.1.6",
+                    },
+                    Object {
+                      "nodeId": "protoduck@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "worker-farm@1.6.0",
+                    },
+                  ],
+                  "nodeId": "libcipm@2.0.2",
+                  "pkgId": "libcipm@2.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                  ],
+                  "nodeId": "npm-registry-fetch@3.1.1",
+                  "pkgId": "npm-registry-fetch@3.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@3.1.1",
+                    },
+                  ],
+                  "nodeId": "libnpmhook@4.0.1",
+                  "pkgId": "libnpmhook@4.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "dotenv@5.0.1",
+                  "pkgId": "dotenv@5.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "ansi-align@2.0.0",
+                  "pkgId": "ansi-align@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "camelcase@4.1.0",
+                  "pkgId": "camelcase@4.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "color-name@1.1.3",
+                  "pkgId": "color-name@1.1.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "color-name@1.1.3",
+                    },
+                  ],
+                  "nodeId": "color-convert@1.9.1",
+                  "pkgId": "color-convert@1.9.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "color-convert@1.9.1",
+                    },
+                  ],
+                  "nodeId": "ansi-styles@3.2.1",
+                  "pkgId": "ansi-styles@3.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "escape-string-regexp@1.0.5",
+                  "pkgId": "escape-string-regexp@1.0.5",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "has-flag@3.0.0",
+                  "pkgId": "has-flag@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "has-flag@3.0.0",
+                    },
+                  ],
+                  "nodeId": "supports-color@5.4.0",
+                  "pkgId": "supports-color@5.4.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-styles@3.2.1",
+                    },
+                    Object {
+                      "nodeId": "escape-string-regexp@1.0.5",
+                    },
+                    Object {
+                      "nodeId": "supports-color@5.4.0",
+                    },
+                  ],
+                  "nodeId": "chalk@2.4.1",
+                  "pkgId": "chalk@2.4.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "cli-boxes@1.0.0",
+                  "pkgId": "cli-boxes@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "shebang-regex@1.0.0",
+                  "pkgId": "shebang-regex@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "shebang-regex@1.0.0",
+                    },
+                  ],
+                  "nodeId": "shebang-command@1.2.0",
+                  "pkgId": "shebang-command@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "shebang-command@1.2.0",
+                    },
+                  ],
+                  "nodeId": "cross-spawn@5.1.0",
+                  "pkgId": "cross-spawn@5.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-stream@1.1.0",
+                  "pkgId": "is-stream@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-key@2.0.1",
+                  "pkgId": "path-key@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "path-key@2.0.1",
+                    },
+                  ],
+                  "nodeId": "npm-run-path@2.0.2",
+                  "pkgId": "npm-run-path@2.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-finally@1.0.0",
+                  "pkgId": "p-finally@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strip-eof@1.0.0",
+                  "pkgId": "strip-eof@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cross-spawn@5.1.0",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-run-path@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "p-finally@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-eof@1.0.0",
+                    },
+                  ],
+                  "nodeId": "execa@0.7.0",
+                  "pkgId": "execa@0.7.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "execa@0.7.0",
+                    },
+                  ],
+                  "nodeId": "term-size@1.2.0",
+                  "pkgId": "term-size@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                  ],
+                  "nodeId": "widest-line@2.0.0",
+                  "pkgId": "widest-line@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ansi-align@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "camelcase@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "chalk@2.4.1",
+                    },
+                    Object {
+                      "nodeId": "cli-boxes@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "term-size@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "widest-line@2.0.0",
+                    },
+                  ],
+                  "nodeId": "boxen@1.3.0",
+                  "pkgId": "boxen@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-obj@1.0.1",
+                  "pkgId": "is-obj@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "is-obj@1.0.1",
+                    },
+                  ],
+                  "nodeId": "dot-prop@4.2.0",
+                  "pkgId": "dot-prop@4.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pify@3.0.0",
+                  "pkgId": "pify@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "pify@3.0.0",
+                    },
+                  ],
+                  "nodeId": "make-dir@1.3.0",
+                  "pkgId": "make-dir@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "crypto-random-string@1.0.0",
+                  "pkgId": "crypto-random-string@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "crypto-random-string@1.0.0",
+                    },
+                  ],
+                  "nodeId": "unique-string@1.0.0",
+                  "pkgId": "unique-string@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "xdg-basedir@3.0.0",
+                  "pkgId": "xdg-basedir@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "dot-prop@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "make-dir@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "unique-string@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "xdg-basedir@3.0.0",
+                    },
+                  ],
+                  "nodeId": "configstore@3.1.2",
+                  "pkgId": "configstore@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "import-lazy@2.1.0",
+                  "pkgId": "import-lazy@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ci-info@1.6.0",
+                    },
+                  ],
+                  "nodeId": "is-ci@1.1.0",
+                  "pkgId": "is-ci@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                  ],
+                  "nodeId": "global-dirs@0.1.1",
+                  "pkgId": "global-dirs@0.1.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                  ],
+                  "nodeId": "is-path-inside@1.0.1",
+                  "pkgId": "is-path-inside@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "global-dirs@0.1.1",
+                    },
+                    Object {
+                      "nodeId": "is-path-inside@1.0.1",
+                    },
+                  ],
+                  "nodeId": "is-installed-globally@0.1.0",
+                  "pkgId": "is-installed-globally@0.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-npm@1.0.0",
+                  "pkgId": "is-npm@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "capture-stack-trace@1.0.0",
+                  "pkgId": "capture-stack-trace@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "capture-stack-trace@1.0.0",
+                    },
+                  ],
+                  "nodeId": "create-error-class@3.0.2",
+                  "pkgId": "create-error-class@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "duplexer3@0.1.4",
+                  "pkgId": "duplexer3@0.1.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-redirect@1.0.0",
+                  "pkgId": "is-redirect@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "is-retry-allowed@1.1.0",
+                  "pkgId": "is-retry-allowed@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lowercase-keys@1.0.1",
+                  "pkgId": "lowercase-keys@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "timed-out@4.0.1",
+                  "pkgId": "timed-out@4.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "unzip-response@2.0.1",
+                  "pkgId": "unzip-response@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "prepend-http@1.0.4",
+                  "pkgId": "prepend-http@1.0.4",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "prepend-http@1.0.4",
+                    },
+                  ],
+                  "nodeId": "url-parse-lax@1.0.0",
+                  "pkgId": "url-parse-lax@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "create-error-class@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "duplexer3@0.1.4",
+                    },
+                    Object {
+                      "nodeId": "get-stream@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-redirect@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "is-retry-allowed@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-stream@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "lowercase-keys@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "timed-out@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "unzip-response@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "url-parse-lax@1.0.0",
+                    },
+                  ],
+                  "nodeId": "got@6.7.1",
+                  "pkgId": "got@6.7.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "deep-extend@0.5.1",
+                  "pkgId": "deep-extend@0.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "minimist@1.2.0",
+                  "pkgId": "minimist@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strip-json-comments@2.0.1",
+                  "pkgId": "strip-json-comments@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "deep-extend@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "minimist@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "strip-json-comments@2.0.1",
+                    },
+                  ],
+                  "nodeId": "rc@1.2.7",
+                  "pkgId": "rc@1.2.7",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "rc@1.2.7",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "registry-auth-token@3.3.2",
+                  "pkgId": "registry-auth-token@3.3.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "rc@1.2.7",
+                    },
+                  ],
+                  "nodeId": "registry-url@3.1.0",
+                  "pkgId": "registry-url@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "got@6.7.1",
+                    },
+                    Object {
+                      "nodeId": "registry-auth-token@3.3.2",
+                    },
+                    Object {
+                      "nodeId": "registry-url@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "package-json@4.0.1",
+                  "pkgId": "package-json@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "package-json@4.0.1",
+                    },
+                  ],
+                  "nodeId": "latest-version@3.1.0",
+                  "pkgId": "latest-version@3.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "semver-diff@2.1.0",
+                  "pkgId": "semver-diff@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "boxen@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "chalk@2.4.1",
+                    },
+                    Object {
+                      "nodeId": "configstore@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "import-lazy@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-ci@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-installed-globally@0.1.0",
+                    },
+                    Object {
+                      "nodeId": "is-npm@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "latest-version@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "semver-diff@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "xdg-basedir@3.0.0",
+                    },
+                  ],
+                  "nodeId": "update-notifier@2.5.0",
+                  "pkgId": "update-notifier@2.5.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@3.0.1",
+                    },
+                  ],
+                  "nodeId": "wrap-ansi@2.1.0",
+                  "pkgId": "wrap-ansi@2.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "strip-ansi@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "wrap-ansi@2.1.0",
+                    },
+                  ],
+                  "nodeId": "cliui@4.1.0",
+                  "pkgId": "cliui@4.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "decamelize@1.2.0",
+                  "pkgId": "decamelize@1.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "p-try@1.0.0",
+                  "pkgId": "p-try@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-try@1.0.0",
+                    },
+                  ],
+                  "nodeId": "p-limit@1.2.0",
+                  "pkgId": "p-limit@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-limit@1.2.0",
+                    },
+                  ],
+                  "nodeId": "p-locate@2.0.0",
+                  "pkgId": "p-locate@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "path-exists@3.0.0",
+                  "pkgId": "path-exists@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "p-locate@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "path-exists@3.0.0",
+                    },
+                  ],
+                  "nodeId": "locate-path@2.0.0",
+                  "pkgId": "locate-path@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "locate-path@2.0.0",
+                    },
+                  ],
+                  "nodeId": "find-up@2.1.0",
+                  "pkgId": "find-up@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "get-caller-file@1.0.2",
+                  "pkgId": "get-caller-file@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "invert-kv@1.0.0",
+                  "pkgId": "invert-kv@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "invert-kv@1.0.0",
+                    },
+                  ],
+                  "nodeId": "lcid@1.0.0",
+                  "pkgId": "lcid@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "mimic-fn@1.2.0",
+                  "pkgId": "mimic-fn@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "mimic-fn@1.2.0",
+                    },
+                  ],
+                  "nodeId": "mem@1.1.0",
+                  "pkgId": "mem@1.1.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "execa@0.7.0",
+                    },
+                    Object {
+                      "nodeId": "lcid@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "mem@1.1.0",
+                    },
+                  ],
+                  "nodeId": "os-locale@2.1.0",
+                  "pkgId": "os-locale@2.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "require-directory@2.1.1",
+                  "pkgId": "require-directory@2.1.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "require-main-filename@1.0.1",
+                  "pkgId": "require-main-filename@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "y18n@3.2.1",
+                  "pkgId": "y18n@3.2.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "camelcase@4.1.0",
+                    },
+                  ],
+                  "nodeId": "yargs-parser@9.0.2",
+                  "pkgId": "yargs-parser@9.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cliui@4.1.0",
+                    },
+                    Object {
+                      "nodeId": "decamelize@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "find-up@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "get-caller-file@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "os-locale@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "require-directory@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "require-main-filename@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "set-blocking@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "string-width@2.1.1",
+                    },
+                    Object {
+                      "nodeId": "y18n@3.2.1",
+                    },
+                    Object {
+                      "nodeId": "yargs-parser@9.0.2",
+                    },
+                  ],
+                  "nodeId": "yargs@11.0.0",
+                  "pkgId": "yargs@11.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "dotenv@5.0.1",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "y18n@4.0.0",
+                    },
+                    Object {
+                      "nodeId": "yargs@11.0.0",
+                    },
+                  ],
+                  "nodeId": "libnpx@10.2.0",
+                  "pkgId": "libnpx@10.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "signal-exit@3.0.2",
+                    },
+                  ],
+                  "nodeId": "lockfile@1.0.4",
+                  "pkgId": "lockfile@1.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._baseindexof@3.1.0",
+                  "pkgId": "lodash._baseindexof@3.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._createset@4.0.3",
+                  "pkgId": "lodash._createset@4.0.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._root@3.0.1",
+                  "pkgId": "lodash._root@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lodash._createset@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "lodash._root@3.0.1",
+                    },
+                  ],
+                  "nodeId": "lodash._baseuniq@4.6.0",
+                  "pkgId": "lodash._baseuniq@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._bindcallback@3.0.1",
+                  "pkgId": "lodash._bindcallback@3.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._cacheindexof@3.0.2",
+                  "pkgId": "lodash._cacheindexof@3.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash._getnative@3.9.1",
+                  "pkgId": "lodash._getnative@3.9.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "lodash._getnative@3.9.1",
+                    },
+                  ],
+                  "nodeId": "lodash._createcache@3.1.2",
+                  "pkgId": "lodash._createcache@3.1.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.clonedeep@4.5.0",
+                  "pkgId": "lodash.clonedeep@4.5.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.restparam@3.6.1",
+                  "pkgId": "lodash.restparam@3.6.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.union@4.6.0",
+                  "pkgId": "lodash.union@4.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.uniq@4.5.0",
+                  "pkgId": "lodash.uniq@4.5.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "lodash.without@4.4.0",
+                  "pkgId": "lodash.without@4.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "meant@1.0.1",
+                  "pkgId": "meant@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                  ],
+                  "nodeId": "nopt@4.0.1",
+                  "pkgId": "nopt@4.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "cli-table3@0.5.0",
+                    },
+                    Object {
+                      "nodeId": "console-control-strings@1.1.0",
+                    },
+                  ],
+                  "nodeId": "npm-audit-report@1.3.1",
+                  "pkgId": "npm-audit-report@1.3.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-cache-filename@1.0.2",
+                  "pkgId": "npm-cache-filename@1.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                  ],
+                  "nodeId": "npm-install-checks@3.0.0",
+                  "pkgId": "npm-install-checks@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@4.0.1",
+                    },
+                  ],
+                  "nodeId": "npm-profile@3.0.2",
+                  "pkgId": "npm-profile@3.0.2",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "ssri@5.3.0",
+                  "pkgId": "ssri@5.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "concat-stream@1.6.2",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.4.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "request@2.88.0",
+                    },
+                    Object {
+                      "nodeId": "retry@0.10.1",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "ssri@5.3.0",
+                    },
+                  ],
+                  "nodeId": "npm-registry-client@8.6.0",
+                  "pkgId": "npm-registry-client@8.6.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "figgy-pudding@2.0.1",
+                  "pkgId": "figgy-pudding@2.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "concat-stream@1.6.2",
+                    },
+                    Object {
+                      "nodeId": "duplexify@3.6.0",
+                    },
+                    Object {
+                      "nodeId": "end-of-stream@1.4.1",
+                    },
+                    Object {
+                      "nodeId": "flush-write-stream@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "from2@2.3.0",
+                    },
+                    Object {
+                      "nodeId": "parallel-transform@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "pump@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "pumpify@1.5.1",
+                    },
+                    Object {
+                      "nodeId": "stream-each@1.2.2",
+                    },
+                    Object {
+                      "nodeId": "through2@2.0.3",
+                    },
+                  ],
+                  "nodeId": "mississippi@2.0.0",
+                  "pkgId": "mississippi@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "move-concurrently@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "ssri@5.3.0",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "y18n@4.0.0",
+                    },
+                  ],
+                  "nodeId": "cacache@10.0.4",
+                  "pkgId": "cacache@10.0.4",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "smart-buffer@1.1.15",
+                  "pkgId": "smart-buffer@1.1.15",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "ip@1.1.5",
+                    },
+                    Object {
+                      "nodeId": "smart-buffer@1.1.15",
+                    },
+                  ],
+                  "nodeId": "socks@1.1.10",
+                  "pkgId": "socks@1.1.10",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agent-base@4.2.0",
+                    },
+                    Object {
+                      "nodeId": "socks@1.1.10",
+                    },
+                  ],
+                  "nodeId": "socks-proxy-agent@3.0.1",
+                  "pkgId": "socks-proxy-agent@3.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "agentkeepalive@3.4.1",
+                    },
+                    Object {
+                      "nodeId": "cacache@10.0.4",
+                    },
+                    Object {
+                      "nodeId": "http-cache-semantics@3.8.1",
+                    },
+                    Object {
+                      "nodeId": "http-proxy-agent@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "https-proxy-agent@2.2.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "node-fetch-npm@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "promise-retry@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "socks-proxy-agent@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "ssri@5.3.0",
+                    },
+                  ],
+                  "nodeId": "make-fetch-happen@3.0.0",
+                  "pkgId": "make-fetch-happen@3.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "make-fetch-happen@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                  ],
+                  "nodeId": "npm-registry-fetch@1.1.0",
+                  "pkgId": "npm-registry-fetch@1.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "npm-user-validate@1.0.0",
+                  "pkgId": "npm-user-validate@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "opener@1.5.1",
+                  "pkgId": "opener@1.5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qrcode-terminal@0.12.0",
+                  "pkgId": "qrcode-terminal@0.12.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "decode-uri-component@0.2.0",
+                  "pkgId": "decode-uri-component@0.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "strict-uri-encode@2.0.0",
+                  "pkgId": "strict-uri-encode@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "decode-uri-component@0.2.0",
+                    },
+                    Object {
+                      "nodeId": "strict-uri-encode@2.0.0",
+                    },
+                  ],
+                  "nodeId": "query-string@6.1.0",
+                  "pkgId": "query-string@6.1.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "qw@1.0.1",
+                  "pkgId": "qw@1.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "debuglog@1.0.1",
+                  "pkgId": "debuglog@1.0.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debuglog@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "dezalgo@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                  ],
+                  "nodeId": "readdir-scoped-modules@1.0.2",
+                  "pkgId": "readdir-scoped-modules@1.0.2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "util-extend@1.0.3",
+                  "pkgId": "util-extend@1.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debuglog@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "readdir-scoped-modules@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "util-extend@1.0.3",
+                    },
+                  ],
+                  "nodeId": "read-installed@4.0.3",
+                  "pkgId": "read-installed@4.0.3",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "debuglog@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "dezalgo@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "readdir-scoped-modules@1.0.2",
+                    },
+                  ],
+                  "nodeId": "read-package-tree@5.2.1",
+                  "pkgId": "read-package-tree@5.2.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "retry@0.12.0",
+                  "pkgId": "retry@0.12.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                  ],
+                  "nodeId": "sha@2.0.1",
+                  "pkgId": "sha@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "sorted-object@2.0.1",
+                  "pkgId": "sorted-object@2.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "isarray@0.0.1",
+                  "pkgId": "isarray@0.0.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "string_decoder@0.10.31",
+                  "pkgId": "string_decoder@0.10.31",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "core-util-is@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "isarray@0.0.1",
+                    },
+                    Object {
+                      "nodeId": "string_decoder@0.10.31",
+                    },
+                  ],
+                  "nodeId": "readable-stream@1.1.14",
+                  "pkgId": "readable-stream@1.1.14",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@1.1.14",
+                    },
+                  ],
+                  "nodeId": "from2@1.3.0",
+                  "pkgId": "from2@1.3.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "stream-shift@1.0.0",
+                    },
+                  ],
+                  "nodeId": "stream-iterate@1.2.0",
+                  "pkgId": "stream-iterate@1.2.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "from2@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "stream-iterate@1.2.0",
+                    },
+                  ],
+                  "nodeId": "sorted-union-stream@2.1.3",
+                  "pkgId": "sorted-union-stream@2.1.3",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stringify-package@1.0.0",
+                  "pkgId": "stringify-package@1.0.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "text-table@0.2.0",
+                  "pkgId": "text-table@0.2.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tiny-relative-date@1.3.0",
+                  "pkgId": "tiny-relative-date@1.3.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "unpipe@1.0.0",
+                  "pkgId": "unpipe@1.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "JSONStream@1.3.4",
+                    },
+                    Object {
+                      "nodeId": "abbrev@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "ansicolors@0.3.2",
+                    },
+                    Object {
+                      "nodeId": "ansistyles@0.1.3",
+                    },
+                    Object {
+                      "nodeId": "aproba@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "archy@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "bin-links@1.1.2",
+                    },
+                    Object {
+                      "nodeId": "bluebird@3.5.3",
+                    },
+                    Object {
+                      "nodeId": "byte-size@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "cacache@11.2.0",
+                    },
+                    Object {
+                      "nodeId": "call-limit@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "chownr@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "ci-info@1.6.0",
+                    },
+                    Object {
+                      "nodeId": "cli-columns@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "cli-table3@0.5.0",
+                    },
+                    Object {
+                      "nodeId": "cmd-shim@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "columnify@1.5.4",
+                    },
+                    Object {
+                      "nodeId": "config-chain@1.1.12",
+                    },
+                    Object {
+                      "nodeId": "detect-indent@5.0.0",
+                    },
+                    Object {
+                      "nodeId": "detect-newline@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "dezalgo@1.0.3",
+                    },
+                    Object {
+                      "nodeId": "editor@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "figgy-pudding@3.5.1",
+                    },
+                    Object {
+                      "nodeId": "find-npm-prefix@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "fs-vacuum@1.2.10",
+                    },
+                    Object {
+                      "nodeId": "fs-write-stream-atomic@1.0.10",
+                    },
+                    Object {
+                      "nodeId": "gentle-fs@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "glob@7.1.3",
+                    },
+                    Object {
+                      "nodeId": "graceful-fs@4.1.15",
+                    },
+                    Object {
+                      "nodeId": "has-unicode@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "hosted-git-info@2.7.1",
+                    },
+                    Object {
+                      "nodeId": "iferr@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "inflight@1.0.6",
+                    },
+                    Object {
+                      "nodeId": "inherits@2.0.3",
+                    },
+                    Object {
+                      "nodeId": "ini@1.3.5",
+                    },
+                    Object {
+                      "nodeId": "init-package-json@1.10.3",
+                    },
+                    Object {
+                      "nodeId": "is-cidr@2.0.6",
+                    },
+                    Object {
+                      "nodeId": "isexe@2.0.0",
+                    },
+                    Object {
+                      "nodeId": "json-parse-better-errors@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "lazy-property@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "libcipm@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "libnpmhook@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "libnpx@10.2.0",
+                    },
+                    Object {
+                      "nodeId": "lock-verify@2.0.2",
+                    },
+                    Object {
+                      "nodeId": "lockfile@1.0.4",
+                    },
+                    Object {
+                      "nodeId": "lodash._baseindexof@3.1.0",
+                    },
+                    Object {
+                      "nodeId": "lodash._baseuniq@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "lodash._bindcallback@3.0.1",
+                    },
+                    Object {
+                      "nodeId": "lodash._cacheindexof@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "lodash._createcache@3.1.2",
+                    },
+                    Object {
+                      "nodeId": "lodash.clonedeep@4.5.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.restparam@3.6.1",
+                    },
+                    Object {
+                      "nodeId": "lodash.union@4.6.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.uniq@4.5.0",
+                    },
+                    Object {
+                      "nodeId": "lodash.without@4.4.0",
+                    },
+                    Object {
+                      "nodeId": "lru-cache@4.1.3",
+                    },
+                    Object {
+                      "nodeId": "meant@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "mississippi@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "mkdirp@0.5.1",
+                    },
+                    Object {
+                      "nodeId": "move-concurrently@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "node-gyp@3.8.0",
+                    },
+                    Object {
+                      "nodeId": "nopt@4.0.1",
+                    },
+                    Object {
+                      "nodeId": "normalize-package-data@2.4.0",
+                    },
+                    Object {
+                      "nodeId": "npm-audit-report@1.3.1",
+                    },
+                    Object {
+                      "nodeId": "npm-cache-filename@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-install-checks@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "npm-lifecycle@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-package-arg@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-packlist@1.1.12",
+                    },
+                    Object {
+                      "nodeId": "npm-pick-manifest@2.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-profile@3.0.2",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-client@8.6.0",
+                    },
+                    Object {
+                      "nodeId": "npm-registry-fetch@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "npm-user-validate@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "npmlog@4.1.2",
+                    },
+                    Object {
+                      "nodeId": "once@1.4.0",
+                    },
+                    Object {
+                      "nodeId": "opener@1.5.1",
+                    },
+                    Object {
+                      "nodeId": "osenv@0.1.5",
+                    },
+                    Object {
+                      "nodeId": "pacote@8.1.6",
+                    },
+                    Object {
+                      "nodeId": "path-is-inside@1.0.2",
+                    },
+                    Object {
+                      "nodeId": "promise-inflight@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "qrcode-terminal@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "query-string@6.1.0",
+                    },
+                    Object {
+                      "nodeId": "qw@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "read@1.0.7",
+                    },
+                    Object {
+                      "nodeId": "read-cmd-shim@1.0.1",
+                    },
+                    Object {
+                      "nodeId": "read-installed@4.0.3",
+                    },
+                    Object {
+                      "nodeId": "read-package-json@2.0.13",
+                    },
+                    Object {
+                      "nodeId": "read-package-tree@5.2.1",
+                    },
+                    Object {
+                      "nodeId": "readable-stream@2.3.6",
+                    },
+                    Object {
+                      "nodeId": "request@2.88.0",
+                    },
+                    Object {
+                      "nodeId": "retry@0.12.0",
+                    },
+                    Object {
+                      "nodeId": "rimraf@2.6.2",
+                    },
+                    Object {
+                      "nodeId": "safe-buffer@5.1.2",
+                    },
+                    Object {
+                      "nodeId": "semver@5.5.1",
+                    },
+                    Object {
+                      "nodeId": "sha@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "slide@1.1.6",
+                    },
+                    Object {
+                      "nodeId": "sorted-object@2.0.1",
+                    },
+                    Object {
+                      "nodeId": "sorted-union-stream@2.1.3",
+                    },
+                    Object {
+                      "nodeId": "ssri@6.0.1",
+                    },
+                    Object {
+                      "nodeId": "stringify-package@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "tar@4.4.8",
+                    },
+                    Object {
+                      "nodeId": "text-table@0.2.0",
+                    },
+                    Object {
+                      "nodeId": "tiny-relative-date@1.3.0",
+                    },
+                    Object {
+                      "nodeId": "uid-number@0.0.6",
+                    },
+                    Object {
+                      "nodeId": "umask@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "unique-filename@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "unpipe@1.0.0",
+                    },
+                    Object {
+                      "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "uuid@3.3.2",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-license@3.0.4",
+                    },
+                    Object {
+                      "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "worker-farm@1.6.0",
+                    },
+                    Object {
+                      "nodeId": "write-file-atomic@2.3.0",
+                    },
+                  ],
+                  "nodeId": "npm@6.5.0",
+                  "pkgId": "npm@6.5.0",
+                },
+              ],
+              "rootNodeId": "root-node",
+            },
+            "pkgManager": Object {
+              "name": "npm",
+            },
+            "pkgs": Array [
+              Object {
+                "id": "lib@",
+                "info": Object {
+                  "name": "lib",
+                  "version": undefined,
+                },
+              },
+              Object {
+                "id": "jsonparse@1.3.1",
+                "info": Object {
+                  "name": "jsonparse",
+                  "version": "1.3.1",
+                },
+              },
+              Object {
+                "id": "through@2.3.8",
+                "info": Object {
+                  "name": "through",
+                  "version": "2.3.8",
+                },
+              },
+              Object {
+                "id": "JSONStream@1.3.4",
+                "info": Object {
+                  "name": "JSONStream",
+                  "version": "1.3.4",
+                },
+              },
+              Object {
+                "id": "abbrev@1.1.1",
+                "info": Object {
+                  "name": "abbrev",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "ansicolors@0.3.2",
+                "info": Object {
+                  "name": "ansicolors",
+                  "version": "0.3.2",
+                },
+              },
+              Object {
+                "id": "ansistyles@0.1.3",
+                "info": Object {
+                  "name": "ansistyles",
+                  "version": "0.1.3",
+                },
+              },
+              Object {
+                "id": "aproba@1.2.0",
+                "info": Object {
+                  "name": "aproba",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "archy@1.0.0",
+                "info": Object {
+                  "name": "archy",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "bluebird@3.5.3",
+                "info": Object {
+                  "name": "bluebird",
+                  "version": "3.5.3",
+                },
+              },
+              Object {
+                "id": "graceful-fs@4.1.15",
+                "info": Object {
+                  "name": "graceful-fs",
+                  "version": "4.1.15",
+                },
+              },
+              Object {
+                "id": "minimist@0.0.8",
+                "info": Object {
+                  "name": "minimist",
+                  "version": "0.0.8",
+                },
+              },
+              Object {
+                "id": "mkdirp@0.5.1",
+                "info": Object {
+                  "name": "mkdirp",
+                  "version": "0.5.1",
+                },
+              },
+              Object {
+                "id": "cmd-shim@2.0.2",
+                "info": Object {
+                  "name": "cmd-shim",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "path-is-inside@1.0.2",
+                "info": Object {
+                  "name": "path-is-inside",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "fs.realpath@1.0.0",
+                "info": Object {
+                  "name": "fs.realpath",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "wrappy@1.0.2",
+                "info": Object {
+                  "name": "wrappy",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "once@1.4.0",
+                "info": Object {
+                  "name": "once",
+                  "version": "1.4.0",
+                },
+              },
+              Object {
+                "id": "inflight@1.0.6",
+                "info": Object {
+                  "name": "inflight",
+                  "version": "1.0.6",
+                },
+              },
+              Object {
+                "id": "inherits@2.0.3",
+                "info": Object {
+                  "name": "inherits",
+                  "version": "2.0.3",
+                },
+              },
+              Object {
+                "id": "balanced-match@1.0.0",
+                "info": Object {
+                  "name": "balanced-match",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "concat-map@0.0.1",
+                "info": Object {
+                  "name": "concat-map",
+                  "version": "0.0.1",
+                },
+              },
+              Object {
+                "id": "brace-expansion@1.1.11",
+                "info": Object {
+                  "name": "brace-expansion",
+                  "version": "1.1.11",
+                },
+              },
+              Object {
+                "id": "minimatch@3.0.4",
+                "info": Object {
+                  "name": "minimatch",
+                  "version": "3.0.4",
+                },
+              },
+              Object {
+                "id": "path-is-absolute@1.0.1",
+                "info": Object {
+                  "name": "path-is-absolute",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "glob@7.1.3",
+                "info": Object {
+                  "name": "glob",
+                  "version": "7.1.3",
+                },
+              },
+              Object {
+                "id": "rimraf@2.6.2",
+                "info": Object {
+                  "name": "rimraf",
+                  "version": "2.6.2",
+                },
+              },
+              Object {
+                "id": "fs-vacuum@1.2.10",
+                "info": Object {
+                  "name": "fs-vacuum",
+                  "version": "1.2.10",
+                },
+              },
+              Object {
+                "id": "iferr@0.1.5",
+                "info": Object {
+                  "name": "iferr",
+                  "version": "0.1.5",
+                },
+              },
+              Object {
+                "id": "read-cmd-shim@1.0.1",
+                "info": Object {
+                  "name": "read-cmd-shim",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "slide@1.1.6",
+                "info": Object {
+                  "name": "slide",
+                  "version": "1.1.6",
+                },
+              },
+              Object {
+                "id": "gentle-fs@2.0.1",
+                "info": Object {
+                  "name": "gentle-fs",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "imurmurhash@0.1.4",
+                "info": Object {
+                  "name": "imurmurhash",
+                  "version": "0.1.4",
+                },
+              },
+              Object {
+                "id": "signal-exit@3.0.2",
+                "info": Object {
+                  "name": "signal-exit",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "write-file-atomic@2.3.0",
+                "info": Object {
+                  "name": "write-file-atomic",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "bin-links@1.1.2",
+                "info": Object {
+                  "name": "bin-links",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "byte-size@4.0.3",
+                "info": Object {
+                  "name": "byte-size",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "chownr@1.0.1",
+                "info": Object {
+                  "name": "chownr",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "figgy-pudding@3.5.1",
+                "info": Object {
+                  "name": "figgy-pudding",
+                  "version": "3.5.1",
+                },
+              },
+              Object {
+                "id": "pseudomap@1.0.2",
+                "info": Object {
+                  "name": "pseudomap",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "yallist@2.1.2",
+                "info": Object {
+                  "name": "yallist",
+                  "version": "2.1.2",
+                },
+              },
+              Object {
+                "id": "lru-cache@4.1.3",
+                "info": Object {
+                  "name": "lru-cache",
+                  "version": "4.1.3",
+                },
+              },
+              Object {
+                "id": "buffer-from@1.0.0",
+                "info": Object {
+                  "name": "buffer-from",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "core-util-is@1.0.2",
+                "info": Object {
+                  "name": "core-util-is",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "isarray@1.0.0",
+                "info": Object {
+                  "name": "isarray",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "process-nextick-args@2.0.0",
+                "info": Object {
+                  "name": "process-nextick-args",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "safe-buffer@5.1.2",
+                "info": Object {
+                  "name": "safe-buffer",
+                  "version": "5.1.2",
+                },
+              },
+              Object {
+                "id": "string_decoder@1.1.1",
+                "info": Object {
+                  "name": "string_decoder",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "util-deprecate@1.0.2",
+                "info": Object {
+                  "name": "util-deprecate",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "readable-stream@2.3.6",
+                "info": Object {
+                  "name": "readable-stream",
+                  "version": "2.3.6",
+                },
+              },
+              Object {
+                "id": "typedarray@0.0.6",
+                "info": Object {
+                  "name": "typedarray",
+                  "version": "0.0.6",
+                },
+              },
+              Object {
+                "id": "concat-stream@1.6.2",
+                "info": Object {
+                  "name": "concat-stream",
+                  "version": "1.6.2",
+                },
+              },
+              Object {
+                "id": "end-of-stream@1.4.1",
+                "info": Object {
+                  "name": "end-of-stream",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "stream-shift@1.0.0",
+                "info": Object {
+                  "name": "stream-shift",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "duplexify@3.6.0",
+                "info": Object {
+                  "name": "duplexify",
+                  "version": "3.6.0",
+                },
+              },
+              Object {
+                "id": "flush-write-stream@1.0.3",
+                "info": Object {
+                  "name": "flush-write-stream",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "from2@2.3.0",
+                "info": Object {
+                  "name": "from2",
+                  "version": "2.3.0",
+                },
+              },
+              Object {
+                "id": "cyclist@0.2.2",
+                "info": Object {
+                  "name": "cyclist",
+                  "version": "0.2.2",
+                },
+              },
+              Object {
+                "id": "parallel-transform@1.1.0",
+                "info": Object {
+                  "name": "parallel-transform",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "pump@3.0.0",
+                "info": Object {
+                  "name": "pump",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "pump@2.0.1",
+                "info": Object {
+                  "name": "pump",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "pumpify@1.5.1",
+                "info": Object {
+                  "name": "pumpify",
+                  "version": "1.5.1",
+                },
+              },
+              Object {
+                "id": "stream-each@1.2.2",
+                "info": Object {
+                  "name": "stream-each",
+                  "version": "1.2.2",
+                },
+              },
+              Object {
+                "id": "xtend@4.0.1",
+                "info": Object {
+                  "name": "xtend",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "through2@2.0.3",
+                "info": Object {
+                  "name": "through2",
+                  "version": "2.0.3",
+                },
+              },
+              Object {
+                "id": "mississippi@3.0.0",
+                "info": Object {
+                  "name": "mississippi",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "fs-write-stream-atomic@1.0.10",
+                "info": Object {
+                  "name": "fs-write-stream-atomic",
+                  "version": "1.0.10",
+                },
+              },
+              Object {
+                "id": "run-queue@1.0.3",
+                "info": Object {
+                  "name": "run-queue",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "copy-concurrently@1.0.5",
+                "info": Object {
+                  "name": "copy-concurrently",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "move-concurrently@1.0.1",
+                "info": Object {
+                  "name": "move-concurrently",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "promise-inflight@1.0.1",
+                "info": Object {
+                  "name": "promise-inflight",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "ssri@6.0.1",
+                "info": Object {
+                  "name": "ssri",
+                  "version": "6.0.1",
+                },
+              },
+              Object {
+                "id": "unique-slug@2.0.0",
+                "info": Object {
+                  "name": "unique-slug",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "unique-filename@1.1.0",
+                "info": Object {
+                  "name": "unique-filename",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "y18n@4.0.0",
+                "info": Object {
+                  "name": "y18n",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "cacache@11.2.0",
+                "info": Object {
+                  "name": "cacache",
+                  "version": "11.2.0",
+                },
+              },
+              Object {
+                "id": "call-limit@1.1.0",
+                "info": Object {
+                  "name": "call-limit",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "ci-info@1.6.0",
+                "info": Object {
+                  "name": "ci-info",
+                  "version": "1.6.0",
+                },
+              },
+              Object {
+                "id": "is-fullwidth-code-point@2.0.0",
+                "info": Object {
+                  "name": "is-fullwidth-code-point",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "ansi-regex@3.0.0",
+                "info": Object {
+                  "name": "ansi-regex",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "strip-ansi@4.0.0",
+                "info": Object {
+                  "name": "strip-ansi",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "string-width@2.1.1",
+                "info": Object {
+                  "name": "string-width",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "ansi-regex@2.1.1",
+                "info": Object {
+                  "name": "ansi-regex",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "strip-ansi@3.0.1",
+                "info": Object {
+                  "name": "strip-ansi",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "cli-columns@3.1.2",
+                "info": Object {
+                  "name": "cli-columns",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "colors@1.1.2",
+                "info": Object {
+                  "name": "colors",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "object-assign@4.1.1",
+                "info": Object {
+                  "name": "object-assign",
+                  "version": "4.1.1",
+                },
+              },
+              Object {
+                "id": "cli-table3@0.5.0",
+                "info": Object {
+                  "name": "cli-table3",
+                  "version": "0.5.0",
+                },
+              },
+              Object {
+                "id": "clone@1.0.4",
+                "info": Object {
+                  "name": "clone",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "defaults@1.0.3",
+                "info": Object {
+                  "name": "defaults",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "wcwidth@1.0.1",
+                "info": Object {
+                  "name": "wcwidth",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "columnify@1.5.4",
+                "info": Object {
+                  "name": "columnify",
+                  "version": "1.5.4",
+                },
+              },
+              Object {
+                "id": "ini@1.3.5",
+                "info": Object {
+                  "name": "ini",
+                  "version": "1.3.5",
+                },
+              },
+              Object {
+                "id": "proto-list@1.2.4",
+                "info": Object {
+                  "name": "proto-list",
+                  "version": "1.2.4",
+                },
+              },
+              Object {
+                "id": "config-chain@1.1.12",
+                "info": Object {
+                  "name": "config-chain",
+                  "version": "1.1.12",
+                },
+              },
+              Object {
+                "id": "detect-indent@5.0.0",
+                "info": Object {
+                  "name": "detect-indent",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "detect-newline@2.1.0",
+                "info": Object {
+                  "name": "detect-newline",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "asap@2.0.6",
+                "info": Object {
+                  "name": "asap",
+                  "version": "2.0.6",
+                },
+              },
+              Object {
+                "id": "dezalgo@1.0.3",
+                "info": Object {
+                  "name": "dezalgo",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "editor@1.0.0",
+                "info": Object {
+                  "name": "editor",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "find-npm-prefix@1.0.2",
+                "info": Object {
+                  "name": "find-npm-prefix",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "has-unicode@2.0.1",
+                "info": Object {
+                  "name": "has-unicode",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "hosted-git-info@2.7.1",
+                "info": Object {
+                  "name": "hosted-git-info",
+                  "version": "2.7.1",
+                },
+              },
+              Object {
+                "id": "iferr@1.0.2",
+                "info": Object {
+                  "name": "iferr",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "os-homedir@1.0.2",
+                "info": Object {
+                  "name": "os-homedir",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "os-tmpdir@1.0.2",
+                "info": Object {
+                  "name": "os-tmpdir",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "osenv@0.1.5",
+                "info": Object {
+                  "name": "osenv",
+                  "version": "0.1.5",
+                },
+              },
+              Object {
+                "id": "semver@5.5.1",
+                "info": Object {
+                  "name": "semver",
+                  "version": "5.5.1",
+                },
+              },
+              Object {
+                "id": "builtins@1.0.3",
+                "info": Object {
+                  "name": "builtins",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "validate-npm-package-name@3.0.0",
+                "info": Object {
+                  "name": "validate-npm-package-name",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "npm-package-arg@6.1.0",
+                "info": Object {
+                  "name": "npm-package-arg",
+                  "version": "6.1.0",
+                },
+              },
+              Object {
+                "id": "mute-stream@0.0.7",
+                "info": Object {
+                  "name": "mute-stream",
+                  "version": "0.0.7",
+                },
+              },
+              Object {
+                "id": "read@1.0.7",
+                "info": Object {
+                  "name": "read",
+                  "version": "1.0.7",
+                },
+              },
+              Object {
+                "id": "promzard@0.3.0",
+                "info": Object {
+                  "name": "promzard",
+                  "version": "0.3.0",
+                },
+              },
+              Object {
+                "id": "json-parse-better-errors@1.0.2",
+                "info": Object {
+                  "name": "json-parse-better-errors",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "builtin-modules@1.1.1",
+                "info": Object {
+                  "name": "builtin-modules",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "is-builtin-module@1.0.0",
+                "info": Object {
+                  "name": "is-builtin-module",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "spdx-exceptions@2.1.0",
+                "info": Object {
+                  "name": "spdx-exceptions",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "spdx-license-ids@3.0.0",
+                "info": Object {
+                  "name": "spdx-license-ids",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "spdx-expression-parse@3.0.0",
+                "info": Object {
+                  "name": "spdx-expression-parse",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "spdx-correct@3.0.0",
+                "info": Object {
+                  "name": "spdx-correct",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "validate-npm-package-license@3.0.4",
+                "info": Object {
+                  "name": "validate-npm-package-license",
+                  "version": "3.0.4",
+                },
+              },
+              Object {
+                "id": "normalize-package-data@2.4.0",
+                "info": Object {
+                  "name": "normalize-package-data",
+                  "version": "2.4.0",
+                },
+              },
+              Object {
+                "id": "slash@1.0.0",
+                "info": Object {
+                  "name": "slash",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "read-package-json@2.0.13",
+                "info": Object {
+                  "name": "read-package-json",
+                  "version": "2.0.13",
+                },
+              },
+              Object {
+                "id": "init-package-json@1.10.3",
+                "info": Object {
+                  "name": "init-package-json",
+                  "version": "1.10.3",
+                },
+              },
+              Object {
+                "id": "ip-regex@2.1.0",
+                "info": Object {
+                  "name": "ip-regex",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "cidr-regex@2.0.9",
+                "info": Object {
+                  "name": "cidr-regex",
+                  "version": "2.0.9",
+                },
+              },
+              Object {
+                "id": "is-cidr@2.0.6",
+                "info": Object {
+                  "name": "is-cidr",
+                  "version": "2.0.6",
+                },
+              },
+              Object {
+                "id": "isexe@2.0.0",
+                "info": Object {
+                  "name": "isexe",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "lazy-property@1.0.0",
+                "info": Object {
+                  "name": "lazy-property",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "lock-verify@2.0.2",
+                "info": Object {
+                  "name": "lock-verify",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "byline@5.0.0",
+                "info": Object {
+                  "name": "byline",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "fstream@1.0.11",
+                "info": Object {
+                  "name": "fstream",
+                  "version": "1.0.11",
+                },
+              },
+              Object {
+                "id": "nopt@3.0.6",
+                "info": Object {
+                  "name": "nopt",
+                  "version": "3.0.6",
+                },
+              },
+              Object {
+                "id": "delegates@1.0.0",
+                "info": Object {
+                  "name": "delegates",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "are-we-there-yet@1.1.4",
+                "info": Object {
+                  "name": "are-we-there-yet",
+                  "version": "1.1.4",
+                },
+              },
+              Object {
+                "id": "console-control-strings@1.1.0",
+                "info": Object {
+                  "name": "console-control-strings",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "code-point-at@1.1.0",
+                "info": Object {
+                  "name": "code-point-at",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "number-is-nan@1.0.1",
+                "info": Object {
+                  "name": "number-is-nan",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-fullwidth-code-point@1.0.0",
+                "info": Object {
+                  "name": "is-fullwidth-code-point",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "string-width@1.0.2",
+                "info": Object {
+                  "name": "string-width",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "wide-align@1.1.2",
+                "info": Object {
+                  "name": "wide-align",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "gauge@2.7.4",
+                "info": Object {
+                  "name": "gauge",
+                  "version": "2.7.4",
+                },
+              },
+              Object {
+                "id": "set-blocking@2.0.0",
+                "info": Object {
+                  "name": "set-blocking",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "npmlog@4.1.2",
+                "info": Object {
+                  "name": "npmlog",
+                  "version": "4.1.2",
+                },
+              },
+              Object {
+                "id": "aws-sign2@0.7.0",
+                "info": Object {
+                  "name": "aws-sign2",
+                  "version": "0.7.0",
+                },
+              },
+              Object {
+                "id": "aws4@1.8.0",
+                "info": Object {
+                  "name": "aws4",
+                  "version": "1.8.0",
+                },
+              },
+              Object {
+                "id": "caseless@0.12.0",
+                "info": Object {
+                  "name": "caseless",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "delayed-stream@1.0.0",
+                "info": Object {
+                  "name": "delayed-stream",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "combined-stream@1.0.6",
+                "info": Object {
+                  "name": "combined-stream",
+                  "version": "1.0.6",
+                },
+              },
+              Object {
+                "id": "extend@3.0.2",
+                "info": Object {
+                  "name": "extend",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "forever-agent@0.6.1",
+                "info": Object {
+                  "name": "forever-agent",
+                  "version": "0.6.1",
+                },
+              },
+              Object {
+                "id": "asynckit@0.4.0",
+                "info": Object {
+                  "name": "asynckit",
+                  "version": "0.4.0",
+                },
+              },
+              Object {
+                "id": "mime-db@1.35.0",
+                "info": Object {
+                  "name": "mime-db",
+                  "version": "1.35.0",
+                },
+              },
+              Object {
+                "id": "mime-types@2.1.19",
+                "info": Object {
+                  "name": "mime-types",
+                  "version": "2.1.19",
+                },
+              },
+              Object {
+                "id": "form-data@2.3.2",
+                "info": Object {
+                  "name": "form-data",
+                  "version": "2.3.2",
+                },
+              },
+              Object {
+                "id": "co@4.6.0",
+                "info": Object {
+                  "name": "co",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "fast-deep-equal@1.1.0",
+                "info": Object {
+                  "name": "fast-deep-equal",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "fast-json-stable-stringify@2.0.0",
+                "info": Object {
+                  "name": "fast-json-stable-stringify",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "json-schema-traverse@0.3.1",
+                "info": Object {
+                  "name": "json-schema-traverse",
+                  "version": "0.3.1",
+                },
+              },
+              Object {
+                "id": "ajv@5.5.2",
+                "info": Object {
+                  "name": "ajv",
+                  "version": "5.5.2",
+                },
+              },
+              Object {
+                "id": "har-schema@2.0.0",
+                "info": Object {
+                  "name": "har-schema",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "har-validator@5.1.0",
+                "info": Object {
+                  "name": "har-validator",
+                  "version": "5.1.0",
+                },
+              },
+              Object {
+                "id": "assert-plus@1.0.0",
+                "info": Object {
+                  "name": "assert-plus",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "extsprintf@1.3.0",
+                "info": Object {
+                  "name": "extsprintf",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "json-schema@0.2.3",
+                "info": Object {
+                  "name": "json-schema",
+                  "version": "0.2.3",
+                },
+              },
+              Object {
+                "id": "verror@1.10.0",
+                "info": Object {
+                  "name": "verror",
+                  "version": "1.10.0",
+                },
+              },
+              Object {
+                "id": "jsprim@1.4.1",
+                "info": Object {
+                  "name": "jsprim",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "safer-buffer@2.1.2",
+                "info": Object {
+                  "name": "safer-buffer",
+                  "version": "2.1.2",
+                },
+              },
+              Object {
+                "id": "asn1@0.2.4",
+                "info": Object {
+                  "name": "asn1",
+                  "version": "0.2.4",
+                },
+              },
+              Object {
+                "id": "tweetnacl@0.14.5",
+                "info": Object {
+                  "name": "tweetnacl",
+                  "version": "0.14.5",
+                },
+              },
+              Object {
+                "id": "bcrypt-pbkdf@1.0.2",
+                "info": Object {
+                  "name": "bcrypt-pbkdf",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "dashdash@1.14.1",
+                "info": Object {
+                  "name": "dashdash",
+                  "version": "1.14.1",
+                },
+              },
+              Object {
+                "id": "jsbn@0.1.1",
+                "info": Object {
+                  "name": "jsbn",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "ecc-jsbn@0.1.2",
+                "info": Object {
+                  "name": "ecc-jsbn",
+                  "version": "0.1.2",
+                },
+              },
+              Object {
+                "id": "getpass@0.1.7",
+                "info": Object {
+                  "name": "getpass",
+                  "version": "0.1.7",
+                },
+              },
+              Object {
+                "id": "sshpk@1.14.2",
+                "info": Object {
+                  "name": "sshpk",
+                  "version": "1.14.2",
+                },
+              },
+              Object {
+                "id": "http-signature@1.2.0",
+                "info": Object {
+                  "name": "http-signature",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "is-typedarray@1.0.0",
+                "info": Object {
+                  "name": "is-typedarray",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "isstream@0.1.2",
+                "info": Object {
+                  "name": "isstream",
+                  "version": "0.1.2",
+                },
+              },
+              Object {
+                "id": "json-stringify-safe@5.0.1",
+                "info": Object {
+                  "name": "json-stringify-safe",
+                  "version": "5.0.1",
+                },
+              },
+              Object {
+                "id": "oauth-sign@0.9.0",
+                "info": Object {
+                  "name": "oauth-sign",
+                  "version": "0.9.0",
+                },
+              },
+              Object {
+                "id": "performance-now@2.1.0",
+                "info": Object {
+                  "name": "performance-now",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "qs@6.5.2",
+                "info": Object {
+                  "name": "qs",
+                  "version": "6.5.2",
+                },
+              },
+              Object {
+                "id": "psl@1.1.29",
+                "info": Object {
+                  "name": "psl",
+                  "version": "1.1.29",
+                },
+              },
+              Object {
+                "id": "punycode@1.4.1",
+                "info": Object {
+                  "name": "punycode",
+                  "version": "1.4.1",
+                },
+              },
+              Object {
+                "id": "tough-cookie@2.4.3",
+                "info": Object {
+                  "name": "tough-cookie",
+                  "version": "2.4.3",
+                },
+              },
+              Object {
+                "id": "tunnel-agent@0.6.0",
+                "info": Object {
+                  "name": "tunnel-agent",
+                  "version": "0.6.0",
+                },
+              },
+              Object {
+                "id": "uuid@3.3.2",
+                "info": Object {
+                  "name": "uuid",
+                  "version": "3.3.2",
+                },
+              },
+              Object {
+                "id": "request@2.88.0",
+                "info": Object {
+                  "name": "request",
+                  "version": "2.88.0",
+                },
+              },
+              Object {
+                "id": "semver@5.3.0",
+                "info": Object {
+                  "name": "semver",
+                  "version": "5.3.0",
+                },
+              },
+              Object {
+                "id": "block-stream@0.0.9",
+                "info": Object {
+                  "name": "block-stream",
+                  "version": "0.0.9",
+                },
+              },
+              Object {
+                "id": "tar@2.2.1",
+                "info": Object {
+                  "name": "tar",
+                  "version": "2.2.1",
+                },
+              },
+              Object {
+                "id": "node-gyp@3.8.0",
+                "info": Object {
+                  "name": "node-gyp",
+                  "version": "3.8.0",
+                },
+              },
+              Object {
+                "id": "resolve-from@4.0.0",
+                "info": Object {
+                  "name": "resolve-from",
+                  "version": "4.0.0",
+                },
+              },
+              Object {
+                "id": "uid-number@0.0.6",
+                "info": Object {
+                  "name": "uid-number",
+                  "version": "0.0.6",
+                },
+              },
+              Object {
+                "id": "umask@1.1.0",
+                "info": Object {
+                  "name": "umask",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "npm-lifecycle@2.1.0",
+                "info": Object {
+                  "name": "npm-lifecycle",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "npm-logical-tree@1.2.1",
+                "info": Object {
+                  "name": "npm-logical-tree",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "get-stream@3.0.0",
+                "info": Object {
+                  "name": "get-stream",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "ms@2.1.1",
+                "info": Object {
+                  "name": "ms",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "humanize-ms@1.2.1",
+                "info": Object {
+                  "name": "humanize-ms",
+                  "version": "1.2.1",
+                },
+              },
+              Object {
+                "id": "agentkeepalive@3.4.1",
+                "info": Object {
+                  "name": "agentkeepalive",
+                  "version": "3.4.1",
+                },
+              },
+              Object {
+                "id": "http-cache-semantics@3.8.1",
+                "info": Object {
+                  "name": "http-cache-semantics",
+                  "version": "3.8.1",
+                },
+              },
+              Object {
+                "id": "es6-promise@4.2.4",
+                "info": Object {
+                  "name": "es6-promise",
+                  "version": "4.2.4",
+                },
+              },
+              Object {
+                "id": "es6-promisify@5.0.0",
+                "info": Object {
+                  "name": "es6-promisify",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "agent-base@4.2.0",
+                "info": Object {
+                  "name": "agent-base",
+                  "version": "4.2.0",
+                },
+              },
+              Object {
+                "id": "ms@2.0.0",
+                "info": Object {
+                  "name": "ms",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "debug@3.1.0",
+                "info": Object {
+                  "name": "debug",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "http-proxy-agent@2.1.0",
+                "info": Object {
+                  "name": "http-proxy-agent",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "https-proxy-agent@2.2.1",
+                "info": Object {
+                  "name": "https-proxy-agent",
+                  "version": "2.2.1",
+                },
+              },
+              Object {
+                "id": "iconv-lite@0.4.23",
+                "info": Object {
+                  "name": "iconv-lite",
+                  "version": "0.4.23",
+                },
+              },
+              Object {
+                "id": "encoding@0.1.12",
+                "info": Object {
+                  "name": "encoding",
+                  "version": "0.1.12",
+                },
+              },
+              Object {
+                "id": "node-fetch-npm@2.0.2",
+                "info": Object {
+                  "name": "node-fetch-npm",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "err-code@1.1.2",
+                "info": Object {
+                  "name": "err-code",
+                  "version": "1.1.2",
+                },
+              },
+              Object {
+                "id": "retry@0.10.1",
+                "info": Object {
+                  "name": "retry",
+                  "version": "0.10.1",
+                },
+              },
+              Object {
+                "id": "promise-retry@1.1.1",
+                "info": Object {
+                  "name": "promise-retry",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "ip@1.1.5",
+                "info": Object {
+                  "name": "ip",
+                  "version": "1.1.5",
+                },
+              },
+              Object {
+                "id": "smart-buffer@4.0.1",
+                "info": Object {
+                  "name": "smart-buffer",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "socks@2.2.0",
+                "info": Object {
+                  "name": "socks",
+                  "version": "2.2.0",
+                },
+              },
+              Object {
+                "id": "socks-proxy-agent@4.0.1",
+                "info": Object {
+                  "name": "socks-proxy-agent",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "make-fetch-happen@4.0.1",
+                "info": Object {
+                  "name": "make-fetch-happen",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "yallist@3.0.2",
+                "info": Object {
+                  "name": "yallist",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "minipass@2.3.3",
+                "info": Object {
+                  "name": "minipass",
+                  "version": "2.3.3",
+                },
+              },
+              Object {
+                "id": "ignore-walk@3.0.1",
+                "info": Object {
+                  "name": "ignore-walk",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "npm-bundled@1.0.5",
+                "info": Object {
+                  "name": "npm-bundled",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "npm-packlist@1.1.12",
+                "info": Object {
+                  "name": "npm-packlist",
+                  "version": "1.1.12",
+                },
+              },
+              Object {
+                "id": "npm-pick-manifest@2.1.0",
+                "info": Object {
+                  "name": "npm-pick-manifest",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "genfun@4.0.1",
+                "info": Object {
+                  "name": "genfun",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "protoduck@5.0.0",
+                "info": Object {
+                  "name": "protoduck",
+                  "version": "5.0.0",
+                },
+              },
+              Object {
+                "id": "chownr@1.1.1",
+                "info": Object {
+                  "name": "chownr",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "fs-minipass@1.2.5",
+                "info": Object {
+                  "name": "fs-minipass",
+                  "version": "1.2.5",
+                },
+              },
+              Object {
+                "id": "yallist@3.0.3",
+                "info": Object {
+                  "name": "yallist",
+                  "version": "3.0.3",
+                },
+              },
+              Object {
+                "id": "minipass@2.3.5",
+                "info": Object {
+                  "name": "minipass",
+                  "version": "2.3.5",
+                },
+              },
+              Object {
+                "id": "minizlib@1.1.1",
+                "info": Object {
+                  "name": "minizlib",
+                  "version": "1.1.1",
+                },
+              },
+              Object {
+                "id": "tar@4.4.8",
+                "info": Object {
+                  "name": "tar",
+                  "version": "4.4.8",
+                },
+              },
+              Object {
+                "id": "pacote@8.1.6",
+                "info": Object {
+                  "name": "pacote",
+                  "version": "8.1.6",
+                },
+              },
+              Object {
+                "id": "prr@1.0.1",
+                "info": Object {
+                  "name": "prr",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "errno@0.1.7",
+                "info": Object {
+                  "name": "errno",
+                  "version": "0.1.7",
+                },
+              },
+              Object {
+                "id": "worker-farm@1.6.0",
+                "info": Object {
+                  "name": "worker-farm",
+                  "version": "1.6.0",
+                },
+              },
+              Object {
+                "id": "libcipm@2.0.2",
+                "info": Object {
+                  "name": "libcipm",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "npm-registry-fetch@3.1.1",
+                "info": Object {
+                  "name": "npm-registry-fetch",
+                  "version": "3.1.1",
+                },
+              },
+              Object {
+                "id": "libnpmhook@4.0.1",
+                "info": Object {
+                  "name": "libnpmhook",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "dotenv@5.0.1",
+                "info": Object {
+                  "name": "dotenv",
+                  "version": "5.0.1",
+                },
+              },
+              Object {
+                "id": "ansi-align@2.0.0",
+                "info": Object {
+                  "name": "ansi-align",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "camelcase@4.1.0",
+                "info": Object {
+                  "name": "camelcase",
+                  "version": "4.1.0",
+                },
+              },
+              Object {
+                "id": "color-name@1.1.3",
+                "info": Object {
+                  "name": "color-name",
+                  "version": "1.1.3",
+                },
+              },
+              Object {
+                "id": "color-convert@1.9.1",
+                "info": Object {
+                  "name": "color-convert",
+                  "version": "1.9.1",
+                },
+              },
+              Object {
+                "id": "ansi-styles@3.2.1",
+                "info": Object {
+                  "name": "ansi-styles",
+                  "version": "3.2.1",
+                },
+              },
+              Object {
+                "id": "escape-string-regexp@1.0.5",
+                "info": Object {
+                  "name": "escape-string-regexp",
+                  "version": "1.0.5",
+                },
+              },
+              Object {
+                "id": "has-flag@3.0.0",
+                "info": Object {
+                  "name": "has-flag",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "supports-color@5.4.0",
+                "info": Object {
+                  "name": "supports-color",
+                  "version": "5.4.0",
+                },
+              },
+              Object {
+                "id": "chalk@2.4.1",
+                "info": Object {
+                  "name": "chalk",
+                  "version": "2.4.1",
+                },
+              },
+              Object {
+                "id": "cli-boxes@1.0.0",
+                "info": Object {
+                  "name": "cli-boxes",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "shebang-regex@1.0.0",
+                "info": Object {
+                  "name": "shebang-regex",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "shebang-command@1.2.0",
+                "info": Object {
+                  "name": "shebang-command",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "cross-spawn@5.1.0",
+                "info": Object {
+                  "name": "cross-spawn",
+                  "version": "5.1.0",
+                },
+              },
+              Object {
+                "id": "is-stream@1.1.0",
+                "info": Object {
+                  "name": "is-stream",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "path-key@2.0.1",
+                "info": Object {
+                  "name": "path-key",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "npm-run-path@2.0.2",
+                "info": Object {
+                  "name": "npm-run-path",
+                  "version": "2.0.2",
+                },
+              },
+              Object {
+                "id": "p-finally@1.0.0",
+                "info": Object {
+                  "name": "p-finally",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "strip-eof@1.0.0",
+                "info": Object {
+                  "name": "strip-eof",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "execa@0.7.0",
+                "info": Object {
+                  "name": "execa",
+                  "version": "0.7.0",
+                },
+              },
+              Object {
+                "id": "term-size@1.2.0",
+                "info": Object {
+                  "name": "term-size",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "widest-line@2.0.0",
+                "info": Object {
+                  "name": "widest-line",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "boxen@1.3.0",
+                "info": Object {
+                  "name": "boxen",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "is-obj@1.0.1",
+                "info": Object {
+                  "name": "is-obj",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "dot-prop@4.2.0",
+                "info": Object {
+                  "name": "dot-prop",
+                  "version": "4.2.0",
+                },
+              },
+              Object {
+                "id": "pify@3.0.0",
+                "info": Object {
+                  "name": "pify",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "make-dir@1.3.0",
+                "info": Object {
+                  "name": "make-dir",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "crypto-random-string@1.0.0",
+                "info": Object {
+                  "name": "crypto-random-string",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "unique-string@1.0.0",
+                "info": Object {
+                  "name": "unique-string",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "xdg-basedir@3.0.0",
+                "info": Object {
+                  "name": "xdg-basedir",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "configstore@3.1.2",
+                "info": Object {
+                  "name": "configstore",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "import-lazy@2.1.0",
+                "info": Object {
+                  "name": "import-lazy",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "is-ci@1.1.0",
+                "info": Object {
+                  "name": "is-ci",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "global-dirs@0.1.1",
+                "info": Object {
+                  "name": "global-dirs",
+                  "version": "0.1.1",
+                },
+              },
+              Object {
+                "id": "is-path-inside@1.0.1",
+                "info": Object {
+                  "name": "is-path-inside",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "is-installed-globally@0.1.0",
+                "info": Object {
+                  "name": "is-installed-globally",
+                  "version": "0.1.0",
+                },
+              },
+              Object {
+                "id": "is-npm@1.0.0",
+                "info": Object {
+                  "name": "is-npm",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "capture-stack-trace@1.0.0",
+                "info": Object {
+                  "name": "capture-stack-trace",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "create-error-class@3.0.2",
+                "info": Object {
+                  "name": "create-error-class",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "duplexer3@0.1.4",
+                "info": Object {
+                  "name": "duplexer3",
+                  "version": "0.1.4",
+                },
+              },
+              Object {
+                "id": "is-redirect@1.0.0",
+                "info": Object {
+                  "name": "is-redirect",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "is-retry-allowed@1.1.0",
+                "info": Object {
+                  "name": "is-retry-allowed",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "lowercase-keys@1.0.1",
+                "info": Object {
+                  "name": "lowercase-keys",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "timed-out@4.0.1",
+                "info": Object {
+                  "name": "timed-out",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "unzip-response@2.0.1",
+                "info": Object {
+                  "name": "unzip-response",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "prepend-http@1.0.4",
+                "info": Object {
+                  "name": "prepend-http",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "url-parse-lax@1.0.0",
+                "info": Object {
+                  "name": "url-parse-lax",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "got@6.7.1",
+                "info": Object {
+                  "name": "got",
+                  "version": "6.7.1",
+                },
+              },
+              Object {
+                "id": "deep-extend@0.5.1",
+                "info": Object {
+                  "name": "deep-extend",
+                  "version": "0.5.1",
+                },
+              },
+              Object {
+                "id": "minimist@1.2.0",
+                "info": Object {
+                  "name": "minimist",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "strip-json-comments@2.0.1",
+                "info": Object {
+                  "name": "strip-json-comments",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "rc@1.2.7",
+                "info": Object {
+                  "name": "rc",
+                  "version": "1.2.7",
+                },
+              },
+              Object {
+                "id": "registry-auth-token@3.3.2",
+                "info": Object {
+                  "name": "registry-auth-token",
+                  "version": "3.3.2",
+                },
+              },
+              Object {
+                "id": "registry-url@3.1.0",
+                "info": Object {
+                  "name": "registry-url",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "package-json@4.0.1",
+                "info": Object {
+                  "name": "package-json",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "latest-version@3.1.0",
+                "info": Object {
+                  "name": "latest-version",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "semver-diff@2.1.0",
+                "info": Object {
+                  "name": "semver-diff",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "update-notifier@2.5.0",
+                "info": Object {
+                  "name": "update-notifier",
+                  "version": "2.5.0",
+                },
+              },
+              Object {
+                "id": "wrap-ansi@2.1.0",
+                "info": Object {
+                  "name": "wrap-ansi",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "cliui@4.1.0",
+                "info": Object {
+                  "name": "cliui",
+                  "version": "4.1.0",
+                },
+              },
+              Object {
+                "id": "decamelize@1.2.0",
+                "info": Object {
+                  "name": "decamelize",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "p-try@1.0.0",
+                "info": Object {
+                  "name": "p-try",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "p-limit@1.2.0",
+                "info": Object {
+                  "name": "p-limit",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "p-locate@2.0.0",
+                "info": Object {
+                  "name": "p-locate",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "path-exists@3.0.0",
+                "info": Object {
+                  "name": "path-exists",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "locate-path@2.0.0",
+                "info": Object {
+                  "name": "locate-path",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "find-up@2.1.0",
+                "info": Object {
+                  "name": "find-up",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "get-caller-file@1.0.2",
+                "info": Object {
+                  "name": "get-caller-file",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "invert-kv@1.0.0",
+                "info": Object {
+                  "name": "invert-kv",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "lcid@1.0.0",
+                "info": Object {
+                  "name": "lcid",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "mimic-fn@1.2.0",
+                "info": Object {
+                  "name": "mimic-fn",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "mem@1.1.0",
+                "info": Object {
+                  "name": "mem",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "os-locale@2.1.0",
+                "info": Object {
+                  "name": "os-locale",
+                  "version": "2.1.0",
+                },
+              },
+              Object {
+                "id": "require-directory@2.1.1",
+                "info": Object {
+                  "name": "require-directory",
+                  "version": "2.1.1",
+                },
+              },
+              Object {
+                "id": "require-main-filename@1.0.1",
+                "info": Object {
+                  "name": "require-main-filename",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "y18n@3.2.1",
+                "info": Object {
+                  "name": "y18n",
+                  "version": "3.2.1",
+                },
+              },
+              Object {
+                "id": "yargs-parser@9.0.2",
+                "info": Object {
+                  "name": "yargs-parser",
+                  "version": "9.0.2",
+                },
+              },
+              Object {
+                "id": "yargs@11.0.0",
+                "info": Object {
+                  "name": "yargs",
+                  "version": "11.0.0",
+                },
+              },
+              Object {
+                "id": "libnpx@10.2.0",
+                "info": Object {
+                  "name": "libnpx",
+                  "version": "10.2.0",
+                },
+              },
+              Object {
+                "id": "lockfile@1.0.4",
+                "info": Object {
+                  "name": "lockfile",
+                  "version": "1.0.4",
+                },
+              },
+              Object {
+                "id": "lodash._baseindexof@3.1.0",
+                "info": Object {
+                  "name": "lodash._baseindexof",
+                  "version": "3.1.0",
+                },
+              },
+              Object {
+                "id": "lodash._createset@4.0.3",
+                "info": Object {
+                  "name": "lodash._createset",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "lodash._root@3.0.1",
+                "info": Object {
+                  "name": "lodash._root",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "lodash._baseuniq@4.6.0",
+                "info": Object {
+                  "name": "lodash._baseuniq",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "lodash._bindcallback@3.0.1",
+                "info": Object {
+                  "name": "lodash._bindcallback",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "lodash._cacheindexof@3.0.2",
+                "info": Object {
+                  "name": "lodash._cacheindexof",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "lodash._getnative@3.9.1",
+                "info": Object {
+                  "name": "lodash._getnative",
+                  "version": "3.9.1",
+                },
+              },
+              Object {
+                "id": "lodash._createcache@3.1.2",
+                "info": Object {
+                  "name": "lodash._createcache",
+                  "version": "3.1.2",
+                },
+              },
+              Object {
+                "id": "lodash.clonedeep@4.5.0",
+                "info": Object {
+                  "name": "lodash.clonedeep",
+                  "version": "4.5.0",
+                },
+              },
+              Object {
+                "id": "lodash.restparam@3.6.1",
+                "info": Object {
+                  "name": "lodash.restparam",
+                  "version": "3.6.1",
+                },
+              },
+              Object {
+                "id": "lodash.union@4.6.0",
+                "info": Object {
+                  "name": "lodash.union",
+                  "version": "4.6.0",
+                },
+              },
+              Object {
+                "id": "lodash.uniq@4.5.0",
+                "info": Object {
+                  "name": "lodash.uniq",
+                  "version": "4.5.0",
+                },
+              },
+              Object {
+                "id": "lodash.without@4.4.0",
+                "info": Object {
+                  "name": "lodash.without",
+                  "version": "4.4.0",
+                },
+              },
+              Object {
+                "id": "meant@1.0.1",
+                "info": Object {
+                  "name": "meant",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "nopt@4.0.1",
+                "info": Object {
+                  "name": "nopt",
+                  "version": "4.0.1",
+                },
+              },
+              Object {
+                "id": "npm-audit-report@1.3.1",
+                "info": Object {
+                  "name": "npm-audit-report",
+                  "version": "1.3.1",
+                },
+              },
+              Object {
+                "id": "npm-cache-filename@1.0.2",
+                "info": Object {
+                  "name": "npm-cache-filename",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "npm-install-checks@3.0.0",
+                "info": Object {
+                  "name": "npm-install-checks",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "npm-profile@3.0.2",
+                "info": Object {
+                  "name": "npm-profile",
+                  "version": "3.0.2",
+                },
+              },
+              Object {
+                "id": "ssri@5.3.0",
+                "info": Object {
+                  "name": "ssri",
+                  "version": "5.3.0",
+                },
+              },
+              Object {
+                "id": "npm-registry-client@8.6.0",
+                "info": Object {
+                  "name": "npm-registry-client",
+                  "version": "8.6.0",
+                },
+              },
+              Object {
+                "id": "figgy-pudding@2.0.1",
+                "info": Object {
+                  "name": "figgy-pudding",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "mississippi@2.0.0",
+                "info": Object {
+                  "name": "mississippi",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "cacache@10.0.4",
+                "info": Object {
+                  "name": "cacache",
+                  "version": "10.0.4",
+                },
+              },
+              Object {
+                "id": "smart-buffer@1.1.15",
+                "info": Object {
+                  "name": "smart-buffer",
+                  "version": "1.1.15",
+                },
+              },
+              Object {
+                "id": "socks@1.1.10",
+                "info": Object {
+                  "name": "socks",
+                  "version": "1.1.10",
+                },
+              },
+              Object {
+                "id": "socks-proxy-agent@3.0.1",
+                "info": Object {
+                  "name": "socks-proxy-agent",
+                  "version": "3.0.1",
+                },
+              },
+              Object {
+                "id": "make-fetch-happen@3.0.0",
+                "info": Object {
+                  "name": "make-fetch-happen",
+                  "version": "3.0.0",
+                },
+              },
+              Object {
+                "id": "npm-registry-fetch@1.1.0",
+                "info": Object {
+                  "name": "npm-registry-fetch",
+                  "version": "1.1.0",
+                },
+              },
+              Object {
+                "id": "npm-user-validate@1.0.0",
+                "info": Object {
+                  "name": "npm-user-validate",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "opener@1.5.1",
+                "info": Object {
+                  "name": "opener",
+                  "version": "1.5.1",
+                },
+              },
+              Object {
+                "id": "qrcode-terminal@0.12.0",
+                "info": Object {
+                  "name": "qrcode-terminal",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "decode-uri-component@0.2.0",
+                "info": Object {
+                  "name": "decode-uri-component",
+                  "version": "0.2.0",
+                },
+              },
+              Object {
+                "id": "strict-uri-encode@2.0.0",
+                "info": Object {
+                  "name": "strict-uri-encode",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "query-string@6.1.0",
+                "info": Object {
+                  "name": "query-string",
+                  "version": "6.1.0",
+                },
+              },
+              Object {
+                "id": "qw@1.0.1",
+                "info": Object {
+                  "name": "qw",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "debuglog@1.0.1",
+                "info": Object {
+                  "name": "debuglog",
+                  "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "readdir-scoped-modules@1.0.2",
+                "info": Object {
+                  "name": "readdir-scoped-modules",
+                  "version": "1.0.2",
+                },
+              },
+              Object {
+                "id": "util-extend@1.0.3",
+                "info": Object {
+                  "name": "util-extend",
+                  "version": "1.0.3",
+                },
+              },
+              Object {
+                "id": "read-installed@4.0.3",
+                "info": Object {
+                  "name": "read-installed",
+                  "version": "4.0.3",
+                },
+              },
+              Object {
+                "id": "read-package-tree@5.2.1",
+                "info": Object {
+                  "name": "read-package-tree",
+                  "version": "5.2.1",
+                },
+              },
+              Object {
+                "id": "retry@0.12.0",
+                "info": Object {
+                  "name": "retry",
+                  "version": "0.12.0",
+                },
+              },
+              Object {
+                "id": "sha@2.0.1",
+                "info": Object {
+                  "name": "sha",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "sorted-object@2.0.1",
+                "info": Object {
+                  "name": "sorted-object",
+                  "version": "2.0.1",
+                },
+              },
+              Object {
+                "id": "isarray@0.0.1",
+                "info": Object {
+                  "name": "isarray",
+                  "version": "0.0.1",
+                },
+              },
+              Object {
+                "id": "string_decoder@0.10.31",
+                "info": Object {
+                  "name": "string_decoder",
+                  "version": "0.10.31",
+                },
+              },
+              Object {
+                "id": "readable-stream@1.1.14",
+                "info": Object {
+                  "name": "readable-stream",
+                  "version": "1.1.14",
+                },
+              },
+              Object {
+                "id": "from2@1.3.0",
+                "info": Object {
+                  "name": "from2",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "stream-iterate@1.2.0",
+                "info": Object {
+                  "name": "stream-iterate",
+                  "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "sorted-union-stream@2.1.3",
+                "info": Object {
+                  "name": "sorted-union-stream",
+                  "version": "2.1.3",
+                },
+              },
+              Object {
+                "id": "stringify-package@1.0.0",
+                "info": Object {
+                  "name": "stringify-package",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "text-table@0.2.0",
+                "info": Object {
+                  "name": "text-table",
+                  "version": "0.2.0",
+                },
+              },
+              Object {
+                "id": "tiny-relative-date@1.3.0",
+                "info": Object {
+                  "name": "tiny-relative-date",
+                  "version": "1.3.0",
+                },
+              },
+              Object {
+                "id": "unpipe@1.0.0",
+                "info": Object {
+                  "name": "unpipe",
+                  "version": "1.0.0",
+                },
+              },
+              Object {
+                "id": "npm@6.5.0",
+                "info": Object {
+                  "name": "npm",
+                  "version": "6.5.0",
+                },
+              },
+            ],
+            "schemaVersion": "1.3.0",
+          },
+          "type": "depGraph",
+        },
+        Object {
+          "data": "/usr/local/lib/node_modules",
+          "type": "testedFiles",
+        },
+        Object {
+          "data": "sha256:ebbf98230a821f1795b10c4df40ce81b1905e47d625cb9b4b0c7c617acb85e53",
+          "type": "imageId",
+        },
+      ],
+      "identity": Object {
+        "targetFile": "/usr/local/lib/node_modules",
+        "type": "npm",
       },
       "target": Object {
         "image": "docker-image|snykgoof/dockerhub-goof",


### PR DESCRIPTION
Co-authored-by: danlucian lucian.rosu@snyk.io

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
With the release of [v6.12.0](https://github.com/snyk/snyk-docker-plugin/releases/tag/v6.12.0) of the docker cli plugin we added support for scanning `npm` projects without manifest/lockfiles. `npm` ecosystem has both global and local scoped dependencies and, to avoid false positives, we decided to ignore a [set of folders](https://github.com/snyk/snyk-docker-plugin/compare/v6.11.2...v6.12.0#diff-578f2462189d520724e9a93b42832b47b088ae4315005902a9abbcc552215250R7) from the containers at that time of release. We realised that the accuracy of the cli was impacted by that change and we decided to remove the ignoring of the `/usr/` and `/opt` folders. 

This PR aims to solve the issue mentioned above and slightly refactor the way we handle node projects discovery as shown in the following diagram: 
![RFC  Removal of ignored folders on container scanning](https://github.com/user-attachments/assets/b4155462-c23f-4cb6-93c4-d7419d4ea405)

