### PR TITLE
fix: compute sha1 on .jar files of size up to buffer.constants.MAX_LENGTH

### DIFF
--- a/lib/analyzer/applications/java.ts
+++ b/lib/analyzer/applications/java.ts
@@ -115,6 +115,7 @@ function unpackJar({
   const nestedJars: JarBuffer[] = [];
   let coords: JarCoords | null = null;
 
+  // TODO: consider switching to node-stream-zip that supports streaming
   let zip: admzip;
   let zipEntries: admzip.IZipEntry[];
 

--- a/lib/buffer-utils.ts
+++ b/lib/buffer-utils.ts
@@ -1,23 +1,24 @@
 import * as crypto from "crypto";
-import { Readable } from "stream";
 import { HashAlgorithm } from "./types";
 
 const HASH_ENCODING = "hex";
 
 export async function bufferToSha1(buffer: Buffer): Promise<string> {
-  const stream = Readable.from(buffer);
   const hash = crypto.createHash(HashAlgorithm.Sha1);
+  const chunkSize = 100 * 1024 * 1024; // 100 MB
 
   return new Promise((resolve, reject) => {
-    stream
-      .pipe(hash)
-      .on("finish", () => {
-        hash.end();
-        const digest = hash.read().toString(HASH_ENCODING);
-        resolve(digest);
-      })
-      .on("error", (err) => {
-        reject(err);
-      });
+    try {
+      for (let offset = 0; offset < buffer.length; offset += chunkSize) {
+        const end = Math.min(offset + chunkSize, buffer.length);
+        const chunk = buffer.slice(offset, end);
+        hash.update(chunk);
+      }
+
+      const digest = hash.digest(HASH_ENCODING);
+      resolve(digest);
+    } catch (err) {
+      reject(err);
+    }
   });
 }

--- a/test/lib/buffer-utils.spec.ts
+++ b/test/lib/buffer-utils.spec.ts
@@ -23,7 +23,7 @@ describe("buffer-utils", () => {
       expect(result).toEqual(hashedText);
     });
 
-    xit("should handle large files", async () => {
+    it("should handle large files", async () => {
       const megabyte = 1024 * 1024;
       const gigabyte = megabyte * 1024;
 


### PR DESCRIPTION
 Because we currently decompress .jar files using adm-zip that does not support streaming,
 we load the .jar file in memory using the Buffer class. Due to the current design,
 we can read .jar files of up to buffer.constants.MAX_LENGTH. On 32-bit architectures, this value
 currently is 230 - 1 (about 1 GiB). On 64-bit architectures, this value currently is 232 (about 4 GiB).

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Refactors `buffertoSha1` function to support hashing of large buffers by reading the buffer in chunks using a `Readable`stream. This fixes the case the crypto module is throwing `The RangeError: data is too long`because it cannot handle the size of data passed to it in one go. However due to the current design, we support hasing .jar files of up to `buffer.constants.MAX_LENGTH`.


#### Additional questions
