### PR TITLE
fix(ci): bump release image to node 24 for npm 11 OIDC support (CN-1393)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ windows_big: &windows_big
 release_defaults: &release_defaults
   resource_class: small
   docker:
-    - image: cimg/node:22.22
+    - image: cimg/node:24.15
   working_directory: ~/snyk-docker-plugin
 
 define: &windows_node_version "20.19.1"
@@ -217,9 +217,6 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run build
-      - run:
-          name: Setup NPM auth
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
           name: Release on GitHub
           command: |


### PR DESCRIPTION
The OIDC publish is still failing with 403 after the semantic-release upgrade. The image upgrade in #823 moved to `cimg/node:22.22`, but Node 22 still ships npm 10.x — and CircleCI OIDC support wasn't added to npm until v11.11.0.

`cimg/node:24.15` ships npm@11.12.1. In npm 11, `oidc()` is called unconditionally before credentials are resolved. It exchanges `NPM_ID_TOKEN` for a short-lived publish token and overwrites whatever `_authToken` was in config before the actual publish request goes out. The read-only token from `nodejs-install` is never used.

Also removes the `Setup NPM auth` step added in #827. Two independent analyses of the `@semantic-release/npm@13.1.5` and npm v11.12.1 source confirmed it's redundant — npm 11's `oidc()` runs regardless of whether a token is already in `~/.npmrc`, so that step was doing nothing useful.

Tracked in [CN-1393](https://snyksec.atlassian.net/browse/CN-1393). Slack investigation thread [here](https://snyk.enterprise.slack.com/archives/C0132695Y7L/p1779806971337009).

## Test plan
- Merge to `main` should trigger a semantic-release run that completes the publish step without 403

[CN-1393]: https://snyksec.atlassian.net/browse/CN-1393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ