### PR TITLE
fix: add ssh2 optional native deps to lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5271,6 +5271,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -5846,6 +5855,20 @@
         "cosmiconfig": ">=7",
         "ts-node": ">=10",
         "typescript": ">=4"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/create-jest": {
@@ -11205,6 +11228,13 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",


### PR DESCRIPTION
## What

Adds the missing `ssh2` optional native-dependency nodes to `package-lock.json`:

- `cpu-features@0.0.10`
- `nan@2.27.0`
- `buildcheck@0.0.7`

All three are marked `"optional": true`. The diff is purely additive (+30 lines, no other churn).

## Why

The **Release to GitHub** job's `npm ci` started failing:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: cpu-features@0.0.10 from lock file
npm error Missing: nan@2.27.0 from lock file
npm error Missing: buildcheck@0.0.7 from lock file
```

`docker-modem@3.0.8` → `ssh2@^1.11.0`, and `ssh2` declares `cpu-features`/`nan`
as `optionalDependencies` (`cpu-features` in turn pulls `buildcheck`). The lockfile
listed ssh2's `optionalDependencies` but omitted the actual package nodes for them.

npm 10 tolerated this in `npm ci`; **npm 11 is stricter** — it resolves the
Linux-applicable optional native deps and requires them present, failing the
package.json/lock sync check. The release runner moved to `cimg/node:24`
(npm 11) in #828, which is what surfaced the pre-existing lockfile gap.

## How it was generated

`npm install --package-lock-only` under npm 11. None of the three deps declare
`os`/`cpu` restrictions, so the lockfile is platform-independent — regenerating
on macOS (npm 11) produced a byte-for-byte identical result to node:24.

## Verification

`npm ci` now exits 0 under npm 11.13.0 (node:24, matching CI). semantic-release
`--dry-run` proceeds past the previously-failing step into the release flow.