### PR TITLE
test: force registry pull path in private-image system tests

### DIFF
--- a/test/system/docker.spec.ts
+++ b/test/system/docker.spec.ts
@@ -1,7 +1,5 @@
-import * as crypto from "crypto";
 import {
   createReadStream,
-  createWriteStream,
   existsSync,
   mkdirSync,
   rmdirSync,
@@ -121,8 +119,7 @@ describe("docker", () => {
     const TEST_TARGET_IMAGE_DESTINATION = path.join(os.tmpdir(), "image.tar");
 
     const docker = new Docker();
-    let expectedChecksum;
-    let tempFilesToCleanup: string[] = [];
+    let expectedManifest: ImageManifest;
 
     beforeAll(async () => {
       const loadImage = path.join(
@@ -130,8 +127,7 @@ describe("docker", () => {
         "../fixtures/docker-archives",
         "docker-save/hello-world.tar",
       );
-      const normalizedLoadImage = await normalizeImageTar(loadImage);
-      expectedChecksum = await calculateImageSHA256(normalizedLoadImage);
+      expectedManifest = await readImageManifest(loadImage);
       await subProcess.execute("docker", ["load", "--input", loadImage]);
     });
 
@@ -139,71 +135,50 @@ describe("docker", () => {
       if (existsSync(TEST_TARGET_IMAGE_DESTINATION)) {
         unlinkSync(TEST_TARGET_IMAGE_DESTINATION);
       }
-      for (const file of tempFilesToCleanup) {
-        if (existsSync(file)) {
-          unlinkSync(file);
-        }
-      }
-      tempFilesToCleanup = [];
     });
 
-    async function calculateImageSHA256(tarFilePath: string): Promise<string> {
-      return new Promise((resolve, reject) => {
-        const hash = crypto.createHash("sha256");
-        const stream = createReadStream(tarFilePath);
-
-        stream.on("data", (data) => {
-          hash.update(data);
-        });
-
-        stream.on("end", () => {
-          resolve(hash.digest("hex"));
-        });
-
-        stream.on("error", (err) => {
-          reject(err);
-        });
-      });
+    interface ImageManifest {
+      Config: string;
+      Layers: string[];
     }
 
-    async function normalizeImageTar(tarFilePath: string): Promise<string> {
+    async function readImageManifest(
+      tarFilePath: string,
+    ): Promise<ImageManifest> {
       return new Promise((resolve, reject) => {
         const extract = tar.extract();
-        const pack = tar.pack();
-        const tempFilePath = path.join(
-          os.tmpdir(),
-          `snyk-docker-plugin-test-${crypto.randomUUID()}.tar`,
-        );
-        tempFilesToCleanup.push(tempFilePath);
-        const output = createWriteStream(tempFilePath);
-        extract.on("entry", (header, stream, next) => {
-          // Normalize the header
-          header.mtime = new Date(0); // Set modification time to the epoch
-          header.uid = 0; // Set user ID to 0
-          header.gid = 0; // Set group ID to 0
+        let manifest: ImageManifest | undefined;
 
-          // Add entry to the new tar file
-          const entry = pack.entry(header, next);
-          stream.pipe(entry);
+        extract.on("entry", (header, stream, next) => {
+          if (header.name === "manifest.json") {
+            const chunks: Buffer[] = [];
+            stream.on("data", (chunk) => chunks.push(chunk));
+            stream.on("end", () => {
+              manifest = JSON.parse(Buffer.concat(chunks).toString("utf8"))[0];
+              next();
+            });
+          } else {
+            stream.on("end", next);
+            stream.resume();
+          }
         });
 
         extract.on("finish", () => {
-          pack.finalize();
-        });
-
-        output.on("finish", () => {
-          resolve(tempFilePath);
+          if (manifest) {
+            resolve(manifest);
+          } else {
+            reject(new Error(`manifest.json not found in ${tarFilePath}`));
+          }
         });
 
         extract.on("error", (err) => {
           reject(err);
         });
 
-        pack.pipe(output);
-
         createReadStream(tarFilePath).pipe(extract);
       });
     }
+
     test("image saved to specified location", async () => {
       const targetImage = TEST_TARGET_IMAGE;
       const targetImageDestination = TEST_TARGET_IMAGE_DESTINATION;
@@ -211,22 +186,27 @@ describe("docker", () => {
       await docker.save(targetImage, targetImageDestination);
 
       expect(existsSync(targetImageDestination)).toBeTruthy();
-      const normalizedTargetImage = await normalizeImageTar(
-        targetImageDestination,
-      );
 
-      const checksum = await calculateImageSHA256(normalizedTargetImage);
-      expect(checksum).toEqual(expectedChecksum);
+      // Compare the manifest's config and layer digests rather than archive
+      // bytes: docker save output is not byte-stable across engine versions
+      // (e.g. Docker 29 omits the empty OnBuild field from the legacy config
+      // blob, which changes the whole-archive checksum).
+      const savedManifest = await readImageManifest(targetImageDestination);
+      expect(savedManifest.Config).toEqual(expectedManifest.Config);
+      expect(savedManifest.Layers).toEqual(expectedManifest.Layers);
     });
 
     test("promise rejects when image doesn't exist", async () => {
-      const image = "someImage:latest";
+      const image = "image-that-does-not-exist:latest";
       const destination = "/tmp/image.tar";
 
       const result = docker.save(image, destination);
 
-      //  rejects with expected error
-      await expect(result).rejects.toThrowError("server error");
+      // The daemon responds 404, which Docker.save surfaces as "not found".
+      // (An invalid reference like "someImage" is no longer usable here:
+      // Docker 29 rejects it with 400 before checking existence, where
+      // older engines returned 500.)
+      await expect(result).rejects.toThrowError("not found");
       expect(existsSync(destination)).toBeFalsy();
     });
 

--- a/test/system/package-managers/chisel.spec.ts
+++ b/test/system/package-managers/chisel.spec.ts
@@ -1,5 +1,15 @@
+import { Docker } from "../../../lib/docker";
 import { scan } from "../../../lib/index";
 import { execute } from "../../../lib/sub-process";
+
+// The image is private; force the registry-API pull path so results match
+// CI regardless of the local daemon cache or the developer's `docker login`.
+beforeAll(() => {
+  jest.spyOn(Docker, "binaryExists").mockResolvedValue(false);
+  jest
+    .spyOn(Docker.prototype, "inspectImage")
+    .mockRejectedValue(new Error("forcing registry pull in tests"));
+});
 
 describe("chisel package manager tests", () => {
   afterAll(async () => {

--- a/test/system/package-managers/chisel.spec.ts
+++ b/test/system/package-managers/chisel.spec.ts
@@ -2,8 +2,12 @@ import { Docker } from "../../../lib/docker";
 import { scan } from "../../../lib/index";
 import { execute } from "../../../lib/sub-process";
 
-// The image is private; force the registry-API pull path so results match
-// CI regardless of the local daemon cache or the developer's `docker login`.
+// The image is private, so force the registry-API pull path the snapshot was
+// recorded from. Without this, the suite failed on developer machines while
+// passing in CI: a locally cached copy of the image (or a successful
+// `docker pull` via the developer's own `docker login`) makes scan() use
+// `docker save` instead, which produces different imageLayers/imageNames
+// facts than the registry pull.
 beforeAll(() => {
   jest.spyOn(Docker, "binaryExists").mockResolvedValue(false);
   jest

--- a/test/system/registry-authentication/username-password.spec.ts
+++ b/test/system/registry-authentication/username-password.spec.ts
@@ -1,9 +1,15 @@
 import { Docker } from "../../../lib/docker";
 import { scan } from "../../../lib/index";
 
-// These tests exercise registry authentication, so they must not be
-// satisfiable by a locally cached image or the developer's own
-// `docker login` — force the registry-API pull path.
+// Force the plugin down the registry-API pull path (pullFromContainerRegistry),
+// which is what these snapshots were recorded from and the only path that uses
+// the credentials under test. Without this, the suite failed on developer
+// machines while passing in CI: scan() prefers `docker save` when the image is
+// already in the local daemon, and otherwise shells out to a plain
+// `docker pull` that authenticates with the developer's own `docker login`.
+// On both of those paths the credentials passed to scan() are ignored (so bad
+// credentials were never rejected) and the resulting imageLayers/imageNames
+// facts don't match the snapshots.
 beforeAll(() => {
   jest.spyOn(Docker, "binaryExists").mockResolvedValue(false);
   jest

--- a/test/system/registry-authentication/username-password.spec.ts
+++ b/test/system/registry-authentication/username-password.spec.ts
@@ -1,4 +1,15 @@
+import { Docker } from "../../../lib/docker";
 import { scan } from "../../../lib/index";
+
+// These tests exercise registry authentication, so they must not be
+// satisfiable by a locally cached image or the developer's own
+// `docker login` — force the registry-API pull path.
+beforeAll(() => {
+  jest.spyOn(Docker, "binaryExists").mockResolvedValue(false);
+  jest
+    .spyOn(Docker.prototype, "inspectImage")
+    .mockRejectedValue(new Error("forcing registry pull in tests"));
+});
 
 describe("username and password authentication", () => {
   const oldSnykRegistryUsernameEnvVar = process.env.SNYK_REGISTRY_USERNAME;


### PR DESCRIPTION
## What

Local `npm run test:system` has been failing for a while even though CI is green. This PR makes the system tests behave the same in both places. Three changes:

**1. The private-image suites now always pull from the registry API.**

`registry-authentication/username-password.spec.ts` and `package-managers/chisel.spec.ts` stub `Docker.binaryExists` and `Docker.prototype.inspectImage` so that `scan()` falls through to `pullFromContainerRegistry`. The snapshots in these suites were recorded from that path, and it's the only path CI can take because its remote daemon starts empty with no `docker login`. On a dev machine the plugin never got that far: if the image was already cached in the daemon it just ran `docker save`, and otherwise a plain `docker pull` succeeded using my personal `docker login`. The credentials passed to `scan()` are ignored on both of those paths, so the facts didn't match the snapshots and the bad-credentials test passed without bad credentials ever reaching a registry.

The suites that scan public images are deliberately left alone so the daemon pull/save path keeps its coverage.

**2. The `docker save` checksum test compares manifests instead of bytes.**

The old test hashed the whole saved archive and compared it against the hello-world fixture. Docker 29 dropped the empty `OnBuild` field from the legacy config blob it writes during save (moby/moby#51154), which changes that blob's digest and with it the archive checksum, even though the image content is identical. The test now extracts `manifest.json` from both archives and compares the config and layer digests, which are stable across engine versions.

**3. The "image doesn't exist" test uses a reference that's actually valid.**

It used `someImage:latest` and expected the daemon's 500 "server error". The uppercase name is an invalid reference, and Docker 29 rejects it with a 400 before it ever checks whether the image exists. The test now uses a valid lowercase name that doesn't exist and asserts the 404 "not found", which old and new engines agree on.

## Why now

CI runs whatever `setup_remote_docker` provisions by default, which is currently Docker 28, while Docker Desktop has auto-updated everyone's laptop to 29. That gap is why the suite passes in CI and fails locally. It also means the `docker.spec.ts` tests would have started failing on `main` whenever CircleCI bumps its default to 29. After this PR the suite passes on both engines.

## Verification

Full `npm run test:system` on Docker 29.4.3 (Desktop 4.73, containerd image store disabled), with the private image cached in my daemon and Docker Hub logged in - the exact setup that used to fail. 50/50 suites pass, 70/70 snapshots.

One side effect: the chisel teardown's `docker image rm` now always logs its tolerated warning, because the registry pull never loads the image into the daemon.

Refs [CN-1416](https://snyksec.atlassian.net/browse/CN-1416)

[CN-1416]: https://snyksec.atlassian.net/browse/CN-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ