### PR TITLE
fix: enable docker client ssrf protections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.12.1",
-        "@snyk/docker-registry-v2-client": "^2.24.2",
+        "@snyk/docker-registry-v2-client": "^4.0.2",
         "@snyk/rpm-parser": "^3.4.1",
-        "@snyk/snyk-docker-pull": "^3.15.1",
+        "@snyk/snyk-docker-pull": "^3.16.0",
         "@swimlane/docker-reference": "^2.0.1",
         "adm-zip": "^0.5.17",
         "chalk": "^2.4.2",
@@ -3485,13 +3485,14 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@snyk/docker-registry-v2-client": {
-      "version": "2.24.2",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.24.2.tgz",
-      "integrity": "sha512-xSZ/1HlmWL9+gV91z2wTKBUQhihDEpDC1T1W05r6KGN4C4FFMtYy+45GS82gUCNaFbNFwAHKOYRQXOv8IX1QUA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-4.0.2.tgz",
+      "integrity": "sha512-sLXh1FTjv/NTj6Vv1+WVftKohaUWxZc5htR6/Vp7qMvp7eKvX9Y6DzVDqPdfjBZZxXLAUCADDf2191zVr+WsfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "needle": "^3.2.0",
+        "needle": "^3.5.0",
         "parse-link-header": "^2.0.0",
+        "psl": "^1.15.0",
         "tslib": "^1.10.0"
       }
     },
@@ -3561,12 +3562,12 @@
       }
     },
     "node_modules/@snyk/snyk-docker-pull": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.15.1.tgz",
-      "integrity": "sha512-bmrpbXgte8NYLjfFzKDbIAMfOQits+G+kq7JIC2ij813VK/mA69+AONM5sYoNElVTADKzs8MDV6nd2bG2NqPgA==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.17.1.tgz",
+      "integrity": "sha512-wvz5Fkmg3tCMlh2QXOlkTGkwbd39l+4C8NmQyolLGGzJ8IxewLqyl8dDqIWOmjUbMZnbGlm45Yj0bOWKOLjXHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@snyk/docker-registry-v2-client": "^2.20.0",
+        "@snyk/docker-registry-v2-client": "^4.0.2",
         "child-process": "^1.0.2",
         "tar-fs": "^3.0.9"
       },
@@ -3832,13 +3833,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/treeify": {
       "version": "1.0.3",
@@ -8121,6 +8115,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -11210,18 +11205,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -11261,9 +11244,10 @@
       "dev": true
     },
     "node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+      "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
@@ -14807,6 +14791,18 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -14830,7 +14826,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15397,9 +15392,13 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/semantic-release": {
       "version": "23.1.1",
@@ -16945,15 +16944,6 @@
       "resolved": "https://registry.npmjs.org/tinylogic/-/tinylogic-2.0.0.tgz",
       "integrity": "sha512-dljTkiLLITtsjqBvTA1MRZQK/sGP4kI3UJKc3yA9fMzYbMF2RhcN04SeROVqJBIYYOoJMM8u0WDnhFwMSFQotw==",
       "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   "dependencies": {
     "@snyk/composer-lockfile-parser": "^1.4.1",
     "@snyk/dep-graph": "^2.12.1",
-    "@snyk/docker-registry-v2-client": "^2.24.2",
+    "@snyk/docker-registry-v2-client": "^4.0.2",
     "@snyk/rpm-parser": "^3.4.1",
-    "@snyk/snyk-docker-pull": "^3.15.1",
+    "@snyk/snyk-docker-pull": "^3.16.0",
     "@swimlane/docker-reference": "^2.0.1",
     "adm-zip": "^0.5.17",
     "chalk": "^2.4.2",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Enables new SSRF protections in `docker-registry-v2-client` by updating the client to ^4.0.2 and `snyk-docker-pull` to ^3.16.0.

#### Any background context you want to provide?

The new protections were tested in dry-run mode on another service with no false positives (i.e. improper connection failures) noted.

#### What are the relevant tickets?

[Jira ticket](https://snyksec.atlassian.net/browse/CN-978)
