### PR TITLE
fix(deps): update node lockfile parser

### DIFF
--- a/lib/analyzer/applications/node.ts
+++ b/lib/analyzer/applications/node.ts
@@ -136,7 +136,7 @@ async function depGraphFromNodeModules(
       }
 
       const depGraph = await legacy.depTreeToGraph(
-        pkgTree,
+        pkgTree as any,
         pkgTree.type || "npm",
       );
 
@@ -417,7 +417,7 @@ function stripUndefinedLabels(
   parserResult: lockFileParser.PkgTree,
 ): lockFileParser.PkgTree {
   const optionalLabels = parserResult.labels;
-  const mandatoryLabels: Record<string, string> = {};
+  const mandatoryLabels: Record<string, any> = {};
   if (optionalLabels) {
     for (const currentLabelName of Object.keys(optionalLabels)) {
       if (optionalLabels[currentLabelName] !== undefined) {
@@ -428,7 +428,7 @@ function stripUndefinedLabels(
   const parserResultWithProperLabels = Object.assign({}, parserResult, {
     labels: mandatoryLabels,
   });
-  return parserResultWithProperLabels;
+  return parserResultWithProperLabels as lockFileParser.PkgTree;
 }
 
 async function buildDepGraph(
@@ -513,7 +513,10 @@ async function buildDepGraphFromDepTree(
     // Don't provide a default manifest file name, prefer the parser to infer it.
   );
   const strippedLabelsParserResult = stripUndefinedLabels(parserResult);
-  return await legacy.depTreeToGraph(strippedLabelsParserResult, lockfileType);
+  return await legacy.depTreeToGraph(
+    strippedLabelsParserResult as any,
+    lockfileType,
+  );
 }
 
 export function getLockFileVersion(

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "packageurl-js": "1.2.0",
         "semver": "^7.7.3",
         "shescape": "^2.1.7",
-        "snyk-nodejs-lockfile-parser": "^2.2.2",
+        "snyk-nodejs-lockfile-parser": "^2.7.0",
         "snyk-poetry-lockfile-parser": "1.9.1",
         "snyk-resolve-deps": "^4.9.1",
         "tar-stream": "^2.2.0",
@@ -14997,12 +14997,12 @@
       }
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.2.2.tgz",
-      "integrity": "sha512-+pJnbEK/yvBimpTEv0xrvhaEpRgz/KwZZGJEV+NfPJ4ytoL0TdIpKYSIpw28VMaaWSLna75SoWEKWujw0vYDLQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.7.0.tgz",
+      "integrity": "sha512-0M4paLnhKSDtj2akT6qztFC2MPfLO7vHxIeXYI1+rMv8fBC5RfzqHcfCraFbEDe961oPWOMXhSryLANtC5OcVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/dep-graph": "^2.12.0",
         "@snyk/error-catalog-nodejs-public": "^5.16.0",
         "@snyk/graphlib": "2.1.9-patch.3",
         "@yarnpkg/core": "^4.4.1",
@@ -27354,11 +27354,11 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.2.2.tgz",
-      "integrity": "sha512-+pJnbEK/yvBimpTEv0xrvhaEpRgz/KwZZGJEV+NfPJ4ytoL0TdIpKYSIpw28VMaaWSLna75SoWEKWujw0vYDLQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.7.0.tgz",
+      "integrity": "sha512-0M4paLnhKSDtj2akT6qztFC2MPfLO7vHxIeXYI1+rMv8fBC5RfzqHcfCraFbEDe961oPWOMXhSryLANtC5OcVw==",
       "requires": {
-        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/dep-graph": "^2.12.0",
         "@snyk/error-catalog-nodejs-public": "^5.16.0",
         "@snyk/graphlib": "2.1.9-patch.3",
         "@yarnpkg/core": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "packageurl-js": "1.2.0",
     "semver": "^7.7.3",
     "shescape": "^2.1.7",
-    "snyk-nodejs-lockfile-parser": "^2.2.2",
+    "snyk-nodejs-lockfile-parser": "^2.7.0",
     "snyk-poetry-lockfile-parser": "1.9.1",
     "snyk-resolve-deps": "^4.9.1",
     "tar-stream": "^2.2.0",

--- a/test/system/application-scans/node.spec.ts
+++ b/test/system/application-scans/node.spec.ts
@@ -403,7 +403,7 @@ describe("node application scans", () => {
       noFromArrays: true,
     });
 
-    const depGraph = await legacy.depTreeToGraph(depRes, "npm");
+    const depGraph = await legacy.depTreeToGraph(depRes as any, "npm");
 
     expect(depGraph.rootPkg.name).toEqual("app");
     expect(depGraph.rootPkg.version).toBe(undefined);


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Resolves TypeScript compilation errors caused by the update of `snyk-nodejs-lockfile-parser` to `^2.2.3`. The lockfile parser update introduced type signature changes that became incompatible with the `legacy.depTreeToGraph` function in `@snyk/dep-graph`.

#### Where should the reviewer start?
- `lib/analyzer/applications/node.ts`: Look at the modifications to `stripUndefinedLabels`, `depGraphFromNodeModules`, and `buildDepGraphFromDepTree`.
- `test/system/application-scans/node.spec.ts`: Test file adjustments.

#### How should this be manually tested?
1. Run `npm run build` and ensure TypeScript compiles without errors.
2. Run `npm run test` to verify that the application scans still parse node dependencies and build the graph correctly.

#### Any background context you want to provide?
**Justification for casting types as `any`:**
The `snyk-nodejs-lockfile-parser` update altered the `DepTreeDep` interface so that the `labels` object now supports an `Alias` type: `{ [key: string]: string | Alias | undefined }`. 
However, `@snyk/dep-graph`'s legacy `DepTree` type expects labels to be strictly `{ [key: string]: string | undefined }`. 

Because of this mismatch between the two libraries' typings, passing the parsed `PkgTree` directly into `legacy.depTreeToGraph` results in TS2345 errors. 

**Why it is necessary:**
Without updating the upstream `@snyk/dep-graph` legacy types (which is deprecated and ideally shouldn't be touched), we have to bridge the gap locally. `stripUndefinedLabels` was updated to handle `Record<string, any>` so it can strip `undefined` fields without crashing on `Alias` values. 

**Why it will not lead to type issues:**
Casting `PkgTree` to `any` at the boundary of `legacy.depTreeToGraph` is safe because `@snyk/dep-graph` processes the tree at runtime without enforcing strict primitive `string` type checks on the label values. The `Alias` information flows through successfully to the `DepGraph` construction without causing runtime exceptions. By restricting the `any` cast strictly to the function call arguments (`pkgTree as any`), we preserve type safety in the rest of the application while appeasing the compiler at the deprecated legacy API boundary.

#### What are the relevant tickets?

[CN-1007](https://snyksec.atlassian.net/browse/CN-1007)

#### Screenshots
N/A

#### Additional questions
N/A



[CN-1007]: https://snyksec.atlassian.net/browse/CN-1007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ