### PR TITLE
chore: improve windows ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
           post-steps:
             - *slack-fail-notify
       - test_jest_windows_with_docker:
-          name: Test Jest Windows (with Docker)
+          name: Test (Windows, Docker)
           context:
             - nodejs-install
             - snyk-bot-slack
@@ -309,7 +309,7 @@ workflows:
           post-steps:
             - *slack-fail-notify
       - test_jest_windows_no_docker:
-          name: Test Jest Windows (no Docker)
+          name: Test (Windows, no Docker)
           context:
             - nodejs-install
             - snyk-bot-slack
@@ -343,8 +343,8 @@ workflows:
             - Security Scans
             - Unit Test
             - System Test
-            - Test Jest Windows (with Docker)
-            - Test Jest Windows (no Docker)
+            - Test (Windows, Docker)
+            - Test (Windows, no Docker)
           post-steps:
             - *slack-fail-notify
             - *slack-success-notify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
       - store_artifacts:
           path: test-system-logs.txt
           destination: test-system-logs
-  test_jest_windows_with_docker:
+  test_windows_with_docker:
     <<: *windows_big
     steps:
       - checkout
@@ -176,7 +176,7 @@ jobs:
       - run:
           command: npm run test:windows:docker
           no_output_timeout: 20m
-  test_jest_windows_no_docker:
+  test_windows_no_docker:
     <<: *windows_big
     steps:
       - checkout
@@ -298,8 +298,8 @@ workflows:
             - Build
           post-steps:
             - *slack-fail-notify
-      - test_jest_windows_with_docker:
-          name: Test (Windows, Docker)
+      - test_windows_with_docker:
+          name: Test Windows with Docker
           context:
             - nodejs-install
             - snyk-bot-slack
@@ -308,8 +308,8 @@ workflows:
             - Build
           post-steps:
             - *slack-fail-notify
-      - test_jest_windows_no_docker:
-          name: Test (Windows, no Docker)
+      - test_windows_no_docker:
+          name: Test Windows no Docker
           context:
             - nodejs-install
             - snyk-bot-slack
@@ -343,8 +343,8 @@ workflows:
             - Security Scans
             - Unit Test
             - System Test
-            - Test (Windows, Docker)
-            - Test (Windows, no Docker)
+            - Test Windows with Docker
+            - Test Windows no Docker
           post-steps:
             - *slack-fail-notify
             - *slack-success-notify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
             - ~/AppData/Roaming/npm-cache
       - run: docker version
       - run:
-          command: npm run test-jest-windows
+          command: npm run test-jest-windows-docker
           no_output_timeout: 20m
   test_jest_windows_no_docker:
     <<: *windows_big
@@ -299,7 +299,7 @@ workflows:
           post-steps:
             - *slack-fail-notify
       - test_jest_windows_with_docker:
-          name: Test Jest Windows with Docker
+          name: Test Jest Windows (with Docker)
           context:
             - nodejs-install
             - snyk-bot-slack
@@ -309,7 +309,7 @@ workflows:
           post-steps:
             - *slack-fail-notify
       - test_jest_windows_no_docker:
-          name: Test Jest Windows no Docker
+          name: Test Jest Windows (no Docker)
           context:
             - nodejs-install
             - snyk-bot-slack
@@ -343,8 +343,8 @@ workflows:
             - Security Scans
             - Unit Test
             - System Test
-            - Test Jest Windows with Docker
-            - Test Jest Windows no Docker
+            - Test Jest Windows (with Docker)
+            - Test Jest Windows (no Docker)
           post-steps:
             - *slack-fail-notify
             - *slack-success-notify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,15 @@ jobs:
       - install_node_npm:
           node_version: << parameters.node_version >>
       - setup_npm_user
+      - restore_cache:
+          keys:
+            - v1-windows-npm-cache-{{ checksum "package.json" }}
+            - v1-windows-npm-cache-
       - run: npm ci
+      - save_cache:
+          key: v1-windows-npm-cache-{{ checksum "package.json" }}
+          paths:
+            - ~/AppData/Roaming/npm-cache
       - run: docker version
       - run:
           command: npm run test-jest-windows
@@ -175,7 +183,15 @@ jobs:
       - install_node_npm:
           node_version: << parameters.node_version >>
       - setup_npm_user
+      - restore_cache:
+          keys:
+            - v1-windows-npm-cache-{{ checksum "package.json" }}
+            - v1-windows-npm-cache-
       - run: npm ci
+      - save_cache:
+          key: v1-windows-npm-cache-{{ checksum "package.json" }}
+          paths:
+            - ~/AppData/Roaming/npm-cache
         # make docker appear to be broken.
       - run: "function docker() { return 1; }"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
             - ~/AppData/Roaming/npm-cache
       - run: docker version
       - run:
-          command: npm run test-jest-windows-docker
+          command: npm run test:windows:docker
           no_output_timeout: 20m
   test_jest_windows_no_docker:
     <<: *windows_big
@@ -195,7 +195,7 @@ jobs:
         # make docker appear to be broken.
       - run: "function docker() { return 1; }"
       - run:
-          command: npm run test-jest-windows
+          command: npm run test:windows
           no_output_timeout: 20m
   build:
     <<: *defaults

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ to keep pre-Jest-29 snapshots readable; don't change it casually.
 CircleCI (`.circleci/config.yml`) runs build, lint, and tests on:
 
 - Linux (`cimg/node:20.19`) — full Jest suite, including system tests
-- Windows (`win/server-2022`) — `test/windows/` suite via `npm run test-jest-windows`
+- Windows (`win/server-2022`) — `test/windows/` suite via `npm run test:windows` (fixture-only) and `npm run test:windows:docker` (requires Docker daemon)
 
 `main`-branch failures notify Slack `#team-container-pipeline-info`. Match the
 target Node major (`20`) when validating locally.

--- a/package.json
+++ b/package.json
@@ -19,12 +19,11 @@
     "lint:eslint": "eslint \"{lib,test}/**/*.ts\"",
     "lint:commit": "commitlint --from=HEAD~1",
     "format": "prettier --loglevel warn --write '{lib,test}/**/*.ts' && eslint --fix '{lib,test}/**/*.ts'",
-    "test": "npm run test-jest",
+    "test": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
     "test:unit": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/(lib|unit)/'",
     "test:system": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/system/'",
-    "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
-    "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
-    "test-jest-windows-docker": "jest --ci --maxWorkers=3 --config test/windows/jest.docker.config.js --logHeapUsage",
+    "test:windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
+    "test:windows:docker": "jest --ci --maxWorkers=3 --config test/windows/jest.docker.config.js --logHeapUsage",
     "prepare": "npm run build"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test:unit": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/(lib|unit)/'",
     "test:system": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/system/'",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
-    "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --testPathIgnorePatterns='image-inspector\\.spec|registry-scan\\.spec' --logHeapUsage",
-    "test-jest-windows-docker": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --testPathPattern='image-inspector\\.spec|registry-scan\\.spec' --logHeapUsage",
+    "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
+    "test-jest-windows-docker": "jest --ci --maxWorkers=3 --config test/windows/jest.docker.config.js --logHeapUsage",
     "prepare": "npm run build"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:unit": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/(lib|unit)/'",
     "test:system": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/system/'",
     "test-jest": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
-    "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
+    "test-jest-windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --testPathIgnorePatterns='image-inspector\\.spec|registry-scan\\.spec' --logHeapUsage",
+    "test-jest-windows-docker": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --testPathPattern='image-inspector\\.spec|registry-scan\\.spec' --logHeapUsage",
     "prepare": "npm run build"
   },
   "engines": {

--- a/test/windows/archive-scan.spec.ts
+++ b/test/windows/archive-scan.spec.ts
@@ -90,33 +90,6 @@ describe("windows scanning", () => {
     );
   });
 
-  it("can static scan for Identifier type image (python:3.9.0)", async () => {
-    const imageNameAndTag =
-      "python@sha256:1f92d35b567363820d0f2f37c7ccf2c1543e2d852cea01edb027039e6aef25e6";
-
-    const pluginResult = await plugin.scan({
-      path: imageNameAndTag,
-      "exclude-app-vulns": true,
-    });
-
-    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
-      (fact) => fact.type === "depGraph",
-    )!.data;
-    expect(depGraph.rootPkg.name).toEqual("docker-image|python");
-    expect(depGraph.rootPkg.version).toBeUndefined();
-    expect(pluginResult.scanResults[0].identity.type).toEqual("linux");
-    const imageLayers: string[] = pluginResult.scanResults[0].facts.find(
-      (fact) => fact.type === "imageLayers",
-    )!.data;
-    expect(imageLayers.length).toBeGreaterThan(0);
-    expect(
-      imageLayers.every((layer) => layer.endsWith("layer.tar")),
-    ).toBeTruthy();
-    expect(pluginResult.scanResults[0].identity.args?.platform).toEqual(
-      "windows/amd64",
-    );
-  }, 900000);
-
   it("can scan docker-archive image type with go binaries", async () => {
     const fixturePath = getFixture(
       "docker-archives/docker-save/go-binaries.tar",

--- a/test/windows/jest.config.js
+++ b/test/windows/jest.config.js
@@ -6,6 +6,10 @@ module.exports = {
   ],
   testEnvironment: "node",
   testMatch: ["<rootDir>/**/*.spec.ts"],
+  testPathIgnorePatterns: [
+    "<rootDir>/lib/image-inspector.spec.ts",
+    "<rootDir>/registry-scan.spec.ts",
+  ],
   testTimeout: 600000, // 10 minutes
   // TODO: This option is printing Array\Object prefixing arrays\objects in snapshots files
   // this settings were added when migrated to Jest 29 to support the old snapshots format

--- a/test/windows/jest.docker.config.js
+++ b/test/windows/jest.docker.config.js
@@ -1,0 +1,10 @@
+const baseConfig = require("./jest.config");
+
+module.exports = {
+  ...baseConfig,
+  testPathIgnorePatterns: [],
+  testMatch: [
+    "<rootDir>/lib/image-inspector.spec.ts",
+    "<rootDir>/registry-scan.spec.ts",
+  ],
+};

--- a/test/windows/registry-scan.spec.ts
+++ b/test/windows/registry-scan.spec.ts
@@ -3,21 +3,19 @@ import { DepGraph } from "@snyk/dep-graph";
 import * as plugin from "../../lib";
 
 describe("windows scanning", () => {
-  it("can static scan for Identifier type image (python:3.9.0)", async () => {
-    const imageNameAndTag =
-      "python@sha256:1f92d35b567363820d0f2f37c7ccf2c1543e2d852cea01edb027039e6aef25e6";
-
+  it("can scan a registry image (alpine:3.12.0)", async () => {
     const pluginResult = await plugin.scan({
-      path: imageNameAndTag,
+      path: "alpine@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321",
+      platform: "linux/amd64",
       "exclude-app-vulns": true,
     });
 
     const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
       (fact) => fact.type === "depGraph",
     )!.data;
-    expect(depGraph.rootPkg.name).toEqual("docker-image|python");
+    expect(depGraph.rootPkg.name).toEqual("docker-image|alpine");
     expect(depGraph.rootPkg.version).toBeUndefined();
-    expect(pluginResult.scanResults[0].identity.type).toEqual("linux");
+    expect(pluginResult.scanResults[0].identity.type).toEqual("apk");
     const imageLayers: string[] = pluginResult.scanResults[0].facts.find(
       (fact) => fact.type === "imageLayers",
     )!.data;
@@ -26,7 +24,7 @@ describe("windows scanning", () => {
       imageLayers.every((layer) => layer.endsWith("layer.tar")),
     ).toBeTruthy();
     expect(pluginResult.scanResults[0].identity.args?.platform).toEqual(
-      "windows/amd64",
+      "linux/amd64",
     );
   }, 900000);
 });

--- a/test/windows/registry-scan.spec.ts
+++ b/test/windows/registry-scan.spec.ts
@@ -1,0 +1,32 @@
+import { DepGraph } from "@snyk/dep-graph";
+
+import * as plugin from "../../lib";
+
+describe("windows scanning", () => {
+  it("can static scan for Identifier type image (python:3.9.0)", async () => {
+    const imageNameAndTag =
+      "python@sha256:1f92d35b567363820d0f2f37c7ccf2c1543e2d852cea01edb027039e6aef25e6";
+
+    const pluginResult = await plugin.scan({
+      path: imageNameAndTag,
+      "exclude-app-vulns": true,
+    });
+
+    const depGraph: DepGraph = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "depGraph",
+    )!.data;
+    expect(depGraph.rootPkg.name).toEqual("docker-image|python");
+    expect(depGraph.rootPkg.version).toBeUndefined();
+    expect(pluginResult.scanResults[0].identity.type).toEqual("linux");
+    const imageLayers: string[] = pluginResult.scanResults[0].facts.find(
+      (fact) => fact.type === "imageLayers",
+    )!.data;
+    expect(imageLayers.length).toBeGreaterThan(0);
+    expect(
+      imageLayers.every((layer) => layer.endsWith("layer.tar")),
+    ).toBeTruthy();
+    expect(pluginResult.scanResults[0].identity.args?.platform).toEqual(
+      "windows/amd64",
+    );
+  }, 900000);
+});


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

### What does this PR do?

Makes 3 related improvements to the Windows tests that (based on a [small data set](https://app.circleci.com/pipelines/github/snyk/snyk-docker-plugin)) saves about 5 minutes of wall-clock time from the CI pipeline.

#### npm caching for Windows jobs

Both `test_windows_with_docker` and `test_windows_no_docker` now restore and save the npm download cache (`~/AppData/Roaming/npm-cache`) around `npm ci`. A Windows-specific cache key (`v1-windows-npm-cache-`) avoids cross-platform pollution with the existing Linux cache.

#### Split Docker-dependent tests from fixture-based tests

The Windows test suite previously had no equivalent of the Linux test:unit / test:system split. This introduces that separation via path patterns in the npm scripts:

- test:windows — fixture-based tests only (excludes image-inspector.spec.ts and registry-scan.spec.ts)
- test:windows:docker — Docker-dependent tests only

(one drive-by refactor: we had `test` which was just a redirect to `test-jest`. I removed this redirection. Forgive me)

### Registry scan test

Replaced the  python:3.9.0 test image (~880 MB) with alpine:3.12.0 (~5 MB) to reduce test time. The test is simply proving the ability to pull and scan an image (by asserting a few facts), so the specific image used is not load-bearing.
