### PR TITLE
fix: expand JVM release file detection to cover Azul Zulu and other distributions

### DIFF
--- a/lib/inputs/base-runtimes/static.ts
+++ b/lib/inputs/base-runtimes/static.ts
@@ -11,8 +11,8 @@ function javaReleaseFilePathMatches(filePath: string): boolean {
     p === normalizePath("/opt/java/openjdk/release") ||
     // official Docker openjdk: /usr/local/openjdk-<version>/release
     (p.startsWith(normalizePath("/usr/local/openjdk-")) && isReleaseFile) ||
-    // Debian/Ubuntu default-jdk: /usr/lib/jvm/java-<version>-openjdk-<arch>/release
-    (p.startsWith(normalizePath("/usr/lib/jvm/java-")) && isReleaseFile) ||
+    // Any JVM installed under /usr/lib/jvm/ (Debian/Ubuntu openjdk, Azul Zulu, Amazon Corretto, Temurin, etc.)
+    (p.startsWith(normalizePath("/usr/lib/jvm/")) && isReleaseFile) ||
     // Oracle JDK: /usr/java/<version>/release
     (p.startsWith(normalizePath("/usr/java/")) && isReleaseFile);
   return matched;

--- a/test/lib/inputs/base-runtimes-static.spec.ts
+++ b/test/lib/inputs/base-runtimes-static.spec.ts
@@ -37,7 +37,7 @@ describe("getJavaRuntimeReleaseAction.filePathMatches", () => {
     });
   });
 
-  describe("Debian/Ubuntu default-jdk (/usr/lib/jvm/java-<version>-openjdk-<arch>/release)", () => {
+  describe("any JVM under /usr/lib/jvm/ (Debian/Ubuntu openjdk, Azul Zulu, Amazon Corretto, Temurin, etc.)", () => {
     it("matches /usr/lib/jvm/java-17-openjdk-amd64/release", () => {
       expect(matches("/usr/lib/jvm/java-17-openjdk-amd64/release")).toBe(true);
     });
@@ -50,10 +50,32 @@ describe("getJavaRuntimeReleaseAction.filePathMatches", () => {
       expect(matches("/usr/lib/jvm/java-21-openjdk-amd64/release")).toBe(true);
     });
 
-    it("does not match non-release files under /usr/lib/jvm/java-*", () => {
+    it("matches Azul Zulu /usr/lib/jvm/zulu17/release", () => {
+      expect(matches("/usr/lib/jvm/zulu17/release")).toBe(true);
+    });
+
+    it("matches Azul Zulu /usr/lib/jvm/zulu11/release", () => {
+      expect(matches("/usr/lib/jvm/zulu11/release")).toBe(true);
+    });
+
+    it("matches Amazon Corretto /usr/lib/jvm/java-17-amazon-corretto/release", () => {
+      expect(matches("/usr/lib/jvm/java-17-amazon-corretto/release")).toBe(
+        true,
+      );
+    });
+
+    it("matches Eclipse Temurin /usr/lib/jvm/temurin-17/release", () => {
+      expect(matches("/usr/lib/jvm/temurin-17/release")).toBe(true);
+    });
+
+    it("does not match non-release files under /usr/lib/jvm/", () => {
       expect(matches("/usr/lib/jvm/java-17-openjdk-amd64/bin/java")).toBe(
         false,
       );
+    });
+
+    it("does not match non-release files under /usr/lib/jvm/zulu17/", () => {
+      expect(matches("/usr/lib/jvm/zulu17/bin/java")).toBe(false);
     });
   });
 
@@ -141,6 +163,18 @@ JAVA_VERSION="17.0.9"`;
         makeLayer("/usr/lib/jvm/java-17-openjdk-amd64/release", content),
       ),
     ).toEqual({ type: "java", version: "17.0.9" });
+  });
+
+  it("detects Azul Zulu via /usr/lib/jvm/zulu17/release", () => {
+    const content = `IMPLEMENTOR="Azul Systems, Inc."
+IMPLEMENTOR_VERSION="Zulu17.48+15-CA"
+JAVA_RUNTIME_VERSION="17.0.10+7"
+JAVA_VERSION="17.0.10"
+OS_ARCH="amd64"
+OS_NAME="Linux"`;
+    expect(
+      detectJavaRuntime(makeLayer("/usr/lib/jvm/zulu17/release", content)),
+    ).toEqual({ type: "java", version: "17.0.10" });
   });
 
   it("detects Oracle JDK via /usr/java/jdk-17.0.1/release", () => {


### PR DESCRIPTION
## Summary

The `javaReleaseFilePathMatches` function previously only matched `/usr/lib/jvm/java-*` paths, which covers Debian/Ubuntu OpenJDK installs but misses other JVM distributions that install under `/usr/lib/jvm/` with different directory naming conventions.

This PR broadens the `/usr/lib/jvm/` branch to match any `release` file directly under that prefix, covering:

- **Azul Zulu** (e.g. `azul/zulu-openjdk-alpine`): `/usr/lib/jvm/zulu17/release`
- **Amazon Corretto**: `/usr/lib/jvm/java-17-amazon-corretto/release`
- **Eclipse Temurin** (on Alpine/Debian): `/usr/lib/jvm/temurin-17/release`
- **Debian/Ubuntu OpenJDK** (unchanged): `/usr/lib/jvm/java-17-openjdk-amd64/release`

The change is a single-line relaxation of the prefix check from `/usr/lib/jvm/java-` to `/usr/lib/jvm/`. The `basename === "release"` guard is still enforced, keeping false-positive risk low — only JVM root directories contain a `release` file at this location.

## Test plan

- [x] Existing Debian/Ubuntu path tests continue to pass
- [x] New match tests added for Azul Zulu (`zulu17`, `zulu11`), Amazon Corretto, and Eclipse Temurin paths
- [x] New negative tests confirm non-`release` files under `/usr/lib/jvm/zulu17/` are not matched
- [x] New end-to-end `detectJavaRuntime` test using a real Azul Zulu `release` file fixture
- [x] Full unit suite passes: `npm run test:unit`