### PR TITLE
fix: update old quay images

### DIFF
--- a/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
@@ -105,13 +105,13 @@ Object {
                       "nodeId": "glib2@2.68.4-16.el9",
                     },
                     Object {
-                      "nodeId": "glibc@2.34-223.el9",
+                      "nodeId": "glibc@2.34-228.el9",
                     },
                     Object {
-                      "nodeId": "glibc-common@2.34-223.el9",
+                      "nodeId": "glibc-common@2.34-228.el9",
                     },
                     Object {
-                      "nodeId": "glibc-minimal-langpack@2.34-223.el9",
+                      "nodeId": "glibc-minimal-langpack@2.34-228.el9",
                     },
                     Object {
                       "nodeId": "gmp@1:6.2.0-13.el9",
@@ -132,7 +132,7 @@ Object {
                       "nodeId": "gzip@1.12-1.el9",
                     },
                     Object {
-                      "nodeId": "ima-evm-utils@1.6.2-1.el9",
+                      "nodeId": "ima-evm-utils@1.6.2-2.el9",
                     },
                     Object {
                       "nodeId": "json-c@0.14-11.el9",
@@ -159,7 +159,7 @@ Object {
                       "nodeId": "libacl@2.3.1-4.el9",
                     },
                     Object {
-                      "nodeId": "libarchive@3.5.3-5.el9",
+                      "nodeId": "libarchive@3.5.3-6.el9",
                     },
                     Object {
                       "nodeId": "libassuan@2.5.5-3.el9",
@@ -195,13 +195,13 @@ Object {
                       "nodeId": "libffi@3.4.2-8.el9",
                     },
                     Object {
-                      "nodeId": "libgcc@11.5.0-9.el9",
+                      "nodeId": "libgcc@11.5.0-11.el9",
                     },
                     Object {
                       "nodeId": "libgcrypt@1.10.0-11.el9",
                     },
                     Object {
-                      "nodeId": "libgomp@11.5.0-9.el9",
+                      "nodeId": "libgomp@11.5.0-11.el9",
                     },
                     Object {
                       "nodeId": "libgpg-error@1.42-5.el9",
@@ -246,7 +246,7 @@ Object {
                       "nodeId": "libsolv@0.7.24-3.el9",
                     },
                     Object {
-                      "nodeId": "libstdc++@11.5.0-9.el9",
+                      "nodeId": "libstdc++@11.5.0-11.el9",
                     },
                     Object {
                       "nodeId": "libtasn1@4.16.0-9.el9",
@@ -324,7 +324,7 @@ Object {
                       "nodeId": "popt@1.18-8.el9",
                     },
                     Object {
-                      "nodeId": "python3@3.9.23-1.el9",
+                      "nodeId": "python3@3.9.23-2.el9",
                     },
                     Object {
                       "nodeId": "python3-dateutil@1:2.8.1-7.el9",
@@ -336,7 +336,7 @@ Object {
                       "nodeId": "python3-dnf@4.14.0-31.el9",
                     },
                     Object {
-                      "nodeId": "python3-dnf-plugins-core@4.3.0-21.el9",
+                      "nodeId": "python3-dnf-plugins-core@4.3.0-22.el9",
                     },
                     Object {
                       "nodeId": "python3-gpg@1.15.1-6.el9",
@@ -351,7 +351,7 @@ Object {
                       "nodeId": "python3-libdnf@0.69.0-16.el9",
                     },
                     Object {
-                      "nodeId": "python3-libs@3.9.23-1.el9",
+                      "nodeId": "python3-libs@3.9.23-2.el9",
                     },
                     Object {
                       "nodeId": "python3-pip-wheel@21.3.1-1.el9",
@@ -393,13 +393,13 @@ Object {
                       "nodeId": "setup@2.13.7-10.el9",
                     },
                     Object {
-                      "nodeId": "shadow-utils@2:4.9-13.el9",
+                      "nodeId": "shadow-utils@2:4.9-15.el9",
                     },
                     Object {
                       "nodeId": "sqlite-libs@3.34.1-8.el9",
                     },
                     Object {
-                      "nodeId": "systemd-libs@252-53.el9",
+                      "nodeId": "systemd-libs@252-55.el9",
                     },
                     Object {
                       "nodeId": "tar@2:1.34-7.el9",
@@ -583,18 +583,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc@2.34-223.el9",
-                  "pkgId": "glibc@2.34-223.el9",
+                  "nodeId": "glibc@2.34-228.el9",
+                  "pkgId": "glibc@2.34-228.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-common@2.34-223.el9",
-                  "pkgId": "glibc-common@2.34-223.el9",
+                  "nodeId": "glibc-common@2.34-228.el9",
+                  "pkgId": "glibc-common@2.34-228.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-minimal-langpack@2.34-223.el9",
-                  "pkgId": "glibc-minimal-langpack@2.34-223.el9",
+                  "nodeId": "glibc-minimal-langpack@2.34-228.el9",
+                  "pkgId": "glibc-minimal-langpack@2.34-228.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -628,8 +628,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "ima-evm-utils@1.6.2-1.el9",
-                  "pkgId": "ima-evm-utils@1.6.2-1.el9",
+                  "nodeId": "ima-evm-utils@1.6.2-2.el9",
+                  "pkgId": "ima-evm-utils@1.6.2-2.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -673,8 +673,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libarchive@3.5.3-5.el9",
-                  "pkgId": "libarchive@3.5.3-5.el9",
+                  "nodeId": "libarchive@3.5.3-6.el9",
+                  "pkgId": "libarchive@3.5.3-6.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -733,8 +733,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libgcc@11.5.0-9.el9",
-                  "pkgId": "libgcc@11.5.0-9.el9",
+                  "nodeId": "libgcc@11.5.0-11.el9",
+                  "pkgId": "libgcc@11.5.0-11.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -743,8 +743,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libgomp@11.5.0-9.el9",
-                  "pkgId": "libgomp@11.5.0-9.el9",
+                  "nodeId": "libgomp@11.5.0-11.el9",
+                  "pkgId": "libgomp@11.5.0-11.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -818,8 +818,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libstdc++@11.5.0-9.el9",
-                  "pkgId": "libstdc++@11.5.0-9.el9",
+                  "nodeId": "libstdc++@11.5.0-11.el9",
+                  "pkgId": "libstdc++@11.5.0-11.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -948,8 +948,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "python3@3.9.23-1.el9",
-                  "pkgId": "python3@3.9.23-1.el9",
+                  "nodeId": "python3@3.9.23-2.el9",
+                  "pkgId": "python3@3.9.23-2.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -968,8 +968,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "python3-dnf-plugins-core@4.3.0-21.el9",
-                  "pkgId": "python3-dnf-plugins-core@4.3.0-21.el9",
+                  "nodeId": "python3-dnf-plugins-core@4.3.0-22.el9",
+                  "pkgId": "python3-dnf-plugins-core@4.3.0-22.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -993,8 +993,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "python3-libs@3.9.23-1.el9",
-                  "pkgId": "python3-libs@3.9.23-1.el9",
+                  "nodeId": "python3-libs@3.9.23-2.el9",
+                  "pkgId": "python3-libs@3.9.23-2.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -1063,8 +1063,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "shadow-utils@2:4.9-13.el9",
-                  "pkgId": "shadow-utils@2:4.9-13.el9",
+                  "nodeId": "shadow-utils@2:4.9-15.el9",
+                  "pkgId": "shadow-utils@2:4.9-15.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -1073,8 +1073,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "systemd-libs@252-53.el9",
-                  "pkgId": "systemd-libs@252-53.el9",
+                  "nodeId": "systemd-libs@252-55.el9",
+                  "pkgId": "systemd-libs@252-55.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -1379,27 +1379,27 @@ Object {
                 },
               },
               Object {
-                "id": "glibc@2.34-223.el9",
+                "id": "glibc@2.34-228.el9",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/centos/glibc@2.34-223.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-223.el9",
+                  "purl": "pkg:rpm/centos/glibc@2.34-228.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-228.el9",
                 },
               },
               Object {
-                "id": "glibc-common@2.34-223.el9",
+                "id": "glibc-common@2.34-228.el9",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/centos/glibc-common@2.34-223.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-223.el9",
+                  "purl": "pkg:rpm/centos/glibc-common@2.34-228.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-228.el9",
                 },
               },
               Object {
-                "id": "glibc-minimal-langpack@2.34-223.el9",
+                "id": "glibc-minimal-langpack@2.34-228.el9",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.34-223.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-223.el9",
+                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.34-228.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-228.el9",
                 },
               },
               Object {
@@ -1451,11 +1451,11 @@ Object {
                 },
               },
               Object {
-                "id": "ima-evm-utils@1.6.2-1.el9",
+                "id": "ima-evm-utils@1.6.2-2.el9",
                 "info": Object {
                   "name": "ima-evm-utils",
-                  "purl": "pkg:rpm/centos/ima-evm-utils@1.6.2-1.el9?distro=centos-9&upstream=ima-evm-utils%401.6.2",
-                  "version": "1.6.2-1.el9",
+                  "purl": "pkg:rpm/centos/ima-evm-utils@1.6.2-2.el9?distro=centos-9&upstream=ima-evm-utils%401.6.2",
+                  "version": "1.6.2-2.el9",
                 },
               },
               Object {
@@ -1523,11 +1523,11 @@ Object {
                 },
               },
               Object {
-                "id": "libarchive@3.5.3-5.el9",
+                "id": "libarchive@3.5.3-6.el9",
                 "info": Object {
                   "name": "libarchive",
-                  "purl": "pkg:rpm/centos/libarchive@3.5.3-5.el9?distro=centos-9&upstream=libarchive%403.5.3",
-                  "version": "3.5.3-5.el9",
+                  "purl": "pkg:rpm/centos/libarchive@3.5.3-6.el9?distro=centos-9&upstream=libarchive%403.5.3",
+                  "version": "3.5.3-6.el9",
                 },
               },
               Object {
@@ -1619,11 +1619,11 @@ Object {
                 },
               },
               Object {
-                "id": "libgcc@11.5.0-9.el9",
+                "id": "libgcc@11.5.0-11.el9",
                 "info": Object {
                   "name": "libgcc",
-                  "purl": "pkg:rpm/centos/libgcc@11.5.0-9.el9?distro=centos-9&upstream=gcc%4011.5.0",
-                  "version": "11.5.0-9.el9",
+                  "purl": "pkg:rpm/centos/libgcc@11.5.0-11.el9?distro=centos-9&upstream=gcc%4011.5.0",
+                  "version": "11.5.0-11.el9",
                 },
               },
               Object {
@@ -1635,11 +1635,11 @@ Object {
                 },
               },
               Object {
-                "id": "libgomp@11.5.0-9.el9",
+                "id": "libgomp@11.5.0-11.el9",
                 "info": Object {
                   "name": "libgomp",
-                  "purl": "pkg:rpm/centos/libgomp@11.5.0-9.el9?distro=centos-9&upstream=gcc%4011.5.0",
-                  "version": "11.5.0-9.el9",
+                  "purl": "pkg:rpm/centos/libgomp@11.5.0-11.el9?distro=centos-9&upstream=gcc%4011.5.0",
+                  "version": "11.5.0-11.el9",
                 },
               },
               Object {
@@ -1755,11 +1755,11 @@ Object {
                 },
               },
               Object {
-                "id": "libstdc++@11.5.0-9.el9",
+                "id": "libstdc++@11.5.0-11.el9",
                 "info": Object {
                   "name": "libstdc++",
-                  "purl": "pkg:rpm/centos/libstdc%2B%2B@11.5.0-9.el9?distro=centos-9&upstream=gcc%4011.5.0",
-                  "version": "11.5.0-9.el9",
+                  "purl": "pkg:rpm/centos/libstdc%2B%2B@11.5.0-11.el9?distro=centos-9&upstream=gcc%4011.5.0",
+                  "version": "11.5.0-11.el9",
                 },
               },
               Object {
@@ -1963,11 +1963,11 @@ Object {
                 },
               },
               Object {
-                "id": "python3@3.9.23-1.el9",
+                "id": "python3@3.9.23-2.el9",
                 "info": Object {
                   "name": "python3",
-                  "purl": "pkg:rpm/centos/python3@3.9.23-1.el9?distro=centos-9&upstream=python3.9%403.9.23",
-                  "version": "3.9.23-1.el9",
+                  "purl": "pkg:rpm/centos/python3@3.9.23-2.el9?distro=centos-9&upstream=python3.9%403.9.23",
+                  "version": "3.9.23-2.el9",
                 },
               },
               Object {
@@ -1995,11 +1995,11 @@ Object {
                 },
               },
               Object {
-                "id": "python3-dnf-plugins-core@4.3.0-21.el9",
+                "id": "python3-dnf-plugins-core@4.3.0-22.el9",
                 "info": Object {
                   "name": "python3-dnf-plugins-core",
-                  "purl": "pkg:rpm/centos/python3-dnf-plugins-core@4.3.0-21.el9?distro=centos-9&upstream=dnf-plugins-core%404.3.0",
-                  "version": "4.3.0-21.el9",
+                  "purl": "pkg:rpm/centos/python3-dnf-plugins-core@4.3.0-22.el9?distro=centos-9&upstream=dnf-plugins-core%404.3.0",
+                  "version": "4.3.0-22.el9",
                 },
               },
               Object {
@@ -2035,11 +2035,11 @@ Object {
                 },
               },
               Object {
-                "id": "python3-libs@3.9.23-1.el9",
+                "id": "python3-libs@3.9.23-2.el9",
                 "info": Object {
                   "name": "python3-libs",
-                  "purl": "pkg:rpm/centos/python3-libs@3.9.23-1.el9?distro=centos-9&upstream=python3.9%403.9.23",
-                  "version": "3.9.23-1.el9",
+                  "purl": "pkg:rpm/centos/python3-libs@3.9.23-2.el9?distro=centos-9&upstream=python3.9%403.9.23",
+                  "version": "3.9.23-2.el9",
                 },
               },
               Object {
@@ -2147,11 +2147,11 @@ Object {
                 },
               },
               Object {
-                "id": "shadow-utils@2:4.9-13.el9",
+                "id": "shadow-utils@2:4.9-15.el9",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/centos/shadow-utils@2:4.9-13.el9?distro=centos-9&epoch=2&upstream=shadow-utils%404.9",
-                  "version": "2:4.9-13.el9",
+                  "purl": "pkg:rpm/centos/shadow-utils@2:4.9-15.el9?distro=centos-9&epoch=2&upstream=shadow-utils%404.9",
+                  "version": "2:4.9-15.el9",
                 },
               },
               Object {
@@ -2163,11 +2163,11 @@ Object {
                 },
               },
               Object {
-                "id": "systemd-libs@252-53.el9",
+                "id": "systemd-libs@252-55.el9",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/centos/systemd-libs@252-53.el9?distro=centos-9&upstream=systemd%40252",
-                  "version": "252-53.el9",
+                  "purl": "pkg:rpm/centos/systemd-libs@252-55.el9?distro=centos-9&upstream=systemd%40252",
+                  "version": "252-55.el9",
                 },
               },
               Object {
@@ -2232,19 +2232,19 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "sha256:8dbc5589a2c80904bd0693619e3e5531c3b2fbf6a9b36b12bf90f62f4a1d8c67",
+          "data": "sha256:ea8f1ca7bc842960deae1d91499dbc20e3cf50bd9c1eaf109104287718b164a5",
           "type": "imageId",
         },
         Object {
           "data": Array [
-            "sha256:b32d3e0da2659d829d05887600b5c557f3405f53f3f83fc8877f651b40fdea7c",
+            "sha256:13a8d65d0ba6bf99518eff47159902465e48ccaf6745c81db4f23ee0113c076e",
           ],
           "type": "imageLayers",
         },
         Object {
           "data": Object {
             "io.buildah.version": "1.33.12",
-            "org.label-schema.build-date": "20250812",
+            "org.label-schema.build-date": "20250826",
             "org.label-schema.license": "GPLv2",
             "org.label-schema.name": "CentOS Stream 9 Base Image",
             "org.label-schema.schema-version": "1.0",
@@ -2253,12 +2253,12 @@ Object {
           "type": "imageLabels",
         },
         Object {
-          "data": "2025-08-12T01:13:50.496825077Z",
+          "data": "2025-08-26T06:14:10.898547431Z",
           "type": "imageCreationTime",
         },
         Object {
           "data": Array [
-            "sha256:c292ef428a853e2e1b488d96739e3564a76fb9dc2aba559acc3599745aa4af9b",
+            "sha256:1946a369c357a54627ae01a24fe87e3664f80a20a69b2c7e39e555e7e3374858",
           ],
           "type": "rootFs",
         },
@@ -2269,8 +2269,8 @@ Object {
         Object {
           "data": Object {
             "names": Array [
-              "quay.io/centos/centos@sha256:feafe3afc13d8bb4401953350dd0ce03be9b8262c388a9dac4210519ec167200",
-              "quay.io/centos/centos@sha256:feafe3afc13d8bb4401953350dd0ce03be9b8262c388a9dac4210519ec167200",
+              "quay.io/centos/centos@sha256:db73b2ac6c8a9f199bdacf2f0e759429b0287a8be95c9a9e26dc1d594e0d84a2",
+              "quay.io/centos/centos@sha256:db73b2ac6c8a9f199bdacf2f0e759429b0287a8be95c9a9e26dc1d594e0d84a2",
             ],
           },
           "type": "imageNames",
@@ -2359,7 +2359,7 @@ Object {
                       "nodeId": "dbus@1:1.14.10-5.el10",
                     },
                     Object {
-                      "nodeId": "dbus-broker@36-2.el10",
+                      "nodeId": "dbus-broker@36-4.el10",
                     },
                     Object {
                       "nodeId": "dbus-common@1:1.14.10-5.el10",
@@ -2428,19 +2428,19 @@ Object {
                       "nodeId": "glib2@2.80.4-8.el10",
                     },
                     Object {
-                      "nodeId": "glibc@2.39-46.el10",
+                      "nodeId": "glibc@2.39-54.el10",
                     },
                     Object {
-                      "nodeId": "glibc-common@2.39-46.el10",
+                      "nodeId": "glibc-common@2.39-54.el10",
                     },
                     Object {
-                      "nodeId": "glibc-gconv-extra@2.39-46.el10",
+                      "nodeId": "glibc-gconv-extra@2.39-54.el10",
                     },
                     Object {
-                      "nodeId": "glibc-langpack-en@2.39-46.el10",
+                      "nodeId": "glibc-langpack-en@2.39-54.el10",
                     },
                     Object {
-                      "nodeId": "glibc-minimal-langpack@2.39-46.el10",
+                      "nodeId": "glibc-minimal-langpack@2.39-54.el10",
                     },
                     Object {
                       "nodeId": "gmp@1:6.2.1-12.el10",
@@ -2482,7 +2482,7 @@ Object {
                       "nodeId": "hunspell-filesystem@1.7.2-9.el10",
                     },
                     Object {
-                      "nodeId": "ima-evm-utils@1.6.2-2.el10",
+                      "nodeId": "ima-evm-utils@1.6.2-3.el10",
                     },
                     Object {
                       "nodeId": "json-c@0.18-3.el10",
@@ -2494,7 +2494,7 @@ Object {
                       "nodeId": "keyutils-libs@1.6.3-5.el10",
                     },
                     Object {
-                      "nodeId": "kmod-libs@31-11.el10",
+                      "nodeId": "kmod-libs@31-12.el10",
                     },
                     Object {
                       "nodeId": "krb5-libs@1.21.3-8.el10",
@@ -2512,16 +2512,16 @@ Object {
                       "nodeId": "libacl@2.3.2-4.el10",
                     },
                     Object {
-                      "nodeId": "libarchive@3.7.7-3.el10",
+                      "nodeId": "libarchive@3.7.7-4.el10",
                     },
                     Object {
                       "nodeId": "libattr@2.5.2-5.el10",
                     },
                     Object {
-                      "nodeId": "libblkid@2.40.2-10.el10",
+                      "nodeId": "libblkid@2.40.2-13.el10",
                     },
                     Object {
-                      "nodeId": "libbpf@2:1.6.0-2.el10",
+                      "nodeId": "libbpf@2:1.6.0-3.el10",
                     },
                     Object {
                       "nodeId": "libcap@2.69-7.el10",
@@ -2548,7 +2548,7 @@ Object {
                       "nodeId": "libedit@3.1-52.20230828cvs.el10",
                     },
                     Object {
-                      "nodeId": "libfdisk@2.40.2-10.el10",
+                      "nodeId": "libfdisk@2.40.2-13.el10",
                     },
                     Object {
                       "nodeId": "libffi@3.4.4-10.el10",
@@ -2566,7 +2566,7 @@ Object {
                       "nodeId": "libmodulemd@2.15.0-12.el10",
                     },
                     Object {
-                      "nodeId": "libmount@2.40.2-10.el10",
+                      "nodeId": "libmount@2.40.2-13.el10",
                     },
                     Object {
                       "nodeId": "libnghttp2@1.64.0-2.el10",
@@ -2590,7 +2590,7 @@ Object {
                       "nodeId": "libsepol@3.9-1.el10",
                     },
                     Object {
-                      "nodeId": "libsmartcols@2.40.2-10.el10",
+                      "nodeId": "libsmartcols@2.40.2-13.el10",
                     },
                     Object {
                       "nodeId": "libsolv@0.7.29-8.el10",
@@ -2605,7 +2605,7 @@ Object {
                       "nodeId": "libunistring@1.1-10.el10",
                     },
                     Object {
-                      "nodeId": "libuuid@2.40.2-10.el10",
+                      "nodeId": "libuuid@2.40.2-13.el10",
                     },
                     Object {
                       "nodeId": "libverto@0.3.2-10.el10",
@@ -2746,19 +2746,19 @@ Object {
                       "nodeId": "setup@2.14.5-7.el10",
                     },
                     Object {
-                      "nodeId": "shadow-utils@2:4.15.0-6.el10",
+                      "nodeId": "shadow-utils@2:4.15.0-8.el10",
                     },
                     Object {
                       "nodeId": "sqlite-libs@3.46.1-4.el10",
                     },
                     Object {
-                      "nodeId": "systemd@257-11.el10",
+                      "nodeId": "systemd@257-13.el10",
                     },
                     Object {
-                      "nodeId": "systemd-libs@257-11.el10",
+                      "nodeId": "systemd-libs@257-13.el10",
                     },
                     Object {
-                      "nodeId": "systemd-pam@257-11.el10",
+                      "nodeId": "systemd-pam@257-13.el10",
                     },
                     Object {
                       "nodeId": "tar@2:1.35-7.el10",
@@ -2767,10 +2767,10 @@ Object {
                       "nodeId": "tpm2-tss@4.1.3-5.el10",
                     },
                     Object {
-                      "nodeId": "tzdata@2025b-1.el10",
+                      "nodeId": "tzdata@2025b-2.el10",
                     },
                     Object {
-                      "nodeId": "util-linux-core@2.40.2-10.el10",
+                      "nodeId": "util-linux-core@2.40.2-13.el10",
                     },
                     Object {
                       "nodeId": "vim-data@2:9.1.083-5.el10",
@@ -2888,8 +2888,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "dbus-broker@36-2.el10",
-                  "pkgId": "dbus-broker@36-2.el10",
+                  "nodeId": "dbus-broker@36-4.el10",
+                  "pkgId": "dbus-broker@36-4.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3003,28 +3003,28 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc@2.39-46.el10",
-                  "pkgId": "glibc@2.39-46.el10",
+                  "nodeId": "glibc@2.39-54.el10",
+                  "pkgId": "glibc@2.39-54.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-common@2.39-46.el10",
-                  "pkgId": "glibc-common@2.39-46.el10",
+                  "nodeId": "glibc-common@2.39-54.el10",
+                  "pkgId": "glibc-common@2.39-54.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-gconv-extra@2.39-46.el10",
-                  "pkgId": "glibc-gconv-extra@2.39-46.el10",
+                  "nodeId": "glibc-gconv-extra@2.39-54.el10",
+                  "pkgId": "glibc-gconv-extra@2.39-54.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-langpack-en@2.39-46.el10",
-                  "pkgId": "glibc-langpack-en@2.39-46.el10",
+                  "nodeId": "glibc-langpack-en@2.39-54.el10",
+                  "pkgId": "glibc-langpack-en@2.39-54.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-minimal-langpack@2.39-46.el10",
-                  "pkgId": "glibc-minimal-langpack@2.39-46.el10",
+                  "nodeId": "glibc-minimal-langpack@2.39-54.el10",
+                  "pkgId": "glibc-minimal-langpack@2.39-54.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3093,8 +3093,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "ima-evm-utils@1.6.2-2.el10",
-                  "pkgId": "ima-evm-utils@1.6.2-2.el10",
+                  "nodeId": "ima-evm-utils@1.6.2-3.el10",
+                  "pkgId": "ima-evm-utils@1.6.2-3.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3113,8 +3113,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "kmod-libs@31-11.el10",
-                  "pkgId": "kmod-libs@31-11.el10",
+                  "nodeId": "kmod-libs@31-12.el10",
+                  "pkgId": "kmod-libs@31-12.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3143,8 +3143,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libarchive@3.7.7-3.el10",
-                  "pkgId": "libarchive@3.7.7-3.el10",
+                  "nodeId": "libarchive@3.7.7-4.el10",
+                  "pkgId": "libarchive@3.7.7-4.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3153,13 +3153,13 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libblkid@2.40.2-10.el10",
-                  "pkgId": "libblkid@2.40.2-10.el10",
+                  "nodeId": "libblkid@2.40.2-13.el10",
+                  "pkgId": "libblkid@2.40.2-13.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libbpf@2:1.6.0-2.el10",
-                  "pkgId": "libbpf@2:1.6.0-2.el10",
+                  "nodeId": "libbpf@2:1.6.0-3.el10",
+                  "pkgId": "libbpf@2:1.6.0-3.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3203,8 +3203,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libfdisk@2.40.2-10.el10",
-                  "pkgId": "libfdisk@2.40.2-10.el10",
+                  "nodeId": "libfdisk@2.40.2-13.el10",
+                  "pkgId": "libfdisk@2.40.2-13.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3233,8 +3233,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libmount@2.40.2-10.el10",
-                  "pkgId": "libmount@2.40.2-10.el10",
+                  "nodeId": "libmount@2.40.2-13.el10",
+                  "pkgId": "libmount@2.40.2-13.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3273,8 +3273,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libsmartcols@2.40.2-10.el10",
-                  "pkgId": "libsmartcols@2.40.2-10.el10",
+                  "nodeId": "libsmartcols@2.40.2-13.el10",
+                  "pkgId": "libsmartcols@2.40.2-13.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3298,8 +3298,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libuuid@2.40.2-10.el10",
-                  "pkgId": "libuuid@2.40.2-10.el10",
+                  "nodeId": "libuuid@2.40.2-13.el10",
+                  "pkgId": "libuuid@2.40.2-13.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3533,8 +3533,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "shadow-utils@2:4.15.0-6.el10",
-                  "pkgId": "shadow-utils@2:4.15.0-6.el10",
+                  "nodeId": "shadow-utils@2:4.15.0-8.el10",
+                  "pkgId": "shadow-utils@2:4.15.0-8.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3543,18 +3543,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "systemd@257-11.el10",
-                  "pkgId": "systemd@257-11.el10",
+                  "nodeId": "systemd@257-13.el10",
+                  "pkgId": "systemd@257-13.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "systemd-libs@257-11.el10",
-                  "pkgId": "systemd-libs@257-11.el10",
+                  "nodeId": "systemd-libs@257-13.el10",
+                  "pkgId": "systemd-libs@257-13.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "systemd-pam@257-11.el10",
-                  "pkgId": "systemd-pam@257-11.el10",
+                  "nodeId": "systemd-pam@257-13.el10",
+                  "pkgId": "systemd-pam@257-13.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3568,13 +3568,13 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "tzdata@2025b-1.el10",
-                  "pkgId": "tzdata@2025b-1.el10",
+                  "nodeId": "tzdata@2025b-2.el10",
+                  "pkgId": "tzdata@2025b-2.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "util-linux-core@2.40.2-10.el10",
-                  "pkgId": "util-linux-core@2.40.2-10.el10",
+                  "nodeId": "util-linux-core@2.40.2-13.el10",
+                  "pkgId": "util-linux-core@2.40.2-13.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3773,11 +3773,11 @@ Object {
                 },
               },
               Object {
-                "id": "dbus-broker@36-2.el10",
+                "id": "dbus-broker@36-4.el10",
                 "info": Object {
                   "name": "dbus-broker",
-                  "purl": "pkg:rpm/centos/dbus-broker@36-2.el10?distro=centos-10&upstream=dbus-broker%4036",
-                  "version": "36-2.el10",
+                  "purl": "pkg:rpm/centos/dbus-broker@36-4.el10?distro=centos-10&upstream=dbus-broker%4036",
+                  "version": "36-4.el10",
                 },
               },
               Object {
@@ -3957,43 +3957,43 @@ Object {
                 },
               },
               Object {
-                "id": "glibc@2.39-46.el10",
+                "id": "glibc@2.39-54.el10",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/centos/glibc@2.39-46.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-46.el10",
+                  "purl": "pkg:rpm/centos/glibc@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-54.el10",
                 },
               },
               Object {
-                "id": "glibc-common@2.39-46.el10",
+                "id": "glibc-common@2.39-54.el10",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/centos/glibc-common@2.39-46.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-46.el10",
+                  "purl": "pkg:rpm/centos/glibc-common@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-54.el10",
                 },
               },
               Object {
-                "id": "glibc-gconv-extra@2.39-46.el10",
+                "id": "glibc-gconv-extra@2.39-54.el10",
                 "info": Object {
                   "name": "glibc-gconv-extra",
-                  "purl": "pkg:rpm/centos/glibc-gconv-extra@2.39-46.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-46.el10",
+                  "purl": "pkg:rpm/centos/glibc-gconv-extra@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-54.el10",
                 },
               },
               Object {
-                "id": "glibc-langpack-en@2.39-46.el10",
+                "id": "glibc-langpack-en@2.39-54.el10",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/centos/glibc-langpack-en@2.39-46.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-46.el10",
+                  "purl": "pkg:rpm/centos/glibc-langpack-en@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-54.el10",
                 },
               },
               Object {
-                "id": "glibc-minimal-langpack@2.39-46.el10",
+                "id": "glibc-minimal-langpack@2.39-54.el10",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.39-46.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-46.el10",
+                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-54.el10",
                 },
               },
               Object {
@@ -4101,11 +4101,11 @@ Object {
                 },
               },
               Object {
-                "id": "ima-evm-utils@1.6.2-2.el10",
+                "id": "ima-evm-utils@1.6.2-3.el10",
                 "info": Object {
                   "name": "ima-evm-utils",
-                  "purl": "pkg:rpm/centos/ima-evm-utils@1.6.2-2.el10?distro=centos-10&upstream=ima-evm-utils%401.6.2",
-                  "version": "1.6.2-2.el10",
+                  "purl": "pkg:rpm/centos/ima-evm-utils@1.6.2-3.el10?distro=centos-10&upstream=ima-evm-utils%401.6.2",
+                  "version": "1.6.2-3.el10",
                 },
               },
               Object {
@@ -4133,11 +4133,11 @@ Object {
                 },
               },
               Object {
-                "id": "kmod-libs@31-11.el10",
+                "id": "kmod-libs@31-12.el10",
                 "info": Object {
                   "name": "kmod-libs",
-                  "purl": "pkg:rpm/centos/kmod-libs@31-11.el10?distro=centos-10&upstream=kmod%4031",
-                  "version": "31-11.el10",
+                  "purl": "pkg:rpm/centos/kmod-libs@31-12.el10?distro=centos-10&upstream=kmod%4031",
+                  "version": "31-12.el10",
                 },
               },
               Object {
@@ -4181,11 +4181,11 @@ Object {
                 },
               },
               Object {
-                "id": "libarchive@3.7.7-3.el10",
+                "id": "libarchive@3.7.7-4.el10",
                 "info": Object {
                   "name": "libarchive",
-                  "purl": "pkg:rpm/centos/libarchive@3.7.7-3.el10?distro=centos-10&upstream=libarchive%403.7.7",
-                  "version": "3.7.7-3.el10",
+                  "purl": "pkg:rpm/centos/libarchive@3.7.7-4.el10?distro=centos-10&upstream=libarchive%403.7.7",
+                  "version": "3.7.7-4.el10",
                 },
               },
               Object {
@@ -4197,19 +4197,19 @@ Object {
                 },
               },
               Object {
-                "id": "libblkid@2.40.2-10.el10",
+                "id": "libblkid@2.40.2-13.el10",
                 "info": Object {
                   "name": "libblkid",
-                  "purl": "pkg:rpm/centos/libblkid@2.40.2-10.el10?distro=centos-10&upstream=util-linux%402.40.2",
-                  "version": "2.40.2-10.el10",
+                  "purl": "pkg:rpm/centos/libblkid@2.40.2-13.el10?distro=centos-10&upstream=util-linux%402.40.2",
+                  "version": "2.40.2-13.el10",
                 },
               },
               Object {
-                "id": "libbpf@2:1.6.0-2.el10",
+                "id": "libbpf@2:1.6.0-3.el10",
                 "info": Object {
                   "name": "libbpf",
-                  "purl": "pkg:rpm/centos/libbpf@2:1.6.0-2.el10?distro=centos-10&epoch=2&upstream=libbpf%401.6.0",
-                  "version": "2:1.6.0-2.el10",
+                  "purl": "pkg:rpm/centos/libbpf@2:1.6.0-3.el10?distro=centos-10&epoch=2&upstream=libbpf%401.6.0",
+                  "version": "2:1.6.0-3.el10",
                 },
               },
               Object {
@@ -4277,11 +4277,11 @@ Object {
                 },
               },
               Object {
-                "id": "libfdisk@2.40.2-10.el10",
+                "id": "libfdisk@2.40.2-13.el10",
                 "info": Object {
                   "name": "libfdisk",
-                  "purl": "pkg:rpm/centos/libfdisk@2.40.2-10.el10?distro=centos-10&upstream=util-linux%402.40.2",
-                  "version": "2.40.2-10.el10",
+                  "purl": "pkg:rpm/centos/libfdisk@2.40.2-13.el10?distro=centos-10&upstream=util-linux%402.40.2",
+                  "version": "2.40.2-13.el10",
                 },
               },
               Object {
@@ -4325,11 +4325,11 @@ Object {
                 },
               },
               Object {
-                "id": "libmount@2.40.2-10.el10",
+                "id": "libmount@2.40.2-13.el10",
                 "info": Object {
                   "name": "libmount",
-                  "purl": "pkg:rpm/centos/libmount@2.40.2-10.el10?distro=centos-10&upstream=util-linux%402.40.2",
-                  "version": "2.40.2-10.el10",
+                  "purl": "pkg:rpm/centos/libmount@2.40.2-13.el10?distro=centos-10&upstream=util-linux%402.40.2",
+                  "version": "2.40.2-13.el10",
                 },
               },
               Object {
@@ -4389,11 +4389,11 @@ Object {
                 },
               },
               Object {
-                "id": "libsmartcols@2.40.2-10.el10",
+                "id": "libsmartcols@2.40.2-13.el10",
                 "info": Object {
                   "name": "libsmartcols",
-                  "purl": "pkg:rpm/centos/libsmartcols@2.40.2-10.el10?distro=centos-10&upstream=util-linux%402.40.2",
-                  "version": "2.40.2-10.el10",
+                  "purl": "pkg:rpm/centos/libsmartcols@2.40.2-13.el10?distro=centos-10&upstream=util-linux%402.40.2",
+                  "version": "2.40.2-13.el10",
                 },
               },
               Object {
@@ -4429,11 +4429,11 @@ Object {
                 },
               },
               Object {
-                "id": "libuuid@2.40.2-10.el10",
+                "id": "libuuid@2.40.2-13.el10",
                 "info": Object {
                   "name": "libuuid",
-                  "purl": "pkg:rpm/centos/libuuid@2.40.2-10.el10?distro=centos-10&upstream=util-linux%402.40.2",
-                  "version": "2.40.2-10.el10",
+                  "purl": "pkg:rpm/centos/libuuid@2.40.2-13.el10?distro=centos-10&upstream=util-linux%402.40.2",
+                  "version": "2.40.2-13.el10",
                 },
               },
               Object {
@@ -4805,11 +4805,11 @@ Object {
                 },
               },
               Object {
-                "id": "shadow-utils@2:4.15.0-6.el10",
+                "id": "shadow-utils@2:4.15.0-8.el10",
                 "info": Object {
                   "name": "shadow-utils",
-                  "purl": "pkg:rpm/centos/shadow-utils@2:4.15.0-6.el10?distro=centos-10&epoch=2&upstream=shadow-utils%404.15.0",
-                  "version": "2:4.15.0-6.el10",
+                  "purl": "pkg:rpm/centos/shadow-utils@2:4.15.0-8.el10?distro=centos-10&epoch=2&upstream=shadow-utils%404.15.0",
+                  "version": "2:4.15.0-8.el10",
                 },
               },
               Object {
@@ -4821,27 +4821,27 @@ Object {
                 },
               },
               Object {
-                "id": "systemd@257-11.el10",
+                "id": "systemd@257-13.el10",
                 "info": Object {
                   "name": "systemd",
-                  "purl": "pkg:rpm/centos/systemd@257-11.el10?distro=centos-10&upstream=systemd%40257",
-                  "version": "257-11.el10",
+                  "purl": "pkg:rpm/centos/systemd@257-13.el10?distro=centos-10&upstream=systemd%40257",
+                  "version": "257-13.el10",
                 },
               },
               Object {
-                "id": "systemd-libs@257-11.el10",
+                "id": "systemd-libs@257-13.el10",
                 "info": Object {
                   "name": "systemd-libs",
-                  "purl": "pkg:rpm/centos/systemd-libs@257-11.el10?distro=centos-10&upstream=systemd%40257",
-                  "version": "257-11.el10",
+                  "purl": "pkg:rpm/centos/systemd-libs@257-13.el10?distro=centos-10&upstream=systemd%40257",
+                  "version": "257-13.el10",
                 },
               },
               Object {
-                "id": "systemd-pam@257-11.el10",
+                "id": "systemd-pam@257-13.el10",
                 "info": Object {
                   "name": "systemd-pam",
-                  "purl": "pkg:rpm/centos/systemd-pam@257-11.el10?distro=centos-10&upstream=systemd%40257",
-                  "version": "257-11.el10",
+                  "purl": "pkg:rpm/centos/systemd-pam@257-13.el10?distro=centos-10&upstream=systemd%40257",
+                  "version": "257-13.el10",
                 },
               },
               Object {
@@ -4861,19 +4861,19 @@ Object {
                 },
               },
               Object {
-                "id": "tzdata@2025b-1.el10",
+                "id": "tzdata@2025b-2.el10",
                 "info": Object {
                   "name": "tzdata",
-                  "purl": "pkg:rpm/centos/tzdata@2025b-1.el10?distro=centos-10&upstream=tzdata%402025b",
-                  "version": "2025b-1.el10",
+                  "purl": "pkg:rpm/centos/tzdata@2025b-2.el10?distro=centos-10&upstream=tzdata%402025b",
+                  "version": "2025b-2.el10",
                 },
               },
               Object {
-                "id": "util-linux-core@2.40.2-10.el10",
+                "id": "util-linux-core@2.40.2-13.el10",
                 "info": Object {
                   "name": "util-linux-core",
-                  "purl": "pkg:rpm/centos/util-linux-core@2.40.2-10.el10?distro=centos-10&upstream=util-linux%402.40.2",
-                  "version": "2.40.2-10.el10",
+                  "purl": "pkg:rpm/centos/util-linux-core@2.40.2-13.el10?distro=centos-10&upstream=util-linux%402.40.2",
+                  "version": "2.40.2-13.el10",
                 },
               },
               Object {
@@ -4922,19 +4922,19 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "sha256:f411d33ff55a49ebae8d74b6eb2fd7458a6b72542e71b3bba01e59601891e3aa",
+          "data": "sha256:10ab27e5c6df6236d59cfa86875dbe00407be8739bd591656d7bd06dc712e042",
           "type": "imageId",
         },
         Object {
           "data": Array [
-            "sha256:5dd2d5bd11729f8115f57afbd74f00ae97e09a95892fdc3a22ac2c09a40b6d87",
+            "sha256:8a209e76238028082eb91e0ca23ba3fe6a3eb17c61d7cfe6182308c6fcaf7d22",
           ],
           "type": "imageLayers",
         },
         Object {
           "data": Object {
             "io.buildah.version": "1.33.12",
-            "org.label-schema.build-date": "20250808",
+            "org.label-schema.build-date": "20250826",
             "org.label-schema.license": "GPLv2",
             "org.label-schema.name": "CentOS Stream 10 Base Image",
             "org.label-schema.schema-version": "1.0",
@@ -4943,12 +4943,12 @@ Object {
           "type": "imageLabels",
         },
         Object {
-          "data": "2025-08-08T05:26:40.071044786Z",
+          "data": "2025-08-26T03:02:52.459378821Z",
           "type": "imageCreationTime",
         },
         Object {
           "data": Array [
-            "sha256:5eabb043ad8dc0a3a18be72144369c4ecdc03a9f263c16e033476c4c4dd5be76",
+            "sha256:aa6e4a4e44e204e7455c342300911f26608460610b9e96c5e9e37d5402061de2",
           ],
           "type": "rootFs",
         },
@@ -4959,8 +4959,8 @@ Object {
         Object {
           "data": Object {
             "names": Array [
-              "quay.io/centos/centos@sha256:683927bd29076a14ff8f74419da9042a5e1d308af048244108247a26365bd1e3",
-              "quay.io/centos/centos@sha256:683927bd29076a14ff8f74419da9042a5e1d308af048244108247a26365bd1e3",
+              "quay.io/centos/centos@sha256:7459813cfcd8a6b8e62c6fd080e000504424c41125045f87a085b2d695ae006e",
+              "quay.io/centos/centos@sha256:7459813cfcd8a6b8e62c6fd080e000504424c41125045f87a085b2d695ae006e",
             ],
           },
           "type": "imageNames",

--- a/test/system/package-managers/rpm.spec.ts
+++ b/test/system/package-managers/rpm.spec.ts
@@ -74,7 +74,7 @@ describe("rpm package manager tests", () => {
     // quay doesn't always keep older shas, so if this fails, get the sha from the latest
     // stream9 at https://quay.io/repository/centos/centos?tab=tags&tag=stream9
     const image =
-      "quay.io/centos/centos@sha256:feafe3afc13d8bb4401953350dd0ce03be9b8262c388a9dac4210519ec167200";
+      "quay.io/centos/centos@sha256:db73b2ac6c8a9f199bdacf2f0e759429b0287a8be95c9a9e26dc1d594e0d84a2";
     const pluginResult = await scan({
       path: image,
       platform: "linux/amd64",
@@ -86,7 +86,7 @@ describe("rpm package manager tests", () => {
     // quay doesn't always keep older shas, so if this fails, get the sha from the latest
     // stream10 at https://quay.io/repository/centos/centos?tab=tags&tag=stream10
     const image =
-      "quay.io/centos/centos@sha256:683927bd29076a14ff8f74419da9042a5e1d308af048244108247a26365bd1e3";
+      "quay.io/centos/centos@sha256:7459813cfcd8a6b8e62c6fd080e000504424c41125045f87a085b2d695ae006e";
     const pluginResult = await scan({
       path: image,
       platform: "linux/amd64",

--- a/test/system/package-managers/rpm.spec.ts
+++ b/test/system/package-managers/rpm.spec.ts
@@ -25,8 +25,8 @@ describe("rpm package manager tests", () => {
       "amazonlinux:2022.0.20220504.1",
       "registry.access.redhat.com/ubi9/ubi@sha256:c113f67e8e70940af28116d75e32f0aa4ffd3bf6fab30e970850475ab1de697f",
       "registry.access.redhat.com/ubi10-beta/ubi@sha256:4b4976d86eefeedab6884c9d2923206c6c3c2e2471206f97fd9d7aaaecbc04ac",
-      "quay.io/centos/centos@sha256:feafe3afc13d8bb4401953350dd0ce03be9b8262c388a9dac4210519ec167200",
-      "quay.io/centos/centos@sha256:683927bd29076a14ff8f74419da9042a5e1d308af048244108247a26365bd1e3",
+      "quay.io/centos/centos@sha256:db73b2ac6c8a9f199bdacf2f0e759429b0287a8be95c9a9e26dc1d594e0d84a2",
+      "quay.io/centos/centos@sha256:7459813cfcd8a6b8e62c6fd080e000504424c41125045f87a085b2d695ae006e",
     ]).catch(() => {
       console.error(`tests teardown failed to remove docker image`);
     });


### PR DESCRIPTION
quay.io deletes previous versions of images as soon as they push a new version. This PR fixes the breaking tests, as they're pointing to now outdated images

We should redo the tests to use a different image that won't get removed every month, but in the meantime this will fix the faililng tests