### PR TITLE
chore: tests for os-release

### DIFF
--- a/test/lib/analyzer/os-release-detector.spec.ts
+++ b/test/lib/analyzer/os-release-detector.spec.ts
@@ -248,18 +248,10 @@ describe("OS Release Analyzer - Error Cases", () => {
     ];
 
     test.each(parsers)(
-      "$name should return null for empty text",
+      "$name should return null for empty/null text",
       async ({ func }) => {
-        const result = await func("");
-        expect(result).toBeNull();
-      },
-    );
-
-    test.each(parsers)(
-      "$name should return null for null text",
-      async ({ func }) => {
-        const result = await func(null);
-        expect(result).toBeNull();
+        expect(await func("")).toBeNull();
+        expect(await func(null)).toBeNull();
       },
     );
   });


### PR DESCRIPTION
#### What does this PR do?
Added some tests to improve the test coverage for snyk-docker-plugin. `os-release` specifically for this PR


#### Screenshots
Before:
<img width="2832" height="2462" alt="image" src="https://github.com/user-attachments/assets/1fd89cba-fed0-4125-85ec-3b58c6ea8258" />

After:
<img width="1513" height="44" alt="image" src="https://github.com/user-attachments/assets/1f7443d7-3233-48ba-a300-7c565d721a4d" />

