### PR TITLE
fix: redhat-content-manifests content sets parsing UNIFY-387

### DIFF
--- a/lib/inputs/redHat/static.ts
+++ b/lib/inputs/redHat/static.ts
@@ -16,6 +16,9 @@ export function getRedHatRepositoriesFromExtractedLayers(
       const contentManifest = extractedLayers[filePath][
         "redhat-content-manifests"
       ] as any;
+      if (!contentManifest || !contentManifest.content_sets) {
+        continue;
+      }
       repositories.push(...contentManifest?.content_sets);
     }
   }

--- a/test/system/operating-systems/__snapshots__/ubi9.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi9.spec.ts.snap
@@ -1,0 +1,449 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`redhat ubi9 tests should correctly analyze an ubi9 image by tag 1`] = `
+Object {
+  "scanResults": Array [
+    Object {
+      "facts": Array [
+        Object {
+          "data": Object {
+            "graph": Object {
+              "nodes": Array [
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "basesystem@11-13.el9",
+                    },
+                    Object {
+                      "nodeId": "bash@5.1.8-9.el9",
+                    },
+                    Object {
+                      "nodeId": "coreutils-single@8.32-36.el9",
+                    },
+                    Object {
+                      "nodeId": "filesystem@3.16-5.el9",
+                    },
+                    Object {
+                      "nodeId": "glibc@2.34-125.el9_5.1",
+                    },
+                    Object {
+                      "nodeId": "glibc-common@2.34-125.el9_5.1",
+                    },
+                    Object {
+                      "nodeId": "glibc-minimal-langpack@2.34-125.el9_5.1",
+                    },
+                    Object {
+                      "nodeId": "gpg-pubkey@5a6340b3-6229229e",
+                    },
+                    Object {
+                      "nodeId": "libacl@2.3.1-4.el9",
+                    },
+                    Object {
+                      "nodeId": "libattr@2.5.1-3.el9",
+                    },
+                    Object {
+                      "nodeId": "libcap@2.48-9.el9_2",
+                    },
+                    Object {
+                      "nodeId": "libgcc@11.5.0-2.el9",
+                    },
+                    Object {
+                      "nodeId": "libselinux@3.6-1.el9",
+                    },
+                    Object {
+                      "nodeId": "libsepol@3.6-1.el9",
+                    },
+                    Object {
+                      "nodeId": "ncurses-base@6.2-10.20210508.el9",
+                    },
+                    Object {
+                      "nodeId": "ncurses-libs@6.2-10.20210508.el9",
+                    },
+                    Object {
+                      "nodeId": "pcre2@10.40-6.el9",
+                    },
+                    Object {
+                      "nodeId": "pcre2-syntax@10.40-6.el9",
+                    },
+                    Object {
+                      "nodeId": "redhat-release@9.5-0.6.el9",
+                    },
+                    Object {
+                      "nodeId": "setup@2.13.7-10.el9",
+                    },
+                    Object {
+                      "nodeId": "tzdata@2024b-2.el9",
+                    },
+                  ],
+                  "nodeId": "root-node",
+                  "pkgId": "docker-image|registry.access.redhat.com/ubi9-micro@latest",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "basesystem@11-13.el9",
+                  "pkgId": "basesystem@11-13.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "bash@5.1.8-9.el9",
+                  "pkgId": "bash@5.1.8-9.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "coreutils-single@8.32-36.el9",
+                  "pkgId": "coreutils-single@8.32-36.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "filesystem@3.16-5.el9",
+                  "pkgId": "filesystem@3.16-5.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc@2.34-125.el9_5.1",
+                  "pkgId": "glibc@2.34-125.el9_5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc-common@2.34-125.el9_5.1",
+                  "pkgId": "glibc-common@2.34-125.el9_5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "glibc-minimal-langpack@2.34-125.el9_5.1",
+                  "pkgId": "glibc-minimal-langpack@2.34-125.el9_5.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "gpg-pubkey@5a6340b3-6229229e",
+                  "pkgId": "gpg-pubkey@5a6340b3-6229229e",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libacl@2.3.1-4.el9",
+                  "pkgId": "libacl@2.3.1-4.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libattr@2.5.1-3.el9",
+                  "pkgId": "libattr@2.5.1-3.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libcap@2.48-9.el9_2",
+                  "pkgId": "libcap@2.48-9.el9_2",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libgcc@11.5.0-2.el9",
+                  "pkgId": "libgcc@11.5.0-2.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libselinux@3.6-1.el9",
+                  "pkgId": "libselinux@3.6-1.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "libsepol@3.6-1.el9",
+                  "pkgId": "libsepol@3.6-1.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ncurses-base@6.2-10.20210508.el9",
+                  "pkgId": "ncurses-base@6.2-10.20210508.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "ncurses-libs@6.2-10.20210508.el9",
+                  "pkgId": "ncurses-libs@6.2-10.20210508.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre2@10.40-6.el9",
+                  "pkgId": "pcre2@10.40-6.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "pcre2-syntax@10.40-6.el9",
+                  "pkgId": "pcre2-syntax@10.40-6.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "redhat-release@9.5-0.6.el9",
+                  "pkgId": "redhat-release@9.5-0.6.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "setup@2.13.7-10.el9",
+                  "pkgId": "setup@2.13.7-10.el9",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "tzdata@2024b-2.el9",
+                  "pkgId": "tzdata@2024b-2.el9",
+                },
+              ],
+              "rootNodeId": "root-node",
+            },
+            "pkgManager": Object {
+              "name": "rpm",
+              "repositories": Array [
+                Object {
+                  "alias": "rhel:9.5",
+                },
+              ],
+            },
+            "pkgs": Array [
+              Object {
+                "id": "docker-image|registry.access.redhat.com/ubi9-micro@latest",
+                "info": Object {
+                  "name": "docker-image|registry.access.redhat.com/ubi9-micro",
+                  "version": "latest",
+                },
+              },
+              Object {
+                "id": "basesystem@11-13.el9",
+                "info": Object {
+                  "name": "basesystem",
+                  "purl": "pkg:rpm/rhel/basesystem@11-13.el9?distro=rhel-9.5",
+                  "version": "11-13.el9",
+                },
+              },
+              Object {
+                "id": "bash@5.1.8-9.el9",
+                "info": Object {
+                  "name": "bash",
+                  "purl": "pkg:rpm/rhel/bash@5.1.8-9.el9?distro=rhel-9.5",
+                  "version": "5.1.8-9.el9",
+                },
+              },
+              Object {
+                "id": "coreutils-single@8.32-36.el9",
+                "info": Object {
+                  "name": "coreutils-single",
+                  "purl": "pkg:rpm/rhel/coreutils-single@8.32-36.el9?distro=rhel-9.5",
+                  "version": "8.32-36.el9",
+                },
+              },
+              Object {
+                "id": "filesystem@3.16-5.el9",
+                "info": Object {
+                  "name": "filesystem",
+                  "purl": "pkg:rpm/rhel/filesystem@3.16-5.el9?distro=rhel-9.5",
+                  "version": "3.16-5.el9",
+                },
+              },
+              Object {
+                "id": "glibc@2.34-125.el9_5.1",
+                "info": Object {
+                  "name": "glibc",
+                  "purl": "pkg:rpm/rhel/glibc@2.34-125.el9_5.1?distro=rhel-9.5",
+                  "version": "2.34-125.el9_5.1",
+                },
+              },
+              Object {
+                "id": "glibc-common@2.34-125.el9_5.1",
+                "info": Object {
+                  "name": "glibc-common",
+                  "purl": "pkg:rpm/rhel/glibc-common@2.34-125.el9_5.1?distro=rhel-9.5",
+                  "version": "2.34-125.el9_5.1",
+                },
+              },
+              Object {
+                "id": "glibc-minimal-langpack@2.34-125.el9_5.1",
+                "info": Object {
+                  "name": "glibc-minimal-langpack",
+                  "purl": "pkg:rpm/rhel/glibc-minimal-langpack@2.34-125.el9_5.1?distro=rhel-9.5",
+                  "version": "2.34-125.el9_5.1",
+                },
+              },
+              Object {
+                "id": "gpg-pubkey@5a6340b3-6229229e",
+                "info": Object {
+                  "name": "gpg-pubkey",
+                  "purl": "pkg:rpm/rhel/gpg-pubkey@5a6340b3-6229229e?distro=rhel-9.5",
+                  "version": "5a6340b3-6229229e",
+                },
+              },
+              Object {
+                "id": "libacl@2.3.1-4.el9",
+                "info": Object {
+                  "name": "libacl",
+                  "purl": "pkg:rpm/rhel/libacl@2.3.1-4.el9?distro=rhel-9.5",
+                  "version": "2.3.1-4.el9",
+                },
+              },
+              Object {
+                "id": "libattr@2.5.1-3.el9",
+                "info": Object {
+                  "name": "libattr",
+                  "purl": "pkg:rpm/rhel/libattr@2.5.1-3.el9?distro=rhel-9.5",
+                  "version": "2.5.1-3.el9",
+                },
+              },
+              Object {
+                "id": "libcap@2.48-9.el9_2",
+                "info": Object {
+                  "name": "libcap",
+                  "purl": "pkg:rpm/rhel/libcap@2.48-9.el9_2?distro=rhel-9.5",
+                  "version": "2.48-9.el9_2",
+                },
+              },
+              Object {
+                "id": "libgcc@11.5.0-2.el9",
+                "info": Object {
+                  "name": "libgcc",
+                  "purl": "pkg:rpm/rhel/libgcc@11.5.0-2.el9?distro=rhel-9.5",
+                  "version": "11.5.0-2.el9",
+                },
+              },
+              Object {
+                "id": "libselinux@3.6-1.el9",
+                "info": Object {
+                  "name": "libselinux",
+                  "purl": "pkg:rpm/rhel/libselinux@3.6-1.el9?distro=rhel-9.5",
+                  "version": "3.6-1.el9",
+                },
+              },
+              Object {
+                "id": "libsepol@3.6-1.el9",
+                "info": Object {
+                  "name": "libsepol",
+                  "purl": "pkg:rpm/rhel/libsepol@3.6-1.el9?distro=rhel-9.5",
+                  "version": "3.6-1.el9",
+                },
+              },
+              Object {
+                "id": "ncurses-base@6.2-10.20210508.el9",
+                "info": Object {
+                  "name": "ncurses-base",
+                  "purl": "pkg:rpm/rhel/ncurses-base@6.2-10.20210508.el9?distro=rhel-9.5",
+                  "version": "6.2-10.20210508.el9",
+                },
+              },
+              Object {
+                "id": "ncurses-libs@6.2-10.20210508.el9",
+                "info": Object {
+                  "name": "ncurses-libs",
+                  "purl": "pkg:rpm/rhel/ncurses-libs@6.2-10.20210508.el9?distro=rhel-9.5",
+                  "version": "6.2-10.20210508.el9",
+                },
+              },
+              Object {
+                "id": "pcre2@10.40-6.el9",
+                "info": Object {
+                  "name": "pcre2",
+                  "purl": "pkg:rpm/rhel/pcre2@10.40-6.el9?distro=rhel-9.5",
+                  "version": "10.40-6.el9",
+                },
+              },
+              Object {
+                "id": "pcre2-syntax@10.40-6.el9",
+                "info": Object {
+                  "name": "pcre2-syntax",
+                  "purl": "pkg:rpm/rhel/pcre2-syntax@10.40-6.el9?distro=rhel-9.5",
+                  "version": "10.40-6.el9",
+                },
+              },
+              Object {
+                "id": "redhat-release@9.5-0.6.el9",
+                "info": Object {
+                  "name": "redhat-release",
+                  "purl": "pkg:rpm/rhel/redhat-release@9.5-0.6.el9?distro=rhel-9.5",
+                  "version": "9.5-0.6.el9",
+                },
+              },
+              Object {
+                "id": "setup@2.13.7-10.el9",
+                "info": Object {
+                  "name": "setup",
+                  "purl": "pkg:rpm/rhel/setup@2.13.7-10.el9?distro=rhel-9.5",
+                  "version": "2.13.7-10.el9",
+                },
+              },
+              Object {
+                "id": "tzdata@2024b-2.el9",
+                "info": Object {
+                  "name": "tzdata",
+                  "purl": "pkg:rpm/rhel/tzdata@2024b-2.el9?distro=rhel-9.5",
+                  "version": "2024b-2.el9",
+                },
+              },
+            ],
+            "schemaVersion": "1.3.0",
+          },
+          "type": "depGraph",
+        },
+        Object {
+          "data": "sha256:e279e18c7ef88c0deccd313495d65a7a3496fa55ce00f7b71a4799b7b7ff8dcf",
+          "type": "imageId",
+        },
+        Object {
+          "data": Array [
+            "sha256:a3f473d976dd15642de7158dee0f686feec38dbd417f420251fb0ee85094204e",
+            "sha256:131e02d886707695c92b9c1bfd3a2dd6422c58d217312ed40c00d1d70c39bde0",
+          ],
+          "type": "imageLayers",
+        },
+        Object {
+          "data": Object {
+            "architecture": "x86_64",
+            "build-date": "2024-11-13T17:41:49Z",
+            "com.redhat.component": "ubi9-micro-container",
+            "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
+            "description": "Very small image which doesn't install the package manager.",
+            "distribution-scope": "public",
+            "io.buildah.version": "1.38.0-dev",
+            "io.k8s.description": "Very small image which doesn't install the package manager.",
+            "io.k8s.display-name": "Red Hat Universal Base Image 9 Micro",
+            "io.openshift.expose-services": "",
+            "maintainer": "Red Hat, Inc.",
+            "name": "ubi9/ubi-micro",
+            "release": "1731519709",
+            "summary": "ubi9 micro image",
+            "url": "https://www.redhat.com",
+            "vcs-ref": "71bcf0319e57a9cc41e25d68fc6a92e19ffe1eda",
+            "vcs-type": "git",
+            "vendor": "Red Hat, Inc.",
+            "version": "9.5",
+          },
+          "type": "imageLabels",
+        },
+        Object {
+          "data": "2024-11-13T17:44:23.86885047Z",
+          "type": "imageCreationTime",
+        },
+        Object {
+          "data": Array [
+            "sha256:a3f473d976dd15642de7158dee0f686feec38dbd417f420251fb0ee85094204e",
+            "sha256:131e02d886707695c92b9c1bfd3a2dd6422c58d217312ed40c00d1d70c39bde0",
+          ],
+          "type": "rootFs",
+        },
+        Object {
+          "data": "Red Hat Enterprise Linux 9.5 (Plow)",
+          "type": "imageOsReleasePrettyName",
+        },
+        Object {
+          "data": Object {
+            "names": Array [
+              "registry.access.redhat.com/ubi9-micro:latest",
+            ],
+          },
+          "type": "imageNames",
+        },
+      ],
+      "identity": Object {
+        "args": Object {
+          "platform": "linux/amd64",
+        },
+        "type": "rpm",
+      },
+      "target": Object {
+        "image": "docker-image|registry.access.redhat.com/ubi9-micro",
+      },
+    },
+  ],
+}
+`;

--- a/test/system/operating-systems/ubi9.spec.ts
+++ b/test/system/operating-systems/ubi9.spec.ts
@@ -1,0 +1,24 @@
+import { scan } from "../../../lib/index";
+import { execute } from "../../../lib/sub-process";
+
+describe("redhat ubi9 tests", () => {
+  afterAll(async () => {
+    await execute("docker", [
+      "image",
+      "rm",
+      "registry.access.redhat.com/ubi9-micro",
+    ]).catch(() => {
+      console.error(`tests teardown failed to remove docker image`);
+    });
+  });
+
+  it("should correctly analyze an ubi9 image by tag", async () => {
+    const image = "registry.access.redhat.com/ubi9-micro";
+    const pluginResult = await scan({
+      path: image,
+      platform: "linux/amd64",
+    });
+
+    expect(pluginResult).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

When content_sets is not present is absent from the redhat-content-manifests we try to cast to string [] an undefined value.
https://app.datadoghq.com/logs?query=%22cli%20analytics%22%20%40polaris.instance%3Apolaris-prod-mt-gcp-1%20%2A%3Aintermediate%2A&agg_m=count&agg_m_source=base&agg_q=%40originalError.message&agg_q_source=base&agg_t=count&cols=host%2Cservice%2C%40originalError.message%2C%40name%2C%40data&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=30&top_o=top&viz=toplist&x_missing=true&from_ts=1730318170926&to_ts=1731614170926&live=true

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
