### PR TITLE
fix: scope npm publish to dist via files directive (CN-1340)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.github
-.travis.yml
-appveyor.yml
-test/
-bin/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.github
+.travis.yml
+appveyor.yml
+test/
+bin/

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "build-watch": "tsc -w",


### PR DESCRIPTION
Adds a `files` allowlist to `package.json` so `npm publish` only ships `dist/`. The package previously had no `files` directive and only a minimal `.npmignore` covering five paths. Because npm uses `.npmignore` over `.gitignore` when both are present, the published tarball was carrying everything else in the working tree — `.circleci/`, `lib/` source, `eslint.config.mjs`, `tsconfig.json`, `.snyk`, `.gitleaksignore`, `AGENTS.md`, `CLAUDE.md`, `jest.config.js`.

This is the same shape of leak that triggered ProdSec to flip `@snyk/snyk-docker-pull` private on 2026-05-15 (INC-3164 / [INC-4725](https://snyksec.atlassian.net/browse/INC-4725)). Drago Costache acknowledged in the original [#team-container thread](https://snyk.slack.com/archives/C08KFUU9R5Z/p1779093066046359) that ProdSec is tracking similar issues across other Snyk packages — `snyk-docker-pull` got the urgent treatment because it leaked CI internals. This PR pre-empts the same outcome on `snyk-docker-plugin`.

`["dist"]` matches the convention used by `@snyk/dep-graph` and `@snyk/docker-registry-v2-client`. The companion fix on `snyk-docker-pull` is [PR #153 there](https://github.com/snyk/snyk-docker-pull/pull/153) ([CN-1337](https://snyksec.atlassian.net/browse/CN-1337)).

## Verified locally

After `npm run build`, `npm pack --dry-run` ships:

```
LICENSE
README.md
dist/**/*.{d.ts,js,js.map}   (273 files)
package.json
```

276 files total. None of the previously-leaked `.circleci/`, repo configs, or source `lib/` makes it in.

## Test plan

- [x] `npm pack --dry-run` confirms only `LICENSE`, `README.md`, `package.json`, and `dist/` ship
- [ ] CI green (build, lint, unit tests)
- [ ] System tests pass (where available)
- [ ] Decision on whether to backport the same fix to `9.1.x` maintenance branch and to v6/v7/v8 release lines

## Related

- Jira: [CN-1340](https://snyksec.atlassian.net/browse/CN-1340)
- Sibling fix: [snyk/snyk-docker-pull#153](https://github.com/snyk/snyk-docker-pull/pull/153) ([CN-1337](https://snyksec.atlassian.net/browse/CN-1337))
- Incident: [INC-4725](https://snyksec.atlassian.net/browse/INC-4725) (FireHydrant INC-3164)
- Post-mortem: [INC-4726](https://snyksec.atlassian.net/browse/INC-4726)
- ProdSec original explanation in [#team-container](https://snyk.slack.com/archives/C08KFUU9R5Z/p1778870447065419?thread_ts=1778848211.222819&cid=C08KFUU9R5Z)

[INC-4725]: https://snyksec.atlassian.net/browse/INC-4725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-1337]: https://snyksec.atlassian.net/browse/CN-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ