### PR TITLE
chore: standardize errors (CN-944)

### DIFF
--- a/lib/analyzer/applications/node-modules-utils.ts
+++ b/lib/analyzer/applications/node-modules-utils.ts
@@ -1,6 +1,7 @@
 import * as Debug from "debug";
 import { mkdir, mkdtemp, rm, stat, writeFile } from "fs/promises";
 import * as path from "path";
+import { getErrorMessage } from "../../error-utils";
 import { FilePathToContent, FilesByDirMap } from "./types";
 const debug = Debug("snyk");
 
@@ -51,7 +52,9 @@ async function createSyntheticManifest(
     await writeFile(tempRootManifestPath, "{}", "utf-8");
   } catch (error) {
     debug(
-      `Error while writing file ${tempRootManifestPath} : ${error.message}`,
+      `Error while writing file ${tempRootManifestPath} : ${getErrorMessage(
+        error,
+      )}`,
     );
   }
 }
@@ -113,7 +116,9 @@ async function persistNodeModules(
     return result;
   } catch (error) {
     debug(
-      `Failed to copy the application manifest files locally: ${error.message}`,
+      `Failed to copy the application manifest files locally: ${getErrorMessage(
+        error,
+      )}`,
     );
     return {
       tempDir: tmpDir,
@@ -127,7 +132,7 @@ async function createFile(filePath, fileContent): Promise<void> {
     await mkdir(path.dirname(filePath), { recursive: true });
     await writeFile(filePath, fileContent, "utf-8");
   } catch (error) {
-    debug(`Error while creating file ${filePath} : ${error.message}`);
+    debug(`Error while creating file ${filePath} : ${getErrorMessage(error)}`);
   }
 }
 
@@ -241,6 +246,6 @@ async function cleanupAppNodeModules(appRootDir: string): Promise<void> {
   try {
     await rm(appRootDir, { recursive: true });
   } catch (error) {
-    debug(`Error while removing ${appRootDir} : ${error.message}`);
+    debug(`Error while removing ${appRootDir} : ${getErrorMessage(error)}`);
   }
 }

--- a/lib/analyzer/applications/node.ts
+++ b/lib/analyzer/applications/node.ts
@@ -3,6 +3,7 @@ import * as Debug from "debug";
 import * as path from "path";
 import * as lockFileParser from "snyk-nodejs-lockfile-parser";
 import * as resolveDeps from "snyk-resolve-deps";
+import { getErrorMessage } from "../../error-utils";
 import { DepGraphFact, TestedFilesFact } from "../../facts";
 
 const debug = Debug("snyk");
@@ -162,7 +163,9 @@ async function depGraphFromNodeModules(
       });
     } catch (error) {
       debug(
-        `An error occurred while analysing node_modules dir: ${error.message}`,
+        `An error occurred while analysing node_modules dir: ${getErrorMessage(
+          error,
+        )}`,
       );
     } finally {
       await cleanupAppNodeModules(tempDir);
@@ -300,7 +303,9 @@ async function depGraphFromManifestFiles(
           );
     } catch (err) {
       debug(
-        `An error occurred while analysing a pair of manifest and lock files: ${err.message}`,
+        `An error occurred while analysing a pair of manifest and lock files: ${getErrorMessage(
+          err,
+        )}`,
       );
       continue;
     }

--- a/lib/analyzer/applications/python/pip.ts
+++ b/lib/analyzer/applications/python/pip.ts
@@ -3,6 +3,7 @@ import * as Debug from "debug";
 import { eventLoopSpinner } from "event-loop-spinner";
 import * as path from "path";
 import * as semver from "semver";
+import { getErrorMessage } from "../../../error-utils";
 import { DepGraphFact } from "../../../facts";
 import { compareVersions } from "../../../python-parser/common";
 import { getPackageInfo } from "../../../python-parser/metadata-parser";
@@ -133,7 +134,7 @@ export async function pipFilesToScannedProjects(
         }
         metadataItems[packageInfo.name.toLowerCase()].push(packageInfo);
       } catch (err) {
-        debug(err.message);
+        debug(getErrorMessage(err));
       }
     }
   }

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -68,12 +68,14 @@ async function pullWithDockerBinary(
         err,
       )}`,
     );
-    const errorMessage =
-      err instanceof Error &&
-      "stderr" in err &&
-      (err as Error & { stderr: string }).stderr
-        ? (err as Error & { stderr: string }).stderr
-        : getErrorMessage(err);
+    const stderrValue =
+      err !== null &&
+      typeof err === "object" &&
+      "stderr" in (err as object) &&
+      (err as { stderr: unknown }).stderr;
+    const errorMessage = stderrValue
+      ? String(stderrValue)
+      : getErrorMessage(err);
     handleDockerPullError(errorMessage, platform);
 
     return false;

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -2,6 +2,7 @@ import * as Debug from "debug";
 import * as fs from "fs";
 import * as mkdirp from "mkdirp";
 import * as path from "path";
+import { getErrorMessage } from "../error-utils";
 
 import { Docker, DockerOptions } from "../docker";
 import { ImageName } from "../extractor/image";
@@ -35,7 +36,11 @@ function cleanupCallback(imageFolderPath: string, imageName: string) {
     try {
       fs.rmdirSync(imageFolderPath);
     } catch (err) {
-      debug(`Can't remove folder ${imageFolderPath}, got error ${err.message}`);
+      debug(
+        `Can't remove folder ${imageFolderPath}, got error ${getErrorMessage(
+          err,
+        )}`,
+      );
     }
   };
 }
@@ -58,8 +63,15 @@ async function pullWithDockerBinary(
     await docker.save(targetImage, saveLocation);
     return true;
   } catch (err) {
-    debug(`couldn't pull ${targetImage} using docker binary: ${err.message}`);
-    const errorMessage = err.stderr || err.message || err.toString();
+    debug(
+      `couldn't pull ${targetImage} using docker binary: ${getErrorMessage(
+        err,
+      )}`,
+    );
+    const errorMessage =
+      err instanceof Error && "stderr" in err
+        ? (err as Error & { stderr: string }).stderr
+        : getErrorMessage(err);
     handleDockerPullError(errorMessage, platform);
 
     return false;
@@ -126,7 +138,7 @@ async function pullFromContainerRegistry(
       platform,
     );
   } catch (err) {
-    handleDockerPullError(err.message);
+    handleDockerPullError(getErrorMessage(err));
     throw err;
   }
 }
@@ -213,7 +225,7 @@ async function getImageArchive(
   } catch (error) {
     debug(
       `${targetImage} does not exist locally, proceeding to pull image.`,
-      error.stack || error,
+      getErrorMessage(error),
     );
   }
 
@@ -370,7 +382,7 @@ function isLocalImageSameArchitecture(
     // Note: this is using the same flag/input pattern as the new Docker buildx: eg. linux/arm64/v8
     platformArchitecture = platformOption.split("/")[1];
   } catch (error) {
-    debug(`Error parsing platform flag: '${error.message}'`);
+    debug(`Error parsing platform flag: '${getErrorMessage(error)}'`);
     return false;
   }
 

--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -69,7 +69,9 @@ async function pullWithDockerBinary(
       )}`,
     );
     const errorMessage =
-      err instanceof Error && "stderr" in err
+      err instanceof Error &&
+      "stderr" in err &&
+      (err as Error & { stderr: string }).stderr
         ? (err as Error & { stderr: string }).stderr
         : getErrorMessage(err);
     handleDockerPullError(errorMessage, platform);

--- a/lib/analyzer/os-release/static.ts
+++ b/lib/analyzer/os-release/static.ts
@@ -1,5 +1,6 @@
 import * as Debug from "debug";
 import { normalize as normalizePath } from "path";
+import { getErrorMessage } from "../../error-utils";
 
 import { DockerFileAnalysis } from "../../dockerfile/types";
 import { ExtractedLayers } from "../../extractor/types";
@@ -74,7 +75,7 @@ export async function detect(
     try {
       osRelease = await handler(osReleaseFile);
     } catch (err) {
-      debug(`Malformed OS release file: ${err.message}`);
+      debug(`Malformed OS release file: ${getErrorMessage(err)}`);
     }
     if (osRelease) {
       break;

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -1,5 +1,6 @@
 import * as Debug from "debug";
 import { DockerFileAnalysis } from "../dockerfile";
+import { getErrorMessage } from "../error-utils";
 import * as archiveExtractor from "../extractor";
 import {
   getGoModulesContentAction,
@@ -203,7 +204,7 @@ export async function analyze(
       dockerfileAnalysis,
     );
   } catch (err) {
-    debug(`Could not detect OS release: ${err.message}`);
+    debug(`Could not detect OS release: ${getErrorMessage(err)}`);
     throw new Error("Failed to detect OS release");
   }
 
@@ -231,7 +232,7 @@ export async function analyze(
       chiselAnalyze(targetImage, chiselPackages),
     ]);
   } catch (err) {
-    debug(`Could not detect installed OS packages: ${err.message}`);
+    debug(`Could not detect installed OS packages: ${getErrorMessage(err)}`);
     throw new Error("Failed to detect installed OS packages");
   }
 

--- a/lib/compression-utils.ts
+++ b/lib/compression-utils.ts
@@ -1,4 +1,5 @@
 import { Decompress as ZstdDecompress } from "fzstd";
+import { getErrorMessage } from "./error-utils";
 
 /**
  * Decompresses zstd-compressed data from a buffer.
@@ -22,10 +23,6 @@ export function decompressZstd(compressed: Buffer): Buffer {
 
     return Buffer.concat(chunks);
   } catch (error) {
-    throw new Error(
-      `Zstd decompression failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
+    throw new Error(`Zstd decompression failed: ${getErrorMessage(error)}`);
   }
 }

--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -1,0 +1,6 @@
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/lib/extractor/decompress-maybe.ts
+++ b/lib/extractor/decompress-maybe.ts
@@ -1,6 +1,7 @@
 import { Decompress as ZstdDecompress } from "fzstd";
 import { Transform } from "stream";
 import { createGunzip } from "zlib";
+import { getErrorMessage } from "../error-utils";
 
 /**
  * Creates a transform stream that automatically detects and decompresses data based on magic numbers.
@@ -73,11 +74,7 @@ export function decompressMaybe(): Transform {
             zstdStream.push(new Uint8Array(combined), false);
           } catch (err) {
             callback(
-              new Error(
-                `zstd decompression failed: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
-              ),
+              new Error(`zstd decompression failed: ${getErrorMessage(err)}`),
             );
             return;
           }
@@ -108,11 +105,7 @@ export function decompressMaybe(): Transform {
             callback();
           } catch (err) {
             callback(
-              new Error(
-                `zstd decompression failed: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
-              ),
+              new Error(`zstd decompression failed: ${getErrorMessage(err)}`),
             );
           }
         } else {
@@ -133,11 +126,7 @@ export function decompressMaybe(): Transform {
           callback();
         } catch (err) {
           callback(
-            new Error(
-              `zstd decompression failed: ${
-                err instanceof Error ? err.message : String(err)
-              }`,
-            ),
+            new Error(`zstd decompression failed: ${getErrorMessage(err)}`),
           );
         }
       } else if (!headerRead && buffer.length > 0) {

--- a/lib/extractor/docker-archive/layer.ts
+++ b/lib/extractor/docker-archive/layer.ts
@@ -5,6 +5,7 @@ import { basename, normalize as normalizePath } from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
 import { InvalidArchiveError } from "..";
+import { getErrorMessage } from "../../error-utils";
 import { streamToJson } from "../../stream-utils";
 import { PluginOptions } from "../../types";
 import { extractImageLayer } from "../layer";
@@ -46,7 +47,11 @@ export async function extractArchive(
               extractActions,
             );
           } catch (error) {
-            debug(`Error extracting layer content from: '${error.message}'`);
+            debug(
+              `Error extracting layer content from: '${getErrorMessage(
+                error,
+              )}'`,
+            );
             reject(new Error("Error reading tar archive"));
           }
         } else if (isManifestFile(normalizedName)) {
@@ -70,7 +75,9 @@ export async function extractArchive(
         );
       } catch (error) {
         debug(
-          `Error getting layers and manifest content from docker archive: ${error.message}`,
+          `Error getting layers and manifest content from docker archive: ${getErrorMessage(
+            error,
+          )}`,
         );
         reject(new InvalidArchiveError("Invalid Docker archive"));
       }

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -4,6 +4,7 @@ import {
   getLayersFromPackages,
   getPackagesFromRunInstructions,
 } from "../dockerfile/instruction-parser";
+import { getErrorMessage } from "../error-utils";
 import { AutoDetectedUserInstructions, ImageType } from "../types";
 import { PluginOptions } from "../types";
 import * as dockerExtractor from "./docker-archive";
@@ -166,7 +167,9 @@ async function extractArchiveContentFallback(
     } catch (error) {
       // imageType is a string enum value like "docker-archive", "oci-archive"
       debug(
-        `Error getting layers and manifest content from ${imageType} archive: ${error.message}`,
+        `Error getting layers and manifest content from ${imageType} archive: ${getErrorMessage(
+          error,
+        )}`,
       );
       continue;
     }

--- a/lib/extractor/kaniko-archive/layer.ts
+++ b/lib/extractor/kaniko-archive/layer.ts
@@ -5,6 +5,7 @@ import { basename, normalize as normalizePath } from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
 import { InvalidArchiveError } from "..";
+import { getErrorMessage } from "../../error-utils";
 import { streamToJson } from "../../stream-utils";
 import { PluginOptions } from "../../types";
 import { extractImageLayer } from "../layer";
@@ -46,7 +47,11 @@ export async function extractArchive(
               extractActions,
             );
           } catch (error) {
-            debug(`Error extracting layer content from: '${error.message}'`);
+            debug(
+              `Error extracting layer content from: '${getErrorMessage(
+                error,
+              )}'`,
+            );
             reject(new Error("Error reading tar.gz archive"));
           }
         } else if (isManifestFile(normalizedName)) {
@@ -71,7 +76,9 @@ export async function extractArchive(
         );
       } catch (error) {
         debug(
-          `Error getting layers and manifest content from Kaniko archive: ${error.message}`,
+          `Error getting layers and manifest content from Kaniko archive: ${getErrorMessage(
+            error,
+          )}`,
         );
         reject(new InvalidArchiveError("Invalid Kaniko archive"));
       }

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
 import { isWhitedOutFile } from ".";
+import { getErrorMessage } from "../error-utils";
 import { applyCallbacks, isResultEmpty } from "./callbacks";
 import { decompressMaybe } from "./decompress-maybe";
 import { ExtractAction, ExtractedLayers } from "./types";
@@ -48,7 +49,9 @@ export async function extractImageLayer(
           } catch (error) {
             // An ExtractAction has thrown an uncaught exception, likely a bug in the code!
             debug(
-              `Exception thrown while applying callbacks during image layer extraction: ${error.message}`,
+              `Exception thrown while applying callbacks during image layer extraction: ${getErrorMessage(
+                error,
+              )}`,
             );
             reject(error);
             return;

--- a/lib/extractor/oci-archive/layer.ts
+++ b/lib/extractor/oci-archive/layer.ts
@@ -4,6 +4,7 @@ import { normalize as normalizePath, sep as pathSeparator } from "path";
 import { Readable } from "stream";
 import { extract, Extract } from "tar-stream";
 import { getPlatformFromConfig, InvalidArchiveError } from "..";
+import { getErrorMessage } from "../../error-utils";
 import { streamToJson } from "../../stream-utils";
 import { PluginOptions } from "../../types";
 import { decompressMaybe } from "../decompress-maybe";
@@ -171,7 +172,9 @@ async function extractMetadata(
         }
       } catch (err) {
         debug(
-          `Error processing OCI archive entry ${header.name}: ${err.message}`,
+          `Error processing OCI archive entry ${header.name}: ${getErrorMessage(
+            err,
+          )}`,
         );
       }
 
@@ -299,8 +302,7 @@ async function extractLayers(
                 const layer = await extractImageLayer(stream, extractActions);
                 layers[digest] = layer;
               } catch (error) {
-                const errorMessage =
-                  error instanceof Error ? error.message : String(error);
+                const errorMessage = getErrorMessage(error);
                 debug(`Failed to extract layer ${digest}: ${errorMessage}`);
                 failedDigests.set(digest, errorMessage);
               }
@@ -308,7 +310,11 @@ async function extractLayers(
           }
         }
       } catch (err) {
-        debug(`Error processing archive entry ${header.name}: ${err.message}`);
+        debug(
+          `Error processing archive entry ${header.name}: ${getErrorMessage(
+            err,
+          )}`,
+        );
       }
 
       stream.resume();

--- a/lib/go-parser/go-binary.ts
+++ b/lib/go-parser/go-binary.ts
@@ -5,6 +5,7 @@ import { eventLoopSpinner } from "event-loop-spinner";
 // This makes it easier to ignore differences between Linux and Windows.
 import { posix as path } from "path";
 import * as varint from "varint";
+import { getErrorMessage } from "../error-utils";
 
 import { DEP_GRAPH_TYPE } from "./";
 import { GoModule } from "./go-module";
@@ -66,7 +67,10 @@ export class GoBinary {
       try {
         this.matchFilesToModules(new LineTable(pclnTab.data).go12MapFiles());
       } catch (err) {
-        debug(`Failed to parse .gopclntab in ${this.name}`, err.stack || err);
+        debug(
+          `Failed to parse .gopclntab in ${this.name}`,
+          getErrorMessage(err),
+        );
       }
     }
   }

--- a/lib/go-parser/index.ts
+++ b/lib/go-parser/index.ts
@@ -5,6 +5,7 @@ import { eventLoopSpinner } from "event-loop-spinner";
 // This makes it easier to ignore differences between Linux and Windows.
 import { posix as path } from "path";
 import { Readable } from "stream";
+import { getErrorMessage } from "../error-utils";
 
 import {
   AppDepsScanResultWithoutTarget,
@@ -212,7 +213,9 @@ export async function goModulesToScannedProjects(
         },
       });
     } catch (err) {
-      debug(`Go binary scan for file ${filePath} failed: ${err.message}`);
+      debug(
+        `Go binary scan for file ${filePath} failed: ${getErrorMessage(err)}`,
+      );
     }
   }
 

--- a/lib/inputs/chisel/static.ts
+++ b/lib/inputs/chisel/static.ts
@@ -2,6 +2,7 @@ import * as Debug from "debug";
 import { normalize as normalizePath } from "path";
 import { ChiselPackage } from "../../analyzer/types";
 import { decompressZstd } from "../../compression-utils";
+import { getErrorMessage } from "../../error-utils";
 import { getContentAsBuffer } from "../../extractor";
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToBuffer } from "../../stream-utils";
@@ -89,11 +90,9 @@ export function getChiselManifestContent(
       } catch (parseError) {
         // Skip malformed JSON lines - manifest may be corrupted or have trailing newlines
         debug(
-          `Failed to parse Chisel manifest line: ${
-            parseError instanceof Error
-              ? parseError.message
-              : String(parseError)
-          }`,
+          `Failed to parse Chisel manifest line: ${getErrorMessage(
+            parseError,
+          )}`,
         );
         continue;
       }
@@ -102,11 +101,7 @@ export function getChiselManifestContent(
     debug(`Found ${packages.length} Chisel packages in manifest`);
     return packages;
   } catch (error) {
-    debug(
-      `Failed to process Chisel manifest: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
+    debug(`Failed to process Chisel manifest: ${getErrorMessage(error)}`);
     return [];
   }
 }

--- a/lib/inputs/rpm/static.ts
+++ b/lib/inputs/rpm/static.ts
@@ -7,6 +7,7 @@ import { PackageInfo } from "@snyk/rpm-parser/lib/rpm/types";
 import { Response } from "@snyk/rpm-parser/lib/types";
 import * as Debug from "debug";
 import { normalize as normalizePath } from "path";
+import { getErrorMessage } from "../../error-utils";
 import { getContentAsBuffer } from "../../extractor";
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToBuffer } from "../../stream-utils";
@@ -36,7 +37,11 @@ export async function getRpmDbFileContent(
     }
     return parserResponse.response;
   } catch (error) {
-    debug(`An error occurred while analysing RPM packages: ${error.message}`);
+    debug(
+      `An error occurred while analysing RPM packages: ${getErrorMessage(
+        error,
+      )}`,
+    );
     return [];
   }
 }
@@ -60,7 +65,11 @@ export async function getRpmSqliteDbFileContent(
     }
     return results.response;
   } catch (error) {
-    debug(`An error occurred while analysing RPM packages: ${error.message}`);
+    debug(
+      `An error occurred while analysing RPM packages: ${getErrorMessage(
+        error,
+      )}`,
+    );
     return [];
   }
 }
@@ -91,7 +100,7 @@ export async function getRpmNdbFileContent(
   } catch (error) {
     debug(
       `An error occurred while analysing RPM NDB packages:`,
-      error.stack || error,
+      getErrorMessage(error),
     );
     return [];
   }

--- a/test/unit/error-utils.spec.ts
+++ b/test/unit/error-utils.spec.ts
@@ -1,0 +1,45 @@
+import { getErrorMessage } from "../../lib/error-utils";
+import { GoFileNameError } from "../../lib/go-parser/go-binary";
+
+describe("getErrorMessage", () => {
+  describe("when the caught value is an Error instance", () => {
+    test("returns the .message of a plain Error", () => {
+      expect(getErrorMessage(new Error("boom"))).toBe("boom");
+    });
+
+    test("returns the .message of a custom Error subclass", () => {
+      const err = new GoFileNameError("main.go", "github.com/org/mod@v1.0.0");
+      expect(getErrorMessage(err)).toBe(err.message);
+    });
+
+    test("returns an empty string when .message is empty", () => {
+      expect(getErrorMessage(new Error(""))).toBe("");
+    });
+  });
+
+  describe("when the caught value is not an Error instance", () => {
+    test("returns a thrown string as-is", () => {
+      expect(getErrorMessage("something broke")).toBe("something broke");
+    });
+
+    test("stringifies a plain object", () => {
+      expect(getErrorMessage({ code: 42 })).toBe("[object Object]");
+    });
+
+    test("stringifies undefined", () => {
+      expect(getErrorMessage(undefined)).toBe("undefined");
+    });
+
+    test("stringifies null", () => {
+      expect(getErrorMessage(null)).toBe("null");
+    });
+
+    test("stringifies a number", () => {
+      expect(getErrorMessage(404)).toBe("404");
+    });
+
+    test("stringifies a boolean", () => {
+      expect(getErrorMessage(false)).toBe("false");
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-    "useUnknownInCatchVariables": false,
+    "useUnknownInCatchVariables": true,
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

# What does this PR do?
- standardize error handling

# Where should the reviewer start?
Our core change was adding [lib/error-utils.ts](https://github.com/snyk/snyk-docker-plugin/blob/68e9bf616b3f1f3b1467467e8f63c82f4fa81c88/lib/error-utils.ts), which exports a `getErrorMessage(error: unknown): string` utility. From there, we migrated all ~21 unsafe catch blocks across `lib/` to use it, replacing direct `.message/.stack` accesses on unverified catch variables, and flipped `useUnknownInCatchVariables` to true in `tsconfig.json` so the compiler enforces this going forward.

# What are the relevant tickets?
[CN-944](https://snyksec.atlassian.net/browse/CN-944)

[CN-944]: https://snyksec.atlassian.net/browse/CN-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ