### PR TITLE
fix(ci): store oidc token in npmrc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,11 +215,14 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run build
-      - setup_npm_user
+      - run:
+          name: Configure NPM Token
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            echo "//registry.npmjs.org/:_authToken=${NPM_ID_TOKEN}" >> .npmrc
       - run:
           name: Release on GitHub
           command: |
-            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             npx semantic-release@25
 
 workflows:


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Deliberately stores `NPM_ID_TOKEN` in `.npmrc` for `semantic-release` to read
