### PR TITLE
chore(ci): cache npm downloads in the windows jobs (CN-1403)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,18 @@ jobs:
           node_version: << parameters.node_version >>
       - setup_npm_user
       - run: npm ci
-        # make docker appear to be broken.
-      - run: "function docker() { return 1; }"
       - run:
-          command: npm run test-jest-windows
+          name: Disable docker, then run only the registry-fallback identifier tests
+          command: |
+            # binaryExists() runs `docker version` via cmd.exe (shell:true). Shadow the real
+            # docker with a stub that always fails so the plugin takes the registry-pull fallback.
+            mkdir -p "$HOME/fake-bin"
+            printf '@echo off\r\nexit /b 1\r\n' > "$HOME/fake-bin/docker.bat"
+            export PATH="$HOME/fake-bin:$PATH"
+            if cmd.exe /c "docker version" >/dev/null 2>&1; then
+              echo "ERROR: docker still resolvable — no-docker simulation ineffective"; exit 1
+            fi
+            npm run test-jest-windows-no-docker
           no_output_timeout: 20m
   build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,15 @@ jobs:
       - install_node_npm:
           node_version: << parameters.node_version >>
       - setup_npm_user
+      - restore_cache:
+          keys:
+            - v2-npm-cache-win-{{ checksum "package-lock.json" }}
+            - v2-npm-cache-win-
       - run: npm ci
+      - save_cache:
+          key: v2-npm-cache-win-{{ checksum "package-lock.json" }}
+          paths:
+            - C:\Users\circleci\AppData\Local\npm-cache
       - run: docker version
       - run:
           command: npm run test-jest-windows
@@ -175,7 +183,15 @@ jobs:
       - install_node_npm:
           node_version: << parameters.node_version >>
       - setup_npm_user
+      - restore_cache:
+          keys:
+            - v2-npm-cache-win-{{ checksum "package-lock.json" }}
+            - v2-npm-cache-win-
       - run: npm ci
+      - save_cache:
+          key: v2-npm-cache-win-{{ checksum "package-lock.json" }}
+          paths:
+            - C:\Users\circleci\AppData\Local\npm-cache
       - run:
           name: Disable docker, then run only the registry-fallback identifier tests
           command: |

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:system": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/system/'",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
     "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
+    "test-jest-windows-no-docker": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --testPathPattern='windows/identifier-fallback' --logHeapUsage",
     "prepare": "npm run build"
   },
   "engines": {

--- a/test/windows/identifier-fallback.spec.ts
+++ b/test/windows/identifier-fallback.spec.ts
@@ -1,0 +1,44 @@
+import { DepGraph } from "@snyk/dep-graph";
+
+import * as plugin from "../../lib";
+
+describe("windows scanning (registry fallback — no docker binary)", () => {
+  it("can static scan for Identifier type image (nginx:1.19.11)", async () => {
+    const imageNameAndTag = "nginx:1.19.11";
+
+    await expect(() =>
+      plugin.scan({
+        path: imageNameAndTag,
+      }),
+    ).rejects.toEqual(
+      new Error("The image does not exist for the current platform"),
+    );
+  });
+
+  it("can static scan for Identifier type image (python:3.9.0)", async () => {
+    const imageNameAndTag =
+      "python@sha256:1f92d35b567363820d0f2f37c7ccf2c1543e2d852cea01edb027039e6aef25e6";
+
+    const pluginResult = await plugin.scan({
+      path: imageNameAndTag,
+      "exclude-app-vulns": true,
+    });
+
+    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "depGraph",
+    )!.data;
+    expect(depGraph.rootPkg.name).toEqual("docker-image|python");
+    expect(depGraph.rootPkg.version).toBeUndefined();
+    expect(pluginResult.scanResults[0].identity.type).toEqual("linux");
+    const imageLayers: string[] = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "imageLayers",
+    )!.data;
+    expect(imageLayers.length).toBeGreaterThan(0);
+    expect(
+      imageLayers.every((layer) => layer.endsWith("layer.tar")),
+    ).toBeTruthy();
+    expect(pluginResult.scanResults[0].identity.args?.platform).toEqual(
+      "windows/amd64",
+    );
+  }, 900000);
+});

--- a/test/windows/plugin.spec.ts
+++ b/test/windows/plugin.spec.ts
@@ -78,45 +78,6 @@ describe("windows scanning", () => {
     ]);
   });
 
-  it("can static scan for Identifier type image (nginx:1.19.11)", async () => {
-    const imageNameAndTag = "nginx:1.19.11";
-
-    await expect(() =>
-      plugin.scan({
-        path: imageNameAndTag,
-      }),
-    ).rejects.toEqual(
-      new Error("The image does not exist for the current platform"),
-    );
-  });
-
-  it("can static scan for Identifier type image (python:3.9.0)", async () => {
-    const imageNameAndTag =
-      "python@sha256:1f92d35b567363820d0f2f37c7ccf2c1543e2d852cea01edb027039e6aef25e6";
-
-    const pluginResult = await plugin.scan({
-      path: imageNameAndTag,
-      "exclude-app-vulns": true,
-    });
-
-    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
-      (fact) => fact.type === "depGraph",
-    )!.data;
-    expect(depGraph.rootPkg.name).toEqual("docker-image|python");
-    expect(depGraph.rootPkg.version).toBeUndefined();
-    expect(pluginResult.scanResults[0].identity.type).toEqual("linux");
-    const imageLayers: string[] = pluginResult.scanResults[0].facts.find(
-      (fact) => fact.type === "imageLayers",
-    )!.data;
-    expect(imageLayers.length).toBeGreaterThan(0);
-    expect(
-      imageLayers.every((layer) => layer.endsWith("layer.tar")),
-    ).toBeTruthy();
-    expect(pluginResult.scanResults[0].identity.args?.platform).toEqual(
-      "windows/amd64",
-    );
-  }, 900000);
-
   it("can scan docker-archive image type with go binaries", async () => {
     const fixturePath = getFixture(
       "docker-archives/docker-save/go-binaries.tar",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds `restore_cache`/`save_cache` around `npm ci` in both Windows jobs, keyed on the `package-lock.json` checksum.

#### Where should the reviewer start?

The two cache blocks in `.circleci/config.yml`. They are identical apart from sitting in different jobs.

#### How should this be manually tested?

On CircleCI: the first run populates the cache (the `save_cache` step), and a second run on the same lockfile shows a restore hit and a quicker `npm ci`.

#### Any background context you want to provide?

Both Windows jobs run a cold `npm ci` on every build. The Build job's workspace is Linux and never gets attached on Windows, so there was nothing to cache against before. This caches the npm download directory rather than `node_modules`, so `npm ci` still runs and stays authoritative for native deps. The cache key uses a `v2-npm-cache-win-` prefix so it does not collide with the Linux `v2-npm-cache-` key.

#### What are the relevant tickets?

[CN-1403](https://snyksec.atlassian.net/browse/CN-1403)

#### Screenshots

N/A, CI config change.

#### Additional questions

The Windows cache path is set to `C:\Users\circleci\AppData\Local\npm-cache`. Worth confirming `npm config get cache` resolves there for the `circleci` user, and adjusting the `paths:` entry if it does not.


[CN-1403]: https://snyksec.atlassian.net/browse/CN-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ