### PR TITLE
chore(ci): slim down the windows no-docker job (CN-1403)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,21 @@ windows_big: &windows_big
       default: ""
   working_directory: ~/snyk-docker-plugin
 
+windows_medium: &windows_medium
+  executor:
+    name: win/server-2022
+    shell: bash.exe
+    size: medium # half the vCPUs of large; the python test is registry-I/O bound
+    # we've pinned the version because without it, it uses "current" (at the time of writing, "2023.06.1"),
+    # which has a broken Docker installation. See https://discuss.circleci.com/t/build-failures-when-running-docker-on-junes-windows-executor/48605
+    # TODO: check if it works again with the next release and unpin the version (keep in sync with windows_big).
+    version: "2023.05.1"
+  parameters:
+    node_version:
+      type: string
+      default: ""
+  working_directory: ~/snyk-docker-plugin
+
 release_defaults: &release_defaults
   resource_class: small
   docker:
@@ -177,7 +192,7 @@ jobs:
           command: npm run test-jest-windows
           no_output_timeout: 20m
   test_jest_windows_no_docker:
-    <<: *windows_big
+    <<: *windows_medium
     steps:
       - checkout
       - install_node_npm:

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test:unit": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/(lib|unit)/'",
     "test:system": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/system/'",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
-    "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
-    "test-jest-windows-no-docker": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --testPathPattern='windows/identifier-fallback' --logHeapUsage",
+    "test-jest-windows": "jest --ci --maxWorkers=3 --forceExit --config test/windows/jest.config.js --logHeapUsage",
+    "test-jest-windows-no-docker": "jest --ci --maxWorkers=1 --forceExit --config test/windows/jest.config.js --testPathPattern='windows/identifier-fallback' --logHeapUsage",
     "prepare": "npm run build"
   },
   "engines": {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Points the no-docker job at a new `windows_medium` executor instead of the shared `large` one, drops its jest run to `--maxWorkers=1`, and adds `--forceExit` to both Windows jest scripts.

#### Where should the reviewer start?

The `windows_medium` anchor and the executor line on `test_jest_windows_no_docker` in `.circleci/config.yml`, then the two script changes in `package.json`.

#### How should this be manually tested?

On CircleCI: the no-docker job should run on a medium executor, run only the two tests with one worker, and finish on its own rather than hanging to the 20-minute `no_output_timeout`.

#### Any background context you want to provide?

After the earlier PRs the no-docker job runs two tests, one of which is registry-I/O bound, so it no longer earns the `large` executor or three workers. The with-docker job keeps `large` because it still runs the full suite. `--forceExit` is there because Jest on Windows can sit waiting on an open handle after the async tests finish, which idles the job until the timeout fires.

One caveat: `--forceExit` can paper over a real open-handle leak. That is an acceptable trade for these CI suites, but I would not copy it onto the Linux suites without a closer look first.

#### What are the relevant tickets?

[CN-1403](https://snyksec.atlassian.net/browse/CN-1403)

#### Screenshots

N/A, CI config change.

#### Additional questions

If we later unpin the `2023.05.1` Windows image, the `version:` needs updating in both `windows_big` and `windows_medium`. Might be worth parameterizing `size` on a single anchor instead of keeping two near-identical ones.


[CN-1403]: https://snyksec.atlassian.net/browse/CN-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ