### PR TITLE
fix: prevent temp directory leak in node-modules-utils

### DIFF
--- a/lib/analyzer/applications/node-modules-utils.ts
+++ b/lib/analyzer/applications/node-modules-utils.ts
@@ -125,7 +125,10 @@ async function persistNodeModules(
   }
 }
 
-async function createFile(filePath: string, fileContent: string): Promise<void> {
+async function createFile(
+  filePath: string,
+  fileContent: string,
+): Promise<void> {
   try {
     await mkdir(path.dirname(filePath), { recursive: true });
     await writeFile(filePath, fileContent, "utf-8");

--- a/lib/analyzer/applications/node-modules-utils.ts
+++ b/lib/analyzer/applications/node-modules-utils.ts
@@ -76,20 +76,23 @@ async function persistNodeModules(
   fileNamesGroupedByDirectory: FilesByDirMap,
 ): Promise<ScanPaths> {
   const modules = fileNamesGroupedByDirectory.get(project);
-  const tmpDir: string = "";
-  const tempProjectRoot: string = "";
 
   if (!modules || modules.size === 0) {
     debug(`Empty application directory tree.`);
-
-    return {
-      tempDir: tmpDir,
-      tempProjectPath: tempProjectRoot,
-    };
+    return { tempDir: "", tempProjectPath: "" };
   }
 
+  // Create the temp directory first so we can return it in the catch block
+  // for cleanup. Previously, the outer tmpDir/tempProjectRoot were always
+  // empty strings, meaning any temp directory created before a failure in
+  // saveOnDisk or later steps would be leaked (caller couldn't clean it up).
+  let tmpDir = "";
+  let tempProjectRoot = "";
+
   try {
-    const { tmpDir, tempProjectRoot } = await createTempProjectDir(project);
+    const created = await createTempProjectDir(project);
+    tmpDir = created.tmpDir;
+    tempProjectRoot = created.tempProjectRoot;
 
     await saveOnDisk(tmpDir, modules, filePathToContent);
 
@@ -122,7 +125,7 @@ async function persistNodeModules(
   }
 }
 
-async function createFile(filePath, fileContent): Promise<void> {
+async function createFile(filePath: string, fileContent: string): Promise<void> {
   try {
     await mkdir(path.dirname(filePath), { recursive: true });
     await writeFile(filePath, fileContent, "utf-8");

--- a/test/lib/analyzer/applications/node-modules-utils.spec.ts
+++ b/test/lib/analyzer/applications/node-modules-utils.spec.ts
@@ -1,0 +1,192 @@
+import * as fsPromises from "fs/promises";
+import * as path from "path";
+import { persistNodeModules } from "../../../../lib/analyzer/applications/node-modules-utils";
+import {
+  FilePathToContent,
+  FilesByDirMap,
+} from "../../../../lib/analyzer/applications/types";
+
+// Mock fs/promises
+jest.mock("fs/promises", () => ({
+  mkdtemp: jest.fn(),
+  mkdir: jest.fn(),
+  writeFile: jest.fn(),
+  stat: jest.fn(),
+  rm: jest.fn(),
+}));
+
+const mockMkdtemp = fsPromises.mkdtemp as jest.MockedFunction<
+  typeof fsPromises.mkdtemp
+>;
+const mockMkdir = fsPromises.mkdir as jest.MockedFunction<
+  typeof fsPromises.mkdir
+>;
+const mockWriteFile = fsPromises.writeFile as jest.MockedFunction<
+  typeof fsPromises.writeFile
+>;
+const mockStat = fsPromises.stat as jest.MockedFunction<typeof fsPromises.stat>;
+
+describe("node-modules-utils", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("persistNodeModules", () => {
+    const project = "my-project";
+
+    it("should return empty paths immediately if modules set is empty or undefined", async () => {
+      const fileNamesGroupedByDirectory: FilesByDirMap = new Map();
+      const filePathToContent: FilePathToContent = {};
+
+      const result = await persistNodeModules(
+        project,
+        filePathToContent,
+        fileNamesGroupedByDirectory,
+      );
+
+      expect(result).toEqual({ tempDir: "", tempProjectPath: "" });
+      expect(mockMkdtemp).not.toHaveBeenCalled();
+      expect(mockMkdir).not.toHaveBeenCalled();
+      expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it("should successfully persist modules and return populated ScanPaths", async () => {
+      const fileNamesGroupedByDirectory: FilesByDirMap = new Map();
+      fileNamesGroupedByDirectory.set(project, new Set(["module1", "module2"]));
+
+      const filePathToContent: FilePathToContent = {
+        module1: "content1",
+        module2: "content2",
+      };
+
+      const mockTmpDir = "/tmp/snyk-random123";
+      mockMkdtemp.mockResolvedValue(mockTmpDir);
+      mockMkdir.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      // Simulate that package.json exists
+      mockStat.mockResolvedValue({} as any);
+
+      const result = await persistNodeModules(
+        project,
+        filePathToContent,
+        fileNamesGroupedByDirectory,
+      );
+
+      const expectedTempProjectPath = path.join(mockTmpDir, project);
+
+      expect(result).toEqual({
+        tempDir: mockTmpDir,
+        tempProjectPath: expectedTempProjectPath,
+        manifestPath: path.join(
+          expectedTempProjectPath.substring(mockTmpDir.length),
+          "package.json",
+        ),
+      });
+
+      expect(mockMkdtemp).toHaveBeenCalledWith("snyk");
+      expect(mockMkdir).toHaveBeenCalledWith(expectedTempProjectPath, {
+        recursive: true,
+      });
+      expect(mockWriteFile).toHaveBeenCalledTimes(2); // One for each module
+      // No synthetic manifest created
+    });
+
+    it("should create synthetic manifest if stat fails (package.json does not exist)", async () => {
+      const fileNamesGroupedByDirectory: FilesByDirMap = new Map();
+      fileNamesGroupedByDirectory.set(project, new Set(["module1"]));
+
+      const filePathToContent: FilePathToContent = {
+        module1: "content1",
+      };
+
+      const mockTmpDir = "/tmp/snyk-random123";
+      mockMkdtemp.mockResolvedValue(mockTmpDir);
+      mockMkdir.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      // Simulate that package.json DOES NOT exist
+      mockStat.mockRejectedValue(new Error("ENOENT"));
+
+      const result = await persistNodeModules(
+        project,
+        filePathToContent,
+        fileNamesGroupedByDirectory,
+      );
+
+      const expectedTempProjectPath = path.join(mockTmpDir, project);
+
+      // manifestPath is deleted from result if synthetic manifest is created
+      expect(result).toEqual({
+        tempDir: mockTmpDir,
+        tempProjectPath: expectedTempProjectPath,
+      });
+
+      // One for module1, one for synthetic manifest
+      expect(mockWriteFile).toHaveBeenCalledTimes(2);
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        path.join(expectedTempProjectPath, "package.json"),
+        "{}",
+        "utf-8",
+      );
+    });
+
+    it("should catch saveOnDisk failure and return populated temporary paths for cleanup (PR #788 fix)", async () => {
+      const fileNamesGroupedByDirectory: FilesByDirMap = new Map();
+      fileNamesGroupedByDirectory.set(project, new Set(["module1"]));
+
+      const filePathToContent: FilePathToContent = {
+        module1: "content1",
+      };
+
+      const mockTmpDir = "/tmp/snyk-random123";
+      mockMkdtemp.mockResolvedValue(mockTmpDir);
+      mockMkdir.mockResolvedValue(undefined);
+
+      // Simulate a failure during saveOnDisk
+      mockWriteFile.mockRejectedValue(new Error("Simulated write error"));
+
+      const result = await persistNodeModules(
+        project,
+        filePathToContent,
+        fileNamesGroupedByDirectory,
+      );
+
+      const expectedTempProjectPath = path.join(mockTmpDir, project);
+
+      expect(result).toEqual({
+        tempDir: mockTmpDir,
+        tempProjectPath: expectedTempProjectPath,
+      });
+      expect(mockMkdtemp).toHaveBeenCalled();
+      expect(mockMkdir).toHaveBeenCalled();
+      expect(mockWriteFile).toHaveBeenCalled();
+    });
+
+    it("should catch initialization failure and return empty paths", async () => {
+      const fileNamesGroupedByDirectory: FilesByDirMap = new Map();
+      fileNamesGroupedByDirectory.set(project, new Set(["module1"]));
+
+      const filePathToContent: FilePathToContent = {
+        module1: "content1",
+      };
+
+      // Simulate a failure during mkdtemp (before assigning local variables)
+      mockMkdtemp.mockRejectedValue(new Error("Simulated mkdtemp error"));
+
+      const result = await persistNodeModules(
+        project,
+        filePathToContent,
+        fileNamesGroupedByDirectory,
+      );
+
+      expect(result).toEqual({
+        tempDir: "",
+        tempProjectPath: "",
+      });
+      expect(mockMkdtemp).toHaveBeenCalled();
+      expect(mockMkdir).not.toHaveBeenCalled();
+      expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- Fixes a variable shadowing bug that caused temporary directories to leak when node_modules persistence failed
- Adds type annotations to the `createFile` function

##### Problem

`persistNodeModules()` creates a temporary directory to write extracted node_modules files for dependency resolution. The function had a scoping bug:

```typescript
async function persistNodeModules(...): Promise<ScanPaths> {
  const tmpDir: string = "";           // outer scope — always empty
  const tempProjectRoot: string = "";  // outer scope — always empty

  if (!modules || modules.size === 0) {
    return { tempDir: tmpDir, tempProjectPath: tempProjectRoot };  // OK, legitimately empty
  }

  try {
    // BUG: This creates NEW block-scoped variables that shadow the outer ones
    const { tmpDir, tempProjectRoot } = await createTempProjectDir(project);
    //     ^^^^^^  ^^^^^^^^^^^^^^^^^ — these are different variables!

    await saveOnDisk(tmpDir, modules, filePathToContent);  // uses inner vars ✓
    // ... more work with inner vars ...
    return result;  // uses inner vars ✓
  } catch (error) {
    return {
      tempDir: tmpDir,            // uses OUTER empty string ✗
      tempProjectPath: tempProjectRoot,  // uses OUTER empty string ✗
    };
  }
}
```

If `createTempProjectDir` succeeds (creating a real directory on disk) but `saveOnDisk` or any later step throws, the catch block returns the **outer** empty strings instead of the actual temp directory path. The caller checks:

```typescript
if (!tempDir) {   // "" is falsy → skips cleanup
  continue;
}
```

This skips cleanup, leaving the temp directory orphaned on disk. Over many scans (especially in CI), these leaked directories accumulate.

##### Fix

Changed from `const` destructuring (which creates new block-scoped variables) to assigning to `let` variables declared in the function scope:

```typescript
let tmpDir = "";
let tempProjectRoot = "";

try {
  const created = await createTempProjectDir(project);
  tmpDir = created.tmpDir;              // updates outer scope
  tempProjectRoot = created.tempProjectRoot;  // updates outer scope
  // ...
} catch (error) {
  return {
    tempDir: tmpDir,            // now has real path if dir was created
    tempProjectPath: tempProjectRoot,
  };
}
```

##### Also

Added `string` type annotations to `createFile(filePath, fileContent)` parameters (were implicit `any`).

##### Risk

**Low.** The fix changes variable scoping to prevent shadowing. The happy path behavior is identical. The error path now correctly returns the temp directory path so the caller can clean it up.



#### How should this be manually tested?
- [ ] Verify node_modules scanning works for images with package.json + node_modules
- [ ] Verify temp directories are cleaned up after scanning
- [ ] Verify empty module directories are handled gracefully

#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CN-1040



#### Additional questions
