### PR TITLE
test: fix mkdtemp assertion broken by #779

### DIFF
--- a/test/lib/analyzer/applications/node-modules-utils.spec.ts
+++ b/test/lib/analyzer/applications/node-modules-utils.spec.ts
@@ -1,4 +1,5 @@
 import * as fsPromises from "fs/promises";
+import * as os from "os";
 import * as path from "path";
 import { persistNodeModules } from "../../../../lib/analyzer/applications/node-modules-utils";
 import {
@@ -84,7 +85,7 @@ describe("node-modules-utils", () => {
         ),
       });
 
-      expect(mockMkdtemp).toHaveBeenCalledWith("snyk");
+      expect(mockMkdtemp).toHaveBeenCalledWith(path.join(os.tmpdir(), "snyk-"));
       expect(mockMkdir).toHaveBeenCalledWith(expectedTempProjectPath, {
         recursive: true,
       });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Fixes a broken unit test that's been failing on main since #788 merged.

The test added in #788 checks that `mkdtemp` is called with `"snyk"`, but that was the old argument — #779 had already changed the call to `mkdtemp(path.join(os.tmpdir(), "snyk-"))` before #788 landed. So the assertion was stale from day one.

#### Where should the reviewer start?

`test/lib/analyzer/applications/node-modules-utils.spec.ts` line 88 — the `toHaveBeenCalledWith` assertion and the new `os` import above it.

#### How should this be manually tested?

```
npm run test:unit
```

All 5 tests in `node-modules-utils.spec.ts` should pass.

#### Any background context you want to provide?

- #779 changed `mkdtemp("snyk")` → `mkdtemp(path.join(os.tmpdir(), "snyk-"))` so temp dirs land in the system temp dir rather than CWD
- #788 fixed the variable scoping bug and added the test suite, but the `toHaveBeenCalledWith` arg referenced the old signature

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CN-1040

#### Screenshots

n/a

#### Additional questions

n/a