### PR TITLE
fix: detect platform from image config file UNIFY-253

### DIFF
--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -153,7 +153,7 @@ export function getRootFsLayersFromConfig(imageConfig: ImageConfig): string[] {
 export function getPlatformFromConfig(
   imageConfig: ImageConfig,
 ): string | undefined {
-  return imageConfig.os && imageConfig.architecture
+  return imageConfig?.os && imageConfig?.architecture
     ? `${imageConfig.os}/${imageConfig.architecture}`
     : undefined;
 }

--- a/lib/extractor/oci-archive/layer.ts
+++ b/lib/extractor/oci-archive/layer.ts
@@ -4,7 +4,7 @@ import * as gunzip from "gunzip-maybe";
 import { normalize as normalizePath, sep as pathSeparator } from "path";
 import { PassThrough } from "stream";
 import { extract, Extract } from "tar-stream";
-import { InvalidArchiveError } from "..";
+import { getPlatformFromConfig, InvalidArchiveError } from "..";
 import { streamToJson } from "../../stream-utils";
 import { PluginOptions } from "../../types";
 import { extractImageLayer } from "../layer";
@@ -133,7 +133,9 @@ function getLayersContentAndArchiveManifest(
   manifest: OciArchiveManifest;
   imageConfig: ImageConfig;
 } {
-  const platform = options?.platform || "linux/amd64";
+  const platform =
+    options?.platform ||
+    (configs.length === 1 ? getPlatformFromConfig(configs[0]) : "linux/amd64");
   const platformInfo = getOciPlatformInfoFromOptionString(platform as string);
 
   // get manifest file first

--- a/test/system/platforms/arm.spec.ts
+++ b/test/system/platforms/arm.spec.ts
@@ -1,5 +1,6 @@
 import { scan } from "../../../lib/index";
 import { execute } from "../../../lib/sub-process";
+import { getFixture } from "../../util";
 
 describe("ARM platform tests", () => {
   afterAll(async () => {
@@ -20,6 +21,18 @@ describe("ARM platform tests", () => {
     });
 
     expect(pluginResult).toMatchSnapshot();
+  });
+  test("should correctly scan an arm64 image when platform flag is missing", async () => {
+    const fixturePath = getFixture("docker-archives/alpine-arm64.tar");
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+    try {
+      const result = await scan({
+        path: imageNameAndTag,
+      });
+      expect(result).toBeDefined();
+    } catch (error) {
+      expect(error.message).not.toBe("Invalid OCI Archive");
+    }
   });
 
   it.todo(


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
The previous implementation of the snyk-docker-plugin ecplicitly required the --platform parameter to be passed in order to scan the correct architecture of the image. If --platform was not provided, it would be defaulted to "linux/amd64" and threw an "invalid OCI Archive" error if the platform was different than "linux/amd64".

The new implementation makes it so that it auto-detects the platform information from config files when --platform in missing, if possible, or default it to "linux/amd64" if not possible.

#### Where should the reviewer start?
lib/extractor/oci-archive/layer.ts

#### How should this be manually tested?
With the fix:
```
SNYK_API=https://app.snyk.io/api/v1 node index.js container monitor arm64v8/debian:latest

Monitoring arm64v8/debian:latest (docker-image|arm64v8/debian)...

Explore this snapshot at https://app.snyk.io/org/unmanaged-licenses-enviroment-tests/project/ce3ef220-730b-49ee-a835-983fda9969da/history/6a55317a-a666-4ac3-9381-a73e68b3d4a6
```
Cli behavior without this fix:
```
SNYK_API=https://app.snyk.io/api/v1 snyk container monitor arm64v8/debian:latest
Invalid OCI archive
```
#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/UNIFY-253

#### Screenshots


#### Additional questions
