### PR TITLE
fix: scope npm publish to dist via files directive (CN-1340, 8.16.x backport)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "build-watch": "tsc -w",


### PR DESCRIPTION
Backport of [#813](https://github.com/snyk/snyk-docker-plugin/pull/813) ([CN-1340](https://snyksec.atlassian.net/browse/CN-1340)) to the `8.16.x` maintenance line.

`v8.16.1` has the same leak shape as `main`, `9.1.x`, `6.18.x`, and `7.1.x`: no `files` directive and a minimal `.npmignore` (`.github`, `.travis.yml`, `appveyor.yml`, `test/`, `bin/`) that lets the whole working tree ship in the published tarball (`.circleci/`, `lib/` source, `tsconfig.json`, etc.). Any future hotfix release cut off this branch would re-leak the same content that got `@snyk/snyk-docker-pull` flipped private on 2026-05-15.

This PR adds `files: ["dist"]`. `.npmignore` is left in place per the most recent guidance on #813 — it's a no-op once `files` is set, and the fix only edits what it needs.

### Sibling PRs in this incident

- snyk-docker-pull: [snyk/snyk-docker-pull#153](https://github.com/snyk/snyk-docker-pull/pull/153) ([CN-1337](https://snyksec.atlassian.net/browse/CN-1337))
- snyk-docker-plugin main: [#813](https://github.com/snyk/snyk-docker-plugin/pull/813)
- snyk-docker-plugin 9.1.x: [#814](https://github.com/snyk/snyk-docker-plugin/pull/814)
- snyk-docker-plugin 6.18.x: [#815](https://github.com/snyk/snyk-docker-plugin/pull/815)
- snyk-docker-plugin 7.1.x: [#816](https://github.com/snyk/snyk-docker-plugin/pull/816)

### Release-branch setup

The `8.16.x` base branch was created off `v8.16.1` and pre-configured for semantic-release in [975db47](https://github.com/snyk/snyk-docker-plugin/commit/975db47) (`chore: configure semantic-release for 8.16.x patch release`). That mirrors the 9.1.x pattern from [c9c5d99](https://github.com/snyk/snyk-docker-plugin/commit/c9c5d99), with one deviation: the forced-patch `analyzeCommitsCmd: "echo patch"` override is intentionally omitted on this backport because (a) adding `@semantic-release/exec` would require touching `package-lock.json` — out of scope per the plan — and (b) the branch is frozen after this fix lands, so commit-analyzer's default handling of a single `fix:` commit is sufficient to produce a patch bump.

### Test plan

- [ ] CI green on `CN-1340-files-directive-8.16.x` (build, lint, unit tests on the v8 Node engine)
- [ ] `npm pack --dry-run` on the merged commit confirms only `LICENSE`, `README.md`, `package.json`, and `dist/` ship — same shape as verified on [#813](https://github.com/snyk/snyk-docker-plugin/pull/813)
- [ ] After ProdSec republishes `@snyk/snyk-docker-pull`, mark ready and merge → semantic-release publishes `v8.16.2` → confirm tarball contents on npmjs.com

### Notes

- This is a one-time backport publish. The `8.16.x` branch should be considered frozen after `v8.16.2` ships and can be deleted (or left to garbage-collect) afterwards. Don't push further commits to it — this isn't a maintained line.
- The dependency on `@snyk/snyk-docker-pull@^3.15.0` already satisfies whatever clean version ProdSec republishes in the 3.x line. No dep-range change is needed unless ProdSec republishes outside 3.x (open question with ProdSec).

### Related

- Jira: [CN-1340](https://snyksec.atlassian.net/browse/CN-1340)
- Incident: [INC-4725](https://snyksec.atlassian.net/browse/INC-4725) (FireHydrant INC-3164)
- Post-mortem: [INC-4726](https://snyksec.atlassian.net/browse/INC-4726)

[CN-1340]: https://snyksec.atlassian.net/browse/CN-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-1337]: https://snyksec.atlassian.net/browse/CN-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-1340]: https://snyksec.atlassian.net/browse/CN-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ