### PR TITLE
fix: scope npm publish to dist via files directive (CN-1340, 9.1.x backport)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.github
-.travis.yml
-appveyor.yml
-test/
-bin/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.github
+.travis.yml
+appveyor.yml
+test/
+bin/

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "build-watch": "tsc -w",


### PR DESCRIPTION
Backport of [#813](https://github.com/snyk/snyk-docker-plugin/pull/813) ([CN-1340](https://snyksec.atlassian.net/browse/CN-1340)) to the `9.1.x` maintenance line.

`9.1.x` has the same package.json shape as `main` — no `files` directive, minimal `.npmignore` that lets the whole working tree ship in the published tarball (`.circleci/`, `lib/` source, `tsconfig.json`, etc.). Any future hotfix release cut off this branch would re-leak the same content that got `@snyk/snyk-docker-pull` flipped private on 2026-05-15.

This change adds `files: ["dist"]` and removes the now-redundant `.npmignore`. Same diff as the `main` PR.

## Test plan

- [ ] CI green on 9.1.x
- [ ] `npm pack --dry-run` confirms only `LICENSE`, `README.md`, `package.json`, and `dist/` ship (verified equivalent shape on main in #813)

## Related

- Main PR: [#813](https://github.com/snyk/snyk-docker-plugin/pull/813)
- Jira: [CN-1340](https://snyksec.atlassian.net/browse/CN-1340)
- Companion fix on snyk-docker-pull: [snyk/snyk-docker-pull#153](https://github.com/snyk/snyk-docker-pull/pull/153) ([CN-1337](https://snyksec.atlassian.net/browse/CN-1337))
- Incident: [INC-4725](https://snyksec.atlassian.net/browse/INC-4725) (FireHydrant INC-3164)

[CN-1340]: https://snyksec.atlassian.net/browse/CN-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-1340]: https://snyksec.atlassian.net/browse/CN-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-1337]: https://snyksec.atlassian.net/browse/CN-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ