### PR TITLE
feat: add support for remote-repo-url UNIFY-506

### DIFF
--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -200,6 +200,10 @@ async function buildResponse(
       facts: [depGraphFact, ...additionalFacts],
       target: {
         image: depGraph.rootPkg.name,
+        ...(options &&
+          options["remote-repo-url"] && {
+            remoteUrl: options["remote-repo-url"],
+          }),
       },
       identity: {
         type: depGraph.pkgManager.name,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -104,6 +104,8 @@ export interface AutoDetectedUserInstructions {
 
 export interface ContainerTarget {
   image: string;
+  /** Set the remote URL for a container image image. */
+  remoteUrl?: string;
 }
 
 /**
@@ -228,6 +230,8 @@ export interface PluginOptions {
   /** The default is "false". */
   "collect-application-files": boolean | string;
   "target-reference": string;
+
+  "remote-repo-url": string;
 }
 
 export interface DepTreeDep {

--- a/test/system/plugin-option.spec.ts
+++ b/test/system/plugin-option.spec.ts
@@ -60,3 +60,18 @@ it("provides imageName fact with imageNameAndDigest and imageNameAndTag scan opt
     ]),
   );
 });
+
+it("remoteUrl is set in ContainerTarget when remote-repo-url scan option is provided", async () => {
+  const fixturePath = getFixture(["/docker-archives", "alpine-arm64.tar"]);
+  const imagePath = `docker-archive:${fixturePath}`;
+
+  const pluginResponse = await plugin.scan({
+    path: imagePath,
+    "remote-repo-url": "https://github.com/org/my-repo-test",
+  });
+  pluginResponse.scanResults.forEach((scanResult) => {
+    expect(scanResult.target.remoteUrl).toEqual(
+      "https://github.com/org/my-repo-test",
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds support for remote-repo-url option for ContainerTarget.
Remote-repo-url allows the user to override the remote URL for the image that is monitored/tested.

Monitoring container images using remote-repo-url groups container images under the same target with other monitored projects.

#### Where should the reviewer start?


#### How should this be manually tested?

#### Any background context you want to provide?


#### What are the relevant tickets?
[https://snyksec.atlassian.net/browse/UNIFY-506](url)

#### Screenshots
<img width="1601" alt="Screenshot 2025-02-20 at 08 46 45" src="https://github.com/user-attachments/assets/ebc9fa05-e124-4f0d-b417-2020cd056269" />

#### Additional questions
