### PR TITLE
fix: CN-928 show full config digest when registry/repo unavailable

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -162,6 +162,7 @@ export async function analyze(
     imageCreationTime,
     containerConfig,
     history,
+    repoTags,
   } = await archiveExtractor.extractImageContent(
     imageType,
     imagePath,
@@ -318,6 +319,7 @@ export async function analyze(
     imageCreationTime,
     containerConfig,
     history,
+    repoTags,
   };
 }
 

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -101,6 +101,8 @@ export interface StaticAnalysis {
     comment?: string | null;
     empty_layer?: boolean | null;
   }> | null;
+  /** From Docker/Kaniko archive manifest; absent for OCI layout archives. */
+  repoTags?: string[];
 }
 
 export interface StaticPackagesAnalysis extends StaticAnalysis {

--- a/lib/dependency-tree/index.ts
+++ b/lib/dependency-tree/index.ts
@@ -1,6 +1,11 @@
 import { AnalyzedPackageWithVersion, OSRelease } from "../analyzer/types";
 import { DepTree, DepTreeDep } from "../types";
 
+/** Bare image config digest (sha256:64hex) — no registry/repo prefix. */
+function isBareConfigDigestReference(targetImage: string): boolean {
+  return /^sha256:[a-f0-9]{64}$/i.test(targetImage);
+}
+
 /** @deprecated Should implement a new function to build a dependency graph instead. */
 export function buildTree(
   targetImage: string,
@@ -8,6 +13,18 @@ export function buildTree(
   depInfosList: AnalyzedPackageWithVersion[],
   targetOS: OSRelease,
 ): DepTree {
+  // CN-928: when the identity is only a config digest (e.g. TAR with no RepoTags),
+  // do not split on ':' inside "sha256:…" — use the full digest as the display name.
+  if (isBareConfigDigestReference(targetImage)) {
+    return buildTreeRoot(
+      targetImage,
+      "",
+      packageFormat,
+      depInfosList,
+      targetOS,
+    );
+  }
+
   // A tag can only occur in the last section of a docker image name, so
   // check any colon separator after the final '/'. If there are no '/',
   // which is common when using Docker's official images such as
@@ -36,10 +53,33 @@ export function buildTree(
   const shaString = "@sha256";
 
   if (imageName.endsWith(shaString)) {
+    const digestHex = imageVersion;
     imageName = imageName.slice(0, imageName.length - shaString.length);
-    imageVersion = "";
+    if (imageName === "" && digestHex) {
+      // CN-928: digest-only reference (no registry/repo) — use full sha256:… as name, no "@"
+      imageName = `sha256:${digestHex}`;
+      imageVersion = "";
+    } else {
+      imageVersion = "";
+    }
   }
 
+  return buildTreeRoot(
+    imageName,
+    imageVersion,
+    packageFormat,
+    depInfosList,
+    targetOS,
+  );
+}
+
+function buildTreeRoot(
+  imageName: string,
+  imageVersion: string,
+  packageFormat: string,
+  depInfosList: AnalyzedPackageWithVersion[],
+  targetOS: OSRelease,
+): DepTree {
   const root: DepTree = {
     // don't use the real image name to avoid scanning it as an issue
     name: "docker-image|" + imageName,

--- a/lib/extractor/docker-archive/layer.ts
+++ b/lib/extractor/docker-archive/layer.ts
@@ -108,6 +108,7 @@ function getLayersContentAndArchiveManifest(
     layers: filteredLayers,
     manifest,
     imageConfig,
+    repoTags: manifest.RepoTags,
   };
 }
 

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -154,6 +154,7 @@ export async function extractImageContent(
     imageLabels: archiveContent.imageConfig.config?.Labels,
     containerConfig: archiveContent.imageConfig.config,
     history: archiveContent.imageConfig.history,
+    repoTags: archiveContent.repoTags,
   };
 }
 

--- a/lib/extractor/kaniko-archive/layer.ts
+++ b/lib/extractor/kaniko-archive/layer.ts
@@ -109,6 +109,7 @@ function getLayersContentAndArchiveManifest(
     layers: filteredLayers,
     manifest,
     imageConfig,
+    repoTags: manifest.RepoTags,
   };
 }
 

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -36,6 +36,8 @@ export interface ExtractionResult {
   imageCreationTime?: string;
   containerConfig?: ContainerConfig | null;
   history?: HistoryEntry[] | null;
+  /** Docker-/Kaniko-style archive manifest RepoTags; OCI archives may omit. */
+  repoTags?: string[];
 }
 
 export interface ExtractedLayers {
@@ -46,6 +48,7 @@ export interface ExtractedLayersAndManifest {
   layers: ExtractedLayers[];
   manifest: DockerArchiveManifest | OciArchiveManifest;
   imageConfig: ImageConfig;
+  repoTags?: string[];
 }
 
 export interface DockerArchiveManifest {
@@ -139,6 +142,7 @@ export interface KanikoExtractedLayersAndManifest {
   layers: KanikoExtractedLayers[];
   manifest: KanikoArchiveManifest;
   imageConfig: ImageConfig;
+  repoTags?: string[];
 }
 
 export interface ExtractAction {

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -12,6 +12,47 @@ import { parseAnalysisResults } from "./parser";
 import { buildResponse } from "./response-builder";
 import { DepTree, ImageType, PluginOptions, PluginResponse } from "./types";
 
+function isArchiveImageType(imageType: ImageType): boolean {
+  return (
+    imageType === ImageType.DockerArchive ||
+    imageType === ImageType.OciArchive ||
+    imageType === ImageType.KanikoArchive ||
+    imageType === ImageType.UnspecifiedArchiveType
+  );
+}
+
+function hasUsableRepoTags(repoTags: string[] | undefined): boolean {
+  if (!repoTags || repoTags.length === 0) {
+    return false;
+  }
+  return repoTags.some((t) => t && t.trim() !== "");
+}
+
+/**
+ * When scanning a TAR/OCI archive with no registry/repo tags, use the config digest
+ * (imageId) as the project root identity so the CLI shows the full sha256:… (CN-928).
+ */
+function resolveEffectiveTargetImage(
+  targetImage: string,
+  imageType: ImageType,
+  imageId: string | undefined,
+  repoTags: string[] | undefined,
+  options: Partial<PluginOptions>,
+): string {
+  if (options.imageNameAndTag) {
+    return targetImage;
+  }
+  if (
+    isArchiveImageType(imageType) &&
+    imageId &&
+    /^sha256:[a-f0-9]{64}$/i.test(imageId) &&
+    !hasUsableRepoTags(repoTags)
+  ) {
+    return imageId;
+  }
+  return targetImage;
+}
+
 export async function analyzeStatically(
   targetImage: string,
   dockerfileAnalysis: DockerFileAnalysis | undefined,
@@ -30,14 +71,22 @@ export async function analyzeStatically(
     options,
   );
 
-  const parsedAnalysisResult = parseAnalysisResults(
+  const effectiveTargetImage = resolveEffectiveTargetImage(
     targetImage,
+    imageType,
+    staticAnalysis.imageId,
+    staticAnalysis.repoTags,
+    options,
+  );
+
+  const parsedAnalysisResult = parseAnalysisResults(
+    effectiveTargetImage,
     staticAnalysis,
   );
 
   /** @deprecated Should try to build a dependency graph instead. */
   const dependenciesTree = buildTree(
-    targetImage,
+    effectiveTargetImage,
     parsedAnalysisResult.packageFormat,
     parsedAnalysisResult.depInfosList,
     parsedAnalysisResult.targetOS,
@@ -56,7 +105,14 @@ export async function analyzeStatically(
 
   const excludeBaseImageVulns = isTrue(options["exclude-base-image-vulns"]);
 
-  const names = getImageNames(options, imageName);
+  let names = getImageNames(options, imageName);
+  if (
+    names.length === 0 &&
+    effectiveTargetImage === staticAnalysis.imageId &&
+    staticAnalysis.imageId
+  ) {
+    names = [staticAnalysis.imageId];
+  }
   let ociDistributionMetadata: OCIDistributionMetadata | undefined;
   if (options.imageNameAndTag && options.digests?.manifest) {
     ociDistributionMetadata = constructOCIDisributionMetadata({

--- a/test/lib/dependency-tree/index.spec.ts
+++ b/test/lib/dependency-tree/index.spec.ts
@@ -48,6 +48,28 @@ function obj2array(obj) {
 
 describe("dependency-tree", () => {
   describe("buildTree", () => {
+    describe("CN-928 digest-only and bare config digest", () => {
+      const hex64 = "a".repeat(64);
+      const bareDigest = `sha256:${hex64}`;
+
+      it("uses full sha256 digest as root name when target is only @sha256:… (no registry/repo)", () => {
+        const tree = buildTree(
+          `@sha256:${hex64}`,
+          "deb",
+          [],
+          targetOS,
+        );
+        expect(tree.name).toEqual(`docker-image|${bareDigest}`);
+        expect(tree.version).toEqual("");
+      });
+
+      it("uses full sha256 digest as root name when target is bare config digest", () => {
+        const tree = buildTree(bareDigest, "deb", [], targetOS);
+        expect(tree.name).toEqual(`docker-image|${bareDigest}`);
+        expect(tree.version).toEqual("");
+      });
+    });
+
     describe("Linux Package Managers", () => {
       it("should attach frequent deps to parent when threshold is exceeded", () => {
         const fixture = buildFreqDepsList(100);


### PR DESCRIPTION
## Summary
Implements [CN-928](https://snyksec.atlassian.net/browse/CN-928): when scanning a TAR/OCI archive with no registry/repository tags, use the full `sha256:…` config digest as the display identity (no leading `@`).

## Changes
- **`buildTree`**: Handle bare `sha256:` + 64 hex config digests without splitting on `:`; fix digest-only `@sha256:…` references to use full `sha256:…` as the name.
- **Archives**: Plumb `RepoTags` from Docker/Kaniko manifests; when there are no usable tags and `imageNameAndTag` is not set (normal CLI path), use `imageId` for the dep graph root and `imageNames` fact.
- **Tests**: Unit tests in `test/lib/dependency-tree/index.spec.ts`.

## Testing
- `npm run build`
- `npx jest test/lib/dependency-tree/index.spec.ts`

Made with [Cursor](https://cursor.com)

[CN-928]: https://snyksec.atlassian.net/browse/CN-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ