### PR TITLE
feat: collect java class files outside of jar

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -123,7 +123,6 @@ export async function analyze(
         getPoetryAppFileContentAction,
         getPipAppFileContentAction,
         getJarFileContentAction,
-        getClassFileContentAction,
         getGoModulesContentAction,
       ],
     );
@@ -132,6 +131,7 @@ export async function analyze(
       staticAnalysisActions.push(
         getNodeJsTsAppFileContentAction,
         getPythonAppFileContentAction,
+        getClassFileContentAction,
       );
     }
   }

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -25,7 +25,10 @@ import {
   getDpkgPackageFileContentAction,
 } from "../inputs/distroless/static";
 import * as filePatternStatic from "../inputs/file-pattern/static";
-import { getJarFileContentAction } from "../inputs/java/static";
+import {
+  getClassFileContentAction,
+  getJarFileContentAction,
+} from "../inputs/java/static";
 import {
   getNodeAppFileContentAction,
   getNodeJsTsAppFileContentAction,
@@ -120,6 +123,7 @@ export async function analyze(
         getPoetryAppFileContentAction,
         getPipAppFileContentAction,
         getJarFileContentAction,
+        getClassFileContentAction,
         getGoModulesContentAction,
       ],
     );

--- a/lib/inputs/java/static.ts
+++ b/lib/inputs/java/static.ts
@@ -8,7 +8,7 @@ const javaClassFileFormats = [".class"];
 
 function jarFilePathMatches(filePath: string): boolean {
   const dirName = path.dirname(filePath);
-  const fileExtension = filePath.slice(-4);
+  const fileExtension = filePath.slice(filePath.lastIndexOf("."));
   return (
     javaArchiveFileFormats.includes(fileExtension) &&
     !ignoredPaths.some((ignorePath) =>
@@ -25,7 +25,7 @@ export const getJarFileContentAction: ExtractAction = {
 
 function classFilePathMatches(filePath: string): boolean {
   const dirName = path.dirname(filePath);
-  const fileExtension = filePath.slice(-6);
+  const fileExtension = filePath.slice(filePath.lastIndexOf("."));
   return (
     javaClassFileFormats.includes(fileExtension) &&
     !ignoredPaths.some((ignorePath) =>

--- a/lib/inputs/java/static.ts
+++ b/lib/inputs/java/static.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { ExtractAction } from "../../extractor/types";
 import { streamToBuffer } from "../../stream-utils";
 
-const ignoredPaths = ["/usr/lib", "gradle/cache"];
+const ignoredPaths = ["/usr/lib", "gradle/cache", ".m2"];
 const javaArchiveFileFormats = [".jar", ".war"];
 const javaClassFileFormats = [".class"];
 
@@ -25,7 +25,7 @@ export const getJarFileContentAction: ExtractAction = {
 
 function classFilePathMatches(filePath: string): boolean {
   const dirName = path.dirname(filePath);
-  const fileExtension = filePath.slice(-4);
+  const fileExtension = filePath.slice(-6);
   return (
     javaClassFileFormats.includes(fileExtension) &&
     !ignoredPaths.some((ignorePath) =>

--- a/lib/inputs/java/static.ts
+++ b/lib/inputs/java/static.ts
@@ -4,8 +4,9 @@ import { streamToBuffer } from "../../stream-utils";
 
 const ignoredPaths = ["/usr/lib", "gradle/cache"];
 const javaArchiveFileFormats = [".jar", ".war"];
+const javaClassFileFormats = [".class"];
 
-function filePathMatches(filePath: string): boolean {
+function jarFilePathMatches(filePath: string): boolean {
   const dirName = path.dirname(filePath);
   const fileExtension = filePath.slice(-4);
   return (
@@ -18,6 +19,23 @@ function filePathMatches(filePath: string): boolean {
 
 export const getJarFileContentAction: ExtractAction = {
   actionName: "jar",
-  filePathMatches,
+  filePathMatches: jarFilePathMatches,
+  callback: streamToBuffer,
+};
+
+function classFilePathMatches(filePath: string): boolean {
+  const dirName = path.dirname(filePath);
+  const fileExtension = filePath.slice(-4);
+  return (
+    javaClassFileFormats.includes(fileExtension) &&
+    !ignoredPaths.some((ignorePath) =>
+      dirName.includes(path.normalize(ignorePath)),
+    )
+  );
+}
+
+export const getClassFileContentAction: ExtractAction = {
+  actionName: "class",
+  filePathMatches: classFilePathMatches,
   callback: streamToBuffer,
 };

--- a/lib/inputs/java/static.ts
+++ b/lib/inputs/java/static.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { ExtractAction } from "../../extractor/types";
-import { streamToBuffer } from "../../stream-utils";
+import { streamToBuffer, streamToSha1 } from "../../stream-utils";
 
 const ignoredPaths = ["/usr/lib", "gradle/cache", ".m2"];
 const javaArchiveFileFormats = [".jar", ".war"];
@@ -37,5 +37,5 @@ function classFilePathMatches(filePath: string): boolean {
 export const getClassFileContentAction: ExtractAction = {
   actionName: "class",
   filePathMatches: classFilePathMatches,
-  callback: streamToBuffer,
+  callback: streamToSha1,
 };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Supports extraction of class files (java) located outside of a jar. 

#### Where should the reviewer start?
lib/inputs/java/static.ts

#### How should this be manually tested?
Runtime team to validate that class files are collected upon CR connector run

#### Any background context you want to provide?
Usually java class files can be found in jars/ wars or simply in the image layers not behind any archived file.
We should collect these class files too which is currently not happening.
Note that this logic is relevant only for CR integrations connectors (collectApplicationFiles must be on).

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RNTM-745

