### PR TITLE
fix(ci): migrate npm publishing to OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,9 +218,6 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run:
-          name: Setup NPM auth
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - run:
           name: Release on GitHub
           command: |
             export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
@@ -319,7 +316,6 @@ workflows:
       - release:
           name: Release to GitHub
           context:
-            - nodejs-install
             - github-release
             - snyk-bot-slack
           filters:


### PR DESCRIPTION
## Summary

- Remove the `Setup NPM auth` step that wrote the revoked `NPM_TOKEN` to `~/.npmrc` in the release job — this was overriding the OIDC path and causing the 403 publish failure
- Remove the `nodejs-install` context from the release workflow job (it carried the now-revoked write token from the `snyk-admin` npm account; all runtime deps are public so no read token is needed at release time either)
- The OIDC token fetch (`NPM_ID_TOKEN` via `circleci run oidc get`) was already in place — this change unblocks it

## Context

npm has revoked all write-access tokens from the `snyk-admin` account that lack 2FA (company-wide, deadline Aug 1 2026). The `NPM_TOKEN` stored in the `nodejs-install` CircleCI context was one of these. See [Migrating NPM Publishing to OIDC Trusted Publishing](https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4767842314/Migrating+NPM+Publishing+to+OIDC+Trusted+Publishing) and [CN-1366](https://snyksec.atlassian.net/browse/CN-1366).

## Test plan

- [ ] Trusted Publisher configured on npmjs.org for `snyk-docker-plugin`
- [ ] Merge to main triggers a release pipeline run
- [ ] Release job passes without 403 error

[CN-1366]: https://snyksec.atlassian.net/browse/CN-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ