### PR TITLE
fix: wrap strict input validation for --nested-jars-depth with feature flag

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -90,32 +90,6 @@ async function getAnalysisParameters(
     );
   }
 
-  // Deprecation warnings (lenient mode only)
-  if (!useStrictMode) {
-    const warnings: string[] = [];
-    if (
-      isDefined(options["shaded-jars-depth"]) &&
-      isDefined(options["nested-jars-depth"])
-    ) {
-      warnings.push(
-        "Using both --shaded-jars-depth and --nested-jars-depth is deprecated, use only --nested-jars-depth",
-      );
-    } else if (isDefined(options["shaded-jars-depth"])) {
-      warnings.push(
-        "--shaded-jars-depth is deprecated, use --nested-jars-depth instead",
-      );
-    }
-    if (
-      !isStrictNumber(nestedJarsDepth) &&
-      typeof nestedJarsDepth !== "undefined"
-    ) {
-      warnings.push(
-        "Non-numeric inputs for --nested-jars-depth are deprecated, replace with a numeric input",
-      );
-    }
-    warnings.forEach((msg) => console.warn(chalk.yellow(msg)));
-  }
-
   // TODO temporary solution to avoid double results for PHP if exists in `globsToFind`
   if (options.globsToFind) {
     options.globsToFind.include = options.globsToFind.include.filter(

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -9,12 +9,7 @@ import { ImageName } from "./extractor/image";
 import { ExtractAction, ExtractionResult } from "./extractor/types";
 import { fullImageSavePath } from "./image-save-path";
 import { getArchivePath, getImageType } from "./image-type";
-import {
-  isDefined,
-  isStrictNumber,
-  isTrue,
-  resolveNestedJarsOption,
-} from "./option-utils";
+import { isNumber, isTrue } from "./option-utils";
 import * as staticModule from "./static";
 import { ImageType, PluginOptions, PluginResponse } from "./types";
 import { isValidDockerImageReference } from "./utils";
@@ -45,24 +40,20 @@ async function getAnalysisParameters(
     throw new Error("No image identifier or path provided");
   }
 
+  const nestedJarsDepth =
+    options["nested-jars-depth"] || options["shaded-jars-depth"];
   if (
-    isDefined(options["shaded-jars-depth"]) &&
-    isDefined(options["nested-jars-depth"])
+    (isTrue(nestedJarsDepth) || isNumber(nestedJarsDepth)) &&
+    isTrue(options["exclude-app-vulns"])
   ) {
-    throw new Error(
-      "Cannot use --shaded-jars-depth together with --nested-jars-depth, please use the latter",
-    );
-  }
-
-  const nestedJarsDepth = resolveNestedJarsOption(options);
-  if (isStrictNumber(nestedJarsDepth) && isTrue(options["exclude-app-vulns"])) {
     throw new Error(
       "To use --nested-jars-depth, you must not use --exclude-app-vulns",
     );
   }
 
   if (
-    (!isStrictNumber(nestedJarsDepth) &&
+    (!isNumber(nestedJarsDepth) &&
+      !isTrue(nestedJarsDepth) &&
       typeof nestedJarsDepth !== "undefined") ||
     Number(nestedJarsDepth) < 0
   ) {

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import * as fs from "fs";
 import * as path from "path";
 

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -46,12 +46,16 @@ async function getAnalysisParameters(
   if (!options.path) {
     throw new Error("No image identifier or path provided");
   }
-  
-// Validate nested-jars-depth / shaded-jars-depth options
+
+  // Validate nested-jars-depth / shaded-jars-depth options
   const useStrictMode = isTrue(options["use-strict-jars-depth"]);
 
   // Strict mode: reject both flags being set
-  if (useStrictMode && isDefined(options["shaded-jars-depth"]) && isDefined(options["nested-jars-depth"])) {
+  if (
+    useStrictMode &&
+    isDefined(options["shaded-jars-depth"]) &&
+    isDefined(options["nested-jars-depth"])
+  ) {
     throw new Error(
       "Cannot use --shaded-jars-depth together with --nested-jars-depth, please use the latter",
     );
@@ -76,7 +80,9 @@ async function getAnalysisParameters(
   // Validate the depth value
   const isInvalidValue = useStrictMode
     ? !isStrictNumber(nestedJarsDepth) && typeof nestedJarsDepth !== "undefined"
-    : !isNumber(nestedJarsDepth) && !isTrue(nestedJarsDepth) && typeof nestedJarsDepth !== "undefined";
+    : !isNumber(nestedJarsDepth) &&
+      !isTrue(nestedJarsDepth) &&
+      typeof nestedJarsDepth !== "undefined";
 
   if (isInvalidValue || Number(nestedJarsDepth) < 0) {
     throw new Error(
@@ -87,14 +93,25 @@ async function getAnalysisParameters(
   // Deprecation warnings (lenient mode only)
   if (!useStrictMode) {
     const warnings: string[] = [];
-    if (isDefined(options["shaded-jars-depth"]) && isDefined(options["nested-jars-depth"])) {
-      warnings.push("Using both --shaded-jars-depth and --nested-jars-depth is deprecated, use only --nested-jars-depth");
+    if (
+      isDefined(options["shaded-jars-depth"]) &&
+      isDefined(options["nested-jars-depth"])
+    ) {
+      warnings.push(
+        "Using both --shaded-jars-depth and --nested-jars-depth is deprecated, use only --nested-jars-depth",
+      );
+    } else if (isDefined(options["shaded-jars-depth"])) {
+      warnings.push(
+        "--shaded-jars-depth is deprecated, use --nested-jars-depth instead",
+      );
     }
-    else if (isDefined(options["shaded-jars-depth"])) {
-      warnings.push("--shaded-jars-depth is deprecated, use --nested-jars-depth instead");
-    }
-    if (!isStrictNumber(nestedJarsDepth) && typeof nestedJarsDepth !== "undefined") {
-      warnings.push("Non-numeric inputs for --nested-jars-depth are deprecated, replace with a numeric input");
+    if (
+      !isStrictNumber(nestedJarsDepth) &&
+      typeof nestedJarsDepth !== "undefined"
+    ) {
+      warnings.push(
+        "Non-numeric inputs for --nested-jars-depth are deprecated, replace with a numeric input",
+      );
     }
     warnings.forEach((msg) => console.warn(chalk.yellow(msg)));
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -230,7 +230,8 @@ export interface PluginOptions {
 
   /** Include system-level JARs and WARs from /usr/lib in scan results. The default is "false". */
   "include-system-jars": boolean | string;
-
+  /** Whether to use strict validation for the nested-jars-depth parameter. The default is "false". */
+  "use-strict-jars-depth": boolean | string;
   "target-reference": string;
 }
 

--- a/test/system/application-scans/java.spec.ts
+++ b/test/system/application-scans/java.spec.ts
@@ -145,15 +145,18 @@ describe("jar binaries scanning", () => {
             expect(fingerprints).not.toContainEqual(nestedJar);
           });
 
-          it(`should throw if ${flagName} flag is set to true`, async () => {
-            // Act + Assert
-            await expect(
-              scan({
-                path: imageNameAndTag,
-                "app-vulns": true,
-                [flagName]: true,
-              }),
-            ).rejects.toThrow();
+          it(`should accept ${flagName} flag set to true and treat as depth 1`, async () => {
+            // Default lenient mode accepts boolean true via isTrue()
+            const result = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              [flagName]: true,
+            });
+
+            expect(result.scanResults).toBeDefined();
+            const fingerprints =
+              result.scanResults[1].facts[0].data.fingerprints;
+            expect(fingerprints).toContainEqual(nestedJar);
           });
 
           it(`should throw if ${flagName} flag is set to -1`, async () => {
@@ -167,15 +170,15 @@ describe("jar binaries scanning", () => {
             ).rejects.toThrow();
           });
 
-          it(`should throw if ${flagName} flag is set to ' '`, async () => {
-            // Act + Assert
-            await expect(
-              scan({
-                path: imageNameAndTag,
-                "app-vulns": true,
-                [flagName]: " ",
-              }),
-            ).rejects.toThrow();
+          it(`should accept ${flagName} flag set to ' ' and treat as depth 0`, async () => {
+            // Default lenient mode accepts whitespace (Number(' ') === 0)
+            const result = await scan({
+              path: imageNameAndTag,
+              "app-vulns": true,
+              [flagName]: " ",
+            });
+
+            expect(result.scanResults).toBeDefined();
           });
 
           it("should throw error if exclude-app-vulns flag is true", async () => {
@@ -494,16 +497,16 @@ describe("jar binaries scanning", () => {
       );
       const imageNameAndTag = `docker-archive:${fixturePath}`;
 
-      it(`should throw if both --shaded-jars-depth and --nested-jars-depth flags are set`, async () => {
-        // Act + Assert
-        await expect(
-          scan({
-            path: imageNameAndTag,
-            "app-vulns": true,
-            "shaded-jars-depth": "2",
-            "nested-jars-depth": "4",
-          }),
-        ).rejects.toThrow();
+      it(`should accept both --shaded-jars-depth and --nested-jars-depth flags and use nested-jars-depth`, async () => {
+        // Default lenient mode silently uses nested-jars-depth when both are set
+        const result = await scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "shaded-jars-depth": "2",
+          "nested-jars-depth": "1",
+        });
+
+        expect(result.scanResults).toBeDefined();
       });
     });
   });

--- a/test/system/flags/strict-jars-depth.spec.ts
+++ b/test/system/flags/strict-jars-depth.spec.ts
@@ -1,0 +1,184 @@
+import { scan } from "../../../lib";
+import { getFixture } from "../../util";
+
+describe("use-strict-jars-depth flag", () => {
+  const fixturePath = getFixture(
+    "docker-archives/docker-save/java-uberjar.tar",
+  );
+  const imageNameAndTag = `docker-archive:${fixturePath}`;
+
+  describe("lenient mode (default)", () => {
+    it("accepts boolean true for nested-jars-depth when use-strict-jars-depth is undefined", async () => {
+      const result = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+        "nested-jars-depth": true,
+      });
+
+      expect(result.scanResults).toBeDefined();
+    });
+
+    it("accepts both shaded-jars-depth and nested-jars-depth when use-strict-jars-depth is undefined", async () => {
+      const result = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+        "shaded-jars-depth": "2",
+        "nested-jars-depth": "1",
+      });
+
+      expect(result.scanResults).toBeDefined();
+    });
+
+    it("accepts boolean true when use-strict-jars-depth is false", async () => {
+      const result = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+        "nested-jars-depth": true,
+        "use-strict-jars-depth": false,
+      });
+
+      expect(result.scanResults).toBeDefined();
+    });
+
+    it("accepts both flags when use-strict-jars-depth is false", async () => {
+      const result = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+        "shaded-jars-depth": "2",
+        "nested-jars-depth": "1",
+        "use-strict-jars-depth": false,
+      });
+
+      expect(result.scanResults).toBeDefined();
+    });
+  });
+
+  describe("lenient mode with string values", () => {
+    it("accepts boolean true when use-strict-jars-depth is 'false'", async () => {
+      const result = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+        "nested-jars-depth": true,
+        "use-strict-jars-depth": "false",
+      });
+
+      expect(result.scanResults).toBeDefined();
+    });
+
+    it("accepts both flags when use-strict-jars-depth is 'false'", async () => {
+      const result = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+        "shaded-jars-depth": "2",
+        "nested-jars-depth": "1",
+        "use-strict-jars-depth": "false",
+      });
+
+      expect(result.scanResults).toBeDefined();
+    });
+  });
+
+  describe("strict mode", () => {
+    it("rejects boolean true for nested-jars-depth when use-strict-jars-depth is true", async () => {
+      await expect(
+        scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "nested-jars-depth": true,
+          "use-strict-jars-depth": true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects boolean true for shaded-jars-depth when use-strict-jars-depth is true", async () => {
+      await expect(
+        scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "shaded-jars-depth": true,
+          "use-strict-jars-depth": true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects both shaded-jars-depth and nested-jars-depth when use-strict-jars-depth is true", async () => {
+      await expect(
+        scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "shaded-jars-depth": "2",
+          "nested-jars-depth": "1",
+          "use-strict-jars-depth": true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects boolean true when use-strict-jars-depth is 'true'", async () => {
+      await expect(
+        scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "nested-jars-depth": true,
+          "use-strict-jars-depth": "true",
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects whitespace-only string for nested-jars-depth when use-strict-jars-depth is true", async () => {
+      await expect(
+        scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "nested-jars-depth": " ",
+          "use-strict-jars-depth": true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects whitespace-only string for shaded-jars-depth when use-strict-jars-depth is true", async () => {
+      await expect(
+        scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "shaded-jars-depth": " ",
+          "use-strict-jars-depth": true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects both flags when use-strict-jars-depth is 'true'", async () => {
+      await expect(
+        scan({
+          path: imageNameAndTag,
+          "app-vulns": true,
+          "shaded-jars-depth": "2",
+          "nested-jars-depth": "1",
+          "use-strict-jars-depth": "true",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("valid inputs work in both modes", () => {
+    it("accepts numeric string in lenient mode", async () => {
+      const result = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+        "nested-jars-depth": "1",
+      });
+
+      expect(result.scanResults).toBeDefined();
+    });
+
+    it("accepts numeric string in strict mode", async () => {
+      const result = await scan({
+        path: imageNameAndTag,
+        "app-vulns": true,
+        "nested-jars-depth": "1",
+        "use-strict-jars-depth": true,
+      });
+
+      expect(result.scanResults).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

# What does this PR do?
Adds a feature-flag to wrap the strict input validation added to the `--nested-jars-parameter` in [v9.0.0 ](https://github.com/snyk/snyk-docker-plugin/releases/tag/v9.0.0)([PR](https://github.com/snyk/snyk-docker-plugin/pull/736))

# Where should the reviewer start?
- Added branching logic in `lib/scan.ts` 
- Added a tests for the feature flag @ `test/system/flags/strict-jars-depth.spec.ts`
- Updated system tests @ `test/system/application-scans/java.spec.ts` 
 
# How should this be manually tested?
## 1. Build this branch via `npm i && npm run build`
## 2. Set the feature flag to `false` and confirm the following outputs

**--nested-jars-depth=true is allowed**
```
ianvidal@KQ0HL976HL cli % SNYK_API=https://app.snyk.io/api/v1 node index.js container test node:6-stretch --nested-jars-depth=true 
Non-numeric inputs for --nested-jars-depth are deprecated, replace with a numeric input
| Analyzing container dependencies for node:6-stretch
```

**--nested-jars-depth=Infinity is allowed**
```
ianvidal@KQ0HL976HL cli % SNYK_API=https://app.snyk.io/api/v1 node index.js container test node:6-stretch --nested-jars-depth=Infinity
Non-numeric inputs for --nested-jars-depth are deprecated, replace with a numeric input
- Analyzing container dependencies for node:6-stretch
```

**--nested-jars-depth and --shaded-jars-depth are allowed simultaneously**
```
ianvidal@KQ0HL976HL cli % SNYK_API=https://app.snyk.io/api/v1 node index.js container test node:6-stretch --nested-jars-depth=3 --shaded-jars-depth=3
Using both --shaded-jars-depth and --nested-jars-depth is deprecated, use only --nested-jars-depth
\ Analyzing container dependencies for node:6-stretch
```

## 4. Set the feature flag to true and confirm the following outputs

**--nested-jars-depth=true is not allowed**
```
ianvidal@KQ0HL976HL cli % SNYK_API=https://app.snyk.io/api/v1 node index.js container test node:6-stretch --nested-jars-depth=true    
--nested-jars-depth accepts only numbers bigger than or equal to 0
```

**--nested-jars-depth=Infinity is not allowed**
```
ianvidal@KQ0HL976HL cli % SNYK_API=https://app.snyk.io/api/v1 node index.js container test node:6-stretch --nested-jars-depth=Infinity 
--nested-jars-depth accepts only numbers bigger than or equal to 0
```

**--nested-jars-depth and --shaded-jars-depth are not allowed simultaneously**
```
ianvidal@KQ0HL976HL cli % SNYK_API=https://app.snyk.io/api/v1 node index.js container test node:6-stretch --nested-jars-depth=3 --shaded-jars-depth=3
Cannot use --shaded-jars-depth together with --nested-jars-depth, please use the latter
```

# Any background context you want to provide?
Further discussions on this topic in this [thread](https://snyk.slack.com/archives/C073HFTPLSF/p1769018367714639)

# What are the relevant tickets?
- [CN-270](https://snyksec.atlassian.net/browse/CN-270)

# Screenshots
## When flag is off
<img width="900" height="272" alt="image" src="https://github.com/user-attachments/assets/d020cbb5-6c8a-4675-906b-93c604cb6053" />

## When flag is on
<img width="900" height="176" alt="image" src="https://github.com/user-attachments/assets/4924fce7-1575-40a1-aec3-29cdf04c26f8" />

[CN-270]: https://snyksec.atlassian.net/browse/CN-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ