### PR TITLE
fix: improve subprocess spawning portability

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -212,8 +212,11 @@ async function getImageArchive(
 
   try {
     inspectResult = await getInspectResult(docker, targetImage);
-  } catch {
-    debug(`${targetImage} does not exist locally, proceeding to pull image.`);
+  } catch (error) {
+    debug(
+      `${targetImage} does not exist locally, proceeding to pull image.`,
+      error.stack || error,
+    );
   }
 
   if (inspectResult === undefined) {

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,5 +1,4 @@
 import * as childProcess from "child_process";
-import { quoteAll } from "shescape/stateless";
 
 export { execute, CmdOutput };
 interface CmdOutput {
@@ -13,13 +12,15 @@ function execute(
   options?,
 ): Promise<CmdOutput> {
   const spawnOptions: any = {
-    shell: process.platform !== "win32" ? "/bin/bash" : true,
+    // Some distributions may not have /bin/bash, which would cause `child_process.spawn` to fail.
+    // By setting `shell: false`, we tell `spawn` to execute the command directly without a shell,
+    // which is more portable.
+    shell: false,
     env: { ...process.env },
   };
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
-  args = quoteAll(args, { ...spawnOptions, flagProtection: false });
 
   // Before spawning an external process, we look if we need to restore the system proxy configuration,
   // which overrides the cli internal proxy configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "mkdirp": "^1.0.4",
         "packageurl-js": "1.2.0",
         "semver": "^7.6.3",
-        "shescape": "2.1.0",
         "snyk-nodejs-lockfile-parser": "^2.0.0",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "snyk-resolve-deps": "^4.7.1",
@@ -9084,33 +9083,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/shescape": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.0.tgz",
-      "integrity": "sha512-VFjtoo9Y25/fprhMo+bIb+OAM+mFUP0Veg57Bg973j2RSWEAoNPia5hBY+lYVIra5Nl/6CtlQYmDGWSvA3IWWw==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "which": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20"
-      }
-    },
-    "node_modules/shescape/node_modules/which": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -17329,24 +17301,6 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true
-    },
-    "shescape": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.0.tgz",
-      "integrity": "sha512-VFjtoo9Y25/fprhMo+bIb+OAM+mFUP0Veg57Bg973j2RSWEAoNPia5hBY+lYVIra5Nl/6CtlQYmDGWSvA3IWWw==",
-      "requires": {
-        "which": "^3.0.0"
-      },
-      "dependencies": {
-        "which": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-          "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "mkdirp": "^1.0.4",
     "packageurl-js": "1.2.0",
     "semver": "^7.6.3",
-    "shescape": "2.1.0",
     "snyk-nodejs-lockfile-parser": "^2.0.0",
     "snyk-poetry-lockfile-parser": "^1.4.0",
     "snyk-resolve-deps": "^4.7.1",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Updates the sub-process execution logic to remove the default shells used in spawning the child processes and execute the docker binaries directly without relying on a shell. This eliminates the need for a specific shell binary (like /bin/bash or /bin/sh) to be present, making the function portable on a broader range of operating systems and minimal distributions like alpine that default to /bin/sh. 
Adds a test to validate that the scanner completes on locally available images. 
#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
