### PR TITLE
feat: cn-1395 parse apk file ownership records

### DIFF
--- a/lib/analyzer/package-managers/apk.ts
+++ b/lib/analyzer/package-managers/apk.ts
@@ -15,55 +15,62 @@ export function analyze(
   });
 }
 
-function parseFile(text: string): AnalyzedPackageWithVersion[] {
+export function parseFile(text: string): AnalyzedPackageWithVersion[] {
   const pkgs: AnalyzedPackageWithVersion[] = [];
-  let curPkg: any = null;
-  for (const line of text.split("\n")) {
-    curPkg = parseLine(line, curPkg, pkgs);
-  }
-  return pkgs;
-}
+  let curPkg: AnalyzedPackageWithVersion | null = null;
 
-function parseLine(
-  text: string,
-  curPkg: AnalyzedPackageWithVersion,
-  pkgs: AnalyzedPackageWithVersion[],
-) {
-  const key = text.charAt(0);
-  const value = text.substr(2).trim();
-  switch (key) {
-    case "P": // Package
-      curPkg = {
-        Name: value,
-        Version: "",
-        Source: undefined,
-        Provides: [],
-        Deps: {},
-        AutoInstalled: undefined,
-      };
-      pkgs.push(curPkg);
-      break;
-    case "V": // Version
-      curPkg.Version = value;
-      break;
-    case "p": // Provides
-      for (let name of value.split(" ")) {
-        name = name.split("=")[0];
-        curPkg.Provides.push(name);
+  for (const line of text.split("\n")) {
+    if (line.length < 2) {
+      continue;
+    }
+    const key = line.charAt(0);
+    const value = line.substr(2).trim();
+
+    switch (key) {
+      case "P": {
+        // Package
+        curPkg = {
+          Name: value,
+          Version: "",
+          Source: undefined,
+          Provides: [],
+          Deps: {},
+          AutoInstalled: undefined,
+        };
+        pkgs.push(curPkg);
+        break;
       }
-      break;
-    case "r": // Depends
-    case "D": // Depends
-      for (let name of value.split(" ")) {
-        if (name.charAt(0) !== "!") {
-          name = name.split("=")[0];
-          curPkg.Deps[name] = true;
+      case "V": // Version
+        if (curPkg) {
+          curPkg.Version = value;
         }
-      }
-      break;
-    case "o": // Origin
-      curPkg.Source = value;
-      break;
+        break;
+      case "p": // Provides
+        if (curPkg) {
+          for (let name of value.split(" ")) {
+            name = name.split("=")[0];
+            curPkg.Provides.push(name);
+          }
+        }
+        break;
+      case "r": // Depends
+      case "D": // Depends
+        if (curPkg) {
+          for (let name of value.split(" ")) {
+            if (name.charAt(0) !== "!") {
+              name = name.split("=")[0];
+              curPkg.Deps[name] = true;
+            }
+          }
+        }
+        break;
+      case "o": // Origin
+        if (curPkg) {
+          curPkg.Source = value;
+        }
+        break;
+    }
   }
-  return curPkg;
+
+  return pkgs;
 }

--- a/lib/analyzer/package-managers/apk.ts
+++ b/lib/analyzer/package-managers/apk.ts
@@ -18,6 +18,8 @@ export function analyze(
 export function parseFile(text: string): AnalyzedPackageWithVersion[] {
   const pkgs: AnalyzedPackageWithVersion[] = [];
   let curPkg: AnalyzedPackageWithVersion | null = null;
+  // Absolute path of the most recent F: record; "" until one is seen.
+  let currentDir = "";
 
   for (const line of text.split("\n")) {
     if (line.length < 2) {
@@ -36,8 +38,11 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
           Provides: [],
           Deps: {},
           AutoInstalled: undefined,
+          Files: [],
+          Directories: [],
         };
         pkgs.push(curPkg);
+        currentDir = "";
         break;
       }
       case "V": // Version
@@ -69,6 +74,36 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
           curPkg.Source = value;
         }
         break;
+      case "F": {
+        // Directory for subsequent R:/M: file-list records, root-relative
+        // like "usr/lib"
+        if (!curPkg) {
+          break;
+        }
+        currentDir = value ? "/" + value : "";
+        if (currentDir && !curPkg.Directories!.includes(currentDir)) {
+          curPkg.Directories!.push(currentDir);
+        }
+        break;
+      }
+      case "R": {
+        // File name relative to the current F: directory
+        if (!curPkg || !currentDir) {
+          break;
+        }
+        curPkg.Files!.push(`${currentDir}/${value}`);
+        break;
+      }
+      case "M": {
+        // Directory metadata for the current F: directory
+        if (!curPkg || !currentDir) {
+          break;
+        }
+        if (!curPkg.Directories!.includes(currentDir)) {
+          curPkg.Directories!.push(currentDir);
+        }
+        break;
+      }
     }
   }
 

--- a/lib/analyzer/package-managers/apk.ts
+++ b/lib/analyzer/package-managers/apk.ts
@@ -75,7 +75,7 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
         }
         break;
       case "F": {
-        // Directory for subsequent R:/M: file-list records, root-relative
+        // Directory for subsequent R: file-list records, root-relative
         // like "usr/lib"
         if (!curPkg) {
           break;
@@ -92,16 +92,6 @@ export function parseFile(text: string): AnalyzedPackageWithVersion[] {
           break;
         }
         curPkg.Files!.push(`${currentDir}/${value}`);
-        break;
-      }
-      case "M": {
-        // Directory metadata for the current F: directory
-        if (!curPkg || !currentDir) {
-          break;
-        }
-        if (!curPkg.Directories!.includes(currentDir)) {
-          curPkg.Directories!.push(currentDir);
-        }
         break;
       }
     }

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -17,6 +17,10 @@ export interface AnalyzedPackage {
   };
   Purl?: string;
   AutoInstalled?: boolean;
+  /** File paths declared by APK installed-db R: records (F:+R:). */
+  Files?: string[];
+  /** Directory paths declared by APK installed-db F: and M: records. */
+  Directories?: string[];
 }
 export interface AnalyzedPackageWithVersion extends AnalyzedPackage {
   Version: string;

--- a/test/unit/apk-file-list.spec.ts
+++ b/test/unit/apk-file-list.spec.ts
@@ -1,0 +1,33 @@
+import * as fs from "fs";
+import * as path from "path";
+import { parseFile } from "../../lib/analyzer/package-managers/apk";
+
+const fixturePath = path.join(
+  __dirname,
+  "../fixtures/os/alpine_3_7_0/fs/lib/apk/db/installed",
+);
+
+describe("apk installed-db file list parsing", () => {
+  it("parses F:/R: file paths for packages", () => {
+    const content = fs.readFileSync(fixturePath, "utf8");
+    const packages = parseFile(content);
+
+    const busybox = packages.find((pkg) => pkg.Name === "busybox");
+    expect(busybox).toBeDefined();
+    expect(busybox!.Files).toEqual(
+      expect.arrayContaining(["/bin/busybox", "/bin/sh", "/etc/securetty"]),
+    );
+    expect(busybox!.Directories).toEqual(
+      expect.arrayContaining(["/bin", "/etc", "/sbin"]),
+    );
+
+    const musl = packages.find((pkg) => pkg.Name === "musl");
+    expect(musl).toBeDefined();
+    expect(musl!.Files).toEqual(
+      expect.arrayContaining([
+        "/lib/libc.musl-x86_64.so.1",
+        "/lib/ld-musl-x86_64.so.1",
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
[CN-1395](https://snyksec.atlassian.net/browse/CN-1395)

**Stack 1/5** — `main` ← **this PR** ← layer symlinks ← ownership library ← ownership fact ← prettyName. Replaces #861 (split per review feedback; see closing comment there for the thread map).

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Parses the `F:`/`R:`/`M:` file-list records of the APK installed database into new optional `Files`/`Directories` fields on `AnalyzedPackage`. Two commits: a behavior-preserving refactor (inline `parseLine` into `parseFile`, typed `curPkg`, null guards), then the new record handling.

**Why:** Chainguard's scanner spec resolves app-dependency ownership by checking that an app's file paths are *wholly contained* in an APK package's declared paths. This PR supplies the "declared paths" side. It is inert on its own — nothing consumes the new fields until the ownership-library PR higher in the stack.

#### Where should the reviewer start?

`lib/analyzer/package-managers/apk.ts`, commit by commit — the refactor commit changes no behavior; the feat commit is only the three new record types and the `currentDir` tracking (a plain string: `F:` lines are full root-relative paths, so there is no push/pop stack semantics).

#### How should this be manually tested?

`npx jest test/unit/apk-file-list.spec.ts` (parses the alpine 3.7 fixture DB and asserts known file/dir paths), plus `npx jest test/system/package-managers/apk.spec.ts` — the full pluginResult snapshots for alpine and chainguard/bash are unchanged, proving the new fields don't leak into existing output.

#### Any background context you want to provide?

Customer escalation: scans of Chainguard images report hundreds of findings for CVEs Chainguard already patched, because app dependencies are matched against generic upstream data with no Chainguard context. The fix (per Chainguard's scanner spec) is an ownership model; this stack implements the plugin side of it.

#### What are the relevant tickets?

CN-1395

#### Screenshots

N/A

#### Additional questions

N/A


[CN-1395]: https://snyksec.atlassian.net/browse/CN-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ