### PR TITLE
chore(ci): ignore graphite temporary branches in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,9 +245,15 @@ workflows:
   version: 2
   test_and_release:
     when:
-      # do not run on a pipeline schedule
-      not:
-        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+      and:
+        # do not run on a pipeline schedule
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        # do not run on graphite temporary branches
+        - not:
+            matches:
+              pattern: "^graphite-base/.*"
+              value: << pipeline.git.branch >>
     jobs:
       - prodsec/secrets-scan:
           name: Scan repository for secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/snyk-docker-plugin
-      - run: npm run test:unit > test-unit-logs.txt 2>&1
-      - store_artifacts:
-          path: test-unit-logs.txt
-          destination: test-unit-logs
+      - run: npm run test:unit
   test_system:
     <<: *defaults
     steps:
@@ -151,11 +148,8 @@ jobs:
       - attach_workspace:
           at: ~/snyk-docker-plugin
       - run:
-          command: npm run test:system > test-system-logs.txt 2>&1
+          command: npm run test:system
           no_output_timeout: 20m
-      - store_artifacts:
-          path: test-system-logs.txt
-          destination: test-system-logs
   test_windows_with_docker:
     <<: *windows_big
     steps:


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Ignore graphite temporary branches in CI IAW [Graphite docs](https://graphite.com/docs/merge-pull-requests#ignoring-graphite’s-temporary-branches-in-your-ci).

Attempting to run the pipeline against temporary branches results in [failures](https://app.circleci.com/pipelines/github/snyk/snyk-docker-plugin/4783/workflows/07baac84-d2c7-47f8-9016-345a9fc12b2e/jobs/31093).

These branches are a purely synthetic tool for Graphite to handle stacks, no code exists on them and they will not be merged into the codebase.
