### PR TITLE
chore: use circle ci output for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/snyk-docker-plugin
-      - run: npm run test:unit > test-unit-logs.txt 2>&1
-      - store_artifacts:
-          path: test-unit-logs.txt
-          destination: test-unit-logs
+      - run: npm run test:unit
   test_system:
     <<: *defaults
     steps:
@@ -151,11 +148,8 @@ jobs:
       - attach_workspace:
           at: ~/snyk-docker-plugin
       - run:
-          command: npm run test:system > test-system-logs.txt 2>&1
+          command: npm run test:system
           no_output_timeout: 20m
-      - store_artifacts:
-          path: test-system-logs.txt
-          destination: test-system-logs
   test_windows_with_docker:
     <<: *windows_big
     steps:


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Prints testing output direct to the CircleCI output rather than piping to a file and saving as an artifact. This makes it easier to monitor tests and review failures (piped files were cluttered with ansi escape characters). Aligned to our other test pipelines.