### PR TITLE
chore(ci): record junit results from the windows jobs (CN-1403)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,8 @@ jobs:
       - run:
           command: npm run test-jest-windows
           no_output_timeout: 20m
+      - store_test_results:
+          path: test-results
   test_jest_windows_no_docker:
     <<: *windows_medium
     steps:
@@ -220,6 +222,8 @@ jobs:
             fi
             npm run test-jest-windows-no-docker
           no_output_timeout: 20m
+      - store_test_results:
+          path: test-results
   build:
     <<: *defaults
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 bin/
 npm-debug.log
 dist/
+test-results/
 yarn.lock
 .DS_Store
 test/fixtures/ls-output/xxx.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.0.0",
         "jest": "^29.7.0",
+        "jest-junit": "^16.0.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
         "semantic-release": "^25.0.3",
@@ -9309,6 +9310,22 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -11202,6 +11219,19 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -17430,6 +17460,13 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-config-prettier": "^10.0.0",
     "typescript-eslint": "^8.56.0",
     "jest": "^29.7.0",
+    "jest-junit": "^16.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "ts-jest": "^29.1.1",

--- a/test/windows/jest.config.js
+++ b/test/windows/jest.config.js
@@ -6,6 +6,10 @@ module.exports = {
   ],
   testEnvironment: "node",
   testMatch: ["<rootDir>/**/*.spec.ts"],
+  reporters: [
+    "default",
+    ["jest-junit", { outputDirectory: "test-results", outputName: "windows-junit.xml" }],
+  ],
   testTimeout: 600000, // 10 minutes
   // TODO: This option is printing Array\Object prefixing arrays\objects in snapshots files
   // this settings were added when migrated to Jest 29 to support the old snapshots format


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds `jest-junit`, wires a junit reporter into the Windows jest config, and adds `store_test_results` to both Windows jobs so per-test results land in CircleCI Test Insights. Also adds `test-results/` to `.gitignore` and regenerates `package-lock.json` for the new devDependency.

#### Where should the reviewer start?

The reporter block in `test/windows/jest.config.js`, then the two `store_test_results` steps in `.circleci/config.yml`.

#### How should this be manually tested?

Locally:
```
npx jest --config test/windows/jest.config.js --testPathPattern='windows/identifier-fallback'
```
writes `test-results/windows-junit.xml`. On CircleCI both Windows jobs should show up in Test Insights with per-test timing.

#### Any background context you want to provide?

This gives us timing per test in CI, which is mostly useful for keeping an eye on the live python registry pull, and it is the piece we would need first if we ever want to split these tests across containers. The lockfile is regenerated because the Windows cache key from earlier in the stack checksums `package-lock.json`, so it has to stay in sync with the new dependency.

#### What are the relevant tickets?

[CN-1403](https://snyksec.atlassian.net/browse/CN-1403)

#### Screenshots

N/A, CI and test config change.

#### Additional questions

None.


[CN-1403]: https://snyksec.atlassian.net/browse/CN-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ