### PR TITLE
fix: resolve platform detection in archives missing index metadata

### DIFF
--- a/test/lib/extractor/extractor.spec.ts
+++ b/test/lib/extractor/extractor.spec.ts
@@ -164,5 +164,25 @@ describe("extractImageContent", () => {
         ).resolves.not.toThrow();
       });
     });
+
+    describe("with multi-tag images missing platform info in index.json", () => {
+      it("extracts when platform is resolved from config blobs", async () => {
+        const fixture = getFixture("docker-oci-archives/busybox.multi-tag.tar");
+        const result = await extractImageContent(type, fixture, [], {
+          platform: "linux/arm64",
+        });
+        expect(result).toBeDefined();
+        expect(result.platform).toBe("linux/arm64");
+      });
+
+      it("fails when requested platform does not match any config blob", async () => {
+        const fixture = getFixture("docker-oci-archives/busybox.multi-tag.tar");
+        await expect(
+          extractImageContent(type, fixture, [], { platform: "linux/amd64" }),
+        ).rejects.toThrow(
+          "Unsupported archive type. Please use a Docker archive, OCI image layout, or Kaniko-compatible tarball.",
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
Modern Docker versions often produce OCI archives where individual manifests in the index.json lack platform information. This caused the OCI extractor to fail when multiple manifests were present because it couldn't disambiguate them. This fix allows the extractor to resolve platform information from image configuration blobs as a fallback.

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Modern Docker versions often produce OCI archives where individual manifests in the index.json lack platform information. This caused the OCI extractor to fail when multiple manifests were present because it couldn't disambiguate them. This fix allows the extractor to resolve platform information from image configuration blobs as a fallback.

#### Where should the reviewer start?

N/A

#### How should this be manually tested?

Create a tar archive containing multiple manifests from a modern docker daemon with containerd disabled as the image store. Running `snyk container test` on such an image fails with existing public versions of the CLI. Running `snyk container test` with this commit succeeds.

#### Any background context you want to provide?

https://snyk.slack.com/archives/C85H8Q12Q/p1769554752582849

#### What are the relevant tickets?


