### PR TITLE
chore(deps): remove stale lodash ignore — already at 4.18.1

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  SNYK-JS-LODASH-15869625:
-    - '*':
-        reason: 'Indirect dependency, waiting for upstream fix'
-        expires: 2026-04-09T00:00:00.000Z
+ignore: {}
 patch: {}


### PR DESCRIPTION
## Summary

- Removes stale `.snyk` ignore for `SNYK-JS-LODASH-15869625`
- The current lockfile already has lodash 4.18.1, which is the fix version
- No package.json or lockfile changes needed

## Why

The ignore entry was added while waiting for an upstream fix. That fix has since landed in the lockfile. This PR cleans up the stale entry so Snyk will correctly report clean state.

Jira: CN-1326