### PR TITLE
chore: reduce lint commit check lowe range from 5 to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "run-p --max-parallel=${JOBS:-5} --aggregate-output lint:*",
     "lint:prettier": "prettier --check \"{lib,test}/**/*.ts\"",
     "lint:tslint": "tslint --format stylish \"{lib,test}/**/*.ts\"",
-    "lint:commit": "commitlint --from=HEAD~5",
+    "lint:commit": "commitlint --from=HEAD~1",
     "format": "prettier --loglevel warn --write '{lib,test}/**/*.ts' && tslint --fix --format stylish '{lib,test}/**/*.ts'",
     "test": "npm run test-jest",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR reduces the lower end of the commit range to lint from HEAD~5 to HEAD~1 to unblock release pipelines after the non-conformant squash commit message from #667. We can revert the change in the future to restore the commit range back to HEAD~5 (if desired).