### PR TITLE
fix: go regression test fix

### DIFF
--- a/lib/go-parser/pclntab.ts
+++ b/lib/go-parser/pclntab.ts
@@ -108,7 +108,7 @@ export class LineTable {
   public go12MapFiles(): string[] {
     this.initFileMap();
     const files: string[] = [];
-    for (const file of Object.keys(this.fileMap)) {
+    for (const file of this.fileMap.keys()) {
       files.push(file);
     }
     return files;
@@ -152,13 +152,13 @@ export class LineTable {
         const fileName = this.string(
           Number(this.binary.Uint32(this.filetab.slice(4 * i))),
         );
-        files[fileName] = i;
+        files.set(fileName, i);
       }
     } else {
       let pos: number = 0;
       for (let i = 0; i < this.nfiletab; i++) {
         const fileName = this.stringFrom(this.filetab, pos);
-        files[fileName] = pos;
+        files.set(fileName, pos);
         pos += fileName.length + 1;
       }
     }

--- a/lib/go-parser/pclntab.ts
+++ b/lib/go-parser/pclntab.ts
@@ -108,7 +108,7 @@ export class LineTable {
   public go12MapFiles(): string[] {
     this.initFileMap();
     const files: string[] = [];
-    for (const file of this.fileMap.keys()) {
+    for (const file of Object.keys(this.fileMap)) {
       files.push(file);
     }
     return files;
@@ -152,13 +152,13 @@ export class LineTable {
         const fileName = this.string(
           Number(this.binary.Uint32(this.filetab.slice(4 * i))),
         );
-        files.set(fileName, i);
+        files[fileName] = i;
       }
     } else {
       let pos: number = 0;
       for (let i = 0; i < this.nfiletab; i++) {
         const fileName = this.stringFrom(this.filetab, pos);
-        files.set(fileName, pos);
+        files[fileName] = pos;
         pos += fileName.length + 1;
       }
     }

--- a/test/unit/go-binaries.spec.ts
+++ b/test/unit/go-binaries.spec.ts
@@ -227,10 +227,9 @@ function stdlib(
 
 function redisModule(goVersion: GoVersion): Module {
   // Go 1.25 doesn't include internal/unsafe.go in the PCLN table
+  const baseFiles = ["log.go", "util.go"];
   const internalFiles =
-    goVersion === GoVersion.Go125
-      ? ["log.go", "util.go"]
-      : ["unsafe.go", "log.go", "util.go"];
+    goVersion === GoVersion.Go125 ? baseFiles : ["unsafe.go", ...baseFiles];
 
   const packages = new Map([
     ["", ["error.go", "cluster.go", "options.go"]],


### PR DESCRIPTION
Go version 1.25 released last week, and it's breaking the pipeline