### PR TITLE
feat: additional metadata from manifest file

### DIFF
--- a/lib/analyzer/applications/node-modules-utils.ts
+++ b/lib/analyzer/applications/node-modules-utils.ts
@@ -34,7 +34,8 @@ async function createTempProjectDir(
   };
 }
 
-const manifestName: string = "package.json";
+export const manifestName: string = "package.json";
+export const manifestLockName: string = "package-lock.json";
 
 async function fileExists(path: string): Promise<boolean> {
   return await stat(path)

--- a/lib/analyzer/applications/runtime-common.ts
+++ b/lib/analyzer/applications/runtime-common.ts
@@ -8,10 +8,9 @@ import {
   FilePathToContent,
   ManifestMetadata,
 } from "./types";
-import { bool } from "aws-sdk/clients/signer";
 
 interface AppFileMetadataExtractor {
-  manifestFileMatcher: (filePath: string) => bool;
+  manifestFileMatcher: (filePath: string) => boolean;
   metadataExtractor: (fileContent: string) => ManifestMetadata | undefined;
 }
 

--- a/lib/analyzer/applications/runtime-common.ts
+++ b/lib/analyzer/applications/runtime-common.ts
@@ -2,16 +2,16 @@ import * as path from "path";
 import { parsePkgJson } from "snyk-nodejs-lockfile-parser";
 import { ApplicationFilesFact } from "../../facts";
 import {
+  manifestLockName as nodeManifestLockName,
+  manifestName as nodeManifestName,
+} from "./node-modules-utils";
+import {
   AppDepsScanResultWithoutTarget,
   AppFileType,
   ApplicationFileInfo,
   FilePathToContent,
   ManifestMetadata,
 } from "./types";
-import {
-  manifestLockName as nodeManifestLockName,
-  manifestName as nodeManifestName,
-} from "./node-modules-utils";
 
 interface AppFileMetadataExtractor {
   manifestFileMatcher: (filePath: string) => boolean;

--- a/lib/analyzer/applications/types.ts
+++ b/lib/analyzer/applications/types.ts
@@ -33,10 +33,14 @@ export interface AggregatedJars {
 }
 export interface ApplicationFileInfo {
   path: string;
+  type?: "Manifest" | "Code";
+  metadata?: {
+    repoUrl?: string;
+    moduleName?: string;
+  };
 }
 export interface ApplicationFiles {
   fileHierarchy: ApplicationFileInfo[];
-  moduleName?: string;
   language: string;
 }
 

--- a/lib/analyzer/applications/types.ts
+++ b/lib/analyzer/applications/types.ts
@@ -31,13 +31,21 @@ export interface FilePathToElfContent {
 export interface AggregatedJars {
   [path: string]: JarBuffer[];
 }
+
+export interface ManifestMetadata {
+  repoUrl?: string;
+  moduleName?: string;
+}
+
+export enum AppFileType {
+  Manifest = "manifest",
+  Code = "code",
+}
+
 export interface ApplicationFileInfo {
   path: string;
-  type?: "Manifest" | "Code";
-  metadata?: {
-    repoUrl?: string;
-    moduleName?: string;
-  };
+  type?: AppFileType;
+  metadata?: ManifestMetadata;
 }
 export interface ApplicationFiles {
   fileHierarchy: ApplicationFileInfo[];

--- a/test/lib/analyzer/runtime-commons.spec.ts
+++ b/test/lib/analyzer/runtime-commons.spec.ts
@@ -1,0 +1,170 @@
+import {
+  filesMetadataExtractorPerLanguage,
+  getAppFileInfos,
+  getRootDir,
+} from "../../../lib/analyzer/applications/runtime-common";
+
+describe("application files root dir extraction", () => {
+  it("should correctly get root dir for js ts files", async () => {
+    let nodeProjectFiles = [
+      "/aaa/bbb/ccc/y.js",
+      "/aaa/bbb/ccc/z.js",
+      "/aaa/x.js",
+    ];
+
+    expect(getRootDir(nodeProjectFiles)).toBe("/aaa");
+
+    nodeProjectFiles = [
+      "/srv/dist/index.js",
+      "/srv/dist/src/app.js",
+      "/srv/dist/src/utils/helpers.js",
+      "/srv/dist/src/components/header.ts",
+      "/srv/dist/src/components/footer.js",
+      "/srv/dist/src/services/api.js",
+      "/srv/dist/src/models/user.js",
+      "/srv/dist/src/config/config.ts",
+      "/srv/dist/package.json",
+      "/srv/dist/package-lock.json",
+    ];
+
+    expect(getRootDir(nodeProjectFiles)).toBe("/srv/dist");
+  });
+
+  it("should return / as the root dir in case nothing's found", async () => {
+    const nodeProjectFiles = ["/srv/dist/index.js", "/opt/app.js"];
+    expect(getRootDir(nodeProjectFiles)).toBe("/");
+  });
+
+  it("should only consider full path segments for common prefix", async () => {
+    const nodeProjectFiles = ["/srv/dist/index.js", "/srv2/app.js"];
+    expect(getRootDir(nodeProjectFiles)).toBe("/");
+  });
+
+  it("should correctly get root dir for python application files", async () => {
+    const pythonProjectFiles = [
+      "/app/index.py",
+      "/app/src/app.py",
+      "/app/src/utils/helpers.py",
+      "/app/src/components/header.py",
+      "/app/src/components/footer.py",
+      "/app/src/services/api.py",
+      "/app/src/models/user.py",
+      "/app/src/config/config.py",
+      "/app/requirements.txt",
+    ];
+    expect(getRootDir(pythonProjectFiles)).toBe("/app");
+  });
+});
+
+describe("application files info extraction", () => {
+  it("should correctly get app infos for js ts files", async () => {
+    const nodeProjectFiles = {
+      "/aaa/bbb/ccc/y.js": "",
+      "/aaa/bbb/ccc/z.js": "",
+      "/aaa/x.js": "",
+    };
+
+    const appFiles = getAppFileInfos(
+      nodeProjectFiles,
+      "/aaa",
+      filesMetadataExtractorPerLanguage.node,
+    );
+    expect(appFiles.length).toBe(3);
+    expect(appFiles).toEqual([
+      { path: "bbb/ccc/y.js" },
+      { path: "bbb/ccc/z.js" },
+      { path: "x.js" },
+    ]);
+  });
+
+  it("should correctly identify node manifest files", async () => {
+    const nodeProjectFiles = {
+      "/srv/dist/index.js": "",
+      "/srv/dist/src/app.js": "",
+      "/srv/dist/src/utils/helpers.js": "",
+      "/srv/dist/src/components/header.ts": "",
+      "/srv/dist/src/components/footer.js": "",
+      "/srv/dist/src/services/api.js": "",
+      "/srv/dist/src/models/user.js": "",
+      "/srv/dist/src/config/config.ts": "",
+      "/srv/dist/package.json": "{}",
+      "/srv/dist/package-lock.json": "{}",
+    };
+
+    const appFiles = getAppFileInfos(
+      nodeProjectFiles,
+      "/srv/dist",
+      filesMetadataExtractorPerLanguage.node,
+    );
+    expect(appFiles.length).toBe(10);
+    expect(appFiles).toEqual([
+      { path: "index.js" },
+      { path: "src/app.js" },
+      { path: "src/utils/helpers.js" },
+      { path: "src/components/header.ts" },
+      { path: "src/components/footer.js" },
+      { path: "src/services/api.js" },
+      { path: "src/models/user.js" },
+      { path: "src/config/config.ts" },
+      {
+        path: "package.json",
+        type: "Manifest",
+        metadata: { moduleName: "package.json" },
+      },
+      {
+        path: "package-lock.json",
+        type: "Manifest",
+        metadata: { moduleName: "package.json" },
+      },
+    ]);
+  });
+
+  it("should not change app files path when root dir is /", async () => {
+    const nodeProjectFiles = {
+      "/srv/dist/index.js": "",
+      "/opt/app.js": "",
+    };
+    const appFiles = getAppFileInfos(
+      nodeProjectFiles,
+      "/",
+      filesMetadataExtractorPerLanguage.node,
+    );
+    expect(appFiles.length).toBe(2);
+    expect(appFiles).toEqual([
+      { path: "srv/dist/index.js" },
+      { path: "opt/app.js" },
+    ]);
+  });
+
+  it("should correctly get app infos for python files", async () => {
+    const pythonProjectFiles = {
+      "/app/index.py": "",
+      "/app/src/app.py": "",
+      "/app/src/utils/helpers.py": "",
+      "/app/src/components/header.py": "",
+      "/app/src/components/footer.py": "",
+      "/app/src/services/api.py": "",
+      "/app/src/models/user.py": "",
+      "/app/src/config/config.py": "",
+      "/app/requirements.txt": "",
+    };
+    const appFiles = getAppFileInfos(
+      pythonProjectFiles,
+      "/app",
+      filesMetadataExtractorPerLanguage.python,
+    );
+
+    expect(appFiles.length).toBe(9);
+    expect(appFiles).toEqual([
+      { path: "index.py" },
+      { path: "src/app.py" },
+      { path: "src/utils/helpers.py" },
+      { path: "src/components/header.py" },
+      { path: "src/components/footer.py" },
+      { path: "src/services/api.py" },
+      { path: "src/models/user.py" },
+      { path: "src/config/config.py" },
+      { path: "requirements.txt" },
+    ]);
+  });
+});

--- a/test/lib/analyzer/runtime-commons.spec.ts
+++ b/test/lib/analyzer/runtime-commons.spec.ts
@@ -3,6 +3,7 @@ import {
   getAppFileInfos,
   getRootDir,
 } from "../../../lib/analyzer/applications/runtime-common";
+import { AppFileType } from "../../../lib/analyzer/applications/types";
 
 describe("application files root dir extraction", () => {
   it("should correctly get root dir for js ts files", async () => {
@@ -88,7 +89,7 @@ describe("application files info extraction", () => {
       "/srv/dist/src/models/user.js": "",
       "/srv/dist/src/config/config.ts": "",
       "/srv/dist/package.json": "{}",
-      "/srv/dist/package-lock.json": "{}",
+      "/srv/dist/package-lock.json": "{", // check that we do not fail bad formatted files.
     };
 
     const appFiles = getAppFileInfos(
@@ -108,13 +109,12 @@ describe("application files info extraction", () => {
       { path: "src/config/config.ts" },
       {
         path: "package.json",
-        type: "Manifest",
+        type: AppFileType.Manifest,
         metadata: { moduleName: "package.json" },
       },
       {
         path: "package-lock.json",
-        type: "Manifest",
-        metadata: { moduleName: "package.json" },
+        type: AppFileType.Manifest,
       },
     ]);
   });

--- a/test/system/application-scans/node.spec.ts
+++ b/test/system/application-scans/node.spec.ts
@@ -10,7 +10,10 @@ import {
   shouldBuildDepTree,
 } from "../../../lib/analyzer/applications/node";
 import * as nodeUtils from "../../../lib/analyzer/applications/node-modules-utils";
-import { FilePathToContent } from "../../../lib/analyzer/applications/types";
+import {
+  AppFileType,
+  FilePathToContent,
+} from "../../../lib/analyzer/applications/types";
 import { getFixture, getObjFromFixture } from "../../util";
 
 describe("node application scans", () => {
@@ -180,7 +183,7 @@ describe("node application scans", () => {
       { path: "lib/v8-compile-cache.js" },
       {
         path: "package.json",
-        type: "Manifest",
+        type: AppFileType.Manifest,
         metadata: { moduleName: "yarn" },
       },
     ]);

--- a/test/system/application-scans/node.spec.ts
+++ b/test/system/application-scans/node.spec.ts
@@ -10,7 +10,6 @@ import {
   shouldBuildDepTree,
 } from "../../../lib/analyzer/applications/node";
 import * as nodeUtils from "../../../lib/analyzer/applications/node-modules-utils";
-import { getAppFilesRootDir } from "../../../lib/analyzer/applications/runtime-common";
 import { FilePathToContent } from "../../../lib/analyzer/applications/types";
 import { getFixture, getObjFromFixture } from "../../util";
 
@@ -179,7 +178,11 @@ describe("node application scans", () => {
       { path: "bin/yarn.js" },
       { path: "lib/cli.js" },
       { path: "lib/v8-compile-cache.js" },
-      { path: "package.json" },
+      {
+        path: "package.json",
+        type: "Manifest",
+        metadata: { moduleName: "yarn" },
+      },
     ]);
   });
 
@@ -659,73 +662,6 @@ describe("node application files grouping", () => {
       "/goof2",
       "/usr/local/lib",
       "/opt/local/lib",
-    ]);
-  });
-
-  it("should correctly group js ts files with root dir", async () => {
-    let nodeProjectFiles = [
-      "/aaa/bbb/ccc/y.js",
-      "/aaa/bbb/ccc/z.js",
-      "/aaa/x.js",
-    ];
-
-    let [appFilesRootDir, appFiles] = getAppFilesRootDir(nodeProjectFiles);
-
-    expect(appFilesRootDir).toBe("/aaa");
-    expect(appFiles.length).toBe(3);
-
-    nodeProjectFiles = [
-      "/srv/dist/index.js",
-      "/srv/dist/src/app.js",
-      "/srv/dist/src/utils/helpers.js",
-      "/srv/dist/src/components/header.ts",
-      "/srv/dist/src/components/footer.js",
-      "/srv/dist/src/services/api.js",
-      "/srv/dist/src/models/user.js",
-      "/srv/dist/src/config/config.ts",
-      "/srv/dist/package.json",
-      "/srv/dist/package-lock.json",
-    ];
-
-    [appFilesRootDir, appFiles] = getAppFilesRootDir(nodeProjectFiles);
-
-    expect(appFilesRootDir).toBe("/srv/dist");
-    expect(appFiles.length).toBe(10);
-    expect(appFiles).toEqual([
-      { path: "index.js" },
-      { path: "src/app.js" },
-      { path: "src/utils/helpers.js" },
-      { path: "src/components/header.ts" },
-      { path: "src/components/footer.js" },
-      { path: "src/services/api.js" },
-      { path: "src/models/user.js" },
-      { path: "src/config/config.ts" },
-      { path: "package.json" },
-      { path: "package-lock.json" },
-    ]);
-  });
-
-  it("should return / as the root dir in case nothing's found", async () => {
-    const nodeProjectFiles = ["/srv/dist/index.js", "/opt/app.js"];
-
-    const [appFilesRootDir, appFiles] = getAppFilesRootDir(nodeProjectFiles);
-    expect(appFilesRootDir).toBe("/");
-    expect(appFiles.length).toBe(2);
-    expect(appFiles).toEqual([
-      { path: "srv/dist/index.js" },
-      { path: "opt/app.js" },
-    ]);
-  });
-
-  it("should only consider full path segments for common prefix", async () => {
-    const nodeProjectFiles = ["/srv/dist/index.js", "/srv2/app.js"];
-
-    const [appFilesRootDir, appFiles] = getAppFilesRootDir(nodeProjectFiles);
-    expect(appFilesRootDir).toBe("/");
-    expect(appFiles.length).toBe(2);
-    expect(appFiles).toEqual([
-      { path: "srv/dist/index.js" },
-      { path: "srv2/app.js" },
     ]);
   });
 });

--- a/test/system/application-scans/python/pip.spec.ts
+++ b/test/system/application-scans/python/pip.spec.ts
@@ -1,5 +1,4 @@
 import { scan } from "../../../../lib";
-import { getAppFilesRootDir } from "../../../../lib/analyzer/applications/runtime-common";
 import { getFixture } from "../../../util";
 
 describe("pip application scan", () => {
@@ -81,36 +80,5 @@ describe("pip application scan", () => {
       )!.data;
     expect(appFiles[0].language).toStrictEqual("python");
     expect(appFiles[0].fileHierarchy).toStrictEqual([{ path: "server.py" }]);
-  });
-});
-
-describe("python application files filtering", () => {
-  it("should correctly filter python application files", async () => {
-    const pythonProjectFiles = [
-      "/app/index.py",
-      "/app/src/app.py",
-      "/app/src/utils/helpers.py",
-      "/app/src/components/header.py",
-      "/app/src/components/footer.py",
-      "/app/src/services/api.py",
-      "/app/src/models/user.py",
-      "/app/src/config/config.py",
-      "/app/requirements.txt",
-    ];
-    const [appFilesRootDir, appFiles] = getAppFilesRootDir(pythonProjectFiles);
-
-    expect(appFilesRootDir).toBe("/app");
-    expect(appFiles.length).toBe(9);
-    expect(appFiles).toEqual([
-      { path: "index.py" },
-      { path: "src/app.py" },
-      { path: "src/utils/helpers.py" },
-      { path: "src/components/header.py" },
-      { path: "src/components/footer.py" },
-      { path: "src/services/api.py" },
-      { path: "src/models/user.py" },
-      { path: "src/config/config.py" },
-      { path: "requirements.txt" },
-    ]);
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When collecting ApplicationFiles, this PR adds additional data for manifest files in nodejs (e.g. `package.json`).
This PR is an addition to [https://github.com/snyk/snyk-docker-plugin/pull/629](https://github.com/snyk/snyk-docker-plugin/pull/629). 

#### Where should the reviewer start?
Following the logical flow starting from `lib/analyzer/static-analyzer.ts` will be easier to follow.

#### How should this be manually tested?
Using the Docker registry agent(DRA) (https://github.com/snyk/docker-registry-agent) update the installed Snyk docker plugin version (in the package.json) to be based on the current branch:
`"snyk-docker-plugin": "github:snyk/snyk-docker-plugin#collect_application_files"`.
Run `npm install`.
Run the DRA locally and from a different terminal execute the following command:
```
curl --location 'http://localhost:17500/scan' \
--header 'snyk-source-credentials: <<CREDENTIALS_FOR_CR>>' \
--header 'Content-Type: application/json' \
--data '{
    "target": {
        "name": "<<IMAGE_ON_CR>>"
    },
    "options": {
        "appScan": true,
        "collectApplicationFiles": true
    },
    "callbacks": {
        "resultUrl": "<<RESULT_URL>>",                                   
        "doneUrl": "<<DONE_URL>>",
        "token": "00000000-0000-0000-0000-000000000000"
    }   
}' 
```
The expected output of the given RESULT_URL endpoint should contain the fact type "applicationFiles" as part of the data.
Each manifest file should include the `type: 'manifest'` and `metadata` with the extracted `moduleName`.
The image should be NodeJS.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RNTM-744
https://snyksec.atlassian.net/browse/RNTM-852
