### PR TITLE
feat: add java application files collection

### DIFF
--- a/lib/analyzer/applications/types.ts
+++ b/lib/analyzer/applications/types.ts
@@ -15,6 +15,7 @@ export interface JarInfo extends JarBuffer {
   coords: JarCoords | null;
   dependencies: JarCoords[];
   nestedJars: JarBuffer[];
+  classFiles?: ApplicationFiles;
 }
 export interface JarBuffer {
   location: string;
@@ -37,6 +38,7 @@ export interface ApplicationFileInfo {
 export interface ApplicationFiles {
   fileHierarchy: ApplicationFileInfo[];
   moduleName?: string;
+  jarPath?: string;
   language: string;
 }
 

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -254,6 +254,7 @@ export async function analyze(
       getBufferContent(extractedLayers, getJarFileContentAction.actionName),
       targetImage,
       desiredLevelsOfUnpacking,
+      collectApplicationFiles,
     );
 
     const goModulesScanResult = await goModulesToScannedProjects(

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -71,6 +71,7 @@ export interface JarFingerprint {
   parentName?: string;
   name?: string;
   version?: string;
+  classFiles?: string[];
   dependencies: JarCoords[];
 }
 export interface StaticAnalysis {

--- a/test/system/application-scans/java.spec.ts
+++ b/test/system/application-scans/java.spec.ts
@@ -468,4 +468,36 @@ describe("jar binaries scanning", () => {
       },
     );
   });
+
+  it("should handle --collect-application-files", async () => {
+    const fixturePath = getFixture(
+      "docker-archives/docker-save/java-uberjar.tar",
+    );
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+    const resultWithoutApplicationFilesFlag = await scan({
+      path: imageNameAndTag,
+      "app-vulns": true,
+    });
+    const resultWithApplicationFilesFlagSetToTrue = await scan({
+      path: imageNameAndTag,
+      "app-vulns": true,
+      "collect-application-files": "true",
+    });
+
+    expect(resultWithoutApplicationFilesFlag.scanResults).toHaveLength(2);
+    expect(resultWithApplicationFilesFlagSetToTrue.scanResults).toHaveLength(3);
+
+    const appFiles =
+      resultWithApplicationFilesFlagSetToTrue.scanResults[2].facts.find(
+        (fact) => fact.type === "applicationFiles",
+      )!.data;
+    expect(appFiles.length).toEqual(2);
+    expect(appFiles[0].fileHierarchy.length).toEqual(1);
+    expect(appFiles[0].jarPath).toEqual("/uberjar.jar");
+    expect(appFiles[0].language).toEqual("java");
+    expect(appFiles[1].fileHierarchy.length).toEqual(12);
+    expect(appFiles[1].jarPath).toEqual("/j2objc-annotations-1.3.jar");
+    expect(appFiles[1].language).toEqual("java");
+  });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

What does this PR do?
https://snyksec.atlassian.net/wiki/x/3oA6o

Where should the reviewer start?
Following the logical flow starting from lib/analyzer/static-analyzer.ts will be easier to follow.

How should this be manually tested?
Using the Docker registry agent(DRA) (https://github.com/snyk/docker-registry-agent) update the installed Snyk docker plugin version (in the package.json) to be based on the current branch:
"snyk-docker-plugin": "github:snyk/snyk-docker-plugin#collect_application_files".
Run npm install.
Run the DRA locally and from a different terminal execute the following command:

```
curl --location 'http://localhost:17500/scan' \
--header 'snyk-source-credentials: <<CREDENTIALS_FOR_CR>>' \
--header 'Content-Type: application/json' \
--data '{
    "target": {
        "name": "<<IMAGE_ON_CR>>"
    },
    "options": {
        "appScan": true,
        "collectApplicationFiles": true
    },
    "callbacks": {
        "resultUrl": "<<RESULT_URL>>",                                   
        "doneUrl": "<<DONE_URL>>",
        "token": "00000000-0000-0000-0000-000000000000"
    }   
}'
```
The expected output of the given RESULT_URL endpoint should contain the fact type "applicationFiles" as part of the data.
The image should be running Java code.

What are the relevant tickets?
https://snyksec.atlassian.net/browse/RNTM-744
https://snyksec.atlassian.net/browse/RNTM-745