### PR TITLE
feat: expand Java runtime release file detection to more JVM base images (CN-528)

### DIFF
--- a/lib/inputs/base-runtimes/static.ts
+++ b/lib/inputs/base-runtimes/static.ts
@@ -1,22 +1,21 @@
-import { normalize as normalizePath } from "path";
+import { basename, normalize as normalizePath } from "path";
 import { getContentAsString } from "../../extractor";
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 
 function javaReleaseFilePathMatches(filePath: string): boolean {
   const p = normalizePath(filePath);
-  return (
+  const isReleaseFile = basename(p) === "release";
+  const matched =
     // eclipse-temurin: /opt/java/openjdk/release
     p === normalizePath("/opt/java/openjdk/release") ||
     // official Docker openjdk: /usr/local/openjdk-<version>/release
-    (p.startsWith(normalizePath("/usr/local/openjdk-")) &&
-      p.endsWith("/release")) ||
+    (p.startsWith(normalizePath("/usr/local/openjdk-")) && isReleaseFile) ||
     // Debian/Ubuntu default-jdk: /usr/lib/jvm/java-<version>-openjdk-<arch>/release
-    (p.startsWith(normalizePath("/usr/lib/jvm/java-")) &&
-      p.endsWith("/release")) ||
+    (p.startsWith(normalizePath("/usr/lib/jvm/java-")) && isReleaseFile) ||
     // Oracle JDK: /usr/java/<version>/release
-    (p.startsWith(normalizePath("/usr/java/")) && p.endsWith("/release"))
-  );
+    (p.startsWith(normalizePath("/usr/java/")) && isReleaseFile);
+  return matched;
 }
 
 export const getJavaRuntimeReleaseAction: ExtractAction = {

--- a/lib/inputs/base-runtimes/static.ts
+++ b/lib/inputs/base-runtimes/static.ts
@@ -3,10 +3,25 @@ import { getContentAsString } from "../../extractor";
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 
+function javaReleaseFilePathMatches(filePath: string): boolean {
+  const p = normalizePath(filePath);
+  return (
+    // eclipse-temurin: /opt/java/openjdk/release
+    p === normalizePath("/opt/java/openjdk/release") ||
+    // official Docker openjdk: /usr/local/openjdk-<version>/release
+    (p.startsWith(normalizePath("/usr/local/openjdk-")) &&
+      p.endsWith("/release")) ||
+    // Debian/Ubuntu default-jdk: /usr/lib/jvm/java-<version>-openjdk-<arch>/release
+    (p.startsWith(normalizePath("/usr/lib/jvm/java-")) &&
+      p.endsWith("/release")) ||
+    // Oracle JDK: /usr/java/<version>/release
+    (p.startsWith(normalizePath("/usr/java/")) && p.endsWith("/release"))
+  );
+}
+
 export const getJavaRuntimeReleaseAction: ExtractAction = {
   actionName: "java-runtime-release",
-  filePathMatches: (filePath) =>
-    filePath === normalizePath("/opt/java/openjdk/release"),
+  filePathMatches: javaReleaseFilePathMatches,
   callback: streamToString,
 };
 

--- a/test/lib/inputs/base-runtimes-static.spec.ts
+++ b/test/lib/inputs/base-runtimes-static.spec.ts
@@ -1,0 +1,168 @@
+import { getJavaRuntimeReleaseAction } from "../../../lib/inputs/base-runtimes/static";
+import { detectJavaRuntime } from "../../../lib/analyzer/base-runtimes";
+import { ExtractedLayers } from "../../../lib/extractor/types";
+
+const matches = getJavaRuntimeReleaseAction.filePathMatches!;
+
+function makeLayer(filePath: string, content: string): ExtractedLayers {
+  return { [filePath]: { "java-runtime-release": content } };
+}
+
+describe("getJavaRuntimeReleaseAction.filePathMatches", () => {
+  describe("eclipse-temurin (/opt/java/openjdk/release)", () => {
+    it("matches the exact path", () => {
+      expect(matches("/opt/java/openjdk/release")).toBe(true);
+    });
+
+    it("does not match other files under /opt/java/openjdk/", () => {
+      expect(matches("/opt/java/openjdk/conf/security")).toBe(false);
+    });
+  });
+
+  describe("official Docker openjdk (/usr/local/openjdk-<version>/release)", () => {
+    it("matches /usr/local/openjdk-11/release", () => {
+      expect(matches("/usr/local/openjdk-11/release")).toBe(true);
+    });
+
+    it("matches /usr/local/openjdk-17/release", () => {
+      expect(matches("/usr/local/openjdk-17/release")).toBe(true);
+    });
+
+    it("matches /usr/local/openjdk-21/release", () => {
+      expect(matches("/usr/local/openjdk-21/release")).toBe(true);
+    });
+
+    it("does not match non-release files under /usr/local/openjdk-*", () => {
+      expect(matches("/usr/local/openjdk-17/bin/java")).toBe(false);
+    });
+  });
+
+  describe("Debian/Ubuntu default-jdk (/usr/lib/jvm/java-<version>-openjdk-<arch>/release)", () => {
+    it("matches /usr/lib/jvm/java-17-openjdk-amd64/release", () => {
+      expect(matches("/usr/lib/jvm/java-17-openjdk-amd64/release")).toBe(true);
+    });
+
+    it("matches /usr/lib/jvm/java-11-openjdk-arm64/release", () => {
+      expect(matches("/usr/lib/jvm/java-11-openjdk-arm64/release")).toBe(true);
+    });
+
+    it("matches /usr/lib/jvm/java-21-openjdk-amd64/release", () => {
+      expect(matches("/usr/lib/jvm/java-21-openjdk-amd64/release")).toBe(true);
+    });
+
+    it("does not match non-release files under /usr/lib/jvm/java-*", () => {
+      expect(matches("/usr/lib/jvm/java-17-openjdk-amd64/bin/java")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("Oracle JDK (/usr/java/<version>/release)", () => {
+    it("matches /usr/java/jdk-17/release", () => {
+      expect(matches("/usr/java/jdk-17/release")).toBe(true);
+    });
+
+    it("matches /usr/java/jdk-17.0.1/release", () => {
+      expect(matches("/usr/java/jdk-17.0.1/release")).toBe(true);
+    });
+
+    it("matches /usr/java/latest/release", () => {
+      expect(matches("/usr/java/latest/release")).toBe(true);
+    });
+
+    it("does not match non-release files under /usr/java/", () => {
+      expect(matches("/usr/java/jdk-17/bin/java")).toBe(false);
+    });
+  });
+
+  describe("non-matching paths", () => {
+    it("does not match an arbitrary file named release", () => {
+      expect(matches("/etc/release")).toBe(false);
+    });
+
+    it("does not match /opt/java/release (missing openjdk segment)", () => {
+      expect(matches("/opt/java/release")).toBe(false);
+    });
+
+    it("does not match an empty string", () => {
+      expect(matches("")).toBe(false);
+    });
+  });
+});
+
+describe("detectJavaRuntime — end-to-end per distribution", () => {
+  it("detects eclipse-temurin via /opt/java/openjdk/release", () => {
+    const content = `IMPLEMENTOR="Eclipse Adoptium"
+IMPLEMENTOR_VERSION="Temurin-17.0.11+9"
+JAVA_RUNTIME_VERSION="17.0.11+9"
+JAVA_VERSION="17.0.11"
+JAVA_VERSION_DATE="2024-04-16"
+OS_ARCH="amd64"
+OS_NAME="Linux"`;
+    expect(
+      detectJavaRuntime(makeLayer("/opt/java/openjdk/release", content)),
+    ).toEqual({
+      type: "java",
+      version: "17.0.11",
+    });
+  });
+
+  it("detects official Docker openjdk via /usr/local/openjdk-17/release", () => {
+    // Official openjdk Docker images ship IMPLEMENTOR="N/A" for community builds
+    const content = `IMPLEMENTOR="N/A"
+IMPLEMENTOR_VERSION="17.0.9+9"
+JAVA_RUNTIME_VERSION="17.0.9+9"
+JAVA_VERSION="17.0.9"
+JAVA_VERSION_DATE="2023-10-17"
+OS_ARCH="amd64"
+OS_NAME="Linux"`;
+    expect(
+      detectJavaRuntime(makeLayer("/usr/local/openjdk-17/release", content)),
+    ).toEqual({ type: "java", version: "17.0.9" });
+  });
+
+  it("detects official Docker openjdk via /usr/local/openjdk-21/release", () => {
+    const content = `IMPLEMENTOR="Oracle Corporation"
+JAVA_VERSION="21.0.1"
+JAVA_VERSION_DATE="2023-10-17"`;
+    expect(
+      detectJavaRuntime(makeLayer("/usr/local/openjdk-21/release", content)),
+    ).toEqual({ type: "java", version: "21.0.1" });
+  });
+
+  it("detects Debian/Ubuntu default-jdk via /usr/lib/jvm/java-17-openjdk-amd64/release", () => {
+    // Debian builds ship IMPLEMENTOR="Debian"
+    const content = `IMPLEMENTOR="Debian"
+IMPLEMENTOR_VERSION="17.0.9+9-1"
+JAVA_RUNTIME_VERSION="17.0.9+9-1"
+JAVA_VERSION="17.0.9"`;
+    expect(
+      detectJavaRuntime(
+        makeLayer("/usr/lib/jvm/java-17-openjdk-amd64/release", content),
+      ),
+    ).toEqual({ type: "java", version: "17.0.9" });
+  });
+
+  it("detects Oracle JDK via /usr/java/jdk-17.0.1/release", () => {
+    const content = `IMPLEMENTOR="Oracle Corporation"
+IMPLEMENTOR_VERSION="17.0.1+12"
+JAVA_VERSION="17.0.1"
+JAVA_VERSION_DATE="2021-10-19"`;
+    expect(
+      detectJavaRuntime(makeLayer("/usr/java/jdk-17.0.1/release", content)),
+    ).toEqual({ type: "java", version: "17.0.1" });
+  });
+
+  it("returns null when no release file is present", () => {
+    expect(detectJavaRuntime({})).toBeNull();
+  });
+
+  it("returns null when the release file has no JAVA_VERSION", () => {
+    const content = `IMPLEMENTOR="Debian"\nOS_ARCH="amd64"`;
+    expect(
+      detectJavaRuntime(
+        makeLayer("/usr/lib/jvm/java-17-openjdk-amd64/release", content),
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Previously only \`/opt/java/openjdk/release\` (eclipse-temurin convention) was matched when detecting the Java runtime version from a container image. This meant images based on official Docker \`openjdk\`, Debian/Ubuntu \`default-jdk\`, or Oracle JDK were silently missed.

This PR expands the \`filePathMatches\` predicate in \`lib/inputs/base-runtimes/static.ts\` to cover four common JVM base image conventions:

| Distribution | Release file path |
|---|---|
| eclipse-temurin | \`/opt/java/openjdk/release\` (exact, unchanged) |
| Official Docker \`openjdk\` | \`/usr/local/openjdk-<version>/release\` |
| Debian/Ubuntu \`default-jdk\` | \`/usr/lib/jvm/java-<version>-openjdk-<arch>/release\` |
| Oracle JDK | \`/usr/java/<version>/release\` |

The version-parametric paths use \`startsWith\` + \`endsWith("/release")\` to avoid false positives on other files under those directories.

The \`release\` file format (\`KEY=VALUE\`) is consistent across all distributions — the existing \`streamToString\` extraction and \`parseJavaRuntimeRelease\` parser require no changes.

**Bonus:** Amazon Corretto (\`/usr/lib/jvm/java-17-amazon-corretto/release\`) is also correctly detected by the \`/usr/lib/jvm/java-\` prefix rule, with no extra work.

## Test plan

- [ ] New spec \`test/lib/inputs/base-runtimes-static.spec.ts\` (24 tests) covers:
  - Path matching (positive + negative) for each of the four distribution conventions
  - End-to-end \`detectJavaRuntime\` with realistic release file content from each vendor (Eclipse Adoptium, \`N/A\`/Oracle for official Docker images, Debian, Oracle Corporation)
- [ ] Existing \`test/unit/base-runtimes-parser.spec.ts\` continues to pass unchanged
- [ ] \`npx jest\` full suite passes

## Manual scan verification

Ran \`scripts/test-java-release-paths.ts\` against real and synthetic Docker images. The \`baseRuntimes\` fact is present and correctly populated in each case.

> Note: official Docker \`openjdk\` images have been removed from Docker Hub, so that path was verified using a synthetic image (Debian base with the release file copied to \`/usr/local/openjdk-17/release\`).

```
── eclipse-temurin:17-jdk-jammy ──────────────────────────────────────
Convention : eclipse-temurin
Release    : /opt/java/openjdk/release
Facts      : baseRuntimes: [{"type":"java","version":"17.0.19"}]
Result     : ✅ PASS

── amazoncorretto:17 ─────────────────────────────────────────────────
Convention : amazon-corretto (matches /usr/lib/jvm/java-* pattern)
Release    : /usr/lib/jvm/java-17-amazon-corretto/release
Facts      : baseRuntimes: [{"type":"java","version":"17.0.19"}]
Result     : ✅ PASS

── snyk-test-debian-jdk:local ────────────────────────────────────────
Convention : debian/ubuntu default-jdk
Release    : /usr/lib/jvm/java-17-openjdk-arm64/release
Facts      : baseRuntimes: [{"type":"java","version":"17.0.19"}]
Result     : ✅ PASS

── snyk-test-openjdk-docker:local (synthetic) ────────────────────────
Convention : official Docker openjdk
Release    : /usr/local/openjdk-17/release
Facts      : baseRuntimes: [{"type":"java","version":"17.0.19"}]
Result     : ✅ PASS

── snyk-test-oracle-jdk:local (synthetic) ────────────────────────────
Convention : oracle JDK
Release    : /usr/java/jdk-17/release
Facts      : baseRuntimes: [{"type":"java","version":"17.0.19"}]
Result     : ✅ PASS

Results: 5 passed, 0 failed
```

Jira: [CN-528](https://snyksec.atlassian.net/browse/CN-528)

[CN-528]: https://snyksec.atlassian.net/browse/CN-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ