### PR TITLE
feat: migrate inspect to direct API call

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -23,7 +23,7 @@ async function getInspectResult(
   targetImage: string,
 ): Promise<DockerInspectOutput> {
   const info = await docker.inspectImage(targetImage);
-  return JSON.parse(info.stdout)[0];
+  return info;
 }
 
 function cleanupCallback(imageFolderPath: string, imageName: string) {

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -22,12 +22,7 @@ export interface AnalyzedPackageWithVersion extends AnalyzedPackage {
 }
 
 export interface DockerInspectOutput {
-  Id: string;
   Architecture: string;
-  RootFS: {
-    Type: string;
-    Layers: string[];
-  };
 }
 
 export interface ImageAnalysis {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Validates a Docker image reference format using the official Docker reference regex.
+ * @param imageReference The Docker image reference to validate
+ * @returns true if valid, false if invalid
+ */
+export function isValidDockerImageReference(imageReference: string): boolean {
+  // Docker image reference validation regex from the official Docker packages:
+  // https://github.com/distribution/reference/blob/ff14fafe2236e51c2894ac07d4bdfc778e96d682/regexp.go#L9
+  // Original regex: ^((?:(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*|\[(?:[a-fA-F0-9:]+)\])(?::[0-9]+)?/)?[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*)*)(?::([\w][\w.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}))?$
+  // Note: Converted [[:xdigit:]] to [a-fA-F0-9] and escaped the forward slashes for JavaScript compatibility.
+  const dockerImageRegex =
+    /^((?:(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*|\[(?:[a-fA-F0-9:]+)\])(?::[0-9]+)?\/)?[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*(?:\/[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*)*)(?::([\w][\w.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][a-fA-F0-9]{32,}))?$/;
+
+  return dockerImageRegex.test(imageReference);
+}

--- a/test/lib/analyzer/image-inspector.spec.ts
+++ b/test/lib/analyzer/image-inspector.spec.ts
@@ -98,7 +98,7 @@ describe("extractImageDetails", () => {
          path: imageNameAndTag,
        }),
      ).rejects.toEqual(
-       new Error("invalid image format"),
+       new Error(`invalid image reference format: ${imageNameAndTag}`),
      );
    });
 });

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -1,0 +1,87 @@
+import { isValidDockerImageReference } from "../../lib/utils";
+
+describe("isValidDockerImageReference", () => {
+  describe("valid image references", () => {
+    const validImages = [
+      "nginx",
+      "ubuntu",
+      "alpine",
+      "nginx:latest",
+      "ubuntu:20.04",
+      "alpine:3.14",
+      "library/nginx",
+      "library/ubuntu:20.04",
+      "docker.io/nginx",
+      "docker.io/library/nginx:latest",
+      "gcr.io/project-id/image-name",
+      "gcr.io/project-id/image-name:tag",
+      "registry.hub.docker.com/library/nginx",
+      "localhost:5000/myimage",
+      "localhost:5000/myimage:latest",
+      "registry.example.com/path/to/image",
+      "registry.example.com:8080/path/to/image:v1.0",
+      "my-registry.com/my-namespace/my-image",
+      "my-registry.com/my-namespace/my-image:v2.1.0",
+      "nginx@sha256:abcd1234567890abcd1234567890abcd1234567890abcd1234567890abcd1234",
+      "ubuntu:20.04@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12",
+      "image_name",
+      "image.name",
+      "image-name",
+      "namespace/image_name.with-dots",
+      "registry.com/namespace/image__double_underscore",
+      "127.0.0.1:5000/test",
+      "[::1]:5000/test",
+      "registry.com/a/b/c/d/e/f/image",
+      "a.b.c/namespace/image:tag",
+    ];
+
+    it.each(validImages)(
+      "should return true for valid image reference: %s",
+      (imageName) => {
+        expect(isValidDockerImageReference(imageName)).toBe(true);
+      },
+    );
+  });
+
+  describe("invalid image references", () => {
+    const invalidImages = [
+      "/test:unknown",
+      "//invalid",
+      "invalid//path",
+      "UPPERCASE",
+      "Invalid:Tag",
+      "registry.com/UPPERCASE/image",
+      "registry.com/namespace/UPPERCASE",
+      "",
+      "image:",
+      ":tag",
+      "image::",
+      "registry.com:",
+      "registry.com:/image",
+      "image@",
+      "image@sha256:",
+      "image@invalid:digest",
+      "registry.com//namespace/image",
+      "registry.com/namespace//image",
+      ".image",
+      "image.",
+      "-image",
+      "image-",
+      "_image",
+      "image_",
+      "registry-.com/image",
+      "registry.com-/image",
+      "image:tag@",
+      "image:tag@sha256",
+      "registry.com:abc/image",
+      "registry.com:-1/image",
+    ];
+
+    it.each(invalidImages)(
+      "should return false for invalid image reference: %s",
+      (imageName) => {
+        expect(isValidDockerImageReference(imageName)).toBe(false);
+      },
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Migrate docker inspect calls to be direct API calls to the docker daemon instead of subprocess calls that use the docker CLI. This is a cleaner approach and mitigates various potential failure scenarios that arise from the subprocess call.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CN-222
