### PR TITLE
chore(ci): add OIDC exchange diagnostic step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,13 +217,18 @@ jobs:
           name: Diagnose OIDC token exchange
           command: |
             OIDC_JWT=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
-            echo "OIDC JWT length: ${#OIDC_JWT}"
-            echo "Exchange response:"
-            curl -s -o /tmp/oidc-response.json -w "%{http_code}" -X POST \
+            echo "OIDC JWT length: ${#OIDC_JWT}" | tee /tmp/oidc-diagnostic.txt
+            HTTP_STATUS=$(curl -s -o /tmp/oidc-response.json -w "%{http_code}" -X POST \
               -H "Authorization: Bearer ${OIDC_JWT}" \
-              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/snyk-docker-plugin" \
-              | xargs -I{} echo "HTTP status: {}"
-            cat /tmp/oidc-response.json
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/snyk-docker-plugin")
+            echo "HTTP status: ${HTTP_STATUS}" | tee -a /tmp/oidc-diagnostic.txt
+            cat /tmp/oidc-response.json | tee -a /tmp/oidc-diagnostic.txt
+      - store_artifacts:
+          path: /tmp/oidc-diagnostic.txt
+          destination: oidc-diagnostic.txt
+      - store_artifacts:
+          path: /tmp/oidc-response.json
+          destination: oidc-response.json
   release:
     <<: *release_defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,8 @@ jobs:
           command: |
             OIDC_JWT=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             echo "OIDC JWT length: ${#OIDC_JWT}" | tee /tmp/oidc-diagnostic.txt
+            echo "JWT claims (payload):" | tee -a /tmp/oidc-diagnostic.txt
+            echo "${OIDC_JWT}" | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool | tee -a /tmp/oidc-diagnostic.txt
             HTTP_STATUS=$(curl -s -o /tmp/oidc-response.json -w "%{http_code}" -X POST \
               -H "Authorization: Bearer ${OIDC_JWT}" \
               "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/snyk-docker-plugin")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,17 @@ jobs:
       - run: npm run build
       - setup_npm_user
       - run:
+          name: Diagnose OIDC token exchange
+          command: |
+            OIDC_JWT=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            echo "OIDC JWT length: ${#OIDC_JWT}"
+            echo "Exchange response:"
+            curl -s -o /tmp/oidc-response.json -w "%{http_code}" -X POST \
+              -H "Authorization: Bearer ${OIDC_JWT}" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/snyk-docker-plugin" \
+              | xargs -I{} echo "HTTP status: {}"
+            cat /tmp/oidc-response.json
+      - run:
           name: Release on GitHub
           command: |
             export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,21 @@ jobs:
       - run:
           name: Run Go binaries unit test
           command: npx jest test/unit/go-binaries.spec.ts
+  diagnose_oidc_job:
+    <<: *release_defaults
+    steps:
+      - checkout
+      - run:
+          name: Diagnose OIDC token exchange
+          command: |
+            OIDC_JWT=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            echo "OIDC JWT length: ${#OIDC_JWT}"
+            echo "Exchange response:"
+            curl -s -o /tmp/oidc-response.json -w "%{http_code}" -X POST \
+              -H "Authorization: Bearer ${OIDC_JWT}" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/snyk-docker-plugin" \
+              | xargs -I{} echo "HTTP status: {}"
+            cat /tmp/oidc-response.json
   release:
     <<: *release_defaults
     steps:
@@ -364,3 +379,11 @@ workflows:
             - Install
           post-steps:
             - *slack-fail-notify
+  diagnose_oidc:
+    when:
+      equal: [diagnose-oidc-exchange, << pipeline.git.branch >>]
+    jobs:
+      - diagnose_oidc_job:
+          context:
+            - nodejs-install
+            - github-release


### PR DESCRIPTION
Temporary diagnostic step to surface what the npm registry OIDC token exchange endpoint actually returns. The job currently 403s silently — this will show us the exact error message so we can fix the Trusted Publisher configuration.

**Remove before the next real release PR.**