### PR TITLE
fix: bump nodejs-lockfile-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "packageurl-js": "1.2.0",
         "semver": "^7.6.3",
         "shescape": "^1.7.4",
-        "snyk-nodejs-lockfile-parser": "^1.58.14",
+        "snyk-nodejs-lockfile-parser": "^1.60.1",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "snyk-resolve-deps": "^4.7.1",
         "tar-stream": "^2.1.0",
@@ -9088,10 +9088,9 @@
       }
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.58.14",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.58.14.tgz",
-      "integrity": "sha512-K6NmAQ9QoibQgJSEuGdA6914kleCPkWrYH+cUjJrzF9W9NI8ExdXr6KEp0mM0x1pFrJvchuxCQN4S9K8HvPkMA==",
-      "license": "Apache-2.0",
+      "version": "1.60.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.60.1.tgz",
+      "integrity": "sha512-O7Dk8zv/x+uNsB5K7zxmkz9vrI1jOwRyLkZm1IWqdmhFhtieaZBFOV/SODim1qIUH43T/murlK41gAXJ6U8HpQ==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/error-catalog-nodejs-public": "^5.16.0",
@@ -17324,9 +17323,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.58.14",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.58.14.tgz",
-      "integrity": "sha512-K6NmAQ9QoibQgJSEuGdA6914kleCPkWrYH+cUjJrzF9W9NI8ExdXr6KEp0mM0x1pFrJvchuxCQN4S9K8HvPkMA==",
+      "version": "1.60.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.60.1.tgz",
+      "integrity": "sha512-O7Dk8zv/x+uNsB5K7zxmkz9vrI1jOwRyLkZm1IWqdmhFhtieaZBFOV/SODim1qIUH43T/murlK41gAXJ6U8HpQ==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/error-catalog-nodejs-public": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "packageurl-js": "1.2.0",
     "semver": "^7.6.3",
     "shescape": "^1.7.4",
-    "snyk-nodejs-lockfile-parser": "^1.58.14",
+    "snyk-nodejs-lockfile-parser": "^1.60.1",
     "snyk-poetry-lockfile-parser": "^1.4.0",
     "snyk-resolve-deps": "^4.7.1",
     "tar-stream": "^2.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumps nodejs-lockfile-parser, mainly to fix a yarn bug in out of sync resolutions erroring: https://github.com/snyk/nodejs-lockfile-parser/pull/267.

Other changes included with this update: https://github.com/snyk/nodejs-lockfile-parser/releases - mostly pnpm bugfixes + an npm bugfix that only works 'under a feature flag' (https://github.com/snyk/nodejs-lockfile-parser/commit/6d81596b4248381bd5eedf6a5199253c38988f79). These should not affect the lockfile parser functionality in this repo.

#### Where should the reviewer start?
This PR https://github.com/snyk/nodejs-lockfile-parser/pull/267.

#### How should this be manually tested?
With a yarn project with manifest files `yarn.lock` and `package.json` from the lockfile-parser test: https://github.com/snyk/nodejs-lockfile-parser/pull/267/files#diff-6df26e787f44dccd9215fd24d8d1624c300d015bab261b87568c3b7793a1f62f. 
A test that would previously fail with `TypeError: Cannot destructure property 'version' of 'pkgs[childNodeKeyFromResolution]' as it is undefined.` should error with `OutOfSync` error.
