### PR TITLE
fix(ci): write npm token to .npmrc before release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,7 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run build
+      - setup_npm_user
       - run:
           name: Release on GitHub
           command: |


### PR DESCRIPTION
## What

Adds `setup_npm_user` (which writes `_authToken=${NPM_TOKEN}` to `.npmrc`) before the `Release on GitHub` step.

## Why

`@semantic-release/npm`'s `set-npmrc-auth.js` has two code paths:

- **Branch A** — an auth token already exists in a config file → copies existing config to the temp npmrc, returns early
- **Branch B** — no config-file token → writes `NPM_TOKEN` env var directly as `_authToken` into the temp npmrc

Without this step, Branch B fires because `NPM_TOKEN` (read-only, from `nodejs-install`) is in the environment but not in any `.npmrc` file. `@semantic-release/npm` then writes the read-only token to the temp npmrc. npm 11's built-in OIDC exchange (via `NPM_ID_TOKEN`) should override this, but the exchange was failing silently, causing npm to fall back to the read-only token → 403.

Writing `_authToken` to `.npmrc` first triggers Branch A. This is the approach described in the [prodsec Confluence troubleshooting guide](https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4835901491/Troubleshooting+NPM+migration) and matches the `enso-sdk` reference implementation.

## Test plan

- [ ] Merge to main and verify the release job completes without 403