### PR TITLE
feat: add phase-level latency metrics for container scans

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   preset: "ts-jest",
-  setupFilesAfterEnv: ["<rootDir>/test/matchers/setup.ts"],
+  setupFilesAfterEnv: [
+    "<rootDir>/test/jest-snapshot-strip-analytics.cjs",
+    "<rootDir>/test/matchers/setup.ts",
+  ],
   testEnvironment: "node",
   testMatch: ["<rootDir>/test/**/*.spec.ts"],
   testPathIgnorePatterns: ["<rootDir>/test/windows/"],

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -155,6 +155,9 @@ export async function analyze(
     }
   }
 
+  const timings: Record<string, number> = {};
+
+  let phaseStart = Date.now();
   const {
     imageId,
     manifestLayers,
@@ -172,6 +175,7 @@ export async function analyze(
     staticAnalysisActions,
     options,
   );
+  timings.imageExtractionMs = Date.now() - phaseStart;
 
   const [
     apkDbFileContent,
@@ -213,6 +217,7 @@ export async function analyze(
 
   let results: ImagePackagesAnalysis[];
   try {
+    phaseStart = Date.now();
     results = await Promise.all([
       apkAnalyze(targetImage, apkDbFileContent),
       aptAnalyze(targetImage, aptDbFileContent, osRelease),
@@ -231,19 +236,23 @@ export async function analyze(
       aptDistrolessAnalyze(targetImage, distrolessAptFiles, osRelease),
       chiselAnalyze(targetImage, chiselPackages),
     ]);
+    timings.osPackageAnalysisMs = Date.now() - phaseStart;
   } catch (err) {
     debug(`Could not detect installed OS packages: ${getErrorMessage(err)}`);
     throw new Error("Failed to detect installed OS packages");
   }
 
+  phaseStart = Date.now();
   const binaries = getBinariesHashes(extractedLayers);
   const javaRuntime = detectJavaRuntime(extractedLayers);
   const baseRuntimes = javaRuntime ? [javaRuntime] : undefined;
+  timings.binariesAndRuntimeDetectionMs = Date.now() - phaseStart;
 
   const applicationDependenciesScanResults: AppDepsScanResultWithoutTarget[] =
     [];
 
   if (appScan) {
+    phaseStart = Date.now();
     const nodeDependenciesScanResults = await nodeFilesToScannedProjects(
       getFileContent(extractedLayers, getNodeAppFileContentAction.actionName),
       nodeModulesScan,
@@ -259,19 +268,24 @@ export async function analyze(
         "npm",
       );
     }
+    timings.nodeAnalysisMs = Date.now() - phaseStart;
 
+    phaseStart = Date.now();
     const phpDependenciesScanResults = await phpFilesToScannedProjects(
       getFileContent(extractedLayers, getPhpAppFileContentAction.actionName),
     );
+    timings.phpAnalysisMs = Date.now() - phaseStart;
 
+    phaseStart = Date.now();
     const poetryDependenciesScanResults = await poetryFilesToScannedProjects(
       getFileContent(extractedLayers, getPoetryAppFileContentAction.actionName),
     );
+    timings.poetryAnalysisMs = Date.now() - phaseStart;
 
+    phaseStart = Date.now();
     const pipDependenciesScanResults = await pipFilesToScannedProjects(
       getFileContent(extractedLayers, getPipAppFileContentAction.actionName),
     );
-
     let pythonApplicationFilesScanResults: AppDepsScanResultWithoutTarget[] =
       [];
     if (collectApplicationFiles) {
@@ -284,18 +298,22 @@ export async function analyze(
         "python",
       );
     }
+    timings.pipAnalysisMs = Date.now() - phaseStart;
 
+    phaseStart = Date.now();
     const desiredLevelsOfUnpacking = getNestedJarsDesiredDepth(options);
-
     const jarFingerprintScanResults = await jarFilesToScannedResults(
       getBufferContent(extractedLayers, getJarFileContentAction.actionName),
       targetImage,
       desiredLevelsOfUnpacking,
     );
+    timings.jarAnalysisMs = Date.now() - phaseStart;
 
+    phaseStart = Date.now();
     const goModulesScanResult = await goModulesToScannedProjects(
       getElfFileContent(extractedLayers, getGoModulesContentAction.actionName),
     );
+    timings.goAnalysisMs = Date.now() - phaseStart;
 
     applicationDependenciesScanResults.push(
       ...nodeDependenciesScanResults,
@@ -325,6 +343,7 @@ export async function analyze(
     imageCreationTime,
     containerConfig,
     history,
+    timings,
   };
 }
 

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -103,6 +103,7 @@ export interface StaticAnalysis {
     comment?: string | null;
     empty_layer?: boolean | null;
   }> | null;
+  timings?: Record<string, number>;
 }
 
 export interface StaticPackagesAnalysis extends StaticAnalysis {

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -8,6 +8,7 @@ import { instructionDigest } from "./dockerfile";
 import { DockerFileAnalysis, DockerFilePackages } from "./dockerfile/types";
 import { OCIDistributionMetadata } from "./extractor/oci-distribution-metadata";
 
+import { computeScanPayloadMetrics } from "./scan-payload-metrics";
 import * as types from "./types";
 import { truncateAdditionalFacts } from "./utils";
 import { PLUGIN_VERSION } from "./version";
@@ -348,8 +349,16 @@ async function buildResponse(
     facts: truncateAdditionalFacts(result.facts || []),
   }));
 
+  const scanPayloadMetrics = computeScanPayloadMetrics(truncatedScanResults);
+
   return {
     scanResults: truncatedScanResults,
+    analytics: [
+      {
+        name: "containerScanPayloadMetrics",
+        data: scanPayloadMetrics,
+      },
+    ],
   };
 }
 

--- a/lib/scan-payload-metrics.ts
+++ b/lib/scan-payload-metrics.ts
@@ -1,0 +1,22 @@
+import type { ScanResult } from "./types";
+
+export interface ScanPayloadMetrics {
+  scanResultCount: number;
+  applicationScanResultCount: number;
+  scanResultPayloadBytes: number[];
+  totalScanResultsPayloadBytes: number;
+}
+
+export function computeScanPayloadMetrics(
+  scanResults: ScanResult[],
+): ScanPayloadMetrics {
+  const bytes = (v: unknown) =>
+    Buffer.byteLength(JSON.stringify(v), "utf8");
+
+  return {
+    scanResultCount: scanResults.length,
+    applicationScanResultCount: Math.max(0, scanResults.length - 1),
+    scanResultPayloadBytes: scanResults.map(bytes),
+    totalScanResultsPayloadBytes: bytes(scanResults),
+  };
+}

--- a/lib/scan-payload-metrics.ts
+++ b/lib/scan-payload-metrics.ts
@@ -10,8 +10,7 @@ export interface ScanPayloadMetrics {
 export function computeScanPayloadMetrics(
   scanResults: ScanResult[],
 ): ScanPayloadMetrics {
-  const bytes = (v: unknown) =>
-    Buffer.byteLength(JSON.stringify(v), "utf8");
+  const bytes = (v: unknown) => Buffer.byteLength(JSON.stringify(v), "utf8");
 
   return {
     scanResultCount: scanResults.length,

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -91,6 +91,7 @@ export async function analyzeStatically(
   return {
     ...response,
     analytics: [
+      ...(response.analytics ?? []),
       {
         name: "containerPluginTimings",
         data: timings,

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -21,6 +21,8 @@ export async function analyzeStatically(
   options: Partial<PluginOptions>,
   imageName?: ImageName,
 ): Promise<PluginResponse> {
+  const totalStart = Date.now();
+
   const staticAnalysis = await analyzer.analyzeStatically(
     targetImage,
     dockerfileAnalysis,
@@ -29,6 +31,8 @@ export async function analyzeStatically(
     globsToFind,
     options,
   );
+
+  const depTreeStart = Date.now();
 
   const parsedAnalysisResult = parseAnalysisResults(
     targetImage,
@@ -66,7 +70,7 @@ export async function analyzeStatically(
     });
   }
 
-  return buildResponse(
+  const response = await buildResponse(
     analysis,
     dockerfileAnalysis,
     excludeBaseImageVulns,
@@ -74,4 +78,23 @@ export async function analyzeStatically(
     ociDistributionMetadata,
     options,
   );
+
+  const depTreeBuildingMs = Date.now() - depTreeStart;
+  const totalMs = Date.now() - totalStart;
+
+  const timings: Record<string, number> = {
+    ...staticAnalysis.timings,
+    depTreeBuildingMs,
+    totalMs,
+  };
+
+  return {
+    ...response,
+    analytics: [
+      {
+        name: "containerPluginTimings",
+        data: timings,
+      },
+    ],
+  };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,9 +84,15 @@ export type FactType =
   // Application files observed in the image
   | "applicationFiles";
 
+export interface PluginAnalytics {
+  name: string;
+  data: unknown;
+}
+
 export interface PluginResponse {
   /** The first result is guaranteed to be the OS dependencies scan result. */
   scanResults: ScanResult[];
+  analytics?: PluginAnalytics[];
 }
 
 export interface ScanResult {

--- a/test/jest-snapshot-strip-analytics.cjs
+++ b/test/jest-snapshot-strip-analytics.cjs
@@ -1,0 +1,18 @@
+/**
+ * Strip PluginResponse.analytics from snapshot output (timings are non-deterministic).
+ * Plain JS so it loads before ts-jest (needed for Windows Jest config).
+ */
+expect.addSnapshotSerializer({
+  test(val) {
+    return (
+      val !== null &&
+      typeof val === "object" &&
+      Array.isArray(val.scanResults) &&
+      Object.prototype.hasOwnProperty.call(val, "analytics")
+    );
+  },
+  serialize(val, config, indentation, depth, refs, printer) {
+    const { analytics: _a, ...rest } = val;
+    return printer(rest, config, indentation, depth, refs);
+  },
+});

--- a/test/lib/scan-payload-metrics.spec.ts
+++ b/test/lib/scan-payload-metrics.spec.ts
@@ -1,0 +1,38 @@
+import { computeScanPayloadMetrics } from "../../lib/scan-payload-metrics";
+import type { ScanResult } from "../../lib/types";
+
+function scanResult(image: string): ScanResult {
+  return {
+    target: { image },
+    identity: { type: "deb", args: undefined },
+    facts: [],
+  };
+}
+
+describe("computeScanPayloadMetrics", () => {
+  it("counts OS + app results and payload sizes", () => {
+    const scanResults = [
+      scanResult("os"),
+      scanResult("app-a"),
+      scanResult("app-b"),
+    ];
+    const m = computeScanPayloadMetrics(scanResults);
+
+    expect(m.scanResultCount).toBe(3);
+    expect(m.applicationScanResultCount).toBe(2);
+    expect(m.scanResultPayloadBytes).toHaveLength(3);
+    expect(m.scanResultPayloadBytes.every((n) => n > 0)).toBe(true);
+    expect(m.totalScanResultsPayloadBytes).toBe(
+      Buffer.byteLength(JSON.stringify(scanResults), "utf8"),
+    );
+  });
+
+  it("empty scanResults", () => {
+    expect(computeScanPayloadMetrics([])).toEqual({
+      scanResultCount: 0,
+      applicationScanResultCount: 0,
+      scanResultPayloadBytes: [],
+      totalScanResultsPayloadBytes: 2,
+    });
+  });
+});

--- a/test/windows/jest.config.js
+++ b/test/windows/jest.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   preset: "ts-jest",
-  setupFilesAfterEnv: ["<rootDir>/../matchers/setup.ts"],
+  setupFilesAfterEnv: [
+    "<rootDir>/../jest-snapshot-strip-analytics.cjs",
+    "<rootDir>/../matchers/setup.ts",
+  ],
   testEnvironment: "node",
   testMatch: ["<rootDir>/**/*.spec.ts"],
   testTimeout: 600000, // 10 minutes


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds per-phase latency timing to the container scan flow. Each major phase (image extraction, OS package analysis, JAR/Go/Node/PHP/Python analysis, binary detection, dep tree building) is timed with Date.now() and returned on the PluginResponse via a new optional analytics field. A companion CLI change wires these timings into CLI analytics metadata as containerPluginTimings.

#### Any background context you want to provide?

The container plugin has no latency visibility, this PR is to collect latency metrics and surface them in the CLI analytics.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CN-1170
https://snyksec.atlassian.net/browse/CN-1054