### PR TITLE
feat: add Go stdlib vulnerability detection to container scans

### DIFF
--- a/lib/go-parser/go-binary.ts
+++ b/lib/go-parser/go-binary.ts
@@ -44,10 +44,12 @@ const debug = Debug("snyk");
 export class GoBinary {
   public name: string;
   public modules: GoModule[];
+  public goVersion: string;
   private hasPclnTab: boolean;
 
   constructor(goElfBinary: Elf) {
-    [this.name, this.modules] = extractModuleInformation(goElfBinary);
+    [this.name, this.modules, this.goVersion] =
+      extractModuleInformation(goElfBinary);
 
     const pclnTab = goElfBinary.body.sections.find(
       (section) => section.name === ".gopclntab",
@@ -106,6 +108,15 @@ export class GoBinary {
         goModulesDepGraph.connectDep(goModulesDepGraph.rootNodeId, nodeId);
       }
       // else: pclnTab exists but module has no packages - don't report anything
+    }
+
+    if (this.goVersion) {
+      const stdlibNodeId = `stdlib@${this.goVersion}`;
+      goModulesDepGraph.addPkgNode(
+        { name: "stdlib", version: this.goVersion },
+        stdlibNodeId,
+      );
+      goModulesDepGraph.connectDep(goModulesDepGraph.rootNodeId, stdlibNodeId);
     }
 
     return goModulesDepGraph.build();
@@ -184,15 +195,29 @@ interface GoFileNameError extends Error {
   moduleName: string;
 }
 
+/**
+ * Strips the "go" prefix from a Go version string and validates the format.
+ * Returns the cleaned version (e.g., "1.21.0") or empty string if invalid.
+ */
+export function parseGoVersion(rawVersion: string): string {
+  const match = rawVersion.match(/^go(\d+\.\d+(?:\.\d+)?)/);
+  if (!match) {
+    return "";
+  }
+  return match[1];
+}
+
 export function extractModuleInformation(
   binary: Elf,
-): [name: string, deps: GoModule[]] {
-  const mod = readRawBuildInfo(binary);
-  if (!mod) {
+): [name: string, deps: GoModule[], goVersion: string] {
+  const { goVersion: rawGoVersion, modInfo } = readRawBuildInfo(binary);
+  if (!modInfo) {
     throw Error("binary contains empty module info");
   }
 
-  const [pathDirective, mainModuleLine, ...versionsLines] = mod
+  const goVersion = parseGoVersion(rawGoVersion);
+
+  const [pathDirective, mainModuleLine, ...versionsLines] = modInfo
     .replace("\r", "")
     .split("\n");
   const lineSplit = mainModuleLine.split("\t");
@@ -224,7 +249,7 @@ export function extractModuleInformation(
     }
   });
 
-  return [name, modules];
+  return [name, modules, goVersion];
 }
 
 // Source
@@ -234,7 +259,12 @@ export function extractModuleInformation(
  * module version information in the executable binary
  * @param binary
  */
-export function readRawBuildInfo(binary: Elf): string {
+export interface RawBuildInfo {
+  goVersion: string;
+  modInfo: string;
+}
+
+export function readRawBuildInfo(binary: Elf): RawBuildInfo {
   const buildInfoMagic = "\xff Go buildinf:";
   // Read the first 64kB of dataAddr to find the build info blob.
   // On some platforms, the blob will be in its own section, and DataStart
@@ -272,9 +302,9 @@ export function readRawBuildInfo(binary: Elf): string {
   const ptrSize = data[14];
   if ((data[15] & 2) !== 0) {
     data = data.subarray(32);
-    [, data] = decodeString(data);
-    const [mod] = decodeString(data);
-    return mod;
+    const [goVersion, rest] = decodeString(data);
+    const [mod] = decodeString(rest);
+    return { goVersion, modInfo: mod };
   } else {
     const bigEndian = data[15] !== 0;
 
@@ -326,7 +356,7 @@ export function readRawBuildInfo(binary: Elf): string {
     // First 16 bytes are unicodes as last 16
     // Mirrors go version source code
     if (mod.length >= 33 && mod[mod.length - 17] === "\n") {
-      return mod.slice(16, mod.length - 16);
+      return { goVersion: version, modInfo: mod.slice(16, mod.length - 16) };
     } else {
       throw Error("binary is not built with go module support");
     }

--- a/lib/go-parser/go-binary.ts
+++ b/lib/go-parser/go-binary.ts
@@ -202,9 +202,13 @@ interface GoFileNameError extends Error {
 /**
  * Strips the "go" prefix from a Go version string and validates the format.
  * Returns the cleaned version (e.g., "1.21.0") or empty string if invalid.
+ * Rejects RC/beta/devel versions since we cannot accurately match vulnerabilities
+ * against pre-release builds.
  */
 export function parseGoVersion(rawVersion: string): string {
-  const match = rawVersion.match(/^go(\d+\.\d+(?:\.\d+)?)/);
+  // Only match release versions (e.g., "go1.21" or "go1.21.5").
+  // Reject RC/beta (go1.21rc1, go1.22beta2) and devel builds.
+  const match = rawVersion.match(/^go(\d+\.\d+(?:\.\d+)?)$/);
   if (!match) {
     return "";
   }

--- a/lib/go-parser/go-binary.ts
+++ b/lib/go-parser/go-binary.ts
@@ -117,6 +117,8 @@ export class GoBinary {
         stdlibNodeId,
       );
       goModulesDepGraph.connectDep(goModulesDepGraph.rootNodeId, stdlibNodeId);
+    } else {
+      debug(`Skipping stdlib node for ${this.name}: could not parse Go version`);
     }
 
     return goModulesDepGraph.build();
@@ -204,7 +206,10 @@ export function parseGoVersion(rawVersion: string): string {
   if (!match) {
     return "";
   }
-  return match[1];
+  const ver = match[1];
+  // Ensure three-segment semver (e.g., "1.19" → "1.19.0") because
+  // @snyk/vuln uses node's semver library which requires three segments.
+  return ver.includes(".", ver.indexOf(".") + 1) ? ver : ver + ".0";
 }
 
 export function extractModuleInformation(

--- a/lib/go-parser/go-binary.ts
+++ b/lib/go-parser/go-binary.ts
@@ -118,7 +118,9 @@ export class GoBinary {
       );
       goModulesDepGraph.connectDep(goModulesDepGraph.rootNodeId, stdlibNodeId);
     } else {
-      debug(`Skipping stdlib node for ${this.name}: could not parse Go version`);
+      debug(
+        `Skipping stdlib node for ${this.name}: could not parse Go version`,
+      );
     }
 
     return goModulesDepGraph.build();

--- a/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
@@ -990,6 +990,9 @@ Object {
                     Object {
                       "nodeId": "gopkg.in/yaml.v3@v3.0.0-20200615113413-eeeca48fe776",
                     },
+                    Object {
+                      "nodeId": "stdlib@1.15.1",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "github.com/mikefarah/yq/v3@",
@@ -1073,6 +1076,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "gopkg.in/yaml.v3@v3.0.0-20200615113413-eeeca48fe776",
                   "pkgId": "gopkg.in/yaml.v3@v3.0.0-20200615113413-eeeca48fe776",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.15.1",
+                  "pkgId": "stdlib@1.15.1",
                 },
               ],
               "rootNodeId": "root-node",
@@ -1197,6 +1205,13 @@ Object {
                 "info": Object {
                   "name": "gopkg.in/yaml.v3",
                   "version": "v3.0.0-20200615113413-eeeca48fe776",
+                },
+              },
+              Object {
+                "id": "stdlib@1.15.1",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.15.1",
                 },
               },
             ],
@@ -1369,6 +1384,9 @@ Object {
                     Object {
                       "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                     },
+                    Object {
+                      "nodeId": "stdlib@1.17.11",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "testgo@",
@@ -1422,6 +1440,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                   "pkgId": "gopkg.in/yaml.v2@v2.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.17.11",
+                  "pkgId": "stdlib@1.17.11",
                 },
               ],
               "rootNodeId": "root-node",
@@ -1504,6 +1527,13 @@ Object {
                 "info": Object {
                   "name": "gopkg.in/yaml.v2",
                   "version": "v2.4.0",
+                },
+              },
+              Object {
+                "id": "stdlib@1.17.11",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.17.11",
                 },
               },
             ],
@@ -1676,6 +1706,9 @@ Object {
                     Object {
                       "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                     },
+                    Object {
+                      "nodeId": "stdlib@1.18.3",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "testgo@",
@@ -1729,6 +1762,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                   "pkgId": "gopkg.in/yaml.v2@v2.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.18.3",
+                  "pkgId": "stdlib@1.18.3",
                 },
               ],
               "rootNodeId": "root-node",
@@ -1811,6 +1849,13 @@ Object {
                 "info": Object {
                   "name": "gopkg.in/yaml.v2",
                   "version": "v2.4.0",
+                },
+              },
+              Object {
+                "id": "stdlib@1.18.3",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.18.3",
                 },
               },
             ],
@@ -1983,6 +2028,9 @@ Object {
                     Object {
                       "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                     },
+                    Object {
+                      "nodeId": "stdlib@1.19",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "testgo@",
@@ -2036,6 +2084,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                   "pkgId": "gopkg.in/yaml.v2@v2.4.0",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.19",
+                  "pkgId": "stdlib@1.19",
                 },
               ],
               "rootNodeId": "root-node",
@@ -2118,6 +2171,13 @@ Object {
                 "info": Object {
                   "name": "gopkg.in/yaml.v2",
                   "version": "v2.4.0",
+                },
+              },
+              Object {
+                "id": "stdlib@1.19",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.19",
                 },
               },
             ],

--- a/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
@@ -2028,9 +2028,6 @@ Object {
                     Object {
                       "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                     },
-                    Object {
-                      "nodeId": "stdlib@1.19.0",
-                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "testgo@",
@@ -2084,11 +2081,6 @@ Object {
                   "deps": Array [],
                   "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                   "pkgId": "gopkg.in/yaml.v2@v2.4.0",
-                },
-                Object {
-                  "deps": Array [],
-                  "nodeId": "stdlib@1.19.0",
-                  "pkgId": "stdlib@1.19.0",
                 },
               ],
               "rootNodeId": "root-node",
@@ -2171,13 +2163,6 @@ Object {
                 "info": Object {
                   "name": "gopkg.in/yaml.v2",
                   "version": "v2.4.0",
-                },
-              },
-              Object {
-                "id": "stdlib@1.19.0",
-                "info": Object {
-                  "name": "stdlib",
-                  "version": "1.19.0",
                 },
               },
             ],

--- a/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
@@ -2029,7 +2029,7 @@ Object {
                       "nodeId": "gopkg.in/yaml.v2@v2.4.0",
                     },
                     Object {
-                      "nodeId": "stdlib@1.19",
+                      "nodeId": "stdlib@1.19.0",
                     },
                   ],
                   "nodeId": "root-node",
@@ -2087,8 +2087,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "stdlib@1.19",
-                  "pkgId": "stdlib@1.19",
+                  "nodeId": "stdlib@1.19.0",
+                  "pkgId": "stdlib@1.19.0",
                 },
               ],
               "rootNodeId": "root-node",
@@ -2174,10 +2174,10 @@ Object {
                 },
               },
               Object {
-                "id": "stdlib@1.19",
+                "id": "stdlib@1.19.0",
                 "info": Object {
                   "name": "stdlib",
-                  "version": "1.19",
+                  "version": "1.19.0",
                 },
               },
             ],

--- a/test/system/application-scans/gomodules.spec.ts
+++ b/test/system/application-scans/gomodules.spec.ts
@@ -155,7 +155,8 @@ describe("Stripped Go binary without .gopclntab: no-pcln-tab fixture", () => {
       expect(found).toBeDefined();
     });
 
-    expect(deps.length).toBe(expectedDepsNoPcln.length);
+    // +1 for stdlib pseudo-dependency when goVersion is present
+    expect(deps.length).toBe(expectedDepsNoPcln.length + 1);
     expect(depGraph.rootPkg.name).toBe(
       "github.com/rootless-containers/rootlesskit",
     );
@@ -231,7 +232,8 @@ describe("Stripped and CGo Go binaries detection scan handler test", () => {
     });
 
     if (detectedBinaries.fleetServer) {
-      expect(detectedBinaries.fleetServer.moduleCount).toEqual(76);
+      // +1 for stdlib pseudo-dependency when goVersion is present
+      expect(detectedBinaries.fleetServer.moduleCount).toEqual(77);
     } else {
       fail("fleet-server not detected");
     }

--- a/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
@@ -2225,6 +2225,9 @@ Object {
                     Object {
                       "nodeId": "github.com/xrash/smetrics@v0.0.0-20201216005158-039620a65673",
                     },
+                    Object {
+                      "nodeId": "stdlib@1.21.5",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "github.com/SUSE/container-suseconnect@",
@@ -2248,6 +2251,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "github.com/xrash/smetrics@v0.0.0-20201216005158-039620a65673",
                   "pkgId": "github.com/xrash/smetrics@v0.0.0-20201216005158-039620a65673",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.21.5",
+                  "pkgId": "stdlib@1.21.5",
                 },
               ],
               "rootNodeId": "root-node",
@@ -2288,6 +2296,13 @@ Object {
                 "info": Object {
                   "name": "github.com/xrash/smetrics",
                   "version": "v0.0.0-20201216005158-039620a65673",
+                },
+              },
+              Object {
+                "id": "stdlib@1.21.5",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.21.5",
                 },
               },
             ],

--- a/test/unit/go-binaries.spec.ts
+++ b/test/unit/go-binaries.spec.ts
@@ -547,13 +547,13 @@ describe("parseGoVersion", () => {
     expect(parseGoVersion("go1.21.0")).toBe("1.21.0");
   });
 
-  it("handles version without patch number", () => {
-    expect(parseGoVersion("go1.21")).toBe("1.21");
+  it("handles version without patch number by appending .0", () => {
+    expect(parseGoVersion("go1.21")).toBe("1.21.0");
   });
 
-  it("extracts version from RC/beta strings", () => {
-    expect(parseGoVersion("go1.21rc1")).toBe("1.21");
-    expect(parseGoVersion("go1.22beta2")).toBe("1.22");
+  it("extracts version from RC/beta strings and normalizes to three segments", () => {
+    expect(parseGoVersion("go1.21rc1")).toBe("1.21.0");
+    expect(parseGoVersion("go1.22beta2")).toBe("1.22.0");
   });
 
   it("returns empty string for devel versions", () => {
@@ -571,17 +571,12 @@ describe("parseGoVersion", () => {
 
 describe("extractModuleInformation returns goVersion", () => {
   it("returns a valid Go version from a real binary", () => {
-    const files = readdirSync(path.join(__dirname, "../fixtures/go-binaries"));
-    const file = files.find((f) => f.match(/^go1\.[0-9]{1,2}\.[0-9]{1,2}_.*/));
-    if (!file) {
-      return;
-    }
     const fileContent = readFileSync(
-      path.join(__dirname, "../fixtures/go-binaries/", file),
+      path.join(__dirname, "../fixtures/go-binaries/go1.18.5_normal"),
     );
     const elfBinary = elf.parse(fileContent);
     const [, , goVersion] = extractModuleInformation(elfBinary);
-    expect(goVersion).toMatch(/^\d+\.\d+(\.\d+)?$/);
+    expect(goVersion).toBe("1.18.5");
   });
 });
 

--- a/test/unit/go-binaries.spec.ts
+++ b/test/unit/go-binaries.spec.ts
@@ -8,6 +8,7 @@ import {
   determinePaths,
   extractModuleInformation,
   GoBinary,
+  parseGoVersion,
 } from "../../lib/go-parser/go-binary";
 import { GoModule } from "../../lib/go-parser/go-module";
 import { LineTable } from "../../lib/go-parser/pclntab";
@@ -375,6 +376,13 @@ describe("test from binaries", () => {
         testCase.depGraphPackages().forEach((pkg) => {
           expect(pkgs).toContainEqual(pkg);
         });
+
+        // stdlib node should always be present with a valid Go version
+        expect(goBin.goVersion).toMatch(/^\d+\.\d+(\.\d+)?$/);
+        expect(pkgs).toContainEqual({
+          name: "stdlib",
+          version: goBin.goVersion,
+        });
       });
 
       // ensures that the mapping process is correct on arbitrary data. For this
@@ -414,7 +422,7 @@ describe("test from binaries", () => {
 });
 
 describe("test stdlib bin project name", () => {
-  it("has correct project name even if mod directive is missing", () => {
+  it("has correct project name even if mod directive is missing", async () => {
     const goBin = new GoBinary(
       elf.parse(
         readFileSync(
@@ -425,6 +433,14 @@ describe("test stdlib bin project name", () => {
     expect(goBin.name).toBe("go-distribution@cmd/pack");
     // binaries from the standard library usually don't have external deps.
     expect(goBin.modules).toHaveLength(0);
+
+    // stdlib node should still be present even with no external deps
+    expect(goBin.goVersion).toMatch(/^\d+\.\d+(\.\d+)?$/);
+    const graph = await goBin.depGraph();
+    expect(graph.getPkgs()).toContainEqual({
+      name: "stdlib",
+      version: goBin.goVersion,
+    });
   });
 });
 
@@ -440,6 +456,20 @@ describe("test binary without pcln table", () => {
       }),
     ).resolves.not.toThrow();
   });
+
+  it("still reports stdlib for stripped binaries", async () => {
+    const fileName = path.join(
+      __dirname,
+      "../fixtures/go-binaries/no-pcln-tab",
+    );
+    const goBin = new GoBinary(elf.parse(readFileSync(fileName)));
+    expect(goBin.goVersion).toMatch(/^\d+\.\d+(\.\d+)?$/);
+    const graph = await goBin.depGraph();
+    expect(graph.getPkgs()).toContainEqual({
+      name: "stdlib",
+      version: goBin.goVersion,
+    });
+  });
 });
 
 // The Go stdlib contains a vendored module, `golang.org/x/net`. If a binary
@@ -454,9 +484,8 @@ describe("test stdlib vendor", () => {
       __dirname,
       "../fixtures/go-binaries/fake-vendor",
     );
-    const graph = await new GoBinary(
-      elf.parse(readFileSync(fileName)),
-    ).depGraph();
+    const goBin = new GoBinary(elf.parse(readFileSync(fileName)));
+    const graph = await goBin.depGraph();
 
     expect(graph.getPkgs()).toContainEqual({
       name: "golang.org/x/net/http/httpguts",
@@ -467,6 +496,12 @@ describe("test stdlib vendor", () => {
       version: "v1.6.1",
     });
     expect(graph.rootPkg.name).toBe("github.com/myrepo/partvend");
+
+    // stdlib should be present
+    expect(graph.getPkgs()).toContainEqual({
+      name: "stdlib",
+      version: goBin.goVersion,
+    });
   });
 });
 
@@ -504,6 +539,49 @@ describe("test replace directive", () => {
       name: "github.com/gorilla/mux",
       version: "v1.6.0",
     });
+  });
+});
+
+describe("parseGoVersion", () => {
+  it("strips go prefix from standard version", () => {
+    expect(parseGoVersion("go1.21.0")).toBe("1.21.0");
+  });
+
+  it("handles version without patch number", () => {
+    expect(parseGoVersion("go1.21")).toBe("1.21");
+  });
+
+  it("extracts version from RC/beta strings", () => {
+    expect(parseGoVersion("go1.21rc1")).toBe("1.21");
+    expect(parseGoVersion("go1.22beta2")).toBe("1.22");
+  });
+
+  it("returns empty string for devel versions", () => {
+    expect(parseGoVersion("devel +abc123")).toBe("");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(parseGoVersion("")).toBe("");
+  });
+
+  it("returns empty string for garbage input", () => {
+    expect(parseGoVersion("not-a-version")).toBe("");
+  });
+});
+
+describe("extractModuleInformation returns goVersion", () => {
+  it("returns a valid Go version from a real binary", () => {
+    const files = readdirSync(path.join(__dirname, "../fixtures/go-binaries"));
+    const file = files.find((f) => f.match(/^go1\.[0-9]{1,2}\.[0-9]{1,2}_.*/));
+    if (!file) {
+      return;
+    }
+    const fileContent = readFileSync(
+      path.join(__dirname, "../fixtures/go-binaries/", file),
+    );
+    const elfBinary = elf.parse(fileContent);
+    const [, , goVersion] = extractModuleInformation(elfBinary);
+    expect(goVersion).toMatch(/^\d+\.\d+(\.\d+)?$/);
   });
 });
 

--- a/test/unit/go-binaries.spec.ts
+++ b/test/unit/go-binaries.spec.ts
@@ -551,9 +551,9 @@ describe("parseGoVersion", () => {
     expect(parseGoVersion("go1.21")).toBe("1.21.0");
   });
 
-  it("extracts version from RC/beta strings and normalizes to three segments", () => {
-    expect(parseGoVersion("go1.21rc1")).toBe("1.21.0");
-    expect(parseGoVersion("go1.22beta2")).toBe("1.22.0");
+  it("returns empty string for RC/beta versions", () => {
+    expect(parseGoVersion("go1.21rc1")).toBe("");
+    expect(parseGoVersion("go1.22beta2")).toBe("");
   });
 
   it("returns empty string for devel versions", () => {

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -458,6 +458,9 @@ Object {
                     Object {
                       "nodeId": "k8s.io/klog/v2@v2.80.1",
                     },
+                    Object {
+                      "nodeId": "stdlib@1.19",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "github.com/kubernetes-csi/livenessprobe@",
@@ -1051,6 +1054,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "k8s.io/klog/v2@v2.80.1",
                   "pkgId": "k8s.io/klog/v2@v2.80.1",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.19",
+                  "pkgId": "stdlib@1.19",
                 },
               ],
               "rootNodeId": "root-node",
@@ -1891,6 +1899,13 @@ Object {
                   "version": "v2.80.1",
                 },
               },
+              Object {
+                "id": "stdlib@1.19",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.19",
+                },
+              },
             ],
             "schemaVersion": "1.3.0",
           },
@@ -2454,9 +2469,18 @@ Object {
             "graph": Object {
               "nodes": Array [
                 Object {
-                  "deps": Array [],
+                  "deps": Array [
+                    Object {
+                      "nodeId": "stdlib@1.20.14",
+                    },
+                  ],
                   "nodeId": "root-node",
                   "pkgId": "go-distribution@command-line-arguments@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.20.14",
+                  "pkgId": "stdlib@1.20.14",
                 },
               ],
               "rootNodeId": "root-node",
@@ -2469,6 +2493,13 @@ Object {
                 "id": "go-distribution@command-line-arguments@",
                 "info": Object {
                   "name": "go-distribution@command-line-arguments",
+                },
+              },
+              Object {
+                "id": "stdlib@1.20.14",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.20.14",
                 },
               },
             ],
@@ -2500,9 +2531,18 @@ Object {
             "graph": Object {
               "nodes": Array [
                 Object {
-                  "deps": Array [],
+                  "deps": Array [
+                    Object {
+                      "nodeId": "stdlib@1.20.14",
+                    },
+                  ],
                   "nodeId": "root-node",
                   "pkgId": "go-distribution@command-line-arguments@",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.20.14",
+                  "pkgId": "stdlib@1.20.14",
                 },
               ],
               "rootNodeId": "root-node",
@@ -2515,6 +2555,13 @@ Object {
                 "id": "go-distribution@command-line-arguments@",
                 "info": Object {
                   "name": "go-distribution@command-line-arguments",
+                },
+              },
+              Object {
+                "id": "stdlib@1.20.14",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.20.14",
                 },
               },
             ],
@@ -2556,6 +2603,9 @@ Object {
                     Object {
                       "nodeId": "golang.org/x/text/encoding@v0.3.7",
                     },
+                    Object {
+                      "nodeId": "stdlib@1.20.14",
+                    },
                   ],
                   "nodeId": "root-node",
                   "pkgId": "go-distribution@command-line-arguments@",
@@ -2574,6 +2624,11 @@ Object {
                   "deps": Array [],
                   "nodeId": "golang.org/x/text/encoding@v0.3.7",
                   "pkgId": "golang.org/x/text/encoding@v0.3.7",
+                },
+                Object {
+                  "deps": Array [],
+                  "nodeId": "stdlib@1.20.14",
+                  "pkgId": "stdlib@1.20.14",
                 },
               ],
               "rootNodeId": "root-node",
@@ -2607,6 +2662,13 @@ Object {
                 "info": Object {
                   "name": "golang.org/x/text/encoding",
                   "version": "v0.3.7",
+                },
+              },
+              Object {
+                "id": "stdlib@1.20.14",
+                "info": Object {
+                  "name": "stdlib",
+                  "version": "1.20.14",
                 },
               },
             ],

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -44,7 +44,7 @@ Object {
         },
         Object {
           "data": Array [
-            "2d0714e906bed2c04c0df856b8928376970d0f163c7dc63cf99bc681d7e668fa\\\\layer.tar",
+            "2d0714e906bed2c04c0df856b8928376970d0f163c7dc63cf99bc681d7e668fa/layer.tar",
           ],
           "type": "imageLayers",
         },
@@ -459,7 +459,7 @@ Object {
                       "nodeId": "k8s.io/klog/v2@v2.80.1",
                     },
                     Object {
-                      "nodeId": "stdlib@1.19",
+                      "nodeId": "stdlib@1.19.0",
                     },
                   ],
                   "nodeId": "root-node",
@@ -1057,8 +1057,8 @@ Object {
                 },
                 Object {
                   "deps": Array [],
-                  "nodeId": "stdlib@1.19",
-                  "pkgId": "stdlib@1.19",
+                  "nodeId": "stdlib@1.19.0",
+                  "pkgId": "stdlib@1.19.0",
                 },
               ],
               "rootNodeId": "root-node",
@@ -1900,10 +1900,10 @@ Object {
                 },
               },
               Object {
-                "id": "stdlib@1.19",
+                "id": "stdlib@1.19.0",
                 "info": Object {
                   "name": "stdlib",
-                  "version": "1.19",
+                  "version": "1.19.0",
                 },
               },
             ],
@@ -1921,7 +1921,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "\\\\livenessprobe",
+        "targetFile": "/livenessprobe",
         "type": "gomodules",
       },
       "target": Object {
@@ -2517,7 +2517,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "\\\\usr\\\\lib\\\\go-standard-2",
+        "targetFile": "/usr/lib/go-standard-2",
         "type": "gomodules",
       },
       "target": Object {
@@ -2579,7 +2579,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "\\\\usr\\\\local\\\\lib\\\\go-standard",
+        "targetFile": "/usr/local/lib/go-standard",
         "type": "gomodules",
       },
       "target": Object {
@@ -2686,7 +2686,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "\\\\app\\\\node_modules\\\\.pnpm\\\\@esbuild+linux-x64@0.23.1\\\\node_modules\\\\@esbuild\\\\linux-x64\\\\bin\\\\esbuild",
+        "targetFile": "/app/node_modules/.pnpm/@esbuild+linux-x64@0.23.1/node_modules/@esbuild/linux-x64/bin/esbuild",
         "type": "gomodules",
       },
       "target": Object {
@@ -2741,7 +2741,7 @@ Object {
         },
         Object {
           "data": Array [
-            "c8f25f0787b14b09638a294eab0b30b81c82295b8aa5e1df3fb36796fa6d0179\\\\layer.tar",
+            "c8f25f0787b14b09638a294eab0b30b81c82295b8aa5e1df3fb36796fa6d0179/layer.tar",
           ],
           "type": "imageLayers",
         },
@@ -2812,11 +2812,11 @@ Object {
               Object {
                 "dependencies": Array [],
                 "digest": "485de3a253e23f645037828c07f1d7f1af40763a",
-                "location": "\\\\app\\\\activation-1.1.1.jar",
+                "location": "/app/activation-1.1.1.jar",
               },
             ],
             "origin": "java-windows.tar",
-            "path": "\\\\app",
+            "path": "/app",
           },
           "type": "jarFingerprints",
         },
@@ -2830,7 +2830,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "\\\\app",
+        "targetFile": "/app",
         "type": "maven",
       },
       "target": Object {
@@ -2847,7 +2847,7 @@ Object {
                 "dependencies": Array [],
                 "digest": null,
                 "groupId": "org.glassfish.hk2.external",
-                "location": "\\\\libs\\\\aopalliance-repackaged-2.5.0.jar",
+                "location": "/libs/aopalliance-repackaged-2.5.0.jar",
                 "version": "2.5.0",
               },
               Object {
@@ -2855,12 +2855,12 @@ Object {
                 "dependencies": Array [],
                 "digest": null,
                 "groupId": "org.apache.yetus",
-                "location": "\\\\libs\\\\audience-annotations-0.5.0.jar",
+                "location": "/libs/audience-annotations-0.5.0.jar",
                 "version": "0.5.0",
               },
             ],
             "origin": "java-windows.tar",
-            "path": "\\\\libs",
+            "path": "/libs",
           },
           "type": "jarFingerprints",
         },
@@ -2874,7 +2874,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "\\\\libs",
+        "targetFile": "/libs",
         "type": "maven",
       },
       "target": Object {
@@ -4750,7 +4750,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "\\\\srv\\\\npm-app\\\\package.json",
+        "targetFile": "/srv/npm-app/package.json",
         "type": "npm",
       },
       "target": Object {
@@ -15044,7 +15044,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "\\\\srv\\\\yarn-app\\\\package.json",
+        "targetFile": "/srv/yarn-app/package.json",
         "type": "yarn",
       },
       "target": Object {

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -44,7 +44,7 @@ Object {
         },
         Object {
           "data": Array [
-            "2d0714e906bed2c04c0df856b8928376970d0f163c7dc63cf99bc681d7e668fa/layer.tar",
+            "2d0714e906bed2c04c0df856b8928376970d0f163c7dc63cf99bc681d7e668fa\\\\layer.tar",
           ],
           "type": "imageLayers",
         },
@@ -1921,7 +1921,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/livenessprobe",
+        "targetFile": "\\\\livenessprobe",
         "type": "gomodules",
       },
       "target": Object {
@@ -2517,7 +2517,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/usr/lib/go-standard-2",
+        "targetFile": "\\\\usr\\\\lib\\\\go-standard-2",
         "type": "gomodules",
       },
       "target": Object {
@@ -2579,7 +2579,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/usr/local/lib/go-standard",
+        "targetFile": "\\\\usr\\\\local\\\\lib\\\\go-standard",
         "type": "gomodules",
       },
       "target": Object {
@@ -2686,7 +2686,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/app/node_modules/.pnpm/@esbuild+linux-x64@0.23.1/node_modules/@esbuild/linux-x64/bin/esbuild",
+        "targetFile": "\\\\app\\\\node_modules\\\\.pnpm\\\\@esbuild+linux-x64@0.23.1\\\\node_modules\\\\@esbuild\\\\linux-x64\\\\bin\\\\esbuild",
         "type": "gomodules",
       },
       "target": Object {
@@ -2741,7 +2741,7 @@ Object {
         },
         Object {
           "data": Array [
-            "c8f25f0787b14b09638a294eab0b30b81c82295b8aa5e1df3fb36796fa6d0179/layer.tar",
+            "c8f25f0787b14b09638a294eab0b30b81c82295b8aa5e1df3fb36796fa6d0179\\\\layer.tar",
           ],
           "type": "imageLayers",
         },
@@ -2812,11 +2812,11 @@ Object {
               Object {
                 "dependencies": Array [],
                 "digest": "485de3a253e23f645037828c07f1d7f1af40763a",
-                "location": "/app/activation-1.1.1.jar",
+                "location": "\\\\app\\\\activation-1.1.1.jar",
               },
             ],
             "origin": "java-windows.tar",
-            "path": "/app",
+            "path": "\\\\app",
           },
           "type": "jarFingerprints",
         },
@@ -2830,7 +2830,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/app",
+        "targetFile": "\\\\app",
         "type": "maven",
       },
       "target": Object {
@@ -2847,7 +2847,7 @@ Object {
                 "dependencies": Array [],
                 "digest": null,
                 "groupId": "org.glassfish.hk2.external",
-                "location": "/libs/aopalliance-repackaged-2.5.0.jar",
+                "location": "\\\\libs\\\\aopalliance-repackaged-2.5.0.jar",
                 "version": "2.5.0",
               },
               Object {
@@ -2855,12 +2855,12 @@ Object {
                 "dependencies": Array [],
                 "digest": null,
                 "groupId": "org.apache.yetus",
-                "location": "/libs/audience-annotations-0.5.0.jar",
+                "location": "\\\\libs\\\\audience-annotations-0.5.0.jar",
                 "version": "0.5.0",
               },
             ],
             "origin": "java-windows.tar",
-            "path": "/libs",
+            "path": "\\\\libs",
           },
           "type": "jarFingerprints",
         },
@@ -2874,7 +2874,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/libs",
+        "targetFile": "\\\\libs",
         "type": "maven",
       },
       "target": Object {
@@ -4750,7 +4750,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/srv/npm-app/package.json",
+        "targetFile": "\\\\srv\\\\npm-app\\\\package.json",
         "type": "npm",
       },
       "target": Object {
@@ -15044,7 +15044,7 @@ Object {
         },
       ],
       "identity": Object {
-        "targetFile": "/srv/yarn-app/package.json",
+        "targetFile": "\\\\srv\\\\yarn-app\\\\package.json",
         "type": "yarn",
       },
       "target": Object {


### PR DESCRIPTION
## Summary

- Extracts the Go compiler version from `.go.buildinfo` in compiled Go binaries and adds a `stdlib` pseudo-dependency node (e.g., `stdlib@1.21.0`) to the container scan dependency graph
- Works for both normal and stripped binaries, since `.go.buildinfo` is always present regardless of build flags (`-ldflags='-s -w'`)
- Companion to vuln-service PR (https://github.com/snyk/vuln-service/pull/483) and snyk/vuln PR https://github.com/snyk/vuln/pull/932 which expands this `stdlib` node into individual `std/*` packages for vulnerability matching

### Changes

| File | Change |
|------|--------|
| `lib/go-parser/go-binary.ts` | `readRawBuildInfo` now returns `{ goVersion, modInfo }` instead of raw string; new `parseGoVersion` helper; `GoBinary` class stores `goVersion` and adds `stdlib` node to dep graph |
| `test/unit/go-binaries.spec.ts` | Added stdlib node assertions to existing tests; new tests for `parseGoVersion`, stripped binary stdlib support, and `extractModuleInformation` goVersion return |

## References

JIRA ticket: https://snyksec.atlassian.net/browse/CN-893