### PR TITLE
feat: add apkPackageOwnership for Chainguard applications

### DIFF
--- a/lib/analyzer/applications/evidence-paths.ts
+++ b/lib/analyzer/applications/evidence-paths.ts
@@ -1,0 +1,32 @@
+import { JarFingerprintsFact, TestedFilesFact } from "../../facts";
+import { AppDepsScanResultWithoutTarget } from "./types";
+
+export function extractEvidencePaths(
+  scanResult: AppDepsScanResultWithoutTarget,
+): string[] {
+  const paths = new Set<string>();
+
+  if (scanResult.identity.targetFile) {
+    paths.add(scanResult.identity.targetFile);
+  }
+
+  for (const fact of scanResult.facts) {
+    if (fact.type === "testedFiles") {
+      const testedFilesFact = fact as TestedFilesFact;
+      for (const filePath of testedFilesFact.data) {
+        paths.add(filePath);
+      }
+    }
+
+    if (fact.type === "jarFingerprints") {
+      const jarFact = fact as JarFingerprintsFact;
+      for (const fingerprint of jarFact.data.fingerprints) {
+        if (fingerprint.location) {
+          paths.add(fingerprint.location);
+        }
+      }
+    }
+  }
+
+  return [...paths];
+}

--- a/lib/analyzer/applications/evidence-paths.ts
+++ b/lib/analyzer/applications/evidence-paths.ts
@@ -1,6 +1,7 @@
 import { JarFingerprintsFact, TestedFilesFact } from "../../facts";
 import { AppDepsScanResultWithoutTarget } from "./types";
 
+/** Collect filesystem paths from an app scan result used to resolve APK ownership. */
 export function extractEvidencePaths(
   scanResult: AppDepsScanResultWithoutTarget,
 ): string[] {

--- a/lib/analyzer/package-managers/apk-ownership.ts
+++ b/lib/analyzer/package-managers/apk-ownership.ts
@@ -111,24 +111,20 @@ function resolveDirectoryOwner(
     node = child;
     if (node.owners.length > 0) {
       best = {
-        owner: pickDirectoryOwner(node.owners),
+        owner: pickExactOwner(node.owners),
         matchKind: "directory",
         prefixLength: i + 1,
       };
     }
   }
 
-  if (!best && node.owners.length > 0) {
-    best = {
-      owner: pickDirectoryOwner(node.owners),
-      matchKind: "directory",
-      prefixLength: segments.length,
-    };
-  }
-
   return best;
 }
 
+/**
+ * Resolve APK package ownership for app evidence paths on Wolfi/Chainguard images.
+ * Every evidence path must match an owner; we skip the fact rather than guess.
+ */
 export function resolveApkOwnership(
   evidencePaths: string[],
   packages: AnalyzedPackageWithVersion[],
@@ -145,6 +141,7 @@ export function resolveApkOwnership(
   for (const evidencePath of evidencePaths) {
     const normalized = normalizeAbsolutePath(evidencePath);
     const match = resolveOwnerForEvidencePath(normalized, index, symlinkGraph);
+    // Require every evidence path to resolve; partial matches are not emitted.
     if (!match) {
       return undefined;
     }
@@ -190,6 +187,7 @@ function pickBestOwnerAcrossPaths(
 
   for (const match of matches) {
     const key = `${match.owner.Name}@${match.owner.Version}`;
+    // Prefer exact file matches over directory-prefix matches when paths disagree.
     const exactBonus = match.matchKind === "exact" ? 1000 : 0;
     const score = exactBonus + match.prefixLength;
     const existing = scores.get(key);
@@ -221,12 +219,6 @@ function pickExactOwner(
   }
   const originMatch = owners.find((o) => o.Name === o.Source);
   return originMatch ?? owners[0];
-}
-
-function pickDirectoryOwner(
-  owners: AnalyzedPackageWithVersion[],
-): AnalyzedPackageWithVersion {
-  return pickExactOwner(owners);
 }
 
 function addToOwnerMap(

--- a/lib/analyzer/package-managers/apk-ownership.ts
+++ b/lib/analyzer/package-managers/apk-ownership.ts
@@ -1,0 +1,270 @@
+import { SymlinkMap } from "../../extractor/types";
+import {
+  AnalysisType,
+  AnalyzedPackageWithVersion,
+  ImageAnalysis,
+  ImagePackagesAnalysis,
+  OSRelease,
+} from "../types";
+import {
+  canonicalizePath,
+  normalizeAbsolutePath,
+  SymlinkGraph,
+} from "./path-canonicalization";
+
+export interface ApkPackageOwnership {
+  distroId: string;
+  packageName: string;
+  packageVersion: string;
+  originPackage: string;
+  evidencePaths: string[];
+}
+
+export type MatchKind = "exact" | "directory";
+
+export interface PathOwnerMatch {
+  owner: AnalyzedPackageWithVersion;
+  matchKind: MatchKind;
+  prefixLength: number;
+}
+
+interface DirectoryTrieNode {
+  owners: AnalyzedPackageWithVersion[];
+  children: Map<string, DirectoryTrieNode>;
+}
+
+export interface ApkPathIndex {
+  exactFileOwners: Map<string, AnalyzedPackageWithVersion[]>;
+  directoryTrie: DirectoryTrieNode;
+}
+
+const CHAINGUARD_DISTROS = new Set(["wolfi", "chainguard"]);
+
+export function isChainguardDistro(osRelease: OSRelease): boolean {
+  return CHAINGUARD_DISTROS.has(osRelease.name);
+}
+
+export function toSymlinkGraph(symlinks?: SymlinkMap): SymlinkGraph {
+  const graph: SymlinkGraph = new Map();
+  if (!symlinks) {
+    return graph;
+  }
+  for (const [symlinkPath, target] of Object.entries(symlinks)) {
+    graph.set(normalizeAbsolutePath(symlinkPath), target);
+  }
+  return graph;
+}
+
+export function buildApkPathIndex(
+  packages: AnalyzedPackageWithVersion[],
+  symlinkGraph: SymlinkGraph,
+): ApkPathIndex {
+  const exactFileOwners = new Map<string, AnalyzedPackageWithVersion[]>();
+  const directoryTrie: DirectoryTrieNode = { owners: [], children: new Map() };
+
+  for (const pkg of packages) {
+    for (const filePath of pkg.Files ?? []) {
+      const canonical = canonicalizePath(filePath, symlinkGraph);
+      addToOwnerMap(exactFileOwners, canonical, pkg);
+    }
+
+    for (const dirPath of pkg.Directories ?? []) {
+      const canonical = canonicalizePath(dirPath, symlinkGraph);
+      insertDirectoryOwner(directoryTrie, canonical, pkg);
+    }
+  }
+
+  return { exactFileOwners, directoryTrie };
+}
+
+export function resolveOwnerForEvidencePath(
+  evidencePath: string,
+  index: ApkPathIndex,
+  symlinkGraph: SymlinkGraph,
+): PathOwnerMatch | undefined {
+  const canonical = canonicalizePath(evidencePath, symlinkGraph);
+  const exactOwners = index.exactFileOwners.get(canonical);
+  if (exactOwners && exactOwners.length > 0) {
+    return {
+      owner: pickExactOwner(exactOwners),
+      matchKind: "exact",
+      prefixLength: canonical.length,
+    };
+  }
+
+  return resolveDirectoryOwner(canonical, index);
+}
+
+function resolveDirectoryOwner(
+  canonicalPath: string,
+  index: ApkPathIndex,
+): PathOwnerMatch | undefined {
+  const segments = canonicalPath.split("/").filter(Boolean);
+  let node = index.directoryTrie;
+  let best: PathOwnerMatch | undefined;
+
+  for (let i = 0; i < segments.length; i++) {
+    const child = node.children.get(segments[i]);
+    if (!child) {
+      break;
+    }
+    node = child;
+    if (node.owners.length > 0) {
+      best = {
+        owner: pickDirectoryOwner(node.owners),
+        matchKind: "directory",
+        prefixLength: i + 1,
+      };
+    }
+  }
+
+  if (!best && node.owners.length > 0) {
+    best = {
+      owner: pickDirectoryOwner(node.owners),
+      matchKind: "directory",
+      prefixLength: segments.length,
+    };
+  }
+
+  return best;
+}
+
+export function resolveApkOwnership(
+  evidencePaths: string[],
+  packages: AnalyzedPackageWithVersion[],
+  osRelease: OSRelease,
+  symlinkGraph: SymlinkGraph,
+): ApkPackageOwnership | undefined {
+  if (!isChainguardDistro(osRelease) || evidencePaths.length === 0) {
+    return undefined;
+  }
+
+  const index = buildApkPathIndex(packages, symlinkGraph);
+  const perPathMatches: PathOwnerMatch[] = [];
+
+  for (const evidencePath of evidencePaths) {
+    const normalized = normalizeAbsolutePath(evidencePath);
+    const match = resolveOwnerForEvidencePath(normalized, index, symlinkGraph);
+    if (!match) {
+      return undefined;
+    }
+    perPathMatches.push(match);
+  }
+
+  const owner = pickConsistentOwner(perPathMatches);
+  if (!owner) {
+    return undefined;
+  }
+
+  return {
+    distroId: osRelease.name,
+    packageName: owner.Name,
+    packageVersion: owner.Version,
+    originPackage: owner.Source ?? owner.Name,
+    evidencePaths,
+  };
+}
+
+function pickConsistentOwner(
+  matches: PathOwnerMatch[],
+): AnalyzedPackageWithVersion | undefined {
+  const ownerKey = (pkg: AnalyzedPackageWithVersion) =>
+    `${pkg.Name}@${pkg.Version}`;
+
+  const firstKey = ownerKey(matches[0].owner);
+  const allSame = matches.every((m) => ownerKey(m.owner) === firstKey);
+  if (allSame) {
+    return matches[0].owner;
+  }
+
+  return pickBestOwnerAcrossPaths(matches);
+}
+
+function pickBestOwnerAcrossPaths(
+  matches: PathOwnerMatch[],
+): AnalyzedPackageWithVersion | undefined {
+  const scores = new Map<
+    string,
+    { pkg: AnalyzedPackageWithVersion; score: number }
+  >();
+
+  for (const match of matches) {
+    const key = `${match.owner.Name}@${match.owner.Version}`;
+    const exactBonus = match.matchKind === "exact" ? 1000 : 0;
+    const score = exactBonus + match.prefixLength;
+    const existing = scores.get(key);
+    if (!existing || score > existing.score) {
+      scores.set(key, { pkg: match.owner, score });
+    }
+  }
+
+  const entries = [...scores.values()];
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  entries.sort((a, b) => b.score - a.score);
+  const topScore = entries[0].score;
+  const topEntries = entries.filter((e) => e.score === topScore);
+  if (topEntries.length === 1) {
+    return topEntries[0].pkg;
+  }
+
+  return undefined;
+}
+
+function pickExactOwner(
+  owners: AnalyzedPackageWithVersion[],
+): AnalyzedPackageWithVersion {
+  if (owners.length === 1) {
+    return owners[0];
+  }
+  const originMatch = owners.find((o) => o.Name === o.Source);
+  return originMatch ?? owners[0];
+}
+
+function pickDirectoryOwner(
+  owners: AnalyzedPackageWithVersion[],
+): AnalyzedPackageWithVersion {
+  return pickExactOwner(owners);
+}
+
+function addToOwnerMap(
+  map: Map<string, AnalyzedPackageWithVersion[]>,
+  canonicalPath: string,
+  pkg: AnalyzedPackageWithVersion,
+): void {
+  const existing = map.get(canonicalPath) ?? [];
+  existing.push(pkg);
+  map.set(canonicalPath, existing);
+}
+
+function insertDirectoryOwner(
+  root: DirectoryTrieNode,
+  dirPath: string,
+  pkg: AnalyzedPackageWithVersion,
+): void {
+  const segments = dirPath.split("/").filter(Boolean);
+  let node = root;
+  for (const segment of segments) {
+    let child = node.children.get(segment);
+    if (!child) {
+      child = { owners: [], children: new Map() };
+      node.children.set(segment, child);
+    }
+    node = child;
+  }
+  node.owners.push(pkg);
+}
+
+export function getApkPackagesFromResults(
+  results?: ImageAnalysis[],
+): AnalyzedPackageWithVersion[] {
+  if (!results) {
+    return [];
+  }
+  const apkResult = results.find((r) => r.AnalyzeType === AnalysisType.Apk) as
+    | ImagePackagesAnalysis
+    | undefined;
+  return apkResult?.Analysis ?? [];
+}

--- a/lib/analyzer/package-managers/apk-ownership.ts
+++ b/lib/analyzer/package-managers/apk-ownership.ts
@@ -1,3 +1,4 @@
+import * as Debug from "debug";
 import { SymlinkMap } from "../../extractor/types";
 import {
   AnalysisType,
@@ -25,6 +26,7 @@ export type MatchKind = "exact" | "directory";
 export interface PathOwnerMatch {
   owner: AnalyzedPackageWithVersion;
   matchKind: MatchKind;
+  /** Number of matched path segments; a deeper directory match outranks a shallower one. */
   prefixLength: number;
 }
 
@@ -37,6 +39,8 @@ export interface ApkPathIndex {
   exactFileOwners: Map<string, AnalyzedPackageWithVersion[]>;
   directoryTrie: DirectoryTrieNode;
 }
+
+const debug = Debug("snyk");
 
 const CHAINGUARD_DISTROS = new Set(["wolfi", "chainguard"]);
 
@@ -88,7 +92,7 @@ export function resolveOwnerForEvidencePath(
     return {
       owner: pickExactOwner(exactOwners),
       matchKind: "exact",
-      prefixLength: canonical.length,
+      prefixLength: canonical.split("/").filter(Boolean).length,
     };
   }
 
@@ -123,7 +127,14 @@ function resolveDirectoryOwner(
 
 /**
  * Resolve APK package ownership for app evidence paths on Wolfi/Chainguard images.
- * Every evidence path must match an owner; we skip the fact rather than guess.
+ *
+ * Per Chainguard's scanner spec, an app dependency is owned by an APK package
+ * only when its evidence paths are wholly contained in that package's declared
+ * paths; a dependency with any unowned path is not covered by Chainguard's
+ * advisory data and must keep its findings. This fact drives downstream
+ * suppression, so we skip it rather than guess and risk suppressing real
+ * vulnerabilities in user-added software.
+ * https://github.com/chainguard-dev/vulnerability-scanner-support/blob/main/docs/scanning_implementation.md
  */
 export function resolveApkOwnership(
   evidencePaths: string[],
@@ -141,8 +152,10 @@ export function resolveApkOwnership(
   for (const evidencePath of evidencePaths) {
     const normalized = normalizeAbsolutePath(evidencePath);
     const match = resolveOwnerForEvidencePath(normalized, index, symlinkGraph);
-    // Require every evidence path to resolve; partial matches are not emitted.
     if (!match) {
+      debug(
+        `apk ownership skipped: no owning package for evidence path ${normalized}`,
+      );
       return undefined;
     }
     perPathMatches.push(match);
@@ -162,53 +175,41 @@ export function resolveApkOwnership(
   };
 }
 
+function ownerKey(pkg: AnalyzedPackageWithVersion): string {
+  return `${pkg.Name}@${pkg.Version}`;
+}
+
 function pickConsistentOwner(
   matches: PathOwnerMatch[],
 ): AnalyzedPackageWithVersion | undefined {
-  const ownerKey = (pkg: AnalyzedPackageWithVersion) =>
-    `${pkg.Name}@${pkg.Version}`;
-
-  const firstKey = ownerKey(matches[0].owner);
-  const allSame = matches.every((m) => ownerKey(m.owner) === firstKey);
-  if (allSame) {
-    return matches[0].owner;
-  }
-
-  return pickBestOwnerAcrossPaths(matches);
+  return uniqueOwner(matches) ?? pickBestOwnerAcrossPaths(matches);
 }
 
+/**
+ * When evidence paths disagree on an owner, an owner backed by an exact file
+ * match outranks owners only inferred from a parent directory; among
+ * directory-only matches, the deepest prefix wins. Evidence that is still
+ * split between owners yields no owner.
+ */
 function pickBestOwnerAcrossPaths(
   matches: PathOwnerMatch[],
 ): AnalyzedPackageWithVersion | undefined {
-  const scores = new Map<
-    string,
-    { pkg: AnalyzedPackageWithVersion; score: number }
-  >();
-
-  for (const match of matches) {
-    const key = `${match.owner.Name}@${match.owner.Version}`;
-    // Prefer exact file matches over directory-prefix matches when paths disagree.
-    const exactBonus = match.matchKind === "exact" ? 1000 : 0;
-    const score = exactBonus + match.prefixLength;
-    const existing = scores.get(key);
-    if (!existing || score > existing.score) {
-      scores.set(key, { pkg: match.owner, score });
-    }
+  const exactMatches = matches.filter((m) => m.matchKind === "exact");
+  if (exactMatches.length > 0) {
+    return uniqueOwner(exactMatches);
   }
 
-  const entries = [...scores.values()];
-  if (entries.length === 0) {
-    return undefined;
-  }
+  const deepest = Math.max(...matches.map((m) => m.prefixLength));
+  return uniqueOwner(matches.filter((m) => m.prefixLength === deepest));
+}
 
-  entries.sort((a, b) => b.score - a.score);
-  const topScore = entries[0].score;
-  const topEntries = entries.filter((e) => e.score === topScore);
-  if (topEntries.length === 1) {
-    return topEntries[0].pkg;
-  }
-
-  return undefined;
+function uniqueOwner(
+  matches: PathOwnerMatch[],
+): AnalyzedPackageWithVersion | undefined {
+  const first = matches[0].owner;
+  return matches.every((m) => ownerKey(m.owner) === ownerKey(first))
+    ? first
+    : undefined;
 }
 
 function pickExactOwner(

--- a/lib/analyzer/package-managers/apk.ts
+++ b/lib/analyzer/package-managers/apk.ts
@@ -18,7 +18,8 @@ export function analyze(
 export function parseFile(text: string): AnalyzedPackageWithVersion[] {
   const pkgs: AnalyzedPackageWithVersion[] = [];
   let curPkg: AnalyzedPackageWithVersion | null = null;
-  let dirStack: string[] = [];
+  // Absolute path of the most recent F: record; "" until one is seen.
+  let currentDir = "";
 
   for (const line of text.split("\n")) {
     if (line.length < 2) {
@@ -29,6 +30,7 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
 
     switch (key) {
       case "P": {
+        // Package
         curPkg = {
           Name: value,
           Version: "",
@@ -40,15 +42,15 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
           Directories: [],
         };
         pkgs.push(curPkg);
-        dirStack = [];
+        currentDir = "";
         break;
       }
-      case "V":
+      case "V": // Version
         if (curPkg) {
           curPkg.Version = value;
         }
         break;
-      case "p":
+      case "p": // Provides
         if (curPkg) {
           for (let name of value.split(" ")) {
             name = name.split("=")[0];
@@ -56,8 +58,8 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
           }
         }
         break;
-      case "r":
-      case "D":
+      case "r": // Depends
+      case "D": // Depends
         if (curPkg) {
           for (let name of value.split(" ")) {
             if (name.charAt(0) !== "!") {
@@ -67,37 +69,38 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
           }
         }
         break;
-      case "o":
+      case "o": // Origin
         if (curPkg) {
           curPkg.Source = value;
         }
         break;
       case "F": {
+        // Directory for subsequent R:/M: file-list records, root-relative
+        // like "usr/lib"
         if (!curPkg) {
           break;
         }
-        dirStack = value.split("/").filter(Boolean);
-        const dirPath = stackToAbsolutePath(dirStack);
-        if (!curPkg.Directories!.includes(dirPath)) {
-          curPkg.Directories!.push(dirPath);
+        currentDir = value ? "/" + value : "";
+        if (currentDir && !curPkg.Directories!.includes(currentDir)) {
+          curPkg.Directories!.push(currentDir);
         }
         break;
       }
       case "R": {
-        if (!curPkg || dirStack.length === 0) {
+        // File name relative to the current F: directory
+        if (!curPkg || !currentDir) {
           break;
         }
-        const filePath = stackToAbsolutePath([...dirStack, value]);
-        curPkg.Files!.push(filePath);
+        curPkg.Files!.push(`${currentDir}/${value}`);
         break;
       }
       case "M": {
-        if (!curPkg || dirStack.length === 0) {
+        // Directory metadata for the current F: directory
+        if (!curPkg || !currentDir) {
           break;
         }
-        const dirPath = stackToAbsolutePath(dirStack);
-        if (!curPkg.Directories!.includes(dirPath)) {
-          curPkg.Directories!.push(dirPath);
+        if (!curPkg.Directories!.includes(currentDir)) {
+          curPkg.Directories!.push(currentDir);
         }
         break;
       }
@@ -105,8 +108,4 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
   }
 
   return pkgs;
-}
-
-function stackToAbsolutePath(stack: string[]): string {
-  return "/" + stack.join("/");
 }

--- a/lib/analyzer/package-managers/apk.ts
+++ b/lib/analyzer/package-managers/apk.ts
@@ -15,55 +15,98 @@ export function analyze(
   });
 }
 
-function parseFile(text: string): AnalyzedPackageWithVersion[] {
+export function parseFile(text: string): AnalyzedPackageWithVersion[] {
   const pkgs: AnalyzedPackageWithVersion[] = [];
-  let curPkg: any = null;
+  let curPkg: AnalyzedPackageWithVersion | null = null;
+  let dirStack: string[] = [];
+
   for (const line of text.split("\n")) {
-    curPkg = parseLine(line, curPkg, pkgs);
+    if (line.length < 2) {
+      continue;
+    }
+    const key = line.charAt(0);
+    const value = line.substr(2).trim();
+
+    switch (key) {
+      case "P": {
+        curPkg = {
+          Name: value,
+          Version: "",
+          Source: undefined,
+          Provides: [],
+          Deps: {},
+          AutoInstalled: undefined,
+          Files: [],
+          Directories: [],
+        };
+        pkgs.push(curPkg);
+        dirStack = [];
+        break;
+      }
+      case "V":
+        if (curPkg) {
+          curPkg.Version = value;
+        }
+        break;
+      case "p":
+        if (curPkg) {
+          for (let name of value.split(" ")) {
+            name = name.split("=")[0];
+            curPkg.Provides.push(name);
+          }
+        }
+        break;
+      case "r":
+      case "D":
+        if (curPkg) {
+          for (let name of value.split(" ")) {
+            if (name.charAt(0) !== "!") {
+              name = name.split("=")[0];
+              curPkg.Deps[name] = true;
+            }
+          }
+        }
+        break;
+      case "o":
+        if (curPkg) {
+          curPkg.Source = value;
+        }
+        break;
+      case "F": {
+        if (!curPkg) {
+          break;
+        }
+        dirStack = value.split("/").filter(Boolean);
+        const dirPath = stackToAbsolutePath(dirStack);
+        if (!curPkg.Directories!.includes(dirPath)) {
+          curPkg.Directories!.push(dirPath);
+        }
+        break;
+      }
+      case "R": {
+        if (!curPkg || dirStack.length === 0) {
+          break;
+        }
+        const filePath = stackToAbsolutePath([...dirStack, value]);
+        curPkg.Files!.push(filePath);
+        break;
+      }
+      case "M": {
+        if (!curPkg || dirStack.length === 0) {
+          break;
+        }
+        const dirPath = stackToAbsolutePath(dirStack);
+        if (!curPkg.Directories!.includes(dirPath)) {
+          curPkg.Directories!.push(dirPath);
+        }
+        break;
+      }
+    }
   }
+
   return pkgs;
 }
 
-function parseLine(
-  text: string,
-  curPkg: AnalyzedPackageWithVersion,
-  pkgs: AnalyzedPackageWithVersion[],
-) {
-  const key = text.charAt(0);
-  const value = text.substr(2).trim();
-  switch (key) {
-    case "P": // Package
-      curPkg = {
-        Name: value,
-        Version: "",
-        Source: undefined,
-        Provides: [],
-        Deps: {},
-        AutoInstalled: undefined,
-      };
-      pkgs.push(curPkg);
-      break;
-    case "V": // Version
-      curPkg.Version = value;
-      break;
-    case "p": // Provides
-      for (let name of value.split(" ")) {
-        name = name.split("=")[0];
-        curPkg.Provides.push(name);
-      }
-      break;
-    case "r": // Depends
-    case "D": // Depends
-      for (let name of value.split(" ")) {
-        if (name.charAt(0) !== "!") {
-          name = name.split("=")[0];
-          curPkg.Deps[name] = true;
-        }
-      }
-      break;
-    case "o": // Origin
-      curPkg.Source = value;
-      break;
-  }
-  return curPkg;
+function stackToAbsolutePath(stack: string[]): string {
+  return "/" + stack.join("/");
 }

--- a/lib/analyzer/package-managers/path-canonicalization.ts
+++ b/lib/analyzer/package-managers/path-canonicalization.ts
@@ -13,7 +13,8 @@ export function normalizeAbsolutePath(filePath: string): string {
 }
 
 /**
- * Resolve symlinks in a path using the provided graph. Returns a canonical absolute path.
+ * Resolve symlinks in a path using the extracted image symlink graph.
+ * Used so evidence paths like /bin/node match APK file lists recorded at /usr/bin/node.
  */
 export function canonicalizePath(
   filePath: string,
@@ -72,17 +73,4 @@ function resolveSymlinkChain(
   }
 
   return current;
-}
-
-/**
- * Merge symlink maps from multiple layers. Later entries override earlier ones.
- */
-export function mergeSymlinkGraphs(layers: SymlinkGraph[]): SymlinkGraph {
-  const merged: SymlinkGraph = new Map();
-  for (const layer of layers) {
-    for (const [symlinkPath, target] of layer.entries()) {
-      merged.set(symlinkPath, target);
-    }
-  }
-  return merged;
 }

--- a/lib/analyzer/package-managers/path-canonicalization.ts
+++ b/lib/analyzer/package-managers/path-canonicalization.ts
@@ -1,0 +1,88 @@
+import { posix as path } from "path";
+
+export type SymlinkGraph = Map<string, string>;
+
+const MAX_SYMLINK_DEPTH = 40;
+
+/**
+ * Normalize a filesystem path to a POSIX absolute path without resolving symlinks.
+ */
+export function normalizeAbsolutePath(filePath: string): string {
+  const normalized = path.normalize(filePath.replace(/\\/g, "/"));
+  return normalized.startsWith("/") ? normalized : `/${normalized}`;
+}
+
+/**
+ * Resolve symlinks in a path using the provided graph. Returns a canonical absolute path.
+ */
+export function canonicalizePath(
+  filePath: string,
+  symlinkGraph: SymlinkGraph,
+): string {
+  const normalized = normalizeAbsolutePath(filePath);
+  const segments = normalized.split("/").filter(Boolean);
+  const resolvedSegments: string[] = [];
+
+  for (const segment of segments) {
+    resolvedSegments.push(segment);
+    const currentPath = `/${resolvedSegments.join("/")}`;
+    const linkTarget = symlinkGraph.get(currentPath);
+    if (!linkTarget) {
+      continue;
+    }
+
+    const resolvedTarget = resolveSymlinkChain(
+      normalizeSymlinkTarget(currentPath, linkTarget),
+      symlinkGraph,
+    );
+    const targetSegments = resolvedTarget.split("/").filter(Boolean);
+    resolvedSegments.length = 0;
+    resolvedSegments.push(...targetSegments);
+  }
+
+  return resolvedSegments.length === 0 ? "/" : `/${resolvedSegments.join("/")}`;
+}
+
+function normalizeSymlinkTarget(basePath: string, linkTarget: string): string {
+  const target = linkTarget.replace(/\\/g, "/");
+  if (target.startsWith("/")) {
+    return path.normalize(target);
+  }
+  const baseDir = path.dirname(basePath);
+  return path.normalize(path.join(baseDir, target));
+}
+
+function resolveSymlinkChain(
+  filePath: string,
+  symlinkGraph: SymlinkGraph,
+): string {
+  let current = normalizeAbsolutePath(filePath);
+  const visited = new Set<string>();
+
+  for (let depth = 0; depth < MAX_SYMLINK_DEPTH; depth++) {
+    const linkTarget = symlinkGraph.get(current);
+    if (!linkTarget) {
+      return current;
+    }
+    if (visited.has(current)) {
+      return current;
+    }
+    visited.add(current);
+    current = normalizeSymlinkTarget(current, linkTarget);
+  }
+
+  return current;
+}
+
+/**
+ * Merge symlink maps from multiple layers. Later entries override earlier ones.
+ */
+export function mergeSymlinkGraphs(layers: SymlinkGraph[]): SymlinkGraph {
+  const merged: SymlinkGraph = new Map();
+  for (const layer of layers) {
+    for (const [symlinkPath, target] of layer.entries()) {
+      merged.set(symlinkPath, target);
+    }
+  }
+  return merged;
+}

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -162,6 +162,7 @@ export async function analyze(
     imageId,
     manifestLayers,
     extractedLayers,
+    symlinks,
     rootFsLayers,
     autoDetectedUserInstructions,
     platform,
@@ -343,6 +344,7 @@ export async function analyze(
     imageCreationTime,
     containerConfig,
     history,
+    symlinks,
     timings,
   };
 }

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -1,4 +1,5 @@
 import { ImageName } from "../extractor/image";
+import { SymlinkMap } from "../extractor/types";
 import { BaseRuntime } from "../facts";
 import { AutoDetectedUserInstructions, ManifestFile } from "../types";
 import {
@@ -17,6 +18,10 @@ export interface AnalyzedPackage {
   };
   Purl?: string;
   AutoInstalled?: boolean;
+  /** File paths declared by APK installed-db R: records (F:+R:). */
+  Files?: string[];
+  /** Directory paths declared by APK installed-db F: and M: records. */
+  Directories?: string[];
 }
 export interface AnalyzedPackageWithVersion extends AnalyzedPackage {
   Version: string;
@@ -103,6 +108,7 @@ export interface StaticAnalysis {
     comment?: string | null;
     empty_layer?: boolean | null;
   }> | null;
+  symlinks?: SymlinkMap;
   timings?: Record<string, number>;
 }
 

--- a/lib/extractor/generic-archive-extractor.ts
+++ b/lib/extractor/generic-archive-extractor.ts
@@ -15,10 +15,9 @@ export class InvalidArchiveError extends Error {
   }
 }
 import { HashAlgorithm, PluginOptions } from "../types";
-import { extractImageLayer } from "./layer";
+import { extractImageLayer, LayerExtractionResult } from "./layer";
 import {
   ExtractAction,
-  ExtractedLayers,
   ExtractedLayersAndManifest,
   ImageConfig,
   TarArchiveManifest,
@@ -60,7 +59,7 @@ export function createExtractArchive(
   return (archiveFilesystemPath, extractActions, _options) =>
     new Promise((resolve, reject) => {
       const tarExtractor: Extract = extract();
-      const layers: Record<string, ExtractedLayers> = {};
+      const layers: Record<string, LayerExtractionResult> = {};
       let manifest: TarArchiveManifest;
       let imageConfig: ImageConfig;
 
@@ -124,22 +123,23 @@ export function createExtractArchive(
 function assembleLayersAndManifest(
   manifest: TarArchiveManifest,
   imageConfig: ImageConfig,
-  layers: Record<string, ExtractedLayers>,
+  layers: Record<string, LayerExtractionResult>,
 ): ExtractedLayersAndManifest {
   const layersWithNormalizedNames = manifest.Layers.map((layerName) =>
     normalizePath(layerName),
   );
-  const filteredLayers = layersWithNormalizedNames
+  const filteredLayerResults = layersWithNormalizedNames
     .filter((layerName) => layers[layerName])
     .map((layerName) => layers[layerName])
     .reverse();
 
-  if (filteredLayers.length === 0) {
+  if (filteredLayerResults.length === 0) {
     throw new Error("We found no layers in the provided image");
   }
 
   return {
-    layers: filteredLayers,
+    layers: filteredLayerResults.map((r) => r.extractedLayers),
+    symlinkLayers: filteredLayerResults.map((r) => r.symlinks),
     manifest,
     imageConfig,
   };

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -144,7 +144,10 @@ export async function extractImageContent(
     manifestLayers: extractor.getManifestLayers(archiveContent.manifest),
     imageCreationTime: archiveContent.imageConfig.created,
     extractedLayers: layersWithLatestFileModifications(archiveContent.layers),
-    symlinks: symlinksWithLatestModifications(archiveContent.symlinkLayers),
+    symlinks: symlinksWithLatestModifications(
+      archiveContent.symlinkLayers,
+      archiveContent.layers,
+    ),
     rootFsLayers: getRootFsLayersFromConfig(archiveContent.imageConfig),
     autoDetectedUserInstructions: getDetectedLayersInfoFromConfig(
       archiveContent.imageConfig,
@@ -228,20 +231,60 @@ export function getUserInstructionLayersFromConfig(imageConfig) {
   return userInstructionLayers;
 }
 
-function symlinksWithLatestModifications(
+/**
+ * Merge per-layer symlink maps into a single view of the running container.
+ * Layers arrive newest-first (see generic-archive / OCI extractors) and the
+ * first layer seen wins, mirroring layersWithLatestFileModifications. A
+ * whiteout entry only hides paths in lower (older) layers; a whiteout and an
+ * entry for the same path may coexist within one layer (e.g. a directory
+ * replaced by a symlink), in which case that layer's own entry survives.
+ */
+export function symlinksWithLatestModifications(
   symlinkLayers?: SymlinkMap[],
+  fileLayers?: ExtractedLayers[],
 ): SymlinkMap | undefined {
   if (!symlinkLayers || symlinkLayers.length === 0) {
     return undefined;
   }
 
   const merged: SymlinkMap = {};
-  for (const layer of symlinkLayers) {
-    for (const [symlinkPath, target] of Object.entries(layer)) {
-      merged[symlinkPath] = target;
+  const removedPathsToIgnore: Set<string> = new Set();
+
+  for (let i = 0; i < symlinkLayers.length; i++) {
+    for (const [symlinkPath, target] of Object.entries(symlinkLayers[i])) {
+      if (removedPathsToIgnore.has(symlinkPath)) {
+        continue;
+      }
+      if (isSymlinkInARemovedFolder(symlinkPath, removedPathsToIgnore)) {
+        continue;
+      }
+      if (!Reflect.has(merged, symlinkPath)) {
+        merged[symlinkPath] = target;
+      }
+    }
+
+    // Register this layer's whiteouts only after its own entries are merged:
+    // they delete paths from older layers, not from this layer or newer ones.
+    const fileLayer = fileLayers?.[i];
+    if (fileLayer) {
+      for (const filename of Object.keys(fileLayer)) {
+        if (isWhitedOutFile(filename)) {
+          removedPathsToIgnore.add(filename.replace(/.wh./, ""));
+        }
+      }
     }
   }
-  return merged;
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function isSymlinkInARemovedFolder(
+  symlinkPath: string,
+  removedPathsToIgnore: Set<string>,
+): boolean {
+  return Array.from(removedPathsToIgnore).some((removedPath) =>
+    isFileInFolder(symlinkPath, removedPath),
+  );
 }
 
 function layersWithLatestFileModifications(

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -22,6 +22,7 @@ import {
   FileContent,
   ImageConfig,
   OciArchiveManifest,
+  SymlinkMap,
 } from "./types";
 
 const debug = Debug("snyk");
@@ -143,6 +144,7 @@ export async function extractImageContent(
     manifestLayers: extractor.getManifestLayers(archiveContent.manifest),
     imageCreationTime: archiveContent.imageConfig.created,
     extractedLayers: layersWithLatestFileModifications(archiveContent.layers),
+    symlinks: symlinksWithLatestModifications(archiveContent.symlinkLayers),
     rootFsLayers: getRootFsLayersFromConfig(archiveContent.imageConfig),
     autoDetectedUserInstructions: getDetectedLayersInfoFromConfig(
       archiveContent.imageConfig,
@@ -224,6 +226,22 @@ export function getUserInstructionLayersFromConfig(imageConfig) {
     return [];
   }
   return userInstructionLayers;
+}
+
+function symlinksWithLatestModifications(
+  symlinkLayers?: SymlinkMap[],
+): SymlinkMap | undefined {
+  if (!symlinkLayers || symlinkLayers.length === 0) {
+    return undefined;
+  }
+
+  const merged: SymlinkMap = {};
+  for (const layer of symlinkLayers) {
+    for (const [symlinkPath, target] of Object.entries(layer)) {
+      merged[symlinkPath] = target;
+    }
+  }
+  return merged;
 }
 
 function layersWithLatestFileModifications(

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -5,7 +5,7 @@ import { extract, Extract } from "tar-stream";
 import { getErrorMessage } from "../error-utils";
 import { applyCallbacks, isResultEmpty } from "./callbacks";
 import { decompressMaybe } from "./decompress-maybe";
-import { ExtractAction, ExtractedLayers } from "./types";
+import { ExtractAction, ExtractedLayers, SymlinkMap } from "./types";
 
 export function isWhitedOutFile(filename: string) {
   return filename.match(/.wh./gm);
@@ -22,17 +22,29 @@ const debug = Debug("snyk");
  * @param extractActions array of pattern, callbacks pairs
  * @returns extracted file products
  */
+export interface LayerExtractionResult {
+  extractedLayers: ExtractedLayers;
+  symlinks: SymlinkMap;
+}
+
 export async function extractImageLayer(
   layerTarStream: Readable,
   extractActions: ExtractAction[],
-): Promise<ExtractedLayers> {
+): Promise<LayerExtractionResult> {
   return new Promise((resolve, reject) => {
     const result: ExtractedLayers = {};
+    const symlinks: SymlinkMap = {};
     const tarExtractor: Extract = extract();
 
     tarExtractor.on("entry", async (headers, stream, next) => {
-      if (headers.type === "file") {
-        const absoluteFileName = path.join(path.sep, headers.name);
+      const absoluteFileName = path.join(path.sep, headers.name);
+
+      if (headers.type === "symlink" || headers.type === "link") {
+        const linkTarget = headers.linkname;
+        if (linkTarget) {
+          symlinks[absoluteFileName] = linkTarget;
+        }
+      } else if (headers.type === "file") {
         const matchedActions = extractActions.filter((action) =>
           action.filePathMatches(absoluteFileName),
         );
@@ -70,7 +82,7 @@ export async function extractImageLayer(
 
     tarExtractor.on("finish", () => {
       // all layer level entries read
-      resolve(result);
+      resolve({ extractedLayers: result, symlinks });
     });
 
     tarExtractor.on("error", (error) => reject(error));

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -39,10 +39,15 @@ export async function extractImageLayer(
     tarExtractor.on("entry", async (headers, stream, next) => {
       const absoluteFileName = path.join(path.sep, headers.name);
 
-      if (headers.type === "symlink" || headers.type === "link") {
+      // Symlinks are path redirects; hard links are alternate names for the same
+      // inode and must not be treated as redirects during path canonicalization.
+      if (headers.type === "symlink") {
         const linkTarget = headers.linkname;
         if (linkTarget) {
-          symlinks[absoluteFileName] = linkTarget;
+          symlinks[absoluteFileName] = absoluteLinkTarget(
+            headers.name,
+            linkTarget,
+          );
         }
       } else if (headers.type === "file") {
         const matchedActions = extractActions.filter((action) =>
@@ -89,4 +94,17 @@ export async function extractImageLayer(
 
     layerTarStream.pipe(decompressMaybe()).pipe(tarExtractor);
   });
+}
+
+/**
+ * Resolve a tar symlink target to an absolute path within the image.
+ * A relative target resolves against the symlink's own directory; tar entry
+ * names always use forward slashes, so this is posix math on every platform.
+ */
+function absoluteLinkTarget(entryName: string, linkTarget: string): string {
+  if (linkTarget.startsWith("/")) {
+    return path.posix.normalize(linkTarget);
+  }
+  const linkDir = path.posix.dirname(path.posix.normalize("/" + entryName));
+  return path.posix.normalize(path.posix.join(linkDir, linkTarget));
 }

--- a/lib/extractor/oci-archive/layer.ts
+++ b/lib/extractor/oci-archive/layer.ts
@@ -8,10 +8,12 @@ import { getErrorMessage } from "../../error-utils";
 import { streamToJson } from "../../stream-utils";
 import { PluginOptions } from "../../types";
 import { decompressMaybe } from "../decompress-maybe";
-import { extractImageLayer } from "../layer";
+import {
+  extractImageLayer,
+  LayerExtractionResult as ImageLayerExtractionResult,
+} from "../layer";
 import {
   ExtractAction,
-  ExtractedLayers,
   ExtractedLayersAndManifest,
   ImageConfig,
   OciArchiveManifest,
@@ -80,10 +82,11 @@ export async function extractArchive(
   }
 
   // Build the result
-  const filteredLayers = manifest.layers
+  const filteredLayerResults = manifest.layers
     .filter((layer) => layers[layer.digest])
     .map((layer) => layers[layer.digest])
     .reverse();
+  const filteredLayers = filteredLayerResults.map((r) => r.extractedLayers);
 
   if (filteredLayers.length === 0) {
     // Provide more context about why extraction failed
@@ -113,6 +116,7 @@ export async function extractArchive(
 
   return {
     layers: filteredLayers,
+    symlinkLayers: filteredLayerResults.map((r) => r.symlinks),
     manifest,
     imageConfig,
   };
@@ -263,8 +267,8 @@ async function tryParseJsonMetadata(stream: Readable): Promise<unknown> {
   });
 }
 
-interface LayerExtractionResult {
-  layers: Record<string, ExtractedLayers>;
+interface OciLayerExtractionPassResult {
+  layers: Record<string, ImageLayerExtractionResult>;
   failedDigests: Map<string, string>;
 }
 
@@ -278,10 +282,10 @@ async function extractLayers(
   ociArchiveFilesystemPath: string,
   requiredDigests: Set<string>,
   extractActions: ExtractAction[],
-): Promise<LayerExtractionResult> {
+): Promise<OciLayerExtractionPassResult> {
   return new Promise((resolve, reject) => {
     const tarExtractor: Extract = extract();
-    const layers: Record<string, ExtractedLayers> = {};
+    const layers: Record<string, ImageLayerExtractionResult> = {};
     const failedDigests: Map<string, string> = new Map();
 
     tarExtractor.on("entry", async (header, stream, next) => {

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -25,10 +25,13 @@ export interface Extractor {
   ): string[];
 }
 
+export type SymlinkMap = Record<string, string>;
+
 export interface ExtractionResult {
   imageId: string;
   manifestLayers: string[];
   extractedLayers: ExtractedLayers;
+  symlinks?: SymlinkMap;
   rootFsLayers?: string[];
   autoDetectedUserInstructions?: AutoDetectedUserInstructions;
   platform?: string;
@@ -58,6 +61,7 @@ export interface KanikoArchiveManifest extends TarArchiveManifest {}
 
 export interface ExtractedLayersAndManifest {
   layers: ExtractedLayers[];
+  symlinkLayers?: SymlinkMap[];
   manifest: TarArchiveManifest | OciArchiveManifest;
   imageConfig: ImageConfig;
 }

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -162,3 +162,19 @@ export interface BaseRuntimesFact {
   type: "baseRuntimes";
   data: BaseRuntime[];
 }
+
+/**
+ * Links an application ScanResult to the Chainguard/Wolfi APK package that owns its
+ * evidence paths. Consumed by @snyk/vuln (follow-up) to reconcile upstream app CVEs
+ * against the owning package origin's existing APK advisory fixed-version data.
+ */
+export interface ApkPackageOwnershipFact {
+  type: "apkPackageOwnership";
+  data: {
+    distroId: string;
+    packageName: string;
+    packageVersion: string;
+    originPackage: string;
+    evidencePaths: string[];
+  };
+}

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -163,11 +163,6 @@ export interface BaseRuntimesFact {
   data: BaseRuntime[];
 }
 
-/**
- * Links an application ScanResult to the Chainguard/Wolfi APK package that owns its
- * evidence paths. Consumed by @snyk/vuln (follow-up) to reconcile upstream app CVEs
- * against the owning package origin's existing APK advisory fixed-version data.
- */
 export interface ApkPackageOwnershipFact {
   type: "apkPackageOwnership";
   data: {

--- a/lib/go-parser/index.ts
+++ b/lib/go-parser/index.ts
@@ -12,7 +12,7 @@ import {
   FilePathToElfContent,
 } from "../analyzer/applications/types";
 import { ExtractAction } from "../extractor/types";
-import { DepGraphFact } from "../facts";
+import { DepGraphFact, TestedFilesFact } from "../facts";
 import { GoBinary, readRawBuildInfo } from "./go-binary";
 
 const debug = Debug("snyk");
@@ -199,8 +199,12 @@ export async function goModulesToScannedProjects(
         type: "depGraph",
         data: depGraph,
       };
+      const testedFilesFact: TestedFilesFact = {
+        type: "testedFiles",
+        data: [filePath],
+      };
       scanResults.push({
-        facts: [depGraphFact],
+        facts: [depGraphFact, testedFilesFact],
         identity: {
           type: DEP_GRAPH_TYPE,
           // TODO: The path will contain forward slashes on Linux or backslashes on Windows.

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -1,4 +1,10 @@
 import { legacy } from "@snyk/dep-graph";
+import { extractEvidencePaths } from "./analyzer/applications/evidence-paths";
+import {
+  getApkPackagesFromResults,
+  resolveApkOwnership,
+  toSymlinkGraph,
+} from "./analyzer/package-managers/apk-ownership";
 import { StaticAnalysis } from "./analyzer/types";
 import * as facts from "./facts";
 // Module that provides functions to collect and build response after all
@@ -260,6 +266,33 @@ async function buildResponse(
       data: PLUGIN_VERSION,
     };
     appDepsScanResult.facts.push(appPluginVersionFact);
+
+    const osRelease = depsAnalysis.osRelease ?? depsAnalysis.depTree.targetOS;
+    if (osRelease?.prettyName) {
+      const imageOsReleasePrettyNameFact: facts.ImageOsReleasePrettyNameFact = {
+        type: "imageOsReleasePrettyName",
+        data: osRelease.prettyName,
+      };
+      appDepsScanResult.facts.push(imageOsReleasePrettyNameFact);
+    }
+
+    const evidencePaths = extractEvidencePaths(appDepsScanResult);
+    const apkPackages = getApkPackagesFromResults(depsAnalysis.results);
+    const ownership =
+      osRelease &&
+      resolveApkOwnership(
+        evidencePaths,
+        apkPackages,
+        osRelease,
+        toSymlinkGraph(depsAnalysis.symlinks),
+      );
+    if (ownership) {
+      const ownershipFact: facts.ApkPackageOwnershipFact = {
+        type: "apkPackageOwnership",
+        data: ownership,
+      };
+      appDepsScanResult.facts.push(ownershipFact);
+    }
 
     return {
       ...appDepsScanResult,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -82,7 +82,9 @@ export type FactType =
   // Used for application dependencies scanning; shows which files were used in the analysis of the dependencies.
   | "testedFiles"
   // Application files observed in the image
-  | "applicationFiles";
+  | "applicationFiles"
+  // Chainguard/Wolfi: APK package that owns application dependency evidence paths
+  | "apkPackageOwnership";
 
 export interface PluginAnalytics {
   name: string;

--- a/test/lib/extractor/docker-archive-symlinks.spec.ts
+++ b/test/lib/extractor/docker-archive-symlinks.spec.ts
@@ -1,0 +1,150 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as tar from "tar-stream";
+import { extractImageContent } from "../../../lib/extractor";
+import { ImageType } from "../../../lib/types";
+
+interface LayerEntry {
+  name: string;
+  type?: "file" | "symlink" | "link";
+  linkname?: string;
+  content?: string;
+}
+
+const CONFIG_FILE_NAME = `${"a".repeat(64)}.json`;
+
+async function packToBuffer(
+  addEntries: (pack: tar.Pack) => void,
+): Promise<Buffer> {
+  const pack = tar.pack();
+  const chunks: Buffer[] = [];
+  const done = new Promise<Buffer>((resolve, reject) => {
+    pack.on("data", (chunk: Buffer) => chunks.push(chunk));
+    pack.on("end", () => resolve(Buffer.concat(chunks)));
+    pack.on("error", reject);
+  });
+  addEntries(pack);
+  pack.finalize();
+  return done;
+}
+
+function createLayerTarball(entries: LayerEntry[]): Promise<Buffer> {
+  return packToBuffer((pack) => {
+    for (const entry of entries) {
+      if (entry.type === "symlink" || entry.type === "link") {
+        pack.entry({
+          name: entry.name,
+          type: entry.type,
+          linkname: entry.linkname,
+        });
+      } else {
+        pack.entry({ name: entry.name, type: "file" }, entry.content ?? "");
+      }
+    }
+  });
+}
+
+/**
+ * Builds a minimal docker-archive tar in memory: manifest.json, a config
+ * file, and one tarball per layer. Layers are given base-first, matching
+ * the order of manifest.json's Layers field in a real docker save archive.
+ */
+async function createTestDockerArchive(
+  layers: LayerEntry[][],
+): Promise<string> {
+  const layerTarballs = await Promise.all(layers.map(createLayerTarball));
+  const layerNames = layers.map((_, i) => `layer${i}.tar`);
+  const manifest = [
+    { Config: CONFIG_FILE_NAME, RepoTags: [], Layers: layerNames },
+  ];
+  const config = {
+    rootfs: {
+      type: "layers",
+      diff_ids: layers.map((_, i) => `sha256:${"b".repeat(63)}${i}`),
+    },
+  };
+
+  const archive = await packToBuffer((pack) => {
+    pack.entry({ name: "manifest.json" }, JSON.stringify(manifest));
+    pack.entry({ name: CONFIG_FILE_NAME }, JSON.stringify(config));
+    layerTarballs.forEach((tarball, i) => {
+      pack.entry({ name: layerNames[i] }, tarball);
+    });
+  });
+
+  const archivePath = path.join(tempDir, `test-image-${Date.now()}.tar`);
+  fs.writeFileSync(archivePath, archive);
+  return archivePath;
+}
+
+let tempDir: string;
+
+describe("docker-archive symlink extraction across layers", () => {
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "docker-archive-test-"));
+  });
+
+  afterAll(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the upper layer's symlink when it replaces a base-layer symlink", async () => {
+    const archivePath = await createTestDockerArchive([
+      // base layer
+      [{ name: "bin", type: "symlink", linkname: "usr/old-bin" }],
+      // upper layer
+      [{ name: "bin", type: "symlink", linkname: "usr/new-bin" }],
+    ]);
+
+    const result = await extractImageContent(
+      ImageType.DockerArchive,
+      archivePath,
+      [],
+      {},
+    );
+
+    expect(result.symlinks).toEqual({ "/bin": "/usr/new-bin" });
+  });
+
+  it("drops a base-layer symlink deleted by an upper-layer whiteout", async () => {
+    const archivePath = await createTestDockerArchive([
+      // base layer
+      [
+        { name: "bin", type: "symlink", linkname: "usr/bin" },
+        { name: "lib", type: "symlink", linkname: "usr/lib" },
+      ],
+      // upper layer deletes /bin
+      [{ name: ".wh.bin", type: "file" }],
+    ]);
+
+    const result = await extractImageContent(
+      ImageType.DockerArchive,
+      archivePath,
+      [],
+      {},
+    );
+
+    expect(result.symlinks).toEqual({ "/lib": "/usr/lib" });
+  });
+
+  it("keeps a base-layer symlink untouched by upper layers", async () => {
+    const archivePath = await createTestDockerArchive([
+      // base layer
+      [{ name: "lib", type: "symlink", linkname: "usr/lib" }],
+      // upper layer adds an unrelated file
+      [{ name: "etc/hostname", type: "file", content: "myhost\n" }],
+    ]);
+
+    const result = await extractImageContent(
+      ImageType.DockerArchive,
+      archivePath,
+      [],
+      {},
+    );
+
+    expect(result.symlinks).toEqual({ "/lib": "/usr/lib" });
+  });
+});

--- a/test/lib/extractor/layer.spec.ts
+++ b/test/lib/extractor/layer.spec.ts
@@ -14,7 +14,7 @@ describe("layer extractor: layer contain bad elf file", () => {
       getFixture("extracted-layers/layer_with_bad_elf_file.tar"),
     );
     const p = extractImageLayer(stream, staticAnalysisActions);
-    expect(p).toMatchObject({});
+    expect(p).resolves.toMatchObject({ extractedLayers: {}, symlinks: {} });
   });
 });
 
@@ -26,6 +26,6 @@ describe("layer extractor: layer contain cgo compiled go file", () => {
       getFixture("extracted-layers/cgo-compiled-file.tar"),
     );
     const p = extractImageLayer(stream, staticAnalysisActions);
-    expect(p).toMatchObject({});
+    expect(p).resolves.toMatchObject({ extractedLayers: {}, symlinks: {} });
   });
 });

--- a/test/lib/extractor/layer.spec.ts
+++ b/test/lib/extractor/layer.spec.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as tar from "tar-stream";
 import { extractImageLayer } from "../../../lib/extractor/layer";
 import { ExtractAction } from "../../../lib/extractor/types";
 import { getGoModulesContentAction } from "../../../lib/go-parser";
@@ -27,5 +28,43 @@ describe("layer extractor: layer contain cgo compiled go file", () => {
     );
     const p = extractImageLayer(stream, staticAnalysisActions);
     expect(p).resolves.toMatchObject({ extractedLayers: {}, symlinks: {} });
+  });
+});
+
+describe("layer extractor: symlink capture", () => {
+  it("records symlinks with absolute targets and ignores other entry types", async () => {
+    const pack = tar.pack();
+    // relative target resolves against the symlink's own directory
+    pack.entry({
+      name: "usr/bin/python3",
+      type: "symlink",
+      linkname: "python3.12",
+    });
+    // ".." segments in relative targets resolve too
+    pack.entry({
+      name: "usr/lib/libfoo.so",
+      type: "symlink",
+      linkname: "../share/foo/libfoo.so",
+    });
+    // absolute targets are stored normalized
+    pack.entry({ name: "bin", type: "symlink", linkname: "/usr//bin" });
+    // hard links are alternate names for the same inode, not redirects
+    pack.entry({
+      name: "usr/bin/[",
+      type: "link",
+      linkname: "usr/bin/busybox",
+    });
+    // regular files are not symlinks
+    pack.entry({ name: "etc/hostname", type: "file" }, "myhost\n");
+    pack.finalize();
+
+    const { symlinks } = await extractImageLayer(pack, []);
+
+    expect(symlinks).toEqual({
+      [path.join(path.sep, "usr", "bin", "python3")]: "/usr/bin/python3.12",
+      [path.join(path.sep, "usr", "lib", "libfoo.so")]:
+        "/usr/share/foo/libfoo.so",
+      [path.join(path.sep, "bin")]: "/usr/bin",
+    });
   });
 });

--- a/test/lib/extractor/symlink-merge.spec.ts
+++ b/test/lib/extractor/symlink-merge.spec.ts
@@ -1,0 +1,104 @@
+import { symlinksWithLatestModifications } from "../../../lib/extractor";
+import { ExtractedLayers, SymlinkMap } from "../../../lib/extractor/types";
+
+describe("symlinksWithLatestModifications", () => {
+  it("uses the newest layer when the same path appears in multiple layers", () => {
+    const symlinkLayers: SymlinkMap[] = [
+      { "/bin": "usr/local/bin" },
+      { "/bin": "usr/bin" },
+    ];
+
+    expect(symlinksWithLatestModifications(symlinkLayers, [{}, {}])).toEqual({
+      "/bin": "usr/local/bin",
+    });
+  });
+
+  it("merges symlinks from all layers when there is no conflict", () => {
+    const symlinkLayers: SymlinkMap[] = [
+      { "/bin": "usr/bin" },
+      { "/lib": "usr/lib" },
+      { "/etc": "usr/etc" },
+    ];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, [{}, {}, {}]),
+    ).toEqual({
+      "/bin": "usr/bin",
+      "/lib": "usr/lib",
+      "/etc": "usr/etc",
+    });
+  });
+
+  it("removes a symlink when a newer layer whiteouts the path", () => {
+    const symlinkLayers: SymlinkMap[] = [{}, { "/bin": "usr/bin" }];
+    const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, fileLayers),
+    ).toBeUndefined();
+  });
+
+  it("does not re-add a whiteouted symlink from an older layer", () => {
+    const symlinkLayers: SymlinkMap[] = [
+      {},
+      { "/bin": "usr/bin" },
+      { "/bin": "usr/old/bin" },
+    ];
+    const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}, {}];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, fileLayers),
+    ).toBeUndefined();
+  });
+
+  it("keeps a symlink re-created in a newer layer after an older layer deleted it", () => {
+    // Newest layer re-creates /bin after the middle layer deleted it; the
+    // middle layer's whiteout must only hide the oldest layer's symlink.
+    const symlinkLayers: SymlinkMap[] = [
+      { "/bin": "usr/bin" },
+      {},
+      { "/bin": "usr/old/bin" },
+    ];
+    const fileLayers: ExtractedLayers[] = [{}, { "/.wh.bin": {} }, {}];
+
+    expect(symlinksWithLatestModifications(symlinkLayers, fileLayers)).toEqual({
+      "/bin": "usr/bin",
+    });
+  });
+
+  it("keeps a symlink created in the same layer that whiteouts the path", () => {
+    // usrmerge pattern: one layer deletes the /bin directory and creates the
+    // /bin symlink; per the OCI spec a whiteout only hides lower layers.
+    const symlinkLayers: SymlinkMap[] = [
+      { "/bin": "usr/bin" },
+      { "/bin": "old/bin" },
+    ];
+    const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}];
+
+    expect(symlinksWithLatestModifications(symlinkLayers, fileLayers)).toEqual({
+      "/bin": "usr/bin",
+    });
+  });
+
+  it("keeps a base-layer symlink untouched by newer layers", () => {
+    const symlinkLayers: SymlinkMap[] = [{}, {}, { "/lib": "usr/lib" }];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, [{}, {}, {}]),
+    ).toEqual({
+      "/lib": "usr/lib",
+    });
+  });
+
+  it("removes symlinks under a folder whited out by a newer layer", () => {
+    const symlinkLayers: SymlinkMap[] = [
+      {},
+      { "/opt/app/current": "releases/1" },
+    ];
+    const fileLayers: ExtractedLayers[] = [{ "/.wh.opt": {} }, {}];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, fileLayers),
+    ).toBeUndefined();
+  });
+});

--- a/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/gomodules.spec.ts.snap
@@ -1220,12 +1220,22 @@ Object {
           "type": "depGraph",
         },
         Object {
+          "data": Array [
+            "/usr/bin/yq",
+          ],
+          "type": "testedFiles",
+        },
+        Object {
           "data": "sha256:0809facff9bd760673e046192ad24a2ee08d451f6dbb6c22552293dc4b15e734",
           "type": "imageId",
         },
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Alpine Linux v3.12",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
@@ -1540,6 +1550,12 @@ Object {
             "schemaVersion": "1.3.0",
           },
           "type": "depGraph",
+        },
+        Object {
+          "data": Array [
+            "/testgo",
+          ],
+          "type": "testedFiles",
         },
         Object {
           "data": "sha256:b5a5cea3c00c659a3bd14bf786644ec0deed22bc30e99260177aca1dc8600449",
@@ -1864,6 +1880,12 @@ Object {
           "type": "depGraph",
         },
         Object {
+          "data": Array [
+            "/testgo",
+          ],
+          "type": "testedFiles",
+        },
+        Object {
           "data": "sha256:b7f8424ea2e9e94dd34b972998957f3210b9caeb968cb53088dfadb775feefe1",
           "type": "imageId",
         },
@@ -2169,6 +2191,12 @@ Object {
             "schemaVersion": "1.3.0",
           },
           "type": "depGraph",
+        },
+        Object {
+          "data": Array [
+            "/testgo",
+          ],
+          "type": "testedFiles",
         },
         Object {
           "data": "sha256:f12d5cc86a0c5c078e16dca419459a91cc555e8cd9ef5750a6b809f2db19a47f",

--- a/test/system/application-scans/__snapshots__/node.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/node.spec.ts.snap
@@ -1863,6 +1863,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Amazon Linux 2",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/srv/npm-app/package.json",
@@ -12156,6 +12160,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Amazon Linux 2",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
@@ -14033,6 +14041,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Amazon Linux 2",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/srv/npm-app/package.json",
@@ -24326,6 +24338,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Amazon Linux 2",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
@@ -30005,6 +30021,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Alpine Linux v3.20",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/app/package.json",
@@ -35683,6 +35703,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Alpine Linux v3.20",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/app/package.json",
@@ -36238,6 +36262,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Alpine Linux v3.18",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/app/package.json",
@@ -36792,6 +36820,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Alpine Linux v3.18",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
@@ -43055,6 +43087,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Alpine Linux v3.20",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/app/package.json",
@@ -49317,6 +49353,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Alpine Linux v3.20",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/app/package.json",
@@ -51875,6 +51915,10 @@ Array [
         "data": "0.0.0-local",
         "type": "pluginVersion",
       },
+      Object {
+        "data": "Alpine Linux v3.11",
+        "type": "imageOsReleasePrettyName",
+      },
     ],
     "identity": Object {
       "targetFile": "/usr/goof2/package.json",
@@ -53970,6 +54014,10 @@ Array [
         "data": "0.0.0-local",
         "type": "pluginVersion",
       },
+      Object {
+        "data": "Alpine Linux v3.11",
+        "type": "imageOsReleasePrettyName",
+      },
     ],
     "identity": Object {
       "targetFile": "/usr/goof2/package.json",
@@ -55199,6 +55247,10 @@ Array [
         "data": "0.0.0-local",
         "type": "pluginVersion",
       },
+      Object {
+        "data": "Alpine Linux v3.11",
+        "type": "imageOsReleasePrettyName",
+      },
     ],
     "identity": Object {
       "targetFile": "/usr/goof3/node_modules",
@@ -56391,6 +56443,10 @@ Array [
       Object {
         "data": "0.0.0-local",
         "type": "pluginVersion",
+      },
+      Object {
+        "data": "Alpine Linux v3.11",
+        "type": "imageOsReleasePrettyName",
       },
     ],
     "identity": Object {
@@ -63680,6 +63736,10 @@ Array [
       Object {
         "data": "0.0.0-local",
         "type": "pluginVersion",
+      },
+      Object {
+        "data": "Alpine Linux v3.11",
+        "type": "imageOsReleasePrettyName",
       },
     ],
     "identity": Object {

--- a/test/system/application-scans/__snapshots__/php.spec.ts.snap
+++ b/test/system/application-scans/__snapshots__/php.spec.ts.snap
@@ -695,6 +695,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Alpine Linux v3.6",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/app/composer.lock",
@@ -1402,6 +1406,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Alpine Linux v3.6",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {

--- a/test/system/application-scans/chainguard-ownership.spec.ts
+++ b/test/system/application-scans/chainguard-ownership.spec.ts
@@ -1,0 +1,32 @@
+import { scan } from "../../../lib/index";
+
+describe("chainguard app ownership", () => {
+  afterAll(async () => {
+    // Best-effort cleanup if the image was pulled during the test.
+    try {
+      const { execute } = await import("../../../lib/sub-process");
+      await execute("docker", [
+        "image",
+        "rm",
+        "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a",
+      ]);
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  it("does not attach apkPackageOwnership on OS-only Chainguard images", async () => {
+    const image =
+      "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a";
+    const pluginResult = await scan({
+      path: image,
+      platform: "linux/amd64",
+    });
+
+    const appResults = pluginResult.scanResults.slice(1);
+    const ownershipFacts = appResults.flatMap((result) =>
+      result.facts.filter((fact) => fact.type === "apkPackageOwnership"),
+    );
+    expect(ownershipFacts).toHaveLength(0);
+  });
+});

--- a/test/system/flags/__snapshots__/app-vulns.spec.ts.snap
+++ b/test/system/flags/__snapshots__/app-vulns.spec.ts.snap
@@ -3643,6 +3643,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Amazon Linux 2",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/srv/npm-app/package.json",
@@ -13936,6 +13940,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Amazon Linux 2",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {

--- a/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/sles15.spec.ts.snap
@@ -2311,6 +2311,12 @@ Object {
           "type": "depGraph",
         },
         Object {
+          "data": Array [
+            "/usr/bin/container-suseconnect",
+          ],
+          "type": "testedFiles",
+        },
+        Object {
           "data": "sha256:8c5d736566b6f5d7a92b48f4236678470ca48c9b6760a9ca87d0ae35f9a89b59",
           "type": "imageId",
         },
@@ -2325,6 +2331,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "SUSE Linux Enterprise Server 15 SP3",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {

--- a/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
+++ b/test/system/operating-systems/__snapshots__/ubi8.spec.ts.snap
@@ -16124,6 +16124,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Red Hat Enterprise Linux 8.2 (Ootpa)",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/usr/lib/node_modules",

--- a/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
+++ b/test/system/registry-authentication/__snapshots__/username-password.spec.ts.snap
@@ -7476,6 +7476,10 @@ Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
         },
+        Object {
+          "data": "Alpine Linux v3.8",
+          "type": "imageOsReleasePrettyName",
+        },
       ],
       "identity": Object {
         "targetFile": "/usr/local/lib/node_modules",
@@ -14964,6 +14968,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Alpine Linux v3.8",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {

--- a/test/unit/apk-file-list.spec.ts
+++ b/test/unit/apk-file-list.spec.ts
@@ -1,0 +1,33 @@
+import * as fs from "fs";
+import * as path from "path";
+import { parseFile } from "../../lib/analyzer/package-managers/apk";
+
+const fixturePath = path.join(
+  __dirname,
+  "../fixtures/os/alpine_3_7_0/fs/lib/apk/db/installed",
+);
+
+describe("apk installed-db file list parsing", () => {
+  it("parses F:/R: file paths for packages", () => {
+    const content = fs.readFileSync(fixturePath, "utf8");
+    const packages = parseFile(content);
+
+    const busybox = packages.find((pkg) => pkg.Name === "busybox");
+    expect(busybox).toBeDefined();
+    expect(busybox!.Files).toEqual(
+      expect.arrayContaining(["/bin/busybox", "/bin/sh", "/etc/securetty"]),
+    );
+    expect(busybox!.Directories).toEqual(
+      expect.arrayContaining(["/bin", "/etc", "/sbin"]),
+    );
+
+    const musl = packages.find((pkg) => pkg.Name === "musl");
+    expect(musl).toBeDefined();
+    expect(musl!.Files).toEqual(
+      expect.arrayContaining([
+        "/lib/libc.musl-x86_64.so.1",
+        "/lib/ld-musl-x86_64.so.1",
+      ]),
+    );
+  });
+});

--- a/test/unit/apk-ownership.spec.ts
+++ b/test/unit/apk-ownership.spec.ts
@@ -112,6 +112,106 @@ describe("apk-ownership", () => {
     expect(exact?.matchKind).toBe("exact");
   });
 
+  it("returns undefined when only some evidence paths are owned", () => {
+    // Chainguard spec: evidence paths must be wholly contained in the owning
+    // package's declared paths; a partially-owned app keeps its findings.
+    const packages = [
+      makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/usr/bin/node", "/opt/custom/app.jar"],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("prefers an exactly matched owner over a directory-matched owner", () => {
+    const packages = [
+      makePackage(
+        "gradle",
+        "8.5-r0",
+        "gradle",
+        ["/usr/share/java/gradle/lib/gradle.jar"],
+        ["/usr/share/java/gradle"],
+      ),
+      makePackage(
+        "java-common",
+        "1-r0",
+        "java-common",
+        [],
+        ["/usr/share/java"],
+      ),
+    ];
+    const ownership = resolveApkOwnership(
+      [
+        "/usr/share/java/gradle/lib/gradle.jar", // exact: gradle
+        "/usr/share/java/other.jar", // directory: java-common
+      ],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership?.packageName).toBe("gradle");
+  });
+
+  it("returns undefined when different owners each have exact matches", () => {
+    const packages = [
+      makePackage("pkg-a", "1-r0", "pkg-a", ["/usr/bin/a"], ["/usr/bin"]),
+      makePackage("pkg-b", "1-r0", "pkg-b", ["/usr/bin/some-b"], ["/usr/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/usr/bin/a", "/usr/bin/some-b"],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("prefers the deepest directory match when no exact matches exist", () => {
+    const packages = [
+      makePackage("python", "3.12-r1", "python", [], ["/usr/lib/python3.12"]),
+      makePackage(
+        "py-foo",
+        "1.0-r0",
+        "py-foo",
+        [],
+        ["/usr/lib/python3.12/site-packages/foo"],
+      ),
+    ];
+    const ownership = resolveApkOwnership(
+      [
+        "/usr/lib/python3.12/site-packages/foo/mod.py", // directory: py-foo (deeper)
+        "/usr/lib/python3.12/abc.py", // directory: python (shallower)
+      ],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership?.packageName).toBe("py-foo");
+  });
+
+  it("returns undefined for a directory-depth tie between different owners", () => {
+    const packages = [
+      makePackage("pkg-a", "1-r0", "pkg-a", [], ["/usr/lib/a"]),
+      makePackage("pkg-b", "1-r0", "pkg-b", [], ["/usr/lib/b"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/usr/lib/a/x.so", "/usr/lib/b/y.so"],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
   it("canonicalizes APK declared paths consistently", () => {
     const packages = [
       makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], []),

--- a/test/unit/apk-ownership.spec.ts
+++ b/test/unit/apk-ownership.spec.ts
@@ -1,0 +1,125 @@
+import {
+  buildApkPathIndex,
+  resolveApkOwnership,
+  resolveOwnerForEvidencePath,
+} from "../../lib/analyzer/package-managers/apk-ownership";
+import { canonicalizePath } from "../../lib/analyzer/package-managers/path-canonicalization";
+import { AnalyzedPackageWithVersion } from "../../lib/analyzer/types";
+
+function makePackage(
+  name: string,
+  version: string,
+  origin: string,
+  files: string[],
+  directories: string[],
+): AnalyzedPackageWithVersion {
+  return {
+    Name: name,
+    Version: version,
+    Source: origin,
+    Provides: [],
+    Deps: {},
+    Files: files,
+    Directories: directories,
+  };
+}
+
+describe("apk-ownership", () => {
+  const symlinkGraph = new Map<string, string>([["/bin", "usr/bin"]]);
+
+  it("resolves exact file owners via O(1) lookup", () => {
+    const packages = [
+      makePackage("git", "2.43-r1", "git", ["/usr/bin/git"], ["/usr/bin"]),
+      makePackage("git-base", "2.43-r1", "git", [], ["/usr", "/usr/bin"]),
+    ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
+
+    const match = resolveOwnerForEvidencePath(
+      "/usr/bin/git",
+      index,
+      symlinkGraph,
+    );
+    expect(match?.owner.Name).toBe("git");
+    expect(match?.matchKind).toBe("exact");
+  });
+
+  it("canonicalizes evidence paths before matching APK file owners", () => {
+    const packages = [
+      makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/bin/node"],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toEqual({
+      distroId: "wolfi",
+      packageName: "nodejs",
+      packageVersion: "20-r1",
+      originPackage: "nodejs",
+      evidencePaths: ["/bin/node"],
+    });
+  });
+
+  it("returns undefined when evidence is not owned by any APK package", () => {
+    const packages = [
+      makePackage("bash", "5.2-r1", "bash", ["/bin/bash"], ["/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/opt/custom/app"],
+      packages,
+      { name: "chainguard", version: "20230214", prettyName: "Chainguard" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("does not run ownership resolution for non-Chainguard distros", () => {
+    const packages = [
+      makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/usr/bin/node"],
+      packages,
+      { name: "alpine", version: "3.19", prettyName: "Alpine" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("uses directory prefix only when exact file match is unavailable", () => {
+    const packages = [
+      makePackage("git-base", "2.43-r1", "git", [], ["/usr", "/usr/libexec"]),
+      makePackage(
+        "git",
+        "2.43-r1",
+        "git",
+        ["/usr/libexec/git-core/git"],
+        ["/usr/libexec"],
+      ),
+    ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
+    const exact = resolveOwnerForEvidencePath(
+      "/usr/libexec/git-core/git",
+      index,
+      symlinkGraph,
+    );
+    expect(exact?.owner.Name).toBe("git");
+    expect(exact?.matchKind).toBe("exact");
+  });
+
+  it("canonicalizes APK declared paths consistently", () => {
+    const packages = [
+      makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], []),
+    ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
+    const canonicalApkPath = canonicalizePath("/usr/bin/node", symlinkGraph);
+    expect(index.exactFileOwners.get(canonicalApkPath)?.[0].Name).toBe(
+      "nodejs",
+    );
+  });
+});

--- a/test/unit/evidence-paths.spec.ts
+++ b/test/unit/evidence-paths.spec.ts
@@ -1,0 +1,29 @@
+import { extractEvidencePaths } from "../../lib/analyzer/applications/evidence-paths";
+import { AppDepsScanResultWithoutTarget } from "../../lib/analyzer/applications/types";
+
+describe("evidence-paths", () => {
+  it("collects targetFile, testedFiles, and jar fingerprint locations", () => {
+    const scanResult: AppDepsScanResultWithoutTarget = {
+      identity: { type: "npm", targetFile: "/app/package.json" },
+      facts: [
+        { type: "testedFiles", data: ["package-lock.json"] },
+        {
+          type: "jarFingerprints",
+          data: {
+            origin: "image",
+            path: "/app/lib",
+            fingerprints: [{ location: "/app/lib/foo.jar" } as any],
+          },
+        },
+      ],
+    };
+
+    expect(extractEvidencePaths(scanResult)).toEqual(
+      expect.arrayContaining([
+        "/app/package.json",
+        "package-lock.json",
+        "/app/lib/foo.jar",
+      ]),
+    );
+  });
+});

--- a/test/unit/path-canonicalization.spec.ts
+++ b/test/unit/path-canonicalization.spec.ts
@@ -1,0 +1,30 @@
+import {
+  canonicalizePath,
+  normalizeAbsolutePath,
+} from "../../lib/analyzer/package-managers/path-canonicalization";
+
+describe("path-canonicalization", () => {
+  it("normalizes paths to POSIX absolute form", () => {
+    expect(normalizeAbsolutePath("usr/bin/node")).toBe("/usr/bin/node");
+    expect(normalizeAbsolutePath("/bin/node")).toBe("/bin/node");
+  });
+
+  it("resolves symlinks when canonicalizing evidence paths", () => {
+    const symlinkGraph = new Map<string, string>([
+      ["/bin", "usr/bin"],
+      ["/lib", "usr/lib"],
+    ]);
+
+    expect(canonicalizePath("/bin/node", symlinkGraph)).toBe("/usr/bin/node");
+    expect(canonicalizePath("/lib/libc.so", symlinkGraph)).toBe(
+      "/usr/lib/libc.so",
+    );
+  });
+
+  it("returns the original path when no symlink exists", () => {
+    const symlinkGraph = new Map<string, string>();
+    expect(canonicalizePath("/opt/app/binary", symlinkGraph)).toBe(
+      "/opt/app/binary",
+    );
+  });
+});

--- a/test/unit/response-builder-ownership.spec.ts
+++ b/test/unit/response-builder-ownership.spec.ts
@@ -1,0 +1,79 @@
+import { AnalysisType } from "../../lib/analyzer/types";
+import { buildResponse } from "../../lib/response-builder";
+
+describe("buildResponse apkPackageOwnership", () => {
+  it("attaches ownership and os release facts to application ScanResults on Wolfi", async () => {
+    const response = await buildResponse(
+      {
+        depTree: {
+          name: "docker-image|chainguard-node",
+          version: "latest",
+          packageFormatVersion: "apk:0.0.1",
+          targetOS: {
+            name: "wolfi",
+            version: "20230201",
+            prettyName: "Wolfi",
+          },
+          dependencies: {},
+        },
+        packageFormat: "apk",
+        imageId: "sha256:abc",
+        osRelease: {
+          name: "wolfi",
+          version: "20230201",
+          prettyName: "Wolfi",
+        },
+        results: [
+          {
+            Image: "chainguard-node",
+            AnalyzeType: AnalysisType.Apk,
+            Analysis: [
+              {
+                Name: "nodejs",
+                Version: "20-r1",
+                Source: "nodejs",
+                Provides: [],
+                Deps: {},
+                Files: ["/usr/bin/node"],
+                Directories: ["/usr/bin"],
+              },
+            ],
+          },
+        ],
+        binaries: [],
+        imageLayers: [],
+        applicationDependenciesScanResults: [
+          {
+            identity: { type: "gomodules", targetFile: "/usr/bin/node" },
+            facts: [
+              {
+                type: "testedFiles",
+                data: ["/usr/bin/node"],
+              },
+            ],
+          },
+        ],
+        manifestFiles: [],
+        symlinks: {
+          "/bin": "usr/bin",
+        },
+      },
+      undefined,
+      false,
+    );
+
+    const appResult = response.scanResults[1];
+    const ownershipFact = appResult.facts.find(
+      (f) => f.type === "apkPackageOwnership",
+    );
+    expect(ownershipFact).toBeDefined();
+    expect(ownershipFact!.data).toMatchObject({
+      distroId: "wolfi",
+      originPackage: "nodejs",
+      packageName: "nodejs",
+    });
+    expect(
+      appResult.facts.some((f) => f.type === "imageOsReleasePrettyName"),
+    ).toBe(true);
+  });
+});

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -1912,6 +1912,12 @@ Object {
           "type": "depGraph",
         },
         Object {
+          "data": Array [
+            "\\\\livenessprobe",
+          ],
+          "type": "testedFiles",
+        },
+        Object {
           "data": "sha256:df6b7f6e1cae591aa79cd0a355e9486a5b145a519f6351904605e17b34ceb63e",
           "type": "imageId",
         },
@@ -2508,12 +2514,22 @@ Object {
           "type": "depGraph",
         },
         Object {
+          "data": Array [
+            "\\\\usr\\\\lib\\\\go-standard-2",
+          ],
+          "type": "testedFiles",
+        },
+        Object {
           "data": "sha256:d995f79578b2f268b71e4cb7360f3baeddd0f07f8a5cf98977472dc563e67825",
           "type": "imageId",
         },
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Alpine Linux v3.22",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
@@ -2570,12 +2586,22 @@ Object {
           "type": "depGraph",
         },
         Object {
+          "data": Array [
+            "\\\\usr\\\\local\\\\lib\\\\go-standard",
+          ],
+          "type": "testedFiles",
+        },
+        Object {
           "data": "sha256:d995f79578b2f268b71e4cb7360f3baeddd0f07f8a5cf98977472dc563e67825",
           "type": "imageId",
         },
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Alpine Linux v3.22",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
@@ -2677,12 +2703,22 @@ Object {
           "type": "depGraph",
         },
         Object {
+          "data": Array [
+            "\\\\app\\\\node_modules\\\\.pnpm\\\\@esbuild+linux-x64@0.23.1\\\\node_modules\\\\@esbuild\\\\linux-x64\\\\bin\\\\esbuild",
+          ],
+          "type": "testedFiles",
+        },
+        Object {
           "data": "sha256:d995f79578b2f268b71e4cb7360f3baeddd0f07f8a5cf98977472dc563e67825",
           "type": "imageId",
         },
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Alpine Linux v3.22",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
@@ -4747,6 +4783,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Amazon Linux 2",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {
@@ -15041,6 +15081,10 @@ Object {
         Object {
           "data": "0.0.0-local",
           "type": "pluginVersion",
+        },
+        Object {
+          "data": "Amazon Linux 2",
+          "type": "imageOsReleasePrettyName",
         },
       ],
       "identity": Object {


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

## What does this PR do?

Adds a new `apkPackageOwnership` fact to application `ScanResult`s on Wolfi/Chainguard images. For each detected app dependency, the plugin resolves evidence paths (`identity.targetFile`, `testedFiles`, `jarFingerprints`) to the APK package that owns those files on disk.

**Supporting changes:**

- **APK DB parsing** — extend `apk.ts` to parse `F:`/`R:`/`M:` records from the installed database into per-package `Files` and `Directories` lists.
- **Ownership resolution** — new `apk-ownership.ts` builds a path index (exact file map + directory trie), canonicalizes paths through symlinks, and picks a consistent owning package across all evidence paths.
- **Symlink plumbing** — extractors now collect per-layer symlinks and pass them through static analysis into `buildResponse`.
- **Scope** — only runs on Wolfi/Chainguard distros (`osRelease.name` is `wolfi` or `chainguard`); skipped when evidence paths cannot be resolved or owners disagree ambiguously.

This is a **public API change**: `apkPackageOwnership` is a new `FactType` consumed downstream for app/OS vulnerability reconciliation.

## Where should the reviewer start?

1. `lib/analyzer/package-managers/apk-ownership.ts` — core ownership logic (`buildApkPathIndex`, `resolveApkOwnership`, distro gating)
2. `lib/response-builder.ts` (~lines 279–295) — where the fact is attached to app scan results
3. `lib/analyzer/package-managers/apk.ts` — installed-db file-list parsing (`F`/`R`/`M` records)
4. `test/unit/apk-ownership.spec.ts` and `test/unit/response-builder-ownership.spec.ts` — expected matching behavior (exact vs directory match, symlink canonicalization, multi-path consistency)
5. `lib/analyzer/applications/evidence-paths.ts` — which paths are considered evidence

## How should this be manually tested?


### Prerequisites

- Node 20+ (`npm install`; run `npm run build` only if exercising `dist/` directly)
- **System test:** running Docker daemon (containerd image store disabled — see `test/README.md`)

### Quick run (all PR-specific tests)

Use explicit file paths — pattern args like `npm run test:unit -- apk-ownership` match unrelated suites.

```bash
npx jest \
  test/unit/apk-ownership.spec.ts \
  test/unit/response-builder-ownership.spec.ts \
  test/unit/path-canonicalization.spec.ts \
  test/unit/evidence-paths.spec.ts \
  test/unit/apk-file-list.spec.ts \
  test/system/application-scans/chainguard-ownership.spec.ts
```

## Background

Chainguard/Wolfi apps are often installed as APK packages. Downstream needs to know which OS package owns an app's files to reconcile app and OS vulnerabilities. Ownership is only emitted when all evidence paths resolve to the same package.

## Tickets
CN-1395