### PR TITLE
chore: add required @types/minimatch dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/adm-zip": "^0.4.34",
         "@types/debug": "^4.1.5",
         "@types/jest": "^29.5.5",
+        "@types/minimatch": "^5.1.2",
         "@types/node": "^14.14.31",
         "@types/tar-stream": "^1.6.1",
         "@types/tmp": "^0.2.0",
@@ -2369,6 +2370,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/minimist": {
       "version": "1.2.4",
@@ -12562,6 +12570,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/adm-zip": "^0.4.34",
     "@types/debug": "^4.1.5",
     "@types/jest": "^29.5.5",
+    "@types/minimatch": "^5.1.2",
     "@types/node": "^14.14.31",
     "@types/tar-stream": "^1.6.1",
     "@types/tmp": "^0.2.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR adds the dev dependency `@types/minimatch`. Typescript compilation fails without this dependency.

#### How should this be manually tested?

Prior to this change, running `npm ci && npm run build` from within a docker container fails with:
```
> build
> tsc


added 927 packages, and audited 928 packages in 12s

119 packages are looking for funding
  run `npm fund` for details

3 vulnerabilities (2 low, 1 moderate)

To address issues that do not require attention, run:
  npm audit fix

To address all issues, run:
  npm audit fix --force

Run `npm audit` for details.
npm notice
npm notice New major version of npm available! 10.8.2 -> 11.4.2
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.4.2
npm notice To update run: npm install -g npm@11.4.2
npm notice

> build
> tsc

lib/inputs/file-pattern/static.ts:15:23 - error TS2349: This expression is not callable.
  Type 'typeof import("/Users/gardiner/src/github.com/snyk/node_modules/minimatch/dist/commonjs/index")' has no call signatures.

15       if (!exclude && minimatch(filePath, g)) {
                         ~~~~~~~~~

lib/inputs/file-pattern/static.ts:21:13 - error TS2349: This expression is not callable.
  Type 'typeof import("/Users/gardiner/src/github.com/snyk/node_modules/minimatch/dist/commonjs/index")' has no call signatures.

21         if (minimatch(filePath, g)) {
               ~~~~~~~~~


Found 2 errors in the same file, starting at: lib/inputs/file-pattern/static.ts:15
```

After adding this dependency, attempting the same operation succeeds. 

#### Any background context you want to provide?

I discovered this because I was struggling to get the tests to run for this repo from a clean node state on my computer was a new joiner.
