### PR TITLE
fix: update quay tests and add a script to update them

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "npm run test-jest",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
     "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
+    "update-quay-tests": "./update_centos_shas.sh",
     "prepare": "npm run build"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "npm run test-jest",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
     "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
-    "update-quay-tests": "./update_centos_shas.sh",
+    "update-quay-tests": "bash update_centos_shas.sh",
     "prepare": "npm run build"
   },
   "engines": {

--- a/test/fixtures/centos-shas.ts
+++ b/test/fixtures/centos-shas.ts
@@ -1,0 +1,8 @@
+// CentOS Stream SHA digests for quay.io/centos/centos images
+// This file is automatically updated by the update_centos_shas.sh script
+// Run `npm run update-quay-tests` to fetch the latest SHA digests
+
+export const CENTOS_SHAS = {
+  stream9: "sha256:60f831ea21128433798b74d2181375c5da2c04e3397a6e7ad3b9abf47159e550",
+  stream10: "sha256:798fbe5c40fba2609fae716f5414af6654df21d2552927e85de6a11d20bbff7d",
+} as const;

--- a/test/fixtures/centos-shas.ts
+++ b/test/fixtures/centos-shas.ts
@@ -3,6 +3,8 @@
 // Run `npm run update-quay-tests` to fetch the latest SHA digests
 
 export const CENTOS_SHAS = {
-  stream9: "sha256:60f831ea21128433798b74d2181375c5da2c04e3397a6e7ad3b9abf47159e550",
-  stream10: "sha256:798fbe5c40fba2609fae716f5414af6654df21d2552927e85de6a11d20bbff7d",
+  stream9:
+    "sha256:60f831ea21128433798b74d2181375c5da2c04e3397a6e7ad3b9abf47159e550",
+  stream10:
+    "sha256:798fbe5c40fba2609fae716f5414af6654df21d2552927e85de6a11d20bbff7d",
 } as const;

--- a/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
@@ -45,13 +45,13 @@ Object {
                       "nodeId": "coreutils-single@8.32-39.el9",
                     },
                     Object {
-                      "nodeId": "crypto-policies@20250804-1.git2c74f3d.el9",
+                      "nodeId": "crypto-policies@20250905-1.git377cc42.el9",
                     },
                     Object {
-                      "nodeId": "crypto-policies-scripts@20250804-1.git2c74f3d.el9",
+                      "nodeId": "crypto-policies-scripts@20250905-1.git377cc42.el9",
                     },
                     Object {
-                      "nodeId": "curl-minimal@7.76.1-31.el9",
+                      "nodeId": "curl-minimal@7.76.1-34.el9",
                     },
                     Object {
                       "nodeId": "cyrus-sasl-lib@2.1.27-21.el9",
@@ -105,13 +105,13 @@ Object {
                       "nodeId": "glib2@2.68.4-16.el9",
                     },
                     Object {
-                      "nodeId": "glibc@2.34-228.el9",
+                      "nodeId": "glibc@2.34-231.el9",
                     },
                     Object {
-                      "nodeId": "glibc-common@2.34-228.el9",
+                      "nodeId": "glibc-common@2.34-231.el9",
                     },
                     Object {
-                      "nodeId": "glibc-minimal-langpack@2.34-228.el9",
+                      "nodeId": "glibc-minimal-langpack@2.34-231.el9",
                     },
                     Object {
                       "nodeId": "gmp@1:6.2.0-13.el9",
@@ -183,7 +183,7 @@ Object {
                       "nodeId": "libcomps@0.1.18-1.el9",
                     },
                     Object {
-                      "nodeId": "libcurl-minimal@7.76.1-31.el9",
+                      "nodeId": "libcurl-minimal@7.76.1-34.el9",
                     },
                     Object {
                       "nodeId": "libdnf@0.69.0-16.el9",
@@ -357,7 +357,7 @@ Object {
                       "nodeId": "python3-pip-wheel@21.3.1-1.el9",
                     },
                     Object {
-                      "nodeId": "python3-rpm@4.16.1.3-38.el9",
+                      "nodeId": "python3-rpm@4.16.1.3-39.el9",
                     },
                     Object {
                       "nodeId": "python3-setuptools-wheel@53.0.0-15.el9",
@@ -375,16 +375,16 @@ Object {
                       "nodeId": "rootfiles@8.1-35.el9",
                     },
                     Object {
-                      "nodeId": "rpm@4.16.1.3-38.el9",
+                      "nodeId": "rpm@4.16.1.3-39.el9",
                     },
                     Object {
-                      "nodeId": "rpm-build-libs@4.16.1.3-38.el9",
+                      "nodeId": "rpm-build-libs@4.16.1.3-39.el9",
                     },
                     Object {
-                      "nodeId": "rpm-libs@4.16.1.3-38.el9",
+                      "nodeId": "rpm-libs@4.16.1.3-39.el9",
                     },
                     Object {
-                      "nodeId": "rpm-sign-libs@4.16.1.3-38.el9",
+                      "nodeId": "rpm-sign-libs@4.16.1.3-39.el9",
                     },
                     Object {
                       "nodeId": "sed@4.8-9.el9",
@@ -483,18 +483,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "crypto-policies@20250804-1.git2c74f3d.el9",
-                  "pkgId": "crypto-policies@20250804-1.git2c74f3d.el9",
+                  "nodeId": "crypto-policies@20250905-1.git377cc42.el9",
+                  "pkgId": "crypto-policies@20250905-1.git377cc42.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "crypto-policies-scripts@20250804-1.git2c74f3d.el9",
-                  "pkgId": "crypto-policies-scripts@20250804-1.git2c74f3d.el9",
+                  "nodeId": "crypto-policies-scripts@20250905-1.git377cc42.el9",
+                  "pkgId": "crypto-policies-scripts@20250905-1.git377cc42.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "curl-minimal@7.76.1-31.el9",
-                  "pkgId": "curl-minimal@7.76.1-31.el9",
+                  "nodeId": "curl-minimal@7.76.1-34.el9",
+                  "pkgId": "curl-minimal@7.76.1-34.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -583,18 +583,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc@2.34-228.el9",
-                  "pkgId": "glibc@2.34-228.el9",
+                  "nodeId": "glibc@2.34-231.el9",
+                  "pkgId": "glibc@2.34-231.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-common@2.34-228.el9",
-                  "pkgId": "glibc-common@2.34-228.el9",
+                  "nodeId": "glibc-common@2.34-231.el9",
+                  "pkgId": "glibc-common@2.34-231.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-minimal-langpack@2.34-228.el9",
-                  "pkgId": "glibc-minimal-langpack@2.34-228.el9",
+                  "nodeId": "glibc-minimal-langpack@2.34-231.el9",
+                  "pkgId": "glibc-minimal-langpack@2.34-231.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -713,8 +713,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "libcurl-minimal@7.76.1-31.el9",
-                  "pkgId": "libcurl-minimal@7.76.1-31.el9",
+                  "nodeId": "libcurl-minimal@7.76.1-34.el9",
+                  "pkgId": "libcurl-minimal@7.76.1-34.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -1003,8 +1003,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "python3-rpm@4.16.1.3-38.el9",
-                  "pkgId": "python3-rpm@4.16.1.3-38.el9",
+                  "nodeId": "python3-rpm@4.16.1.3-39.el9",
+                  "pkgId": "python3-rpm@4.16.1.3-39.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -1033,23 +1033,23 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm@4.16.1.3-38.el9",
-                  "pkgId": "rpm@4.16.1.3-38.el9",
+                  "nodeId": "rpm@4.16.1.3-39.el9",
+                  "pkgId": "rpm@4.16.1.3-39.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm-build-libs@4.16.1.3-38.el9",
-                  "pkgId": "rpm-build-libs@4.16.1.3-38.el9",
+                  "nodeId": "rpm-build-libs@4.16.1.3-39.el9",
+                  "pkgId": "rpm-build-libs@4.16.1.3-39.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm-libs@4.16.1.3-38.el9",
-                  "pkgId": "rpm-libs@4.16.1.3-38.el9",
+                  "nodeId": "rpm-libs@4.16.1.3-39.el9",
+                  "pkgId": "rpm-libs@4.16.1.3-39.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm-sign-libs@4.16.1.3-38.el9",
-                  "pkgId": "rpm-sign-libs@4.16.1.3-38.el9",
+                  "nodeId": "rpm-sign-libs@4.16.1.3-39.el9",
+                  "pkgId": "rpm-sign-libs@4.16.1.3-39.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -1219,27 +1219,27 @@ Object {
                 },
               },
               Object {
-                "id": "crypto-policies@20250804-1.git2c74f3d.el9",
+                "id": "crypto-policies@20250905-1.git377cc42.el9",
                 "info": Object {
                   "name": "crypto-policies",
-                  "purl": "pkg:rpm/centos/crypto-policies@20250804-1.git2c74f3d.el9?distro=centos-9&upstream=crypto-policies%4020250804",
-                  "version": "20250804-1.git2c74f3d.el9",
+                  "purl": "pkg:rpm/centos/crypto-policies@20250905-1.git377cc42.el9?distro=centos-9&upstream=crypto-policies%4020250905",
+                  "version": "20250905-1.git377cc42.el9",
                 },
               },
               Object {
-                "id": "crypto-policies-scripts@20250804-1.git2c74f3d.el9",
+                "id": "crypto-policies-scripts@20250905-1.git377cc42.el9",
                 "info": Object {
                   "name": "crypto-policies-scripts",
-                  "purl": "pkg:rpm/centos/crypto-policies-scripts@20250804-1.git2c74f3d.el9?distro=centos-9&upstream=crypto-policies%4020250804",
-                  "version": "20250804-1.git2c74f3d.el9",
+                  "purl": "pkg:rpm/centos/crypto-policies-scripts@20250905-1.git377cc42.el9?distro=centos-9&upstream=crypto-policies%4020250905",
+                  "version": "20250905-1.git377cc42.el9",
                 },
               },
               Object {
-                "id": "curl-minimal@7.76.1-31.el9",
+                "id": "curl-minimal@7.76.1-34.el9",
                 "info": Object {
                   "name": "curl-minimal",
-                  "purl": "pkg:rpm/centos/curl-minimal@7.76.1-31.el9?distro=centos-9&upstream=curl%407.76.1",
-                  "version": "7.76.1-31.el9",
+                  "purl": "pkg:rpm/centos/curl-minimal@7.76.1-34.el9?distro=centos-9&upstream=curl%407.76.1",
+                  "version": "7.76.1-34.el9",
                 },
               },
               Object {
@@ -1379,27 +1379,27 @@ Object {
                 },
               },
               Object {
-                "id": "glibc@2.34-228.el9",
+                "id": "glibc@2.34-231.el9",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/centos/glibc@2.34-228.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-228.el9",
+                  "purl": "pkg:rpm/centos/glibc@2.34-231.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-231.el9",
                 },
               },
               Object {
-                "id": "glibc-common@2.34-228.el9",
+                "id": "glibc-common@2.34-231.el9",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/centos/glibc-common@2.34-228.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-228.el9",
+                  "purl": "pkg:rpm/centos/glibc-common@2.34-231.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-231.el9",
                 },
               },
               Object {
-                "id": "glibc-minimal-langpack@2.34-228.el9",
+                "id": "glibc-minimal-langpack@2.34-231.el9",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.34-228.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-228.el9",
+                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.34-231.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-231.el9",
                 },
               },
               Object {
@@ -1587,11 +1587,11 @@ Object {
                 },
               },
               Object {
-                "id": "libcurl-minimal@7.76.1-31.el9",
+                "id": "libcurl-minimal@7.76.1-34.el9",
                 "info": Object {
                   "name": "libcurl-minimal",
-                  "purl": "pkg:rpm/centos/libcurl-minimal@7.76.1-31.el9?distro=centos-9&upstream=curl%407.76.1",
-                  "version": "7.76.1-31.el9",
+                  "purl": "pkg:rpm/centos/libcurl-minimal@7.76.1-34.el9?distro=centos-9&upstream=curl%407.76.1",
+                  "version": "7.76.1-34.el9",
                 },
               },
               Object {
@@ -2051,11 +2051,11 @@ Object {
                 },
               },
               Object {
-                "id": "python3-rpm@4.16.1.3-38.el9",
+                "id": "python3-rpm@4.16.1.3-39.el9",
                 "info": Object {
                   "name": "python3-rpm",
-                  "purl": "pkg:rpm/centos/python3-rpm@4.16.1.3-38.el9?distro=centos-9&upstream=rpm%404.16.1.3",
-                  "version": "4.16.1.3-38.el9",
+                  "purl": "pkg:rpm/centos/python3-rpm@4.16.1.3-39.el9?distro=centos-9&upstream=rpm%404.16.1.3",
+                  "version": "4.16.1.3-39.el9",
                 },
               },
               Object {
@@ -2099,35 +2099,35 @@ Object {
                 },
               },
               Object {
-                "id": "rpm@4.16.1.3-38.el9",
+                "id": "rpm@4.16.1.3-39.el9",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/centos/rpm@4.16.1.3-38.el9?distro=centos-9&upstream=rpm%404.16.1.3",
-                  "version": "4.16.1.3-38.el9",
+                  "purl": "pkg:rpm/centos/rpm@4.16.1.3-39.el9?distro=centos-9&upstream=rpm%404.16.1.3",
+                  "version": "4.16.1.3-39.el9",
                 },
               },
               Object {
-                "id": "rpm-build-libs@4.16.1.3-38.el9",
+                "id": "rpm-build-libs@4.16.1.3-39.el9",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/centos/rpm-build-libs@4.16.1.3-38.el9?distro=centos-9&upstream=rpm%404.16.1.3",
-                  "version": "4.16.1.3-38.el9",
+                  "purl": "pkg:rpm/centos/rpm-build-libs@4.16.1.3-39.el9?distro=centos-9&upstream=rpm%404.16.1.3",
+                  "version": "4.16.1.3-39.el9",
                 },
               },
               Object {
-                "id": "rpm-libs@4.16.1.3-38.el9",
+                "id": "rpm-libs@4.16.1.3-39.el9",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/centos/rpm-libs@4.16.1.3-38.el9?distro=centos-9&upstream=rpm%404.16.1.3",
-                  "version": "4.16.1.3-38.el9",
+                  "purl": "pkg:rpm/centos/rpm-libs@4.16.1.3-39.el9?distro=centos-9&upstream=rpm%404.16.1.3",
+                  "version": "4.16.1.3-39.el9",
                 },
               },
               Object {
-                "id": "rpm-sign-libs@4.16.1.3-38.el9",
+                "id": "rpm-sign-libs@4.16.1.3-39.el9",
                 "info": Object {
                   "name": "rpm-sign-libs",
-                  "purl": "pkg:rpm/centos/rpm-sign-libs@4.16.1.3-38.el9?distro=centos-9&upstream=rpm%404.16.1.3",
-                  "version": "4.16.1.3-38.el9",
+                  "purl": "pkg:rpm/centos/rpm-sign-libs@4.16.1.3-39.el9?distro=centos-9&upstream=rpm%404.16.1.3",
+                  "version": "4.16.1.3-39.el9",
                 },
               },
               Object {
@@ -2232,19 +2232,19 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "sha256:ea8f1ca7bc842960deae1d91499dbc20e3cf50bd9c1eaf109104287718b164a5",
+          "data": "sha256:176af7fd968fb5c4089a70f7f8292b83d3319ad280411eca1e85d72a7a0f3e6c",
           "type": "imageId",
         },
         Object {
           "data": Array [
-            "sha256:13a8d65d0ba6bf99518eff47159902465e48ccaf6745c81db4f23ee0113c076e",
+            "sha256:de26b07477a040a7067efc3831eddd6518f3cb31890e04cdb16254127a90c3f0",
           ],
           "type": "imageLayers",
         },
         Object {
           "data": Object {
             "io.buildah.version": "1.33.12",
-            "org.label-schema.build-date": "20250826",
+            "org.label-schema.build-date": "20250909",
             "org.label-schema.license": "GPLv2",
             "org.label-schema.name": "CentOS Stream 9 Base Image",
             "org.label-schema.schema-version": "1.0",
@@ -2253,12 +2253,12 @@ Object {
           "type": "imageLabels",
         },
         Object {
-          "data": "2025-08-26T06:14:10.898547431Z",
+          "data": "2025-09-09T00:54:43.711279439Z",
           "type": "imageCreationTime",
         },
         Object {
           "data": Array [
-            "sha256:1946a369c357a54627ae01a24fe87e3664f80a20a69b2c7e39e555e7e3374858",
+            "sha256:fdfcedefe5fe7b2f2571b04b2777afdc922aeb85b9590cd355f49001b675f64e",
           ],
           "type": "rootFs",
         },
@@ -2269,8 +2269,8 @@ Object {
         Object {
           "data": Object {
             "names": Array [
-              "quay.io/centos/centos@sha256:db73b2ac6c8a9f199bdacf2f0e759429b0287a8be95c9a9e26dc1d594e0d84a2",
-              "quay.io/centos/centos@sha256:db73b2ac6c8a9f199bdacf2f0e759429b0287a8be95c9a9e26dc1d594e0d84a2",
+              "quay.io/centos/centos@sha256:3d97213cc9e44fc6d055968dac5b922a106eb7e557148973d1e7717320ca9801",
+              "quay.io/centos/centos@sha256:3d97213cc9e44fc6d055968dac5b922a106eb7e557148973d1e7717320ca9801",
             ],
           },
           "type": "imageNames",
@@ -2323,13 +2323,13 @@ Object {
                       "nodeId": "ca-certificates@2024.2.69_v8.0.303-102.3.el10",
                     },
                     Object {
-                      "nodeId": "centos-gpg-keys@10.0-10.el10",
+                      "nodeId": "centos-gpg-keys@10.0-11.el10",
                     },
                     Object {
-                      "nodeId": "centos-stream-release@10.0-10.el10",
+                      "nodeId": "centos-stream-release@10.0-11.el10",
                     },
                     Object {
-                      "nodeId": "centos-stream-repos@10.0-10.el10",
+                      "nodeId": "centos-stream-repos@10.0-11.el10",
                     },
                     Object {
                       "nodeId": "chrony@4.6.1-2.el10",
@@ -2344,10 +2344,10 @@ Object {
                       "nodeId": "cracklib-dicts@2.9.11-8.el10",
                     },
                     Object {
-                      "nodeId": "crypto-policies@20250804-1.git2ca4115.el10",
+                      "nodeId": "crypto-policies@20250905-1.gitc7eb7b2.el10",
                     },
                     Object {
-                      "nodeId": "crypto-policies-scripts@20250804-1.git2ca4115.el10",
+                      "nodeId": "crypto-policies-scripts@20250905-1.gitc7eb7b2.el10",
                     },
                     Object {
                       "nodeId": "cryptsetup-libs@2.7.5-2.el10",
@@ -2428,19 +2428,19 @@ Object {
                       "nodeId": "glib2@2.80.4-8.el10",
                     },
                     Object {
-                      "nodeId": "glibc@2.39-54.el10",
+                      "nodeId": "glibc@2.39-56.el10",
                     },
                     Object {
-                      "nodeId": "glibc-common@2.39-54.el10",
+                      "nodeId": "glibc-common@2.39-56.el10",
                     },
                     Object {
-                      "nodeId": "glibc-gconv-extra@2.39-54.el10",
+                      "nodeId": "glibc-gconv-extra@2.39-56.el10",
                     },
                     Object {
-                      "nodeId": "glibc-langpack-en@2.39-54.el10",
+                      "nodeId": "glibc-langpack-en@2.39-56.el10",
                     },
                     Object {
-                      "nodeId": "glibc-minimal-langpack@2.39-54.el10",
+                      "nodeId": "glibc-minimal-langpack@2.39-56.el10",
                     },
                     Object {
                       "nodeId": "gmp@1:6.2.1-12.el10",
@@ -2665,10 +2665,10 @@ Object {
                       "nodeId": "popt@1.19-8.el10",
                     },
                     Object {
-                      "nodeId": "python-unversioned-command@3.12.11-2.el10",
+                      "nodeId": "python-unversioned-command@3.12.11-3.el10",
                     },
                     Object {
-                      "nodeId": "python3@3.12.11-2.el10",
+                      "nodeId": "python3@3.12.11-3.el10",
                     },
                     Object {
                       "nodeId": "python3-dateutil@1:2.9.0.post0-1.el10",
@@ -2692,13 +2692,13 @@ Object {
                       "nodeId": "python3-libdnf@0.73.1-12.el10",
                     },
                     Object {
-                      "nodeId": "python3-libs@3.12.11-2.el10",
+                      "nodeId": "python3-libs@3.12.11-3.el10",
                     },
                     Object {
                       "nodeId": "python3-pip-wheel@23.3.2-7.el10",
                     },
                     Object {
-                      "nodeId": "python3-rpm@4.19.1.1-18.el10",
+                      "nodeId": "python3-rpm@4.19.1.1-20.el10",
                     },
                     Object {
                       "nodeId": "python3-six@1.16.0-16.el10",
@@ -2719,25 +2719,25 @@ Object {
                       "nodeId": "rootfiles@8.1-54.el10",
                     },
                     Object {
-                      "nodeId": "rpm@4.19.1.1-18.el10",
+                      "nodeId": "rpm@4.19.1.1-20.el10",
                     },
                     Object {
-                      "nodeId": "rpm-build-libs@4.19.1.1-18.el10",
+                      "nodeId": "rpm-build-libs@4.19.1.1-20.el10",
                     },
                     Object {
-                      "nodeId": "rpm-libs@4.19.1.1-18.el10",
+                      "nodeId": "rpm-libs@4.19.1.1-20.el10",
                     },
                     Object {
-                      "nodeId": "rpm-plugin-audit@4.19.1.1-18.el10",
+                      "nodeId": "rpm-plugin-audit@4.19.1.1-20.el10",
                     },
                     Object {
-                      "nodeId": "rpm-plugin-systemd-inhibit@4.19.1.1-18.el10",
+                      "nodeId": "rpm-plugin-systemd-inhibit@4.19.1.1-20.el10",
                     },
                     Object {
                       "nodeId": "rpm-sequoia@1.9.0.1-1.el10",
                     },
                     Object {
-                      "nodeId": "rpm-sign-libs@4.19.1.1-18.el10",
+                      "nodeId": "rpm-sign-libs@4.19.1.1-20.el10",
                     },
                     Object {
                       "nodeId": "sed@4.9-3.el10",
@@ -2828,18 +2828,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "centos-gpg-keys@10.0-10.el10",
-                  "pkgId": "centos-gpg-keys@10.0-10.el10",
+                  "nodeId": "centos-gpg-keys@10.0-11.el10",
+                  "pkgId": "centos-gpg-keys@10.0-11.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "centos-stream-release@10.0-10.el10",
-                  "pkgId": "centos-stream-release@10.0-10.el10",
+                  "nodeId": "centos-stream-release@10.0-11.el10",
+                  "pkgId": "centos-stream-release@10.0-11.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "centos-stream-repos@10.0-10.el10",
-                  "pkgId": "centos-stream-repos@10.0-10.el10",
+                  "nodeId": "centos-stream-repos@10.0-11.el10",
+                  "pkgId": "centos-stream-repos@10.0-11.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -2863,13 +2863,13 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "crypto-policies@20250804-1.git2ca4115.el10",
-                  "pkgId": "crypto-policies@20250804-1.git2ca4115.el10",
+                  "nodeId": "crypto-policies@20250905-1.gitc7eb7b2.el10",
+                  "pkgId": "crypto-policies@20250905-1.gitc7eb7b2.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "crypto-policies-scripts@20250804-1.git2ca4115.el10",
-                  "pkgId": "crypto-policies-scripts@20250804-1.git2ca4115.el10",
+                  "nodeId": "crypto-policies-scripts@20250905-1.gitc7eb7b2.el10",
+                  "pkgId": "crypto-policies-scripts@20250905-1.gitc7eb7b2.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3003,28 +3003,28 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc@2.39-54.el10",
-                  "pkgId": "glibc@2.39-54.el10",
+                  "nodeId": "glibc@2.39-56.el10",
+                  "pkgId": "glibc@2.39-56.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-common@2.39-54.el10",
-                  "pkgId": "glibc-common@2.39-54.el10",
+                  "nodeId": "glibc-common@2.39-56.el10",
+                  "pkgId": "glibc-common@2.39-56.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-gconv-extra@2.39-54.el10",
-                  "pkgId": "glibc-gconv-extra@2.39-54.el10",
+                  "nodeId": "glibc-gconv-extra@2.39-56.el10",
+                  "pkgId": "glibc-gconv-extra@2.39-56.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-langpack-en@2.39-54.el10",
-                  "pkgId": "glibc-langpack-en@2.39-54.el10",
+                  "nodeId": "glibc-langpack-en@2.39-56.el10",
+                  "pkgId": "glibc-langpack-en@2.39-56.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-minimal-langpack@2.39-54.el10",
-                  "pkgId": "glibc-minimal-langpack@2.39-54.el10",
+                  "nodeId": "glibc-minimal-langpack@2.39-56.el10",
+                  "pkgId": "glibc-minimal-langpack@2.39-56.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3398,13 +3398,13 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "python-unversioned-command@3.12.11-2.el10",
-                  "pkgId": "python-unversioned-command@3.12.11-2.el10",
+                  "nodeId": "python-unversioned-command@3.12.11-3.el10",
+                  "pkgId": "python-unversioned-command@3.12.11-3.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "python3@3.12.11-2.el10",
-                  "pkgId": "python3@3.12.11-2.el10",
+                  "nodeId": "python3@3.12.11-3.el10",
+                  "pkgId": "python3@3.12.11-3.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3443,8 +3443,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "python3-libs@3.12.11-2.el10",
-                  "pkgId": "python3-libs@3.12.11-2.el10",
+                  "nodeId": "python3-libs@3.12.11-3.el10",
+                  "pkgId": "python3-libs@3.12.11-3.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3453,8 +3453,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "python3-rpm@4.19.1.1-18.el10",
-                  "pkgId": "python3-rpm@4.19.1.1-18.el10",
+                  "nodeId": "python3-rpm@4.19.1.1-20.el10",
+                  "pkgId": "python3-rpm@4.19.1.1-20.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3488,28 +3488,28 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm@4.19.1.1-18.el10",
-                  "pkgId": "rpm@4.19.1.1-18.el10",
+                  "nodeId": "rpm@4.19.1.1-20.el10",
+                  "pkgId": "rpm@4.19.1.1-20.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm-build-libs@4.19.1.1-18.el10",
-                  "pkgId": "rpm-build-libs@4.19.1.1-18.el10",
+                  "nodeId": "rpm-build-libs@4.19.1.1-20.el10",
+                  "pkgId": "rpm-build-libs@4.19.1.1-20.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm-libs@4.19.1.1-18.el10",
-                  "pkgId": "rpm-libs@4.19.1.1-18.el10",
+                  "nodeId": "rpm-libs@4.19.1.1-20.el10",
+                  "pkgId": "rpm-libs@4.19.1.1-20.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm-plugin-audit@4.19.1.1-18.el10",
-                  "pkgId": "rpm-plugin-audit@4.19.1.1-18.el10",
+                  "nodeId": "rpm-plugin-audit@4.19.1.1-20.el10",
+                  "pkgId": "rpm-plugin-audit@4.19.1.1-20.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm-plugin-systemd-inhibit@4.19.1.1-18.el10",
-                  "pkgId": "rpm-plugin-systemd-inhibit@4.19.1.1-18.el10",
+                  "nodeId": "rpm-plugin-systemd-inhibit@4.19.1.1-20.el10",
+                  "pkgId": "rpm-plugin-systemd-inhibit@4.19.1.1-20.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3518,8 +3518,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "rpm-sign-libs@4.19.1.1-18.el10",
-                  "pkgId": "rpm-sign-libs@4.19.1.1-18.el10",
+                  "nodeId": "rpm-sign-libs@4.19.1.1-20.el10",
+                  "pkgId": "rpm-sign-libs@4.19.1.1-20.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3677,27 +3677,27 @@ Object {
                 },
               },
               Object {
-                "id": "centos-gpg-keys@10.0-10.el10",
+                "id": "centos-gpg-keys@10.0-11.el10",
                 "info": Object {
                   "name": "centos-gpg-keys",
-                  "purl": "pkg:rpm/centos/centos-gpg-keys@10.0-10.el10?distro=centos-10&upstream=centos-stream-release%4010.0",
-                  "version": "10.0-10.el10",
+                  "purl": "pkg:rpm/centos/centos-gpg-keys@10.0-11.el10?distro=centos-10&upstream=centos-stream-release%4010.0",
+                  "version": "10.0-11.el10",
                 },
               },
               Object {
-                "id": "centos-stream-release@10.0-10.el10",
+                "id": "centos-stream-release@10.0-11.el10",
                 "info": Object {
                   "name": "centos-stream-release",
-                  "purl": "pkg:rpm/centos/centos-stream-release@10.0-10.el10?distro=centos-10&upstream=centos-stream-release%4010.0",
-                  "version": "10.0-10.el10",
+                  "purl": "pkg:rpm/centos/centos-stream-release@10.0-11.el10?distro=centos-10&upstream=centos-stream-release%4010.0",
+                  "version": "10.0-11.el10",
                 },
               },
               Object {
-                "id": "centos-stream-repos@10.0-10.el10",
+                "id": "centos-stream-repos@10.0-11.el10",
                 "info": Object {
                   "name": "centos-stream-repos",
-                  "purl": "pkg:rpm/centos/centos-stream-repos@10.0-10.el10?distro=centos-10&upstream=centos-stream-release%4010.0",
-                  "version": "10.0-10.el10",
+                  "purl": "pkg:rpm/centos/centos-stream-repos@10.0-11.el10?distro=centos-10&upstream=centos-stream-release%4010.0",
+                  "version": "10.0-11.el10",
                 },
               },
               Object {
@@ -3733,19 +3733,19 @@ Object {
                 },
               },
               Object {
-                "id": "crypto-policies@20250804-1.git2ca4115.el10",
+                "id": "crypto-policies@20250905-1.gitc7eb7b2.el10",
                 "info": Object {
                   "name": "crypto-policies",
-                  "purl": "pkg:rpm/centos/crypto-policies@20250804-1.git2ca4115.el10?distro=centos-10&upstream=crypto-policies%4020250804",
-                  "version": "20250804-1.git2ca4115.el10",
+                  "purl": "pkg:rpm/centos/crypto-policies@20250905-1.gitc7eb7b2.el10?distro=centos-10&upstream=crypto-policies%4020250905",
+                  "version": "20250905-1.gitc7eb7b2.el10",
                 },
               },
               Object {
-                "id": "crypto-policies-scripts@20250804-1.git2ca4115.el10",
+                "id": "crypto-policies-scripts@20250905-1.gitc7eb7b2.el10",
                 "info": Object {
                   "name": "crypto-policies-scripts",
-                  "purl": "pkg:rpm/centos/crypto-policies-scripts@20250804-1.git2ca4115.el10?distro=centos-10&upstream=crypto-policies%4020250804",
-                  "version": "20250804-1.git2ca4115.el10",
+                  "purl": "pkg:rpm/centos/crypto-policies-scripts@20250905-1.gitc7eb7b2.el10?distro=centos-10&upstream=crypto-policies%4020250905",
+                  "version": "20250905-1.gitc7eb7b2.el10",
                 },
               },
               Object {
@@ -3957,43 +3957,43 @@ Object {
                 },
               },
               Object {
-                "id": "glibc@2.39-54.el10",
+                "id": "glibc@2.39-56.el10",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/centos/glibc@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-54.el10",
+                  "purl": "pkg:rpm/centos/glibc@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-56.el10",
                 },
               },
               Object {
-                "id": "glibc-common@2.39-54.el10",
+                "id": "glibc-common@2.39-56.el10",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/centos/glibc-common@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-54.el10",
+                  "purl": "pkg:rpm/centos/glibc-common@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-56.el10",
                 },
               },
               Object {
-                "id": "glibc-gconv-extra@2.39-54.el10",
+                "id": "glibc-gconv-extra@2.39-56.el10",
                 "info": Object {
                   "name": "glibc-gconv-extra",
-                  "purl": "pkg:rpm/centos/glibc-gconv-extra@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-54.el10",
+                  "purl": "pkg:rpm/centos/glibc-gconv-extra@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-56.el10",
                 },
               },
               Object {
-                "id": "glibc-langpack-en@2.39-54.el10",
+                "id": "glibc-langpack-en@2.39-56.el10",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/centos/glibc-langpack-en@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-54.el10",
+                  "purl": "pkg:rpm/centos/glibc-langpack-en@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-56.el10",
                 },
               },
               Object {
-                "id": "glibc-minimal-langpack@2.39-54.el10",
+                "id": "glibc-minimal-langpack@2.39-56.el10",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.39-54.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-54.el10",
+                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-56.el10",
                 },
               },
               Object {
@@ -4589,19 +4589,19 @@ Object {
                 },
               },
               Object {
-                "id": "python-unversioned-command@3.12.11-2.el10",
+                "id": "python-unversioned-command@3.12.11-3.el10",
                 "info": Object {
                   "name": "python-unversioned-command",
-                  "purl": "pkg:rpm/centos/python-unversioned-command@3.12.11-2.el10?distro=centos-10&upstream=python3.12%403.12.11",
-                  "version": "3.12.11-2.el10",
+                  "purl": "pkg:rpm/centos/python-unversioned-command@3.12.11-3.el10?distro=centos-10&upstream=python3.12%403.12.11",
+                  "version": "3.12.11-3.el10",
                 },
               },
               Object {
-                "id": "python3@3.12.11-2.el10",
+                "id": "python3@3.12.11-3.el10",
                 "info": Object {
                   "name": "python3",
-                  "purl": "pkg:rpm/centos/python3@3.12.11-2.el10?distro=centos-10&upstream=python3.12%403.12.11",
-                  "version": "3.12.11-2.el10",
+                  "purl": "pkg:rpm/centos/python3@3.12.11-3.el10?distro=centos-10&upstream=python3.12%403.12.11",
+                  "version": "3.12.11-3.el10",
                 },
               },
               Object {
@@ -4661,11 +4661,11 @@ Object {
                 },
               },
               Object {
-                "id": "python3-libs@3.12.11-2.el10",
+                "id": "python3-libs@3.12.11-3.el10",
                 "info": Object {
                   "name": "python3-libs",
-                  "purl": "pkg:rpm/centos/python3-libs@3.12.11-2.el10?distro=centos-10&upstream=python3.12%403.12.11",
-                  "version": "3.12.11-2.el10",
+                  "purl": "pkg:rpm/centos/python3-libs@3.12.11-3.el10?distro=centos-10&upstream=python3.12%403.12.11",
+                  "version": "3.12.11-3.el10",
                 },
               },
               Object {
@@ -4677,11 +4677,11 @@ Object {
                 },
               },
               Object {
-                "id": "python3-rpm@4.19.1.1-18.el10",
+                "id": "python3-rpm@4.19.1.1-20.el10",
                 "info": Object {
                   "name": "python3-rpm",
-                  "purl": "pkg:rpm/centos/python3-rpm@4.19.1.1-18.el10?distro=centos-10&upstream=rpm%404.19.1.1",
-                  "version": "4.19.1.1-18.el10",
+                  "purl": "pkg:rpm/centos/python3-rpm@4.19.1.1-20.el10?distro=centos-10&upstream=rpm%404.19.1.1",
+                  "version": "4.19.1.1-20.el10",
                 },
               },
               Object {
@@ -4733,43 +4733,43 @@ Object {
                 },
               },
               Object {
-                "id": "rpm@4.19.1.1-18.el10",
+                "id": "rpm@4.19.1.1-20.el10",
                 "info": Object {
                   "name": "rpm",
-                  "purl": "pkg:rpm/centos/rpm@4.19.1.1-18.el10?distro=centos-10&upstream=rpm%404.19.1.1",
-                  "version": "4.19.1.1-18.el10",
+                  "purl": "pkg:rpm/centos/rpm@4.19.1.1-20.el10?distro=centos-10&upstream=rpm%404.19.1.1",
+                  "version": "4.19.1.1-20.el10",
                 },
               },
               Object {
-                "id": "rpm-build-libs@4.19.1.1-18.el10",
+                "id": "rpm-build-libs@4.19.1.1-20.el10",
                 "info": Object {
                   "name": "rpm-build-libs",
-                  "purl": "pkg:rpm/centos/rpm-build-libs@4.19.1.1-18.el10?distro=centos-10&upstream=rpm%404.19.1.1",
-                  "version": "4.19.1.1-18.el10",
+                  "purl": "pkg:rpm/centos/rpm-build-libs@4.19.1.1-20.el10?distro=centos-10&upstream=rpm%404.19.1.1",
+                  "version": "4.19.1.1-20.el10",
                 },
               },
               Object {
-                "id": "rpm-libs@4.19.1.1-18.el10",
+                "id": "rpm-libs@4.19.1.1-20.el10",
                 "info": Object {
                   "name": "rpm-libs",
-                  "purl": "pkg:rpm/centos/rpm-libs@4.19.1.1-18.el10?distro=centos-10&upstream=rpm%404.19.1.1",
-                  "version": "4.19.1.1-18.el10",
+                  "purl": "pkg:rpm/centos/rpm-libs@4.19.1.1-20.el10?distro=centos-10&upstream=rpm%404.19.1.1",
+                  "version": "4.19.1.1-20.el10",
                 },
               },
               Object {
-                "id": "rpm-plugin-audit@4.19.1.1-18.el10",
+                "id": "rpm-plugin-audit@4.19.1.1-20.el10",
                 "info": Object {
                   "name": "rpm-plugin-audit",
-                  "purl": "pkg:rpm/centos/rpm-plugin-audit@4.19.1.1-18.el10?distro=centos-10&upstream=rpm%404.19.1.1",
-                  "version": "4.19.1.1-18.el10",
+                  "purl": "pkg:rpm/centos/rpm-plugin-audit@4.19.1.1-20.el10?distro=centos-10&upstream=rpm%404.19.1.1",
+                  "version": "4.19.1.1-20.el10",
                 },
               },
               Object {
-                "id": "rpm-plugin-systemd-inhibit@4.19.1.1-18.el10",
+                "id": "rpm-plugin-systemd-inhibit@4.19.1.1-20.el10",
                 "info": Object {
                   "name": "rpm-plugin-systemd-inhibit",
-                  "purl": "pkg:rpm/centos/rpm-plugin-systemd-inhibit@4.19.1.1-18.el10?distro=centos-10&upstream=rpm%404.19.1.1",
-                  "version": "4.19.1.1-18.el10",
+                  "purl": "pkg:rpm/centos/rpm-plugin-systemd-inhibit@4.19.1.1-20.el10?distro=centos-10&upstream=rpm%404.19.1.1",
+                  "version": "4.19.1.1-20.el10",
                 },
               },
               Object {
@@ -4781,11 +4781,11 @@ Object {
                 },
               },
               Object {
-                "id": "rpm-sign-libs@4.19.1.1-18.el10",
+                "id": "rpm-sign-libs@4.19.1.1-20.el10",
                 "info": Object {
                   "name": "rpm-sign-libs",
-                  "purl": "pkg:rpm/centos/rpm-sign-libs@4.19.1.1-18.el10?distro=centos-10&upstream=rpm%404.19.1.1",
-                  "version": "4.19.1.1-18.el10",
+                  "purl": "pkg:rpm/centos/rpm-sign-libs@4.19.1.1-20.el10?distro=centos-10&upstream=rpm%404.19.1.1",
+                  "version": "4.19.1.1-20.el10",
                 },
               },
               Object {
@@ -4922,19 +4922,19 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "sha256:10ab27e5c6df6236d59cfa86875dbe00407be8739bd591656d7bd06dc712e042",
+          "data": "sha256:499f4e705aa0cd70f6177f1185bf4cb2fef5247ad034f228da9871047d9488fe",
           "type": "imageId",
         },
         Object {
           "data": Array [
-            "sha256:8a209e76238028082eb91e0ca23ba3fe6a3eb17c61d7cfe6182308c6fcaf7d22",
+            "sha256:cf42a3734a2180e4cfdc8ad11ec7e457a8dcb7edc4a234c863efa04e2e6cb035",
           ],
           "type": "imageLayers",
         },
         Object {
           "data": Object {
             "io.buildah.version": "1.33.12",
-            "org.label-schema.build-date": "20250826",
+            "org.label-schema.build-date": "20250909",
             "org.label-schema.license": "GPLv2",
             "org.label-schema.name": "CentOS Stream 10 Base Image",
             "org.label-schema.schema-version": "1.0",
@@ -4943,12 +4943,12 @@ Object {
           "type": "imageLabels",
         },
         Object {
-          "data": "2025-08-26T03:02:52.459378821Z",
+          "data": "2025-09-09T01:43:13.399791163Z",
           "type": "imageCreationTime",
         },
         Object {
           "data": Array [
-            "sha256:aa6e4a4e44e204e7455c342300911f26608460610b9e96c5e9e37d5402061de2",
+            "sha256:ebf6966c1c62fb8983f46fe1531243219f37cab83284b1f56e3967e6bc104212",
           ],
           "type": "rootFs",
         },
@@ -4959,8 +4959,8 @@ Object {
         Object {
           "data": Object {
             "names": Array [
-              "quay.io/centos/centos@sha256:7459813cfcd8a6b8e62c6fd080e000504424c41125045f87a085b2d695ae006e",
-              "quay.io/centos/centos@sha256:7459813cfcd8a6b8e62c6fd080e000504424c41125045f87a085b2d695ae006e",
+              "quay.io/centos/centos@sha256:277f2b6361ea16917abf73bdaab672ff137045c181be7f0ed5c826cf00542dcf",
+              "quay.io/centos/centos@sha256:277f2b6361ea16917abf73bdaab672ff137045c181be7f0ed5c826cf00542dcf",
             ],
           },
           "type": "imageNames",

--- a/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
+++ b/test/system/package-managers/__snapshots__/rpm.spec.ts.snap
@@ -105,13 +105,13 @@ Object {
                       "nodeId": "glib2@2.68.4-16.el9",
                     },
                     Object {
-                      "nodeId": "glibc@2.34-231.el9",
+                      "nodeId": "glibc@2.34-232.el9",
                     },
                     Object {
-                      "nodeId": "glibc-common@2.34-231.el9",
+                      "nodeId": "glibc-common@2.34-232.el9",
                     },
                     Object {
-                      "nodeId": "glibc-minimal-langpack@2.34-231.el9",
+                      "nodeId": "glibc-minimal-langpack@2.34-232.el9",
                     },
                     Object {
                       "nodeId": "gmp@1:6.2.0-13.el9",
@@ -300,10 +300,10 @@ Object {
                       "nodeId": "openldap@2.6.8-4.el9",
                     },
                     Object {
-                      "nodeId": "openssl-fips-provider@1:3.5.1-3.el9",
+                      "nodeId": "openssl-fips-provider@1:3.5.1-5.el9",
                     },
                     Object {
-                      "nodeId": "openssl-libs@1:3.5.1-3.el9",
+                      "nodeId": "openssl-libs@1:3.5.1-5.el9",
                     },
                     Object {
                       "nodeId": "p11-kit@0.25.3-3.el9",
@@ -583,18 +583,18 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc@2.34-231.el9",
-                  "pkgId": "glibc@2.34-231.el9",
+                  "nodeId": "glibc@2.34-232.el9",
+                  "pkgId": "glibc@2.34-232.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-common@2.34-231.el9",
-                  "pkgId": "glibc-common@2.34-231.el9",
+                  "nodeId": "glibc-common@2.34-232.el9",
+                  "pkgId": "glibc-common@2.34-232.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-minimal-langpack@2.34-231.el9",
-                  "pkgId": "glibc-minimal-langpack@2.34-231.el9",
+                  "nodeId": "glibc-minimal-langpack@2.34-232.el9",
+                  "pkgId": "glibc-minimal-langpack@2.34-232.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -908,13 +908,13 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "openssl-fips-provider@1:3.5.1-3.el9",
-                  "pkgId": "openssl-fips-provider@1:3.5.1-3.el9",
+                  "nodeId": "openssl-fips-provider@1:3.5.1-5.el9",
+                  "pkgId": "openssl-fips-provider@1:3.5.1-5.el9",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "openssl-libs@1:3.5.1-3.el9",
-                  "pkgId": "openssl-libs@1:3.5.1-3.el9",
+                  "nodeId": "openssl-libs@1:3.5.1-5.el9",
+                  "pkgId": "openssl-libs@1:3.5.1-5.el9",
                 },
                 Object {
                   "deps": Array [],
@@ -1379,27 +1379,27 @@ Object {
                 },
               },
               Object {
-                "id": "glibc@2.34-231.el9",
+                "id": "glibc@2.34-232.el9",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/centos/glibc@2.34-231.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-231.el9",
+                  "purl": "pkg:rpm/centos/glibc@2.34-232.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-232.el9",
                 },
               },
               Object {
-                "id": "glibc-common@2.34-231.el9",
+                "id": "glibc-common@2.34-232.el9",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/centos/glibc-common@2.34-231.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-231.el9",
+                  "purl": "pkg:rpm/centos/glibc-common@2.34-232.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-232.el9",
                 },
               },
               Object {
-                "id": "glibc-minimal-langpack@2.34-231.el9",
+                "id": "glibc-minimal-langpack@2.34-232.el9",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.34-231.el9?distro=centos-9&upstream=glibc%402.34",
-                  "version": "2.34-231.el9",
+                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.34-232.el9?distro=centos-9&upstream=glibc%402.34",
+                  "version": "2.34-232.el9",
                 },
               },
               Object {
@@ -1899,19 +1899,19 @@ Object {
                 },
               },
               Object {
-                "id": "openssl-fips-provider@1:3.5.1-3.el9",
+                "id": "openssl-fips-provider@1:3.5.1-5.el9",
                 "info": Object {
                   "name": "openssl-fips-provider",
-                  "purl": "pkg:rpm/centos/openssl-fips-provider@1:3.5.1-3.el9?distro=centos-9&epoch=1&upstream=openssl%403.5.1",
-                  "version": "1:3.5.1-3.el9",
+                  "purl": "pkg:rpm/centos/openssl-fips-provider@1:3.5.1-5.el9?distro=centos-9&epoch=1&upstream=openssl%403.5.1",
+                  "version": "1:3.5.1-5.el9",
                 },
               },
               Object {
-                "id": "openssl-libs@1:3.5.1-3.el9",
+                "id": "openssl-libs@1:3.5.1-5.el9",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/centos/openssl-libs@1:3.5.1-3.el9?distro=centos-9&epoch=1&upstream=openssl%403.5.1",
-                  "version": "1:3.5.1-3.el9",
+                  "purl": "pkg:rpm/centos/openssl-libs@1:3.5.1-5.el9?distro=centos-9&epoch=1&upstream=openssl%403.5.1",
+                  "version": "1:3.5.1-5.el9",
                 },
               },
               Object {
@@ -2232,19 +2232,19 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "sha256:176af7fd968fb5c4089a70f7f8292b83d3319ad280411eca1e85d72a7a0f3e6c",
+          "data": "sha256:961c50f6ebc8e5f5c3a167ac730e3f34609d170f551f62423f6bdb7ef2514e66",
           "type": "imageId",
         },
         Object {
           "data": Array [
-            "sha256:de26b07477a040a7067efc3831eddd6518f3cb31890e04cdb16254127a90c3f0",
+            "sha256:c321a9d837c4e0c20fcd622b1d4962694a6a46b0c21b5da258d63aaaa880ab6c",
           ],
           "type": "imageLayers",
         },
         Object {
           "data": Object {
             "io.buildah.version": "1.33.12",
-            "org.label-schema.build-date": "20250909",
+            "org.label-schema.build-date": "20250916",
             "org.label-schema.license": "GPLv2",
             "org.label-schema.name": "CentOS Stream 9 Base Image",
             "org.label-schema.schema-version": "1.0",
@@ -2253,12 +2253,12 @@ Object {
           "type": "imageLabels",
         },
         Object {
-          "data": "2025-09-09T00:54:43.711279439Z",
+          "data": "2025-09-16T01:00:02.451168844Z",
           "type": "imageCreationTime",
         },
         Object {
           "data": Array [
-            "sha256:fdfcedefe5fe7b2f2571b04b2777afdc922aeb85b9590cd355f49001b675f64e",
+            "sha256:3133d3a1c7a2da42aee7171a6ebfa8984679e3a25990c487a3b572f3f849d4ff",
           ],
           "type": "rootFs",
         },
@@ -2269,8 +2269,8 @@ Object {
         Object {
           "data": Object {
             "names": Array [
-              "quay.io/centos/centos@sha256:3d97213cc9e44fc6d055968dac5b922a106eb7e557148973d1e7717320ca9801",
-              "quay.io/centos/centos@sha256:3d97213cc9e44fc6d055968dac5b922a106eb7e557148973d1e7717320ca9801",
+              "quay.io/centos/centos@sha256:60f831ea21128433798b74d2181375c5da2c04e3397a6e7ad3b9abf47159e550",
+              "quay.io/centos/centos@sha256:60f831ea21128433798b74d2181375c5da2c04e3397a6e7ad3b9abf47159e550",
             ],
           },
           "type": "imageNames",
@@ -2428,19 +2428,19 @@ Object {
                       "nodeId": "glib2@2.80.4-8.el10",
                     },
                     Object {
-                      "nodeId": "glibc@2.39-56.el10",
+                      "nodeId": "glibc@2.39-59.el10",
                     },
                     Object {
-                      "nodeId": "glibc-common@2.39-56.el10",
+                      "nodeId": "glibc-common@2.39-59.el10",
                     },
                     Object {
-                      "nodeId": "glibc-gconv-extra@2.39-56.el10",
+                      "nodeId": "glibc-gconv-extra@2.39-59.el10",
                     },
                     Object {
-                      "nodeId": "glibc-langpack-en@2.39-56.el10",
+                      "nodeId": "glibc-langpack-en@2.39-59.el10",
                     },
                     Object {
-                      "nodeId": "glibc-minimal-langpack@2.39-56.el10",
+                      "nodeId": "glibc-minimal-langpack@2.39-59.el10",
                     },
                     Object {
                       "nodeId": "gmp@1:6.2.1-12.el10",
@@ -2641,10 +2641,10 @@ Object {
                       "nodeId": "ncurses-libs@6.4-14.20240127.el10",
                     },
                     Object {
-                      "nodeId": "openssl-fips-provider@1:3.5.1-3.el10",
+                      "nodeId": "openssl-fips-provider@1:3.5.1-5.el10",
                     },
                     Object {
-                      "nodeId": "openssl-libs@1:3.5.1-3.el10",
+                      "nodeId": "openssl-libs@1:3.5.1-5.el10",
                     },
                     Object {
                       "nodeId": "p11-kit@0.25.5-7.el10",
@@ -2749,7 +2749,7 @@ Object {
                       "nodeId": "shadow-utils@2:4.15.0-8.el10",
                     },
                     Object {
-                      "nodeId": "sqlite-libs@3.46.1-4.el10",
+                      "nodeId": "sqlite-libs@3.46.1-5.el10",
                     },
                     Object {
                       "nodeId": "systemd@257-13.el10",
@@ -3003,28 +3003,28 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc@2.39-56.el10",
-                  "pkgId": "glibc@2.39-56.el10",
+                  "nodeId": "glibc@2.39-59.el10",
+                  "pkgId": "glibc@2.39-59.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-common@2.39-56.el10",
-                  "pkgId": "glibc-common@2.39-56.el10",
+                  "nodeId": "glibc-common@2.39-59.el10",
+                  "pkgId": "glibc-common@2.39-59.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-gconv-extra@2.39-56.el10",
-                  "pkgId": "glibc-gconv-extra@2.39-56.el10",
+                  "nodeId": "glibc-gconv-extra@2.39-59.el10",
+                  "pkgId": "glibc-gconv-extra@2.39-59.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-langpack-en@2.39-56.el10",
-                  "pkgId": "glibc-langpack-en@2.39-56.el10",
+                  "nodeId": "glibc-langpack-en@2.39-59.el10",
+                  "pkgId": "glibc-langpack-en@2.39-59.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "glibc-minimal-langpack@2.39-56.el10",
-                  "pkgId": "glibc-minimal-langpack@2.39-56.el10",
+                  "nodeId": "glibc-minimal-langpack@2.39-59.el10",
+                  "pkgId": "glibc-minimal-langpack@2.39-59.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3358,13 +3358,13 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "openssl-fips-provider@1:3.5.1-3.el10",
-                  "pkgId": "openssl-fips-provider@1:3.5.1-3.el10",
+                  "nodeId": "openssl-fips-provider@1:3.5.1-5.el10",
+                  "pkgId": "openssl-fips-provider@1:3.5.1-5.el10",
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "openssl-libs@1:3.5.1-3.el10",
-                  "pkgId": "openssl-libs@1:3.5.1-3.el10",
+                  "nodeId": "openssl-libs@1:3.5.1-5.el10",
+                  "pkgId": "openssl-libs@1:3.5.1-5.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3538,8 +3538,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "sqlite-libs@3.46.1-4.el10",
-                  "pkgId": "sqlite-libs@3.46.1-4.el10",
+                  "nodeId": "sqlite-libs@3.46.1-5.el10",
+                  "pkgId": "sqlite-libs@3.46.1-5.el10",
                 },
                 Object {
                   "deps": Array [],
@@ -3957,43 +3957,43 @@ Object {
                 },
               },
               Object {
-                "id": "glibc@2.39-56.el10",
+                "id": "glibc@2.39-59.el10",
                 "info": Object {
                   "name": "glibc",
-                  "purl": "pkg:rpm/centos/glibc@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-56.el10",
+                  "purl": "pkg:rpm/centos/glibc@2.39-59.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-59.el10",
                 },
               },
               Object {
-                "id": "glibc-common@2.39-56.el10",
+                "id": "glibc-common@2.39-59.el10",
                 "info": Object {
                   "name": "glibc-common",
-                  "purl": "pkg:rpm/centos/glibc-common@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-56.el10",
+                  "purl": "pkg:rpm/centos/glibc-common@2.39-59.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-59.el10",
                 },
               },
               Object {
-                "id": "glibc-gconv-extra@2.39-56.el10",
+                "id": "glibc-gconv-extra@2.39-59.el10",
                 "info": Object {
                   "name": "glibc-gconv-extra",
-                  "purl": "pkg:rpm/centos/glibc-gconv-extra@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-56.el10",
+                  "purl": "pkg:rpm/centos/glibc-gconv-extra@2.39-59.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-59.el10",
                 },
               },
               Object {
-                "id": "glibc-langpack-en@2.39-56.el10",
+                "id": "glibc-langpack-en@2.39-59.el10",
                 "info": Object {
                   "name": "glibc-langpack-en",
-                  "purl": "pkg:rpm/centos/glibc-langpack-en@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-56.el10",
+                  "purl": "pkg:rpm/centos/glibc-langpack-en@2.39-59.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-59.el10",
                 },
               },
               Object {
-                "id": "glibc-minimal-langpack@2.39-56.el10",
+                "id": "glibc-minimal-langpack@2.39-59.el10",
                 "info": Object {
                   "name": "glibc-minimal-langpack",
-                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.39-56.el10?distro=centos-10&upstream=glibc%402.39",
-                  "version": "2.39-56.el10",
+                  "purl": "pkg:rpm/centos/glibc-minimal-langpack@2.39-59.el10?distro=centos-10&upstream=glibc%402.39",
+                  "version": "2.39-59.el10",
                 },
               },
               Object {
@@ -4525,19 +4525,19 @@ Object {
                 },
               },
               Object {
-                "id": "openssl-fips-provider@1:3.5.1-3.el10",
+                "id": "openssl-fips-provider@1:3.5.1-5.el10",
                 "info": Object {
                   "name": "openssl-fips-provider",
-                  "purl": "pkg:rpm/centos/openssl-fips-provider@1:3.5.1-3.el10?distro=centos-10&epoch=1&upstream=openssl%403.5.1",
-                  "version": "1:3.5.1-3.el10",
+                  "purl": "pkg:rpm/centos/openssl-fips-provider@1:3.5.1-5.el10?distro=centos-10&epoch=1&upstream=openssl%403.5.1",
+                  "version": "1:3.5.1-5.el10",
                 },
               },
               Object {
-                "id": "openssl-libs@1:3.5.1-3.el10",
+                "id": "openssl-libs@1:3.5.1-5.el10",
                 "info": Object {
                   "name": "openssl-libs",
-                  "purl": "pkg:rpm/centos/openssl-libs@1:3.5.1-3.el10?distro=centos-10&epoch=1&upstream=openssl%403.5.1",
-                  "version": "1:3.5.1-3.el10",
+                  "purl": "pkg:rpm/centos/openssl-libs@1:3.5.1-5.el10?distro=centos-10&epoch=1&upstream=openssl%403.5.1",
+                  "version": "1:3.5.1-5.el10",
                 },
               },
               Object {
@@ -4813,11 +4813,11 @@ Object {
                 },
               },
               Object {
-                "id": "sqlite-libs@3.46.1-4.el10",
+                "id": "sqlite-libs@3.46.1-5.el10",
                 "info": Object {
                   "name": "sqlite-libs",
-                  "purl": "pkg:rpm/centos/sqlite-libs@3.46.1-4.el10?distro=centos-10&upstream=sqlite%403.46.1",
-                  "version": "3.46.1-4.el10",
+                  "purl": "pkg:rpm/centos/sqlite-libs@3.46.1-5.el10?distro=centos-10&upstream=sqlite%403.46.1",
+                  "version": "3.46.1-5.el10",
                 },
               },
               Object {
@@ -4922,19 +4922,19 @@ Object {
           "type": "depGraph",
         },
         Object {
-          "data": "sha256:499f4e705aa0cd70f6177f1185bf4cb2fef5247ad034f228da9871047d9488fe",
+          "data": "sha256:2538192b93b75090d3212f5a445d300a2d5d3e48dcdafaf96a4ee9696016097d",
           "type": "imageId",
         },
         Object {
           "data": Array [
-            "sha256:cf42a3734a2180e4cfdc8ad11ec7e457a8dcb7edc4a234c863efa04e2e6cb035",
+            "sha256:380e5264cbded1bb6d85ac7dfdf4f6b3d9a2e90df2f63ce08b14b8afb92350fe",
           ],
           "type": "imageLayers",
         },
         Object {
           "data": Object {
             "io.buildah.version": "1.33.12",
-            "org.label-schema.build-date": "20250909",
+            "org.label-schema.build-date": "20250916",
             "org.label-schema.license": "GPLv2",
             "org.label-schema.name": "CentOS Stream 10 Base Image",
             "org.label-schema.schema-version": "1.0",
@@ -4943,12 +4943,12 @@ Object {
           "type": "imageLabels",
         },
         Object {
-          "data": "2025-09-09T01:43:13.399791163Z",
+          "data": "2025-09-16T05:15:20.112847896Z",
           "type": "imageCreationTime",
         },
         Object {
           "data": Array [
-            "sha256:ebf6966c1c62fb8983f46fe1531243219f37cab83284b1f56e3967e6bc104212",
+            "sha256:15eb6f655ad99b818100aa16da80cac7e417bdcf8ee52cdf34910a6d99cd7193",
           ],
           "type": "rootFs",
         },
@@ -4959,8 +4959,8 @@ Object {
         Object {
           "data": Object {
             "names": Array [
-              "quay.io/centos/centos@sha256:277f2b6361ea16917abf73bdaab672ff137045c181be7f0ed5c826cf00542dcf",
-              "quay.io/centos/centos@sha256:277f2b6361ea16917abf73bdaab672ff137045c181be7f0ed5c826cf00542dcf",
+              "quay.io/centos/centos@sha256:798fbe5c40fba2609fae716f5414af6654df21d2552927e85de6a11d20bbff7d",
+              "quay.io/centos/centos@sha256:798fbe5c40fba2609fae716f5414af6654df21d2552927e85de6a11d20bbff7d",
             ],
           },
           "type": "imageNames",

--- a/test/system/package-managers/rpm.spec.ts
+++ b/test/system/package-managers/rpm.spec.ts
@@ -25,8 +25,8 @@ describe("rpm package manager tests", () => {
       "amazonlinux:2022.0.20220504.1",
       "registry.access.redhat.com/ubi9/ubi@sha256:c113f67e8e70940af28116d75e32f0aa4ffd3bf6fab30e970850475ab1de697f",
       "registry.access.redhat.com/ubi10-beta/ubi@sha256:4b4976d86eefeedab6884c9d2923206c6c3c2e2471206f97fd9d7aaaecbc04ac",
-      "quay.io/centos/centos@sha256:db73b2ac6c8a9f199bdacf2f0e759429b0287a8be95c9a9e26dc1d594e0d84a2",
-      "quay.io/centos/centos@sha256:7459813cfcd8a6b8e62c6fd080e000504424c41125045f87a085b2d695ae006e",
+      "quay.io/centos/centos@sha256:3d97213cc9e44fc6d055968dac5b922a106eb7e557148973d1e7717320ca9801", // stream9
+      "quay.io/centos/centos@sha256:277f2b6361ea16917abf73bdaab672ff137045c181be7f0ed5c826cf00542dcf", // stream10
     ]).catch(() => {
       console.error(`tests teardown failed to remove docker image`);
     });
@@ -73,8 +73,9 @@ describe("rpm package manager tests", () => {
   it("should correctly analyze a CentOS Stream 9 image", async () => {
     // quay doesn't always keep older shas, so if this fails, get the sha from the latest
     // stream9 at https://quay.io/repository/centos/centos?tab=tags&tag=stream9
+    // OR run npm run update-quay-tests to update the shas
     const image =
-      "quay.io/centos/centos@sha256:db73b2ac6c8a9f199bdacf2f0e759429b0287a8be95c9a9e26dc1d594e0d84a2";
+      "quay.io/centos/centos@sha256:3d97213cc9e44fc6d055968dac5b922a106eb7e557148973d1e7717320ca9801";
     const pluginResult = await scan({
       path: image,
       platform: "linux/amd64",
@@ -85,8 +86,9 @@ describe("rpm package manager tests", () => {
   it("should correctly analyze a CentOS Stream 10 image", async () => {
     // quay doesn't always keep older shas, so if this fails, get the sha from the latest
     // stream10 at https://quay.io/repository/centos/centos?tab=tags&tag=stream10
+    // OR run npm run update-quay-tests to update the shas
     const image =
-      "quay.io/centos/centos@sha256:7459813cfcd8a6b8e62c6fd080e000504424c41125045f87a085b2d695ae006e";
+      "quay.io/centos/centos@sha256:277f2b6361ea16917abf73bdaab672ff137045c181be7f0ed5c826cf00542dcf";
     const pluginResult = await scan({
       path: image,
       platform: "linux/amd64",

--- a/test/system/package-managers/rpm.spec.ts
+++ b/test/system/package-managers/rpm.spec.ts
@@ -1,6 +1,7 @@
 import { Docker } from "../../../lib/docker";
 import { scan } from "../../../lib/index";
 import { execute } from "../../../lib/sub-process";
+import { CENTOS_SHAS } from "../../fixtures/centos-shas";
 
 describe("rpm package manager tests", () => {
   beforeAll(() => {
@@ -25,8 +26,8 @@ describe("rpm package manager tests", () => {
       "amazonlinux:2022.0.20220504.1",
       "registry.access.redhat.com/ubi9/ubi@sha256:c113f67e8e70940af28116d75e32f0aa4ffd3bf6fab30e970850475ab1de697f",
       "registry.access.redhat.com/ubi10-beta/ubi@sha256:4b4976d86eefeedab6884c9d2923206c6c3c2e2471206f97fd9d7aaaecbc04ac",
-      "quay.io/centos/centos@sha256:3d97213cc9e44fc6d055968dac5b922a106eb7e557148973d1e7717320ca9801", // stream9
-      "quay.io/centos/centos@sha256:277f2b6361ea16917abf73bdaab672ff137045c181be7f0ed5c826cf00542dcf", // stream10
+      `quay.io/centos/centos@${CENTOS_SHAS.stream9}`, // stream9
+      `quay.io/centos/centos@${CENTOS_SHAS.stream10}`, // stream10
     ]).catch(() => {
       console.error(`tests teardown failed to remove docker image`);
     });
@@ -74,8 +75,7 @@ describe("rpm package manager tests", () => {
     // quay doesn't always keep older shas, so if this fails, get the sha from the latest
     // stream9 at https://quay.io/repository/centos/centos?tab=tags&tag=stream9
     // OR run npm run update-quay-tests to update the shas
-    const image =
-      "quay.io/centos/centos@sha256:3d97213cc9e44fc6d055968dac5b922a106eb7e557148973d1e7717320ca9801";
+    const image = `quay.io/centos/centos@${CENTOS_SHAS.stream9}`;
     const pluginResult = await scan({
       path: image,
       platform: "linux/amd64",
@@ -87,8 +87,7 @@ describe("rpm package manager tests", () => {
     // quay doesn't always keep older shas, so if this fails, get the sha from the latest
     // stream10 at https://quay.io/repository/centos/centos?tab=tags&tag=stream10
     // OR run npm run update-quay-tests to update the shas
-    const image =
-      "quay.io/centos/centos@sha256:277f2b6361ea16917abf73bdaab672ff137045c181be7f0ed5c826cf00542dcf";
+    const image = `quay.io/centos/centos@${CENTOS_SHAS.stream10}`;
     const pluginResult = await scan({
       path: image,
       platform: "linux/amd64",

--- a/update_centos_shas.sh
+++ b/update_centos_shas.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Script to fetch latest SHA256 digests for CentOS stream images and update test file
+
+set -e
+
+echo "Fetching SHA256 digest for quay.io/centos/centos:stream9..."
+STREAM9_SHA=$(docker manifest inspect --verbose quay.io/centos/centos:stream9 | jq -r '.[] | select(.Descriptor.platform.architecture == "amd64" and .Descriptor.platform.os == "linux") | .Descriptor.digest')
+
+echo "Fetching SHA256 digest for quay.io/centos/centos:stream10..."
+STREAM10_SHA=$(docker manifest inspect --verbose quay.io/centos/centos:stream10 | jq -r '.[] | select(.Descriptor.platform.architecture == "amd64" and .Descriptor.platform.os == "linux") | .Descriptor.digest')
+
+echo "Stream 9 SHA: $STREAM9_SHA"
+echo "Stream 10 SHA: $STREAM10_SHA"
+
+# Validate we got proper SHA digests
+if [[ ! $STREAM9_SHA =~ ^sha256:[a-f0-9]{64}$ ]]; then
+    echo "Error: Invalid stream9 SHA format: $STREAM9_SHA"
+    exit 1
+fi
+
+if [[ ! $STREAM10_SHA =~ ^sha256:[a-f0-9]{64}$ ]]; then
+    echo "Error: Invalid stream10 SHA format: $STREAM10_SHA"
+    exit 1
+fi
+
+TEST_FILE="test/system/package-managers/rpm.spec.ts"
+
+echo "Updating $TEST_FILE with new SHA digests..."
+
+# Update line 28 (stream9 in afterAll cleanup)
+sed -i.bak "28s|quay.io/centos/centos@sha256:[a-f0-9]*|quay.io/centos/centos@$STREAM9_SHA|" "$TEST_FILE"
+
+# Update line 29 (stream10 in afterAll cleanup)  
+sed -i.bak "29s|quay.io/centos/centos@sha256:[a-f0-9]*|quay.io/centos/centos@$STREAM10_SHA|" "$TEST_FILE"
+
+# Update line 78 (stream9 in test)
+sed -i.bak "78s|quay.io/centos/centos@sha256:[a-f0-9]*|quay.io/centos/centos@$STREAM9_SHA|" "$TEST_FILE"
+
+# Update line 91 (stream10 in test)
+sed -i.bak "91s|quay.io/centos/centos@sha256:[a-f0-9]*|quay.io/centos/centos@$STREAM10_SHA|" "$TEST_FILE"
+
+# Remove backup file
+rm "${TEST_FILE}.bak"
+
+echo "Successfully updated $TEST_FILE with:"
+echo "  Stream 9: $STREAM9_SHA"
+echo "  Stream 10: $STREAM10_SHA"
+
+echo ""
+echo "Updated lines:"
+echo "Line 28: $(sed -n '28p' "$TEST_FILE")"
+echo "Line 29: $(sed -n '29p' "$TEST_FILE")"
+echo "Line 78: $(sed -n '78p' "$TEST_FILE")"
+echo "Line 91: $(sed -n '91p' "$TEST_FILE")"
+
+echo ""
+echo "Running RPM tests to update snapshots..."
+npm run test-jest -- test/system/package-managers/rpm.spec.ts --updateSnapshot
+
+echo ""
+echo "SHA update and snapshot refresh completed successfully!"

--- a/update_centos_shas.sh
+++ b/update_centos_shas.sh
@@ -24,35 +24,25 @@ if [[ ! $STREAM10_SHA =~ ^sha256:[a-f0-9]{64}$ ]]; then
     exit 1
 fi
 
-TEST_FILE="test/system/package-managers/rpm.spec.ts"
+SHA_FILE="test/fixtures/centos-shas.ts"
 
-echo "Updating $TEST_FILE with new SHA digests..."
+echo "Updating $SHA_FILE with new SHA digests..."
 
-# Update line 28 (stream9 in afterAll cleanup)
-sed -i.bak "28s|quay.io/centos/centos@sha256:[a-f0-9]*|quay.io/centos/centos@$STREAM9_SHA|" "$TEST_FILE"
+# Update the SHA file with new digests
+cat > "$SHA_FILE" << EOF
+// CentOS Stream SHA digests for quay.io/centos/centos images
+// This file is automatically updated by the update_centos_shas.sh script
+// Run \`npm run update-quay-tests\` to fetch the latest SHA digests
 
-# Update line 29 (stream10 in afterAll cleanup)  
-sed -i.bak "29s|quay.io/centos/centos@sha256:[a-f0-9]*|quay.io/centos/centos@$STREAM10_SHA|" "$TEST_FILE"
+export const CENTOS_SHAS = {
+  stream9: "$STREAM9_SHA",
+  stream10: "$STREAM10_SHA",
+} as const;
+EOF
 
-# Update line 78 (stream9 in test)
-sed -i.bak "78s|quay.io/centos/centos@sha256:[a-f0-9]*|quay.io/centos/centos@$STREAM9_SHA|" "$TEST_FILE"
-
-# Update line 91 (stream10 in test)
-sed -i.bak "91s|quay.io/centos/centos@sha256:[a-f0-9]*|quay.io/centos/centos@$STREAM10_SHA|" "$TEST_FILE"
-
-# Remove backup file
-rm "${TEST_FILE}.bak"
-
-echo "Successfully updated $TEST_FILE with:"
+echo "Successfully updated $SHA_FILE with:"
 echo "  Stream 9: $STREAM9_SHA"
 echo "  Stream 10: $STREAM10_SHA"
-
-echo ""
-echo "Updated lines:"
-echo "Line 28: $(sed -n '28p' "$TEST_FILE")"
-echo "Line 29: $(sed -n '29p' "$TEST_FILE")"
-echo "Line 78: $(sed -n '78p' "$TEST_FILE")"
-echo "Line 91: $(sed -n '91p' "$TEST_FILE")"
 
 echo ""
 echo "Running RPM tests to update snapshots..."


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
StreamOS 9 and StreamOS 10 tests constantly fail in snyk-docker-plugin.

This is because Redhat’s [quay.io](http://quay.io/) repo does not store old shas once an image is updated. So every time they update the image, the hardcoded sha values need to be updated

To alleviate this, I’ve written a shell script to update the shas and update the test snapshot

So if these fail in the future, run:
`npm run update-quay-tests`


