### PR TITLE
fix: store token in npmrc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,9 +193,7 @@ jobs:
     resource_class: medium
     steps:
       - checkout_and_merge
-      - run:
-          name: Setup NPM credentials
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ../.npmrc
+      - setup_npm_user
       - run:
           name: Build Snyk CLI with latest changes
           command: ./.circleci/build-cli.sh
@@ -217,6 +215,7 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run build
+      - setup_npm_user
       - run:
           name: Release on GitHub
           command: |


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Stores npm token in `.npmrc` for use by `semantic-release`

