### PR TITLE
fix: prevent memory alloc errors when processing large files

### DIFF
--- a/lib/go-parser/index.ts
+++ b/lib/go-parser/index.ts
@@ -61,7 +61,8 @@ async function findGoBinaries(
     // ELF section headers and so ".go.buildinfo" & ".note.go.buildid" blobs are available in the first 64kb
     const elfBuildInfoSize = 64 * 1024;
 
-    const buffer: Buffer = Buffer.alloc(streamSize ?? elfBuildInfoSize);
+    // Only allocate what we actually need (64KB max), regardless of file size
+    const buffer: Buffer = Buffer.alloc(elfBuildInfoSize);
     let bytesWritten = 0;
 
     stream.on("end", () => {

--- a/test/unit/go-binaries-large-file.spec.ts
+++ b/test/unit/go-binaries-large-file.spec.ts
@@ -1,0 +1,41 @@
+import { Readable } from "stream";
+import { getGoModulesContentAction } from "../../lib/go-parser";
+
+// Mock Buffer.alloc to track what size is being allocated
+const originalBufferAlloc = Buffer.alloc;
+let allocatedSize: number | undefined;
+
+describe("Go binary processing with large files", () => {
+  beforeEach(() => {
+    allocatedSize = undefined;
+    // Mock Buffer.alloc to capture the size being allocated
+    Buffer.alloc = jest.fn((size: number, ...args: any[]) => {
+      allocatedSize = size;
+      return originalBufferAlloc(size, ...args);
+    });
+  });
+
+  afterEach(() => {
+    // Restore original Buffer.alloc
+    Buffer.alloc = originalBufferAlloc;
+  });
+
+  test("should only allocate 64KB buffer regardless of file size", async () => {
+    // Test with the exact size that caused the customer's issue
+    const largeSize = 5472699905; // 5GB+ file size
+    
+    const largeStream = new Readable({
+      read() {
+        this.push(null); // End immediately
+      }
+    });
+
+    // Process the large file
+    await getGoModulesContentAction.callback!(largeStream, largeSize);
+    
+    // Verify that only 64KB was allocated, not the full file size
+    expect(allocatedSize).toBe(64 * 1024); // Should be 65536 bytes (64KB)
+    expect(allocatedSize).not.toBe(largeSize); // Should NOT be 5GB+
+  });
+
+});


### PR DESCRIPTION
Go binary processing was attempting to allocate buffers equal to the entire file size instead of the required 64KB for ELF header analysis. This caused RangeError crashes when processing large files that matched the Go binary pattern.

- Fix buffer allocation in findGoBinaries to always use 64KB limit
- Add test to verify only 64KB is allocated regardless of file size
- Hopefully resolves a customer issue with 5GB+ files causing memory allocation errors

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team
