### PR TITLE
fix(ci): make the windows no-docker job run without docker (CN-1403)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,18 @@ jobs:
           node_version: << parameters.node_version >>
       - setup_npm_user
       - run: npm ci
-        # make docker appear to be broken.
-      - run: "function docker() { return 1; }"
       - run:
-          command: npm run test-jest-windows
+          name: Disable docker, then run only the registry-fallback identifier tests
+          command: |
+            # binaryExists() runs `docker version` via cmd.exe (shell:true). Shadow the real
+            # docker with a stub that always fails so the plugin takes the registry-pull fallback.
+            mkdir -p "$HOME/fake-bin"
+            printf '@echo off\r\nexit /b 1\r\n' > "$HOME/fake-bin/docker.bat"
+            export PATH="$HOME/fake-bin:$PATH"
+            if cmd.exe /c "docker version" >/dev/null 2>&1; then
+              echo "ERROR: docker still resolvable — no-docker simulation ineffective"; exit 1
+            fi
+            npm run test-jest-windows-no-docker
           no_output_timeout: 20m
   build:
     <<: *defaults

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:system": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/system/'",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
     "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
+    "test-jest-windows-no-docker": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --testPathPattern='windows/identifier-fallback' --logHeapUsage",
     "prepare": "npm run build"
   },
   "engines": {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Rewrites the `test_jest_windows_no_docker` job so it actually runs with Docker unavailable, and adds a `test-jest-windows-no-docker` npm script that runs only the identifier-fallback spec.

#### Where should the reviewer start?

The `test_jest_windows_no_docker` job in `.circleci/config.yml`.

#### How should this be manually tested?

This one needs the Windows executor, so watch the CircleCI run. The gate step should pass (Docker disabled), and Jest should report only the two identifier-fallback tests, taking the registry-pull path rather than a docker-CLI save.

#### Any background context you want to provide?

The old job tried to fake a broken Docker with `- run: "function docker() { return 1; }"` in its own `run:` step. CircleCI starts a fresh shell for every `run:` step, so the function was gone before the test step ever started. Even in the same step it would not have worked: `binaryExists()` shells out to `docker version` through cmd.exe (Node uses `shell: true` on Windows), and a bash function cannot intercept a cmd.exe lookup of `docker.exe`. So the job ran the whole suite against the real Docker and just duplicated the with-docker job.

The fix drops a failing `docker.bat` onto `PATH` ahead of the real binary, in the same `run:` step as the tests, and gates it with `cmd.exe /c "docker version"` so the job fails loudly if Docker is still resolvable instead of quietly passing. Then it runs only the registry-fallback tests.

Stacked on #851, which extracts the spec this job targets.

#### What are the relevant tickets?

[CN-1403](https://snyksec.atlassian.net/browse/CN-1403)

#### Screenshots

N/A, CI config change.

#### Additional questions

The thing I most want eyes on is whether the PATH shim actually wins on `win/server-2022` (PATHEXT ordering and cmd.exe `App Paths` resolution). The `cmd.exe /c "docker version"` gate is there to catch the case where it does not. If the shim turns out to be too weak, the fallback is to move the real binary aside with `mv "$(command -v docker)" .../docker.disabled`, which needs executor write permissions.


[CN-1403]: https://snyksec.atlassian.net/browse/CN-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ