### PR TITLE
fix: ensure revert is in new version

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -39,7 +39,7 @@ async function getAnalysisParameters(
   if (!options.path) {
     throw new Error("No image identifier or path provided");
   }
-
+  // keeping this validation logic
   const nestedJarsDepth =
     options["nested-jars-depth"] || options["shaded-jars-depth"];
   if (


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Snyk-docker-plugin v9.1.0 did not have the revert for nested-graph validation as seen here. 
I believe when I was testing the semantic release, I had generated the tag 9.1.0 (without the full release) before the revert was pushed, which meant when pushing the final version, the revert was not included in the tag. 

I simply want to generate a new tag for snyk-docker-plugin (9.1.1) which includes both the revert and my new changes. 
