### PR TITLE
refactor: split out the windows identifier-fallback tests (CN-1403)

### DIFF
--- a/test/windows/identifier-fallback.spec.ts
+++ b/test/windows/identifier-fallback.spec.ts
@@ -1,0 +1,44 @@
+import { DepGraph } from "@snyk/dep-graph";
+
+import * as plugin from "../../lib";
+
+describe("windows scanning (registry fallback — no docker binary)", () => {
+  it("can static scan for Identifier type image (nginx:1.19.11)", async () => {
+    const imageNameAndTag = "nginx:1.19.11";
+
+    await expect(() =>
+      plugin.scan({
+        path: imageNameAndTag,
+      }),
+    ).rejects.toEqual(
+      new Error("The image does not exist for the current platform"),
+    );
+  });
+
+  it("can static scan for Identifier type image (python:3.9.0)", async () => {
+    const imageNameAndTag =
+      "python@sha256:1f92d35b567363820d0f2f37c7ccf2c1543e2d852cea01edb027039e6aef25e6";
+
+    const pluginResult = await plugin.scan({
+      path: imageNameAndTag,
+      "exclude-app-vulns": true,
+    });
+
+    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "depGraph",
+    )!.data;
+    expect(depGraph.rootPkg.name).toEqual("docker-image|python");
+    expect(depGraph.rootPkg.version).toBeUndefined();
+    expect(pluginResult.scanResults[0].identity.type).toEqual("linux");
+    const imageLayers: string[] = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "imageLayers",
+    )!.data;
+    expect(imageLayers.length).toBeGreaterThan(0);
+    expect(
+      imageLayers.every((layer) => layer.endsWith("layer.tar")),
+    ).toBeTruthy();
+    expect(pluginResult.scanResults[0].identity.args?.platform).toEqual(
+      "windows/amd64",
+    );
+  }, 900000);
+});

--- a/test/windows/plugin.spec.ts
+++ b/test/windows/plugin.spec.ts
@@ -78,45 +78,6 @@ describe("windows scanning", () => {
     ]);
   });
 
-  it("can static scan for Identifier type image (nginx:1.19.11)", async () => {
-    const imageNameAndTag = "nginx:1.19.11";
-
-    await expect(() =>
-      plugin.scan({
-        path: imageNameAndTag,
-      }),
-    ).rejects.toEqual(
-      new Error("The image does not exist for the current platform"),
-    );
-  });
-
-  it("can static scan for Identifier type image (python:3.9.0)", async () => {
-    const imageNameAndTag =
-      "python@sha256:1f92d35b567363820d0f2f37c7ccf2c1543e2d852cea01edb027039e6aef25e6";
-
-    const pluginResult = await plugin.scan({
-      path: imageNameAndTag,
-      "exclude-app-vulns": true,
-    });
-
-    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
-      (fact) => fact.type === "depGraph",
-    )!.data;
-    expect(depGraph.rootPkg.name).toEqual("docker-image|python");
-    expect(depGraph.rootPkg.version).toBeUndefined();
-    expect(pluginResult.scanResults[0].identity.type).toEqual("linux");
-    const imageLayers: string[] = pluginResult.scanResults[0].facts.find(
-      (fact) => fact.type === "imageLayers",
-    )!.data;
-    expect(imageLayers.length).toBeGreaterThan(0);
-    expect(
-      imageLayers.every((layer) => layer.endsWith("layer.tar")),
-    ).toBeTruthy();
-    expect(pluginResult.scanResults[0].identity.args?.platform).toEqual(
-      "windows/amd64",
-    );
-  }, 900000);
-
   it("can scan docker-archive image type with go binaries", async () => {
     const fixturePath = getFixture(
       "docker-archives/docker-save/go-binaries.tar",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Moves the two unmocked Identifier-scan cases out of `test/windows/plugin.spec.ts` into a new `test/windows/identifier-fallback.spec.ts`: the `nginx:1.19.11` platform-mismatch case and the `python:3.9.0` real registry pull. Nothing about how they run changes. The Windows jest config globs `**/*.spec.ts`, so the full Windows suite still discovers and runs both.

#### Where should the reviewer start?

Compare the new file against the deletion in `plugin.spec.ts`. It is a straight move, including the 900000ms per-test timeout on the python case.

#### How should this be manually tested?

```
npx jest --config test/windows/jest.config.js --testPathPattern='windows/identifier-fallback'
```
picks up both cases. `npm run test-jest-windows` (the full run) still picks them up too.

#### Any background context you want to provide?

This is the first of a five-PR stack that fixes the Windows no-docker CI job. Those two cases are the only Windows tests whose behavior differs when the Docker CLI is missing, since they fall back to a registry pull. A later PR runs just them in the no-docker job, and selecting by file path is steadier than matching against test titles that might get reworded.

#### What are the relevant tickets?

[CN-1403](https://snyksec.atlassian.net/browse/CN-1403)

#### Screenshots

N/A, test-file move only.

#### Additional questions

None.


[CN-1403]: https://snyksec.atlassian.net/browse/CN-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ