### PR TITLE
fix(ci): write NPM_TOKEN to ~/.npmrc before semantic-release (CN-1393)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,9 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run:
+          name: Setup NPM auth
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run:
           name: Release on GitHub
           command: |
             export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')


### PR DESCRIPTION
The release job has been failing with `403 Forbidden` since the OIDC migration. Every publish attempt hits a read-only token instead of doing the OIDC exchange — here's why and what fixes it.

`@semantic-release/npm` picks its auth strategy based on whether a token already exists in `~/.npmrc`. If one's there, it hands off to its bundled npm CLI, which reads `NPM_ID_TOKEN` from the environment and does the OIDC exchange correctly. If `~/.npmrc` is empty, it falls back to writing `NPM_TOKEN` (the read-only one from `nodejs-install`) into a temp config and running `npm publish` against that. The registry rejects it because classic tokens are disallowed when trusted publishing is enabled.

The release job had no step writing to `~/.npmrc`, so it always hit the fallback. Adding `echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc` before semantic-release is enough to switch code paths. `snyk-docker-pull` and `snyk-gradle-plugin` both use this same pattern and publish successfully.

Thread on May 27 discussing this [here](https://snyk.enterprise.slack.com/archives/C0132695Y7L/p1779806971337009). Tracked in [CN-1393](https://snyksec.atlassian.net/browse/CN-1393).

## Test plan
- Merge to `main` triggers a semantic-release run that completes the publish step without 403

[CN-1393]: https://snyksec.atlassian.net/browse/CN-1393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ