### PR TITLE
fix: default to /bin/bash only on darwin platforms

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -212,11 +212,8 @@ async function getImageArchive(
 
   try {
     inspectResult = await getInspectResult(docker, targetImage);
-  } catch (error) {
-    debug(
-      `${targetImage} does not exist locally, proceeding to pull image.`,
-      error.stack || error,
-    );
+  } catch {
+    debug(`${targetImage} does not exist locally, proceeding to pull image.`);
   }
 
   if (inspectResult === undefined) {

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -212,8 +212,11 @@ async function getImageArchive(
 
   try {
     inspectResult = await getInspectResult(docker, targetImage);
-  } catch {
-    debug(`${targetImage} does not exist locally, proceeding to pull image.`);
+  } catch (error) {
+    debug(
+      `${targetImage} does not exist locally, proceeding to pull image.`,
+      error.stack || error,
+    );
   }
 
   if (inspectResult === undefined) {

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,4 +1,5 @@
 import * as childProcess from "child_process";
+import { quoteAll } from "shescape/stateless";
 
 export { execute, CmdOutput };
 interface CmdOutput {
@@ -12,15 +13,13 @@ function execute(
   options?,
 ): Promise<CmdOutput> {
   const spawnOptions: any = {
-    // Some distributions may not have /bin/bash, which would cause `child_process.spawn` to fail.
-    // By setting `shell: false`, we tell `spawn` to execute the command directly without a shell,
-    // which is more portable.
-    shell: false,
+    shell: process.platform !== "win32" ? "/bin/bash" : true,
     env: { ...process.env },
   };
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
+  args = quoteAll(args, { ...spawnOptions, flagProtection: false });
 
   // Before spawning an external process, we look if we need to restore the system proxy configuration,
   // which overrides the cli internal proxy configuration.

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -13,7 +13,7 @@ function execute(
   options?,
 ): Promise<CmdOutput> {
   const spawnOptions: any = {
-    shell: process.platform !== "win32" ? "/bin/bash" : true,
+    shell: process.platform === "darwin" ? "/bin/bash" : true,
     env: { ...process.env },
   };
   if (options && options.cwd) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "mkdirp": "^1.0.4",
         "packageurl-js": "1.2.0",
         "semver": "^7.6.3",
+        "shescape": "2.1.0",
         "snyk-nodejs-lockfile-parser": "^2.0.0",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "snyk-resolve-deps": "^4.7.1",
@@ -9083,6 +9084,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shescape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.0.tgz",
+      "integrity": "sha512-VFjtoo9Y25/fprhMo+bIb+OAM+mFUP0Veg57Bg973j2RSWEAoNPia5hBY+lYVIra5Nl/6CtlQYmDGWSvA3IWWw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "which": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20"
+      }
+    },
+    "node_modules/shescape/node_modules/which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -17301,6 +17329,24 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true
+    },
+    "shescape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.0.tgz",
+      "integrity": "sha512-VFjtoo9Y25/fprhMo+bIb+OAM+mFUP0Veg57Bg973j2RSWEAoNPia5hBY+lYVIra5Nl/6CtlQYmDGWSvA3IWWw==",
+      "requires": {
+        "which": "^3.0.0"
+      },
+      "dependencies": {
+        "which": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+          "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "mkdirp": "^1.0.4",
     "packageurl-js": "1.2.0",
     "semver": "^7.6.3",
+    "shescape": "2.1.0",
     "snyk-nodejs-lockfile-parser": "^2.0.0",
     "snyk-poetry-lockfile-parser": "^1.4.0",
     "snyk-resolve-deps": "^4.7.1",

--- a/test/system/plugin.spec.ts
+++ b/test/system/plugin.spec.ts
@@ -1,6 +1,5 @@
 import { DepGraph } from "@snyk/dep-graph";
 import * as plugin from "../../lib";
-import * as subProcess from "../../lib/sub-process";
 import { getFixture } from "../util";
 
 describe("plugin", () => {
@@ -89,35 +88,6 @@ describe("plugin", () => {
       await expect(result).rejects.toThrow(
         "The provided archive path is not a file",
       );
-    });
-  });
-
-  describe("when scanning a locally loaded image", () => {
-    const imageName = "busybox";
-    const imageTag = "latest";
-    const imageNameWithTag = `${imageName}:${imageTag}`;
-
-    beforeAll(async () => {
-      const fixturePath = getFixture([
-        "../fixtures/docker-archives",
-        "skopeo-copy/busybox.tar",
-      ]);
-      await subProcess.execute("docker", ["load", "--input", fixturePath]);
-    }, 10000); // 10s timeout for loading image
-
-    afterAll(async () => {
-      await subProcess.execute("docker", ["rmi", imageNameWithTag]);
-    });
-
-    test("should successfully scan a local image loaded from a tar archive", async () => {
-      const pluginResult = await plugin.scan({ path: imageNameWithTag });
-      const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
-        (fact) => fact.type === "depGraph",
-      )!.data;
-
-      expect(depGraph.rootPkg.name).toEqual(`docker-image|${imageName}`);
-      expect(depGraph.rootPkg.version).toEqual(imageTag);
-      expect(pluginResult.scanResults[0].identity.type).toEqual("linux");
     });
   });
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes how the child process is spawned. It defaults to `/bin/bash` only on macOs (darwin platforms).
Specifying `shell:true` will leave the system to use the default shell, ensuring portability on alpine images that may not have `/bin/bash `installed.

#### Where should the reviewer start?


#### How should this be manually tested?
Running snyk on any linux machine without `/bin/bash` being the default shell.

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
