### PR TITLE
fix: vuln fixes — on-call sweep [CN-1323]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,9 @@ ignore:
     - '*':
         reason: 'Indirect dependency, waiting for upstream fix'
         expires: 2026-04-09T00:00:00.000Z
+  SNYK-JS-UUID-16133035:
+    - '*':
+        reason: "No non-major fix available as of 2026-05-19; revisit in 7 days"
+        expires: '2026-05-26T00:00:00.000Z'
+        created: '2026-05-19T00:00:00.000Z'
 patch: {}


### PR DESCRIPTION
Jira: https://snyksec.atlassian.net/browse/CN-1323

## Summary

On-call vuln triage sweep for `snyk/snyk-docker-plugin`. All medium+ severity findings addressed.

## Vulnerabilities fixed

None were directly upgradable within the same major version — only snoozes were applicable.

## Snoozed (7-day ignore, expires 2026-05-26)

- **SNYK-JS-UUID-16133035** (medium) — `uuid@8.3.2` and `uuid@9.0.1` (transitive via `snyk-nodejs-lockfile-parser` and `snyk-poetry-lockfile-parser`). Fix versions are 11.1.1 and 14.0.0 — both are major upgrades, which are forbidden under policy. Added `.snyk` ignore entry; revisit when upstream packages bump their own uuid dependency.

## Base image updates

None — no `us-docker.pkg.dev/polaris-gcp-gar` or `snyk-base-images` references found in this repo.