### PR TITLE
Expose image content extraction

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,7 +12,7 @@ import {
   UpdateDockerfileBaseImageNameErrorCode,
 } from "./dockerfile/types";
 import * as facts from "./facts";
-import { scan } from "./scan";
+import { extractContent, scan } from "./scan";
 import {
   AutoDetectedUserInstructions,
   ContainerTarget,
@@ -28,6 +28,7 @@ export {
   scan,
   display,
   dockerFile,
+  extractContent,
   facts,
   ScanResult,
   PluginResponse,

--- a/test/system/application-scans/gomodules.spec.ts
+++ b/test/system/application-scans/gomodules.spec.ts
@@ -1,6 +1,7 @@
 import * as elf from "elfy";
 
-import { scan } from "../../../lib";
+import { extractContent, scan } from "../../../lib";
+import { getGoModulesContentAction } from "../../../lib/go-parser";
 import { getFixture } from "../../util";
 
 describe("gomodules binaries scanning", () => {
@@ -21,6 +22,19 @@ describe("gomodules binaries scanning", () => {
 
     // Assert
     expect(pluginResult).toMatchSnapshot();
+  });
+
+  it("should extract image content successfully", async () => {
+    const fixturePath = getFixture(
+      "docker-archives/docker-save/testgo-1.17.tar",
+    );
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+    const result = await extractContent([getGoModulesContentAction], {
+      path: imageNameAndTag,
+    });
+    const testgoBinary = result.extractedLayers["/testgo"];
+    expect(testgoBinary).toBeTruthy();
+    expect("gomodules" in testgoBinary).toBeTruthy();
   });
 
   it("return plugin result when Go binary cannot be parsed do not break layer iterator", async () => {

--- a/test/system/application-scans/python/pip.spec.ts
+++ b/test/system/application-scans/python/pip.spec.ts
@@ -1,5 +1,6 @@
-import { scan } from "../../../../lib";
+import { extractContent, scan } from "../../../../lib";
 import { getAppFilesRootDir } from "../../../../lib/analyzer/applications/runtime-common";
+import { getPythonAppFileContentAction } from "../../../../lib/inputs/python/static";
 import { getFixture } from "../../../util";
 
 describe("pip application scan", () => {
@@ -58,6 +59,17 @@ describe("pip application scan", () => {
 
     expect(pluginResultExcludeAppVulnsTrueString.scanResults).toHaveLength(1);
     expect(pluginResultExcludeAppVulnsTrueBoolean.scanResults).toHaveLength(1);
+  });
+
+  it("should extract image content successfully", async () => {
+    const fixturePath = getFixture("docker-archives/docker-save/pip-flask.tar");
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+    const result = await extractContent([getPythonAppFileContentAction], {
+      path: imageNameAndTag,
+    });
+    const serverPyFile = result.extractedLayers["/app/server.py"];
+    expect(serverPyFile).toBeTruthy();
+    expect("python-app-files" in serverPyFile).toBeTruthy();
   });
 
   it("should handle --collect-application-files", async () => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Exposes a new function aside the existing `scan` function which collects the application files from within an image.

#### Where should the reviewer start?
- Follow the existing `scan` method and see it's current logic did not break
- Review the new `exposeContent` method and make sure it does collect the intended data

#### How should this be manually tested?
Install locally using `file:../snyk-docker-plugin` and add a call to the function using a known image.

#### Any background context you want to provide?
This is part of the Runtime team efforts to collect application files from images. See more details here - https://snyksec.atlassian.net/wiki/spaces/RD/pages/2688188638/Code+lineage+-+collect+file+hierarchy+from+container+registry

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RNTM-825

