### PR TITLE
fix(ci): change ci npm token variable name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       - run:
           name: Release on GitHub
           command: |
-            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            export NPM_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             npx semantic-release@25
 
 workflows:


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Updates the npm token env variable name to `NPM_TOKEN` in the CircleCI context.

