### PR TITLE
fix: whiteout regex bug CN-272

### DIFF
--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -10,7 +10,6 @@ import { PluginOptions } from "../types";
 import * as dockerExtractor from "./docker-archive";
 import { InvalidArchiveError } from "./generic-archive-extractor";
 import * as kanikoExtractor from "./kaniko-archive";
-import { isWhitedOutFile } from "./layer";
 import * as ociExtractor from "./oci-archive";
 import {
   DockerArchiveManifest,
@@ -23,6 +22,11 @@ import {
   ImageConfig,
   OciArchiveManifest,
 } from "./types";
+import {
+  isOpaqueWhiteout,
+  isWhitedOutFile,
+  removeWhiteoutPrefix,
+} from "./whiteout";
 
 const debug = Debug("snyk");
 
@@ -231,15 +235,24 @@ function layersWithLatestFileModifications(
 ): ExtractedLayers {
   const extractedLayers: ExtractedLayers = {};
   const removedFilesToIgnore: Set<string> = new Set();
+  const opaqueWhiteoutDirs: Set<string> = new Set();
 
   // TODO: This removes the information about the layer name, maybe we would need it in the future?
   for (const layer of layers) {
+    // Collect opaque whiteout dirs from this layer, but don't apply yet —
+    // they only affect older layers, not the current one.
+    const layerOpaqueDirs: Set<string> = new Set();
+
     // go over extracted files products found in this layer
     for (const filename of Object.keys(layer)) {
       // if finding a deleted file - trimming to its original file name for excluding it from extractedLayers
       // + not adding this file
+      if (isOpaqueWhiteout(filename)) {
+        layerOpaqueDirs.add(path.dirname(filename));
+        continue;
+      }
       if (isWhitedOutFile(filename)) {
-        removedFilesToIgnore.add(filename.replace(/.wh./, ""));
+        removedFilesToIgnore.add(removeWhiteoutPrefix(filename));
         continue;
       }
       // not adding previously found to be whited out files to extractedLayers
@@ -250,16 +263,34 @@ function layersWithLatestFileModifications(
       if (isFileInARemovedFolder(filename, removedFilesToIgnore)) {
         continue;
       }
+      // not adding files in directories covered by an opaque whiteout from a newer layer
+      if (isFileInOpaqueDir(filename, opaqueWhiteoutDirs)) {
+        continue;
+      }
       // file not already in extractedLayers
       if (!Reflect.has(extractedLayers, filename)) {
         extractedLayers[filename] = layer[filename];
       }
     }
+
+    // Apply this layer's opaque whiteouts to older layers
+    for (const dir of layerOpaqueDirs) {
+      opaqueWhiteoutDirs.add(dir);
+    }
   }
   return extractedLayers;
 }
 
-export { isWhitedOutFile } from "./layer";
+export { isOpaqueWhiteout, isWhitedOutFile, removeWhiteoutPrefix };
+
+function isFileInOpaqueDir(
+  filename: string,
+  opaqueWhiteoutDirs: Set<string>,
+): boolean {
+  return Array.from(opaqueWhiteoutDirs).some((opaqueDir) =>
+    isFileInFolder(filename, opaqueDir),
+  );
+}
 
 function isBufferType(type: FileContent): type is Buffer {
   return (type as Buffer).buffer !== undefined;

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -6,10 +6,7 @@ import { getErrorMessage } from "../error-utils";
 import { applyCallbacks, isResultEmpty } from "./callbacks";
 import { decompressMaybe } from "./decompress-maybe";
 import { ExtractAction, ExtractedLayers } from "./types";
-
-export function isWhitedOutFile(filename: string) {
-  return filename.match(/.wh./gm);
-}
+import { isOpaqueWhiteout, isWhitedOutFile } from "./whiteout";
 
 const debug = Debug("snyk");
 
@@ -36,7 +33,10 @@ export async function extractImageLayer(
         const matchedActions = extractActions.filter((action) =>
           action.filePathMatches(absoluteFileName),
         );
-        if (matchedActions.length > 0) {
+        if (isOpaqueWhiteout(absoluteFileName)) {
+          // Opaque whiteout: record it so layersWithLatestFileModifications can process it
+          result[absoluteFileName] = {};
+        } else if (matchedActions.length > 0) {
           try {
             const callbackResult = await applyCallbacks(
               matchedActions,

--- a/lib/extractor/whiteout.ts
+++ b/lib/extractor/whiteout.ts
@@ -1,0 +1,37 @@
+/**
+ * check if a file is 'whited out' (filename starts with .wh.)
+ * https://www.madebymikal.com/interpreting-whiteout-files-in-docker-image-layers
+ * https://github.com/opencontainers/image-spec/blob/main/layer.md#whiteouts
+ */
+export function isWhitedOutFile(filename: string): boolean {
+  return getBasename(filename).startsWith(".wh.");
+}
+
+/**
+ * Check if a file is an opaque whiteout (.wh..wh..opq).
+ * Opaque whiteouts mean "delete everything in this directory from lower layers."
+ * https://github.com/opencontainers/image-spec/blob/main/layer.md#opaque-whiteout
+ */
+export function isOpaqueWhiteout(filename: string): boolean {
+  return getBasename(filename) === ".wh..wh..opq";
+}
+
+/**
+ * Remove the .wh. prefix from a whiteout file to get the original filename
+ */
+export function removeWhiteoutPrefix(filename: string): string {
+  // Replace .wh. at the start or after the last slash/backslash.
+  // Don't match if there are slashes after .wh.
+  return filename.replace(/^(.*[\/\\])?\.wh\.([^\/\\]*)$/, "$1$2");
+}
+
+/**
+ * Extract the basename from a path, handling both / and \ separators cross-platform.
+ */
+function getBasename(filename: string): string {
+  const lastSlash = Math.max(
+    filename.lastIndexOf("/"),
+    filename.lastIndexOf("\\"),
+  );
+  return lastSlash === -1 ? filename : filename.substring(lastSlash + 1);
+}

--- a/test/lib/extractor/index.spec.ts
+++ b/test/lib/extractor/index.spec.ts
@@ -1,4 +1,9 @@
-import { getContentAsString } from "../../../lib/extractor";
+import {
+  getContentAsString,
+  isOpaqueWhiteout,
+  isWhitedOutFile,
+  removeWhiteoutPrefix,
+} from "../../../lib/extractor";
 import { ExtractAction, ExtractedLayers } from "../../../lib/extractor/types";
 
 describe("index", () => {
@@ -16,5 +21,117 @@ describe("index", () => {
 
     //  extracted string matches
     expect(result).toEqual("Hello, world!");
+  });
+});
+
+describe("isWhitedOutFile", () => {
+  test("should return true for files containing .wh. in their path", () => {
+    expect(isWhitedOutFile("/etc/.wh.hosts")).toBe(true);
+    expect(isWhitedOutFile("/var/lib/.wh.data")).toBe(true);
+    expect(isWhitedOutFile("/.wh.config")).toBe(true);
+  });
+
+  test("should return false for files not containing .wh.", () => {
+    expect(isWhitedOutFile("/etc/hosts")).toBe(false);
+    expect(isWhitedOutFile("")).toBe(false);
+    expect(isWhitedOutFile("/")).toBe(false);
+  });
+
+  test("should return false for similar but different patterns", () => {
+    // make sure the dots are literal and not match all
+    expect(isWhitedOutFile("/etc/wh.hosts")).toBe(false);
+    expect(isWhitedOutFile("/etc/.whosts")).toBe(false);
+    expect(isWhitedOutFile("/etc/whhosts")).toBe(false);
+
+    // dots in wrong places
+    expect(isWhitedOutFile("/etc/.w.h.hosts")).toBe(false);
+    expect(isWhitedOutFile("/etc/..wh..hosts")).toBe(false);
+
+    // case sensitive
+    expect(isWhitedOutFile("/etc/.WH.hosts")).toBe(false);
+    expect(isWhitedOutFile("/etc/.Wh.hosts")).toBe(false);
+  });
+
+  test("should handle .wh. at different positions", () => {
+    expect(isWhitedOutFile(".wh.start")).toBe(true);
+    expect(isWhitedOutFile("middle.wh.file")).toBe(false);
+    expect(isWhitedOutFile("end.wh.")).toBe(false);
+    expect(isWhitedOutFile("/deeply/nested/path/.wh.present")).toBe(true);
+    expect(isWhitedOutFile("/the/.wh./in/path/present")).toBe(false);
+  });
+});
+
+describe("isOpaqueWhiteout", () => {
+  test("should return true for opaque whiteout files", () => {
+    expect(isOpaqueWhiteout("/etc/.wh..wh..opq")).toBe(true);
+    expect(isOpaqueWhiteout("/.wh..wh..opq")).toBe(true);
+    expect(isOpaqueWhiteout(".wh..wh..opq")).toBe(true);
+    expect(isOpaqueWhiteout("/deeply/nested/path/.wh..wh..opq")).toBe(true);
+  });
+
+  test("should return false for regular whiteout files", () => {
+    expect(isOpaqueWhiteout("/etc/.wh.hosts")).toBe(false);
+    expect(isOpaqueWhiteout("/.wh.config")).toBe(false);
+  });
+
+  test("should return false for non-whiteout files", () => {
+    expect(isOpaqueWhiteout("/etc/hosts")).toBe(false);
+    expect(isOpaqueWhiteout("")).toBe(false);
+    expect(isOpaqueWhiteout("/")).toBe(false);
+  });
+
+  test("should return false for similar but incorrect patterns", () => {
+    expect(isOpaqueWhiteout("/etc/.wh..wh..opq.extra")).toBe(false);
+    expect(isOpaqueWhiteout("/etc/.wh..opq")).toBe(false);
+    expect(isOpaqueWhiteout("/etc/.WH..WH..OPQ")).toBe(false);
+  });
+});
+
+describe("removeWhiteoutPrefix", () => {
+  test("should remove .wh. prefix from filenames without slashes", () => {
+    expect(removeWhiteoutPrefix(".wh.hosts")).toBe("hosts");
+    expect(removeWhiteoutPrefix(".wh.data")).toBe("data");
+    expect(removeWhiteoutPrefix(".wh.config")).toBe("config");
+    expect(removeWhiteoutPrefix(".wh.")).toBe("");
+    expect(removeWhiteoutPrefix(".wh.file.txt")).toBe("file.txt");
+  });
+
+  test("should remove .wh. prefix after the last slash in paths", () => {
+    expect(removeWhiteoutPrefix("/etc/.wh.hosts")).toBe("/etc/hosts");
+    expect(removeWhiteoutPrefix("/var/lib/.wh.data")).toBe("/var/lib/data");
+    expect(removeWhiteoutPrefix("/.wh.config")).toBe("/config");
+    expect(removeWhiteoutPrefix("/deeply/nested/path/.wh.present")).toBe(
+      "/deeply/nested/path/present",
+    );
+    expect(removeWhiteoutPrefix("/path/to/.wh.")).toBe("/path/to/");
+  });
+
+  test("should not modify files that don't have .wh. prefix in the correct position", () => {
+    expect(removeWhiteoutPrefix("normal.file")).toBe("normal.file");
+    expect(removeWhiteoutPrefix("/etc/hosts")).toBe("/etc/hosts");
+    expect(removeWhiteoutPrefix("middle.wh.file")).toBe("middle.wh.file");
+    expect(removeWhiteoutPrefix("/path/middle.wh.file")).toBe(
+      "/path/middle.wh.file",
+    );
+    expect(removeWhiteoutPrefix(".whfile")).toBe(".whfile");
+    expect(removeWhiteoutPrefix("/path/.whfile")).toBe("/path/.whfile");
+    expect(removeWhiteoutPrefix("/xwh.txt")).toBe("/xwh.txt");
+  });
+
+  test("should handle edge cases", () => {
+    expect(removeWhiteoutPrefix("")).toBe("");
+    expect(removeWhiteoutPrefix("/")).toBe("/");
+    expect(removeWhiteoutPrefix("//")).toBe("//");
+    expect(removeWhiteoutPrefix("/.wh.")).toBe("/");
+    expect(removeWhiteoutPrefix("//.wh.test")).toBe("//test");
+  });
+
+  test("should not remove .wh. that appears in the middle of paths", () => {
+    expect(removeWhiteoutPrefix("/the/.wh./in/path/file")).toBe(
+      "/the/.wh./in/path/file",
+    );
+    expect(removeWhiteoutPrefix("/path/.wh.dir/.wh.file")).toBe(
+      "/path/.wh.dir/file",
+    );
   });
 });

--- a/test/system/application-scans/__snapshots__/node.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/node.spec.ts.snap
@@ -57649,11 +57649,6 @@ Array [
               },
               Object {
                 "deps": Array [],
-                "nodeId": "isexe@2.0.0",
-                "pkgId": "isexe@2.0.0",
-              },
-              Object {
-                "deps": Array [],
                 "nodeId": "lazy-property@1.0.0",
                 "pkgId": "lazy-property@1.0.0",
               },
@@ -58286,6 +58281,20 @@ Array [
                 "pkgId": "tar@4.4.13",
               },
               Object {
+                "deps": Array [],
+                "nodeId": "isexe@2.0.0",
+                "pkgId": "isexe@2.0.0",
+              },
+              Object {
+                "deps": Array [
+                  Object {
+                    "nodeId": "isexe@2.0.0",
+                  },
+                ],
+                "nodeId": "which@1.3.1",
+                "pkgId": "which@1.3.1",
+              },
+              Object {
                 "deps": Array [
                   Object {
                     "nodeId": "env-paths@2.2.0",
@@ -58316,6 +58325,9 @@ Array [
                   },
                   Object {
                     "nodeId": "tar@4.4.13",
+                  },
+                  Object {
+                    "nodeId": "which@1.3.1",
                   },
                 ],
                 "nodeId": "node-gyp@5.1.0",
@@ -58358,6 +58370,9 @@ Array [
                   },
                   Object {
                     "nodeId": "umask@1.1.0",
+                  },
+                  Object {
+                    "nodeId": "which@1.3.1",
                   },
                 ],
                 "nodeId": "npm-lifecycle@3.1.4",
@@ -58785,6 +58800,9 @@ Array [
                   },
                   Object {
                     "nodeId": "unique-filename@1.1.1",
+                  },
+                  Object {
+                    "nodeId": "which@1.3.1",
                   },
                 ],
                 "nodeId": "pacote@9.5.12",
@@ -59263,6 +59281,9 @@ Array [
                   },
                   Object {
                     "nodeId": "shebang-command@1.2.0",
+                  },
+                  Object {
+                    "nodeId": "which@1.3.1",
                   },
                 ],
                 "nodeId": "cross-spawn@5.1.0",
@@ -59817,6 +59838,9 @@ Array [
                   Object {
                     "nodeId": "shebang-command@1.2.0",
                   },
+                  Object {
+                    "nodeId": "which@1.3.1",
+                  },
                 ],
                 "nodeId": "cross-spawn@6.0.5",
                 "pkgId": "cross-spawn@6.0.5",
@@ -59928,6 +59952,11 @@ Array [
               },
               Object {
                 "deps": Array [],
+                "nodeId": "which-module@2.0.0",
+                "pkgId": "which-module@2.0.0",
+              },
+              Object {
+                "deps": Array [],
                 "nodeId": "y18n@3.2.1",
                 "pkgId": "y18n@3.2.1",
               },
@@ -59970,6 +59999,9 @@ Array [
                     "nodeId": "string-width@2.1.1",
                   },
                   Object {
+                    "nodeId": "which-module@2.0.0",
+                  },
+                  Object {
                     "nodeId": "y18n@3.2.1",
                   },
                   Object {
@@ -59995,6 +60027,9 @@ Array [
                   },
                   Object {
                     "nodeId": "update-notifier@2.5.0",
+                  },
+                  Object {
+                    "nodeId": "which@1.3.1",
                   },
                   Object {
                     "nodeId": "y18n@4.0.0",
@@ -60594,9 +60629,6 @@ Array [
                     "nodeId": "is-cidr@3.0.0",
                   },
                   Object {
-                    "nodeId": "isexe@2.0.0",
-                  },
-                  Object {
                     "nodeId": "json-parse-better-errors@1.0.2",
                   },
                   Object {
@@ -60832,6 +60864,9 @@ Array [
                   },
                   Object {
                     "nodeId": "validate-npm-package-name@3.0.0",
+                  },
+                  Object {
+                    "nodeId": "which@1.3.1",
                   },
                   Object {
                     "nodeId": "worker-farm@1.7.0",
@@ -61761,13 +61796,6 @@ Array [
               },
             },
             Object {
-              "id": "isexe@2.0.0",
-              "info": Object {
-                "name": "isexe",
-                "version": "2.0.0",
-              },
-            },
-            Object {
               "id": "lazy-property@1.0.0",
               "info": Object {
                 "name": "lazy-property",
@@ -62220,6 +62248,20 @@ Array [
               "info": Object {
                 "name": "tar",
                 "version": "4.4.13",
+              },
+            },
+            Object {
+              "id": "isexe@2.0.0",
+              "info": Object {
+                "name": "isexe",
+                "version": "2.0.0",
+              },
+            },
+            Object {
+              "id": "which@1.3.1",
+              "info": Object {
+                "name": "which",
+                "version": "1.3.1",
               },
             },
             Object {
@@ -63228,6 +63270,13 @@ Array [
               "info": Object {
                 "name": "require-main-filename",
                 "version": "1.0.1",
+              },
+            },
+            Object {
+              "id": "which-module@2.0.0",
+              "info": Object {
+                "name": "which-module",
+                "version": "2.0.0",
               },
             },
             Object {

--- a/test/system/application-scans/node.spec.ts
+++ b/test/system/application-scans/node.spec.ts
@@ -273,7 +273,7 @@ describe("node application scans", () => {
     const result = await extractContent([getNodeAppFileContentAction], {
       path: imageNameAndTag,
     });
-    expect(Object.keys(result.extractedLayers).length).toEqual(608);
+    expect(Object.keys(result.extractedLayers).length).toEqual(610);
     Object.keys(result.extractedLayers).forEach((fileName) => {
       expect(
         fileName.endsWith("/package.json") ||

--- a/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
@@ -7443,11 +7443,6 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "isexe@2.0.0",
-                  "pkgId": "isexe@2.0.0",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "duplexer@0.1.1",
                   "pkgId": "duplexer@0.1.1",
                 },
@@ -7733,12 +7728,29 @@ Object {
                   "pkgId": "shebang-command@1.2.0",
                 },
                 Object {
+                  "deps": Array [],
+                  "nodeId": "isexe@2.0.0",
+                  "pkgId": "isexe@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "isexe@2.0.0",
+                    },
+                  ],
+                  "nodeId": "which@1.3.0",
+                  "pkgId": "which@1.3.0",
+                },
+                Object {
                   "deps": Array [
                     Object {
                       "nodeId": "lru-cache@4.1.1",
                     },
                     Object {
                       "nodeId": "shebang-command@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.0",
                     },
                   ],
                   "nodeId": "cross-spawn@5.1.0|1",
@@ -7751,6 +7763,9 @@ Object {
                     },
                     Object {
                       "nodeId": "shebang-command@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "cross-spawn@5.1.0|2",
@@ -8385,9 +8400,6 @@ Object {
                     },
                     Object {
                       "nodeId": "ignore-by-default@1.0.1",
-                    },
-                    Object {
-                      "nodeId": "isexe@2.0.0",
                     },
                     Object {
                       "nodeId": "minimatch@3.0.4|1",
@@ -10181,6 +10193,15 @@ Object {
                 Object {
                   "deps": Array [
                     Object {
+                      "nodeId": "isexe@2.0.0",
+                    },
+                  ],
+                  "nodeId": "which@1.3.1",
+                  "pkgId": "which@1.3.1",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
                       "nodeId": "env-paths@2.2.0",
                     },
                     Object {
@@ -10209,6 +10230,9 @@ Object {
                     },
                     Object {
                       "nodeId": "tar@4.4.13",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "node-gyp@5.1.0",
@@ -10251,6 +10275,9 @@ Object {
                     },
                     Object {
                       "nodeId": "umask@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "npm-lifecycle@3.1.4",
@@ -10664,6 +10691,9 @@ Object {
                     },
                     Object {
                       "nodeId": "unique-filename@1.1.1",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "pacote@9.5.12",
@@ -11305,6 +11335,9 @@ Object {
                     Object {
                       "nodeId": "shebang-command@1.2.0",
                     },
+                    Object {
+                      "nodeId": "which@1.3.1",
+                    },
                   ],
                   "nodeId": "cross-spawn@6.0.5",
                   "pkgId": "cross-spawn@6.0.5",
@@ -11416,6 +11449,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "which-module@2.0.0",
+                  "pkgId": "which-module@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "y18n@3.2.1",
                   "pkgId": "y18n@3.2.1",
                 },
@@ -11458,6 +11496,9 @@ Object {
                       "nodeId": "string-width@2.1.1",
                     },
                     Object {
+                      "nodeId": "which-module@2.0.0",
+                    },
+                    Object {
                       "nodeId": "y18n@3.2.1",
                     },
                     Object {
@@ -11483,6 +11524,9 @@ Object {
                     },
                     Object {
                       "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                     Object {
                       "nodeId": "y18n@4.0.0",
@@ -12077,9 +12121,6 @@ Object {
                       "nodeId": "is-cidr@3.0.0",
                     },
                     Object {
-                      "nodeId": "isexe@2.0.0",
-                    },
-                    Object {
                       "nodeId": "json-parse-better-errors@1.0.2",
                     },
                     Object {
@@ -12315,6 +12356,9 @@ Object {
                     },
                     Object {
                       "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                     Object {
                       "nodeId": "worker-farm@1.7.0",
@@ -13146,13 +13190,6 @@ Object {
                 },
               },
               Object {
-                "id": "isexe@2.0.0",
-                "info": Object {
-                  "name": "isexe",
-                  "version": "2.0.0",
-                },
-              },
-              Object {
                 "id": "duplexer@0.1.1",
                 "info": Object {
                   "name": "duplexer",
@@ -13402,6 +13439,20 @@ Object {
                 "info": Object {
                   "name": "shebang-command",
                   "version": "1.2.0",
+                },
+              },
+              Object {
+                "id": "isexe@2.0.0",
+                "info": Object {
+                  "name": "isexe",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "which@1.3.0",
+                "info": Object {
+                  "name": "which",
+                  "version": "1.3.0",
                 },
               },
               Object {
@@ -15001,6 +15052,13 @@ Object {
                 },
               },
               Object {
+                "id": "which@1.3.1",
+                "info": Object {
+                  "name": "which",
+                  "version": "1.3.1",
+                },
+              },
+              Object {
                 "id": "node-gyp@5.1.0",
                 "info": Object {
                   "name": "node-gyp",
@@ -15670,6 +15728,13 @@ Object {
                 "info": Object {
                   "name": "require-main-filename",
                   "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "which-module@2.0.0",
+                "info": Object {
+                  "name": "which-module",
+                  "version": "2.0.0",
                 },
               },
               Object {

--- a/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
+++ b/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
@@ -1835,11 +1835,6 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "isexe@2.0.0",
-                  "pkgId": "isexe@2.0.0",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "lazy-property@1.0.0",
                   "pkgId": "lazy-property@1.0.0",
                 },
@@ -2454,6 +2449,20 @@ Object {
                   "pkgId": "tar@2.2.1",
                 },
                 Object {
+                  "deps": Array [],
+                  "nodeId": "isexe@2.0.0",
+                  "pkgId": "isexe@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "isexe@2.0.0",
+                    },
+                  ],
+                  "nodeId": "which@1.3.1",
+                  "pkgId": "which@1.3.1",
+                },
+                Object {
                   "deps": Array [
                     Object {
                       "nodeId": "fstream@1.0.11",
@@ -2487,6 +2496,9 @@ Object {
                     },
                     Object {
                       "nodeId": "tar@2.2.1",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "node-gyp@3.8.0",
@@ -2529,6 +2541,9 @@ Object {
                     },
                     Object {
                       "nodeId": "umask@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "npm-lifecycle@2.1.0",
@@ -2971,6 +2986,9 @@ Object {
                     Object {
                       "nodeId": "unique-filename@1.1.0",
                     },
+                    Object {
+                      "nodeId": "which@1.3.1",
+                    },
                   ],
                   "nodeId": "pacote@8.1.6",
                   "pkgId": "pacote@8.1.6",
@@ -3181,6 +3199,9 @@ Object {
                     },
                     Object {
                       "nodeId": "shebang-command@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "cross-spawn@5.1.0",
@@ -3771,6 +3792,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "which-module@2.0.0",
+                  "pkgId": "which-module@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "y18n@3.2.1",
                   "pkgId": "y18n@3.2.1",
                 },
@@ -3813,6 +3839,9 @@ Object {
                       "nodeId": "string-width@2.1.1",
                     },
                     Object {
+                      "nodeId": "which-module@2.0.0",
+                    },
+                    Object {
                       "nodeId": "y18n@3.2.1",
                     },
                     Object {
@@ -3838,6 +3867,9 @@ Object {
                     },
                     Object {
                       "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                     Object {
                       "nodeId": "y18n@4.0.0",
@@ -4556,9 +4588,6 @@ Object {
                       "nodeId": "is-cidr@2.0.6",
                     },
                     Object {
-                      "nodeId": "isexe@2.0.0",
-                    },
-                    Object {
                       "nodeId": "json-parse-better-errors@1.0.2",
                     },
                     Object {
@@ -4779,6 +4808,9 @@ Object {
                     },
                     Object {
                       "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                     Object {
                       "nodeId": "worker-farm@1.6.0",
@@ -5701,13 +5733,6 @@ Object {
                 },
               },
               Object {
-                "id": "isexe@2.0.0",
-                "info": Object {
-                  "name": "isexe",
-                  "version": "2.0.0",
-                },
-              },
-              Object {
                 "id": "lazy-property@1.0.0",
                 "info": Object {
                   "name": "lazy-property",
@@ -6153,6 +6178,20 @@ Object {
                 "info": Object {
                   "name": "tar",
                   "version": "2.2.1",
+                },
+              },
+              Object {
+                "id": "isexe@2.0.0",
+                "info": Object {
+                  "name": "isexe",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "which@1.3.1",
+                "info": Object {
+                  "name": "which",
+                  "version": "1.3.1",
                 },
               },
               Object {
@@ -7028,6 +7067,13 @@ Object {
                 "info": Object {
                   "name": "require-main-filename",
                   "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "which-module@2.0.0",
+                "info": Object {
+                  "name": "which-module",
+                  "version": "2.0.0",
                 },
               },
               Object {
@@ -9324,11 +9370,6 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "isexe@2.0.0",
-                  "pkgId": "isexe@2.0.0",
-                },
-                Object {
-                  "deps": Array [],
                   "nodeId": "lazy-property@1.0.0",
                   "pkgId": "lazy-property@1.0.0",
                 },
@@ -9943,6 +9984,20 @@ Object {
                   "pkgId": "tar@2.2.1",
                 },
                 Object {
+                  "deps": Array [],
+                  "nodeId": "isexe@2.0.0",
+                  "pkgId": "isexe@2.0.0",
+                },
+                Object {
+                  "deps": Array [
+                    Object {
+                      "nodeId": "isexe@2.0.0",
+                    },
+                  ],
+                  "nodeId": "which@1.3.1",
+                  "pkgId": "which@1.3.1",
+                },
+                Object {
                   "deps": Array [
                     Object {
                       "nodeId": "fstream@1.0.11",
@@ -9976,6 +10031,9 @@ Object {
                     },
                     Object {
                       "nodeId": "tar@2.2.1",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "node-gyp@3.8.0",
@@ -10018,6 +10076,9 @@ Object {
                     },
                     Object {
                       "nodeId": "umask@1.1.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "npm-lifecycle@2.1.0",
@@ -10460,6 +10521,9 @@ Object {
                     Object {
                       "nodeId": "unique-filename@1.1.0",
                     },
+                    Object {
+                      "nodeId": "which@1.3.1",
+                    },
                   ],
                   "nodeId": "pacote@8.1.6",
                   "pkgId": "pacote@8.1.6",
@@ -10670,6 +10734,9 @@ Object {
                     },
                     Object {
                       "nodeId": "shebang-command@1.2.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                   ],
                   "nodeId": "cross-spawn@5.1.0",
@@ -11260,6 +11327,11 @@ Object {
                 },
                 Object {
                   "deps": Array [],
+                  "nodeId": "which-module@2.0.0",
+                  "pkgId": "which-module@2.0.0",
+                },
+                Object {
+                  "deps": Array [],
                   "nodeId": "y18n@3.2.1",
                   "pkgId": "y18n@3.2.1",
                 },
@@ -11302,6 +11374,9 @@ Object {
                       "nodeId": "string-width@2.1.1",
                     },
                     Object {
+                      "nodeId": "which-module@2.0.0",
+                    },
+                    Object {
                       "nodeId": "y18n@3.2.1",
                     },
                     Object {
@@ -11327,6 +11402,9 @@ Object {
                     },
                     Object {
                       "nodeId": "update-notifier@2.5.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                     Object {
                       "nodeId": "y18n@4.0.0",
@@ -12045,9 +12123,6 @@ Object {
                       "nodeId": "is-cidr@2.0.6",
                     },
                     Object {
-                      "nodeId": "isexe@2.0.0",
-                    },
-                    Object {
                       "nodeId": "json-parse-better-errors@1.0.2",
                     },
                     Object {
@@ -12268,6 +12343,9 @@ Object {
                     },
                     Object {
                       "nodeId": "validate-npm-package-name@3.0.0",
+                    },
+                    Object {
+                      "nodeId": "which@1.3.1",
                     },
                     Object {
                       "nodeId": "worker-farm@1.6.0",
@@ -13190,13 +13268,6 @@ Object {
                 },
               },
               Object {
-                "id": "isexe@2.0.0",
-                "info": Object {
-                  "name": "isexe",
-                  "version": "2.0.0",
-                },
-              },
-              Object {
                 "id": "lazy-property@1.0.0",
                 "info": Object {
                   "name": "lazy-property",
@@ -13642,6 +13713,20 @@ Object {
                 "info": Object {
                   "name": "tar",
                   "version": "2.2.1",
+                },
+              },
+              Object {
+                "id": "isexe@2.0.0",
+                "info": Object {
+                  "name": "isexe",
+                  "version": "2.0.0",
+                },
+              },
+              Object {
+                "id": "which@1.3.1",
+                "info": Object {
+                  "name": "which",
+                  "version": "1.3.1",
                 },
               },
               Object {
@@ -14517,6 +14602,13 @@ Object {
                 "info": Object {
                   "name": "require-main-filename",
                   "version": "1.0.1",
+                },
+              },
+              Object {
+                "id": "which-module@2.0.0",
+                "info": Object {
+                  "name": "which-module",
+                  "version": "2.0.0",
                 },
               },
               Object {

--- a/test/system/registry-authentication/username-password.spec.ts
+++ b/test/system/registry-authentication/username-password.spec.ts
@@ -10,7 +10,7 @@ describe("username and password authentication", () => {
       process.env.SNYK_REGISTRY_USERNAME = oldSnykRegistryUsernameEnvVar;
     }
     if (oldSnykRegistryPasswordEnvVar !== undefined) {
-      process.env.SNYK_REGISTRY_PASSWPRD = oldSnykRegistryPasswordEnvVar;
+      process.env.SNYK_REGISTRY_PASSWORD = oldSnykRegistryPasswordEnvVar;
     }
   });
 


### PR DESCRIPTION
We were using `.wh.` to look for whited out files, but we didn't escape the `.`, so it was a match-any character

We also weren't following the OpenContainer spec: https://github.com/opencontainers/image-spec/blob/main/layer.md#whiteouts

.wh. needs to be the prefix of the filename. So it either needs to prefix everything (no slashes, just filename) or it needs to prefix the filename after the last slash (full path)

Our current implementation just looks for .wh. to appear anywhere, so we are incorrectly whiting out files. This includes libraries, so all of the node 'which' packages were being skipped, for example