### PR TITLE
feat: [CN-280] Add parameter to support usr/lib jar files

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -59,7 +59,8 @@ async function pullWithDockerBinary(
     return true;
   } catch (err) {
     debug(`couldn't pull ${targetImage} using docker binary: ${err.message}`);
-    handleDockerPullError(err.stderr, platform);
+    const errorMessage = err.stderr || err.message || err.toString();
+    handleDockerPullError(errorMessage, platform);
 
     return false;
   }

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -25,7 +25,10 @@ import {
   getDpkgPackageFileContentAction,
 } from "../inputs/distroless/static";
 import * as filePatternStatic from "../inputs/file-pattern/static";
-import { getJarFileContentAction } from "../inputs/java/static";
+import {
+  getJarFileContentAction,
+  getUsrLibJarFileContentAction,
+} from "../inputs/java/static";
 import {
   getNodeAppFileContentAction,
   getNodeJsTsAppFileContentAction,
@@ -116,13 +119,20 @@ export async function analyze(
   const collectApplicationFiles = isTrue(options["collect-application-files"]);
 
   if (appScan) {
+    const jarActions = [getJarFileContentAction];
+
+    // Include system JARs from /usr/lib if flag is enabled
+    if (isTrue(options["include-system-jars"])) {
+      jarActions.push(getUsrLibJarFileContentAction);
+    }
+
     staticAnalysisActions.push(
       ...[
         getNodeAppFileContentAction,
         getPhpAppFileContentAction,
         getPoetryAppFileContentAction,
         getPipAppFileContentAction,
-        getJarFileContentAction,
+        ...jarActions,
         getGoModulesContentAction,
       ],
     );

--- a/lib/inputs/java/static.ts
+++ b/lib/inputs/java/static.ts
@@ -2,7 +2,8 @@ import * as path from "path";
 import { ExtractAction } from "../../extractor/types";
 import { streamToBuffer } from "../../stream-utils";
 
-const ignoredPaths = ["/usr/lib", "gradle/cache"];
+const usrLibPath = "/usr/lib";
+const ignoredPaths = [usrLibPath, "gradle/cache"];
 const javaArchiveFileFormats = [".jar", ".war"];
 
 function filePathMatches(filePath: string): boolean {
@@ -19,5 +20,20 @@ function filePathMatches(filePath: string): boolean {
 export const getJarFileContentAction: ExtractAction = {
   actionName: "jar",
   filePathMatches,
+  callback: streamToBuffer,
+};
+
+function usrLibFilePathMatches(filePath: string): boolean {
+  const dirName = path.dirname(filePath);
+  const fileExtension = filePath.slice(-4);
+  return (
+    javaArchiveFileFormats.includes(fileExtension) &&
+    dirName.includes(path.normalize(usrLibPath))
+  );
+}
+
+export const getUsrLibJarFileContentAction: ExtractAction = {
+  actionName: "jar",
+  filePathMatches: usrLibFilePathMatches,
   callback: streamToBuffer,
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -227,6 +227,10 @@ export interface PluginOptions {
 
   /** The default is "false". */
   "collect-application-files": boolean | string;
+
+  /** Include system-level JARs and WARs from /usr/lib in scan results. The default is "false". */
+  "include-system-jars": boolean | string;
+
   "target-reference": string;
 }
 

--- a/test/lib/inputs/java-static.spec.ts
+++ b/test/lib/inputs/java-static.spec.ts
@@ -1,0 +1,113 @@
+import {
+  getJarFileContentAction,
+  getUsrLibJarFileContentAction,
+} from "../../../lib/inputs/java/static";
+
+describe("Java static input", () => {
+  describe("getJarFileContentAction", () => {
+    it("should exclude /usr/lib JARs by default", () => {
+      expect(getJarFileContentAction.actionName).toBe("jar");
+      expect(getJarFileContentAction.filePathMatches).toBeDefined();
+
+      // Test that /usr/lib JARs are excluded
+      const usrLibJar = "/usr/lib/java/some-lib.jar";
+      expect(getJarFileContentAction.filePathMatches!(usrLibJar)).toBe(false);
+
+      // Test that gradle cache is still excluded
+      const gradleCacheJar = "/gradle/cache/some-lib.jar";
+      expect(getJarFileContentAction.filePathMatches!(gradleCacheJar)).toBe(
+        false,
+      );
+
+      // Test regular JARs are included
+      const regularJar = "/app/lib/app.jar";
+      expect(getJarFileContentAction.filePathMatches!(regularJar)).toBe(true);
+    });
+
+    it("should only match JAR and WAR files", () => {
+      // Test JAR files
+      expect(getJarFileContentAction.filePathMatches!("/app/lib/app.jar")).toBe(
+        true,
+      );
+
+      // Test WAR files
+      expect(getJarFileContentAction.filePathMatches!("/app/lib/app.war")).toBe(
+        true,
+      );
+
+      // Test non-archive files
+      expect(getJarFileContentAction.filePathMatches!("/app/lib/app.txt")).toBe(
+        false,
+      );
+      expect(
+        getJarFileContentAction.filePathMatches!("/app/lib/app.class"),
+      ).toBe(false);
+      expect(getJarFileContentAction.filePathMatches!("/app/lib/app.xml")).toBe(
+        false,
+      );
+    });
+
+    it("should exclude gradle cache paths", () => {
+      const gradleCacheJar =
+        "/home/user/.gradle/cache/modules-2/files-2.1/some-lib.jar";
+      expect(getJarFileContentAction.filePathMatches!(gradleCacheJar)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("getUsrLibJarFileContentAction", () => {
+    it("should only include JARs from /usr/lib", () => {
+      expect(getUsrLibJarFileContentAction.actionName).toBe("jar");
+      expect(getUsrLibJarFileContentAction.filePathMatches).toBeDefined();
+
+      // Test that /usr/lib JARs are included
+      const usrLibJar = "/usr/lib/java/some-lib.jar";
+      expect(getUsrLibJarFileContentAction.filePathMatches!(usrLibJar)).toBe(
+        true,
+      );
+
+      // Test that non-/usr/lib JARs are excluded
+      const regularJar = "/app/lib/app.jar";
+      expect(getUsrLibJarFileContentAction.filePathMatches!(regularJar)).toBe(
+        false,
+      );
+
+      // Test that gradle cache is excluded (even though it wouldn't contain /usr/lib)
+      const gradleCacheJar = "/gradle/cache/some-lib.jar";
+      expect(
+        getUsrLibJarFileContentAction.filePathMatches!(gradleCacheJar),
+      ).toBe(false);
+    });
+
+    it("should only match JAR and WAR files in /usr/lib", () => {
+      // Test JAR files in /usr/lib
+      expect(
+        getUsrLibJarFileContentAction.filePathMatches!("/usr/lib/app.jar"),
+      ).toBe(true);
+
+      // Test WAR files in /usr/lib
+      expect(
+        getUsrLibJarFileContentAction.filePathMatches!("/usr/lib/app.war"),
+      ).toBe(true);
+
+      // Test non-archive files in /usr/lib
+      expect(
+        getUsrLibJarFileContentAction.filePathMatches!("/usr/lib/app.txt"),
+      ).toBe(false);
+      expect(
+        getUsrLibJarFileContentAction.filePathMatches!("/usr/lib/app.class"),
+      ).toBe(false);
+      expect(
+        getUsrLibJarFileContentAction.filePathMatches!("/usr/lib/app.xml"),
+      ).toBe(false);
+    });
+
+    it("should match nested paths within /usr/lib", () => {
+      const nestedUsrLibJar = "/usr/lib/java/jvm/lib/some-lib.jar";
+      expect(
+        getUsrLibJarFileContentAction.filePathMatches!(nestedUsrLibJar),
+      ).toBe(true);
+    });
+  });
+});

--- a/test/system/flags/include-system-jars.spec.ts
+++ b/test/system/flags/include-system-jars.spec.ts
@@ -1,0 +1,99 @@
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
+
+describe("include-system-jars flag", () => {
+  it("excludes system JARs by default", async () => {
+    const fixturePath = getFixture("docker-archives/docker-save/java.tar");
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+    const pluginResult = await scan({
+      path: imageNameAndTag,
+    });
+
+    expect(pluginResult.scanResults).toBeDefined();
+
+    // Verify that no system JARs from /usr/lib are included
+    const javaResults = pluginResult.scanResults.filter(
+      (result) => result.identity.type === "maven",
+    );
+
+    for (const result of javaResults) {
+      if (result.identity?.targetFile) {
+        expect(result.identity.targetFile).not.toContain("/usr/lib");
+      }
+    }
+  });
+
+  it("includes system JARs when --include-system-jars is true", async () => {
+    const fixturePath = getFixture("docker-archives/docker-save/java.tar");
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+    const pluginResult = await scan({
+      path: imageNameAndTag,
+      "include-system-jars": true,
+    });
+
+    // Verify the scan runs successfully and that the option is properly processed
+    expect(pluginResult.scanResults).toBeDefined();
+
+    // Since the test fixture doesn't contain /usr/lib JARs, we verify the flag is processed
+    // by checking that Maven results are still present (confirms our logic didn't break anything)
+    const javaResults = pluginResult.scanResults.filter(
+      (result) => result.identity.type === "maven",
+    );
+    expect(javaResults.length).toBeGreaterThan(0);
+  });
+
+  it("excludes system JARs when --include-system-jars is false", async () => {
+    const fixturePath = getFixture("docker-archives/docker-save/java.tar");
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+    const pluginResult = await scan({
+      path: imageNameAndTag,
+      "include-system-jars": false,
+    });
+
+    expect(pluginResult.scanResults).toBeDefined();
+
+    // Verify that no system JARs from /usr/lib are included
+    const javaResults = pluginResult.scanResults.filter(
+      (result) => result.identity.type === "maven",
+    );
+
+    for (const result of javaResults) {
+      if (result.identity?.targetFile) {
+        expect(result.identity.targetFile).not.toContain("/usr/lib");
+      }
+    }
+  });
+
+  it("handles string values for include-system-jars flag", async () => {
+    const fixturePath = getFixture("docker-archives/docker-save/java.tar");
+    const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+    const pluginResultTrue = await scan({
+      path: imageNameAndTag,
+      "include-system-jars": "true",
+    });
+
+    const pluginResultFalse = await scan({
+      path: imageNameAndTag,
+      "include-system-jars": "false",
+    });
+
+    // Both should run successfully with proper flag handling
+    expect(pluginResultTrue.scanResults).toBeDefined();
+    expect(pluginResultFalse.scanResults).toBeDefined();
+
+    // Verify both produce Maven scan results
+    const javaResultsTrue = pluginResultTrue.scanResults.filter(
+      (result) => result.identity.type === "maven",
+    );
+    const javaResultsFalse = pluginResultFalse.scanResults.filter(
+      (result) => result.identity.type === "maven",
+    );
+
+    expect(javaResultsTrue.length).toBeGreaterThan(0);
+    expect(javaResultsFalse.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
This PR adds a parameter to support jars under the usr/lib directory

#### Where should the reviewer start?
There is a new parameter "include-system-jars" that should control this feature.  It should default to off.

#### How should this be manually tested?
test with include-system-jars=false and then compare to include-system-jars=true

#### Any background context you want to provide?
Make sure you are using a container image with jar files in the usr/lib file to properly evaluate

#### What are the relevant tickets?
CN-280

#### Screenshots


#### Additional questions
