### PR TITLE
feat: cn-1395 capture and merge layer symlinks during extraction

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -171,6 +171,7 @@ export async function analyze(
     manifestLayers,
     extractedLayers,
     orderedLayers,
+    symlinks,
     rootFsLayers,
     autoDetectedUserInstructions,
     platform,
@@ -401,6 +402,7 @@ export async function analyze(
     imageCreationTime,
     containerConfig,
     history,
+    symlinks,
     timings,
   };
 }

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -1,4 +1,5 @@
 import { ImageName } from "../extractor/image";
+import { SymlinkMap } from "../extractor/types";
 import { BaseRuntime } from "../facts";
 import { AutoDetectedUserInstructions, ManifestFile } from "../types";
 import {
@@ -141,6 +142,7 @@ export interface StaticAnalysis {
     comment?: string | null;
     empty_layer?: boolean | null;
   }> | null;
+  symlinks?: SymlinkMap;
   timings?: Record<string, number>;
 }
 

--- a/lib/extractor/generic-archive-extractor.ts
+++ b/lib/extractor/generic-archive-extractor.ts
@@ -15,10 +15,9 @@ export class InvalidArchiveError extends Error {
   }
 }
 import { HashAlgorithm, PluginOptions } from "../types";
-import { extractImageLayer } from "./layer";
+import { extractImageLayer, LayerExtractionResult } from "./layer";
 import {
   ExtractAction,
-  ExtractedLayers,
   ExtractedLayersAndManifest,
   ImageConfig,
   TarArchiveManifest,
@@ -60,7 +59,7 @@ export function createExtractArchive(
   return (archiveFilesystemPath, extractActions, _options) =>
     new Promise((resolve, reject) => {
       const tarExtractor: Extract = extract();
-      const layers: Record<string, ExtractedLayers> = {};
+      const layers: Record<string, LayerExtractionResult> = {};
       let manifest: TarArchiveManifest;
       let imageConfig: ImageConfig;
 
@@ -124,22 +123,23 @@ export function createExtractArchive(
 function assembleLayersAndManifest(
   manifest: TarArchiveManifest,
   imageConfig: ImageConfig,
-  layers: Record<string, ExtractedLayers>,
+  layers: Record<string, LayerExtractionResult>,
 ): ExtractedLayersAndManifest {
   const layersWithNormalizedNames = manifest.Layers.map((layerName) =>
     normalizePath(layerName),
   );
-  const filteredLayers = layersWithNormalizedNames
+  const filteredLayerResults = layersWithNormalizedNames
     .filter((layerName) => layers[layerName])
     .map((layerName) => layers[layerName])
     .reverse();
 
-  if (filteredLayers.length === 0) {
+  if (filteredLayerResults.length === 0) {
     throw new Error("We found no layers in the provided image");
   }
 
   return {
-    layers: filteredLayers,
+    layers: filteredLayerResults.map((r) => r.extractedLayers),
+    symlinkLayers: filteredLayerResults.map((r) => r.symlinks),
     manifest,
     imageConfig,
   };

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -23,6 +23,7 @@ import {
   FileContent,
   ImageConfig,
   OciArchiveManifest,
+  SymlinkMap,
 } from "./types";
 
 const debug = Debug("snyk");
@@ -150,6 +151,10 @@ export async function extractImageContent(
     orderedLayers: isTrue(options?.["layer-attribution"])
       ? [...archiveContent.layers].reverse()
       : undefined,
+    symlinks: symlinksWithLatestModifications(
+      archiveContent.symlinkLayers,
+      archiveContent.layers,
+    ),
     rootFsLayers: getRootFsLayersFromConfig(archiveContent.imageConfig),
     autoDetectedUserInstructions: getDetectedLayersInfoFromConfig(
       archiveContent.imageConfig,
@@ -231,6 +236,62 @@ export function getUserInstructionLayersFromConfig(imageConfig) {
     return [];
   }
   return userInstructionLayers;
+}
+
+/**
+ * Merge per-layer symlink maps into a single view of the running container.
+ * Layers arrive newest-first (see generic-archive / OCI extractors) and the
+ * first layer seen wins, mirroring layersWithLatestFileModifications. A
+ * whiteout entry only hides paths in lower (older) layers; a whiteout and an
+ * entry for the same path may coexist within one layer (e.g. a directory
+ * replaced by a symlink), in which case that layer's own entry survives.
+ */
+export function symlinksWithLatestModifications(
+  symlinkLayers?: SymlinkMap[],
+  fileLayers?: ExtractedLayers[],
+): SymlinkMap | undefined {
+  if (!symlinkLayers || symlinkLayers.length === 0) {
+    return undefined;
+  }
+
+  const merged: SymlinkMap = {};
+  const removedPathsToIgnore: Set<string> = new Set();
+
+  for (let i = 0; i < symlinkLayers.length; i++) {
+    for (const [symlinkPath, target] of Object.entries(symlinkLayers[i])) {
+      if (removedPathsToIgnore.has(symlinkPath)) {
+        continue;
+      }
+      if (isSymlinkInARemovedFolder(symlinkPath, removedPathsToIgnore)) {
+        continue;
+      }
+      if (!Reflect.has(merged, symlinkPath)) {
+        merged[symlinkPath] = target;
+      }
+    }
+
+    // Register this layer's whiteouts only after its own entries are merged:
+    // they delete paths from older layers, not from this layer or newer ones.
+    const fileLayer = fileLayers?.[i];
+    if (fileLayer) {
+      for (const filename of Object.keys(fileLayer)) {
+        if (isWhitedOutFile(filename)) {
+          removedPathsToIgnore.add(filename.replace(/.wh./, ""));
+        }
+      }
+    }
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function isSymlinkInARemovedFolder(
+  symlinkPath: string,
+  removedPathsToIgnore: Set<string>,
+): boolean {
+  return Array.from(removedPathsToIgnore).some((removedPath) =>
+    isFileInFolder(symlinkPath, removedPath),
+  );
 }
 
 function layersWithLatestFileModifications(

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -5,7 +5,7 @@ import { extract, Extract } from "tar-stream";
 import { getErrorMessage } from "../error-utils";
 import { applyCallbacks, isResultEmpty } from "./callbacks";
 import { decompressMaybe } from "./decompress-maybe";
-import { ExtractAction, ExtractedLayers } from "./types";
+import { ExtractAction, ExtractedLayers, SymlinkMap } from "./types";
 
 export function isWhitedOutFile(filename: string) {
   return filename.match(/.wh./gm);
@@ -22,17 +22,34 @@ const debug = Debug("snyk");
  * @param extractActions array of pattern, callbacks pairs
  * @returns extracted file products
  */
+export interface LayerExtractionResult {
+  extractedLayers: ExtractedLayers;
+  symlinks: SymlinkMap;
+}
+
 export async function extractImageLayer(
   layerTarStream: Readable,
   extractActions: ExtractAction[],
-): Promise<ExtractedLayers> {
+): Promise<LayerExtractionResult> {
   return new Promise((resolve, reject) => {
     const result: ExtractedLayers = {};
+    const symlinks: SymlinkMap = {};
     const tarExtractor: Extract = extract();
 
     tarExtractor.on("entry", async (headers, stream, next) => {
-      if (headers.type === "file") {
-        const absoluteFileName = path.join(path.sep, headers.name);
+      const absoluteFileName = path.join(path.sep, headers.name);
+
+      // Symlinks are path redirects; hard links are alternate names for the same
+      // inode and must not be treated as redirects during path canonicalization.
+      if (headers.type === "symlink") {
+        const linkTarget = headers.linkname;
+        if (linkTarget) {
+          symlinks[absoluteFileName] = absoluteLinkTarget(
+            headers.name,
+            linkTarget,
+          );
+        }
+      } else if (headers.type === "file") {
         const matchedActions = extractActions.filter((action) =>
           action.filePathMatches(absoluteFileName),
         );
@@ -70,11 +87,24 @@ export async function extractImageLayer(
 
     tarExtractor.on("finish", () => {
       // all layer level entries read
-      resolve(result);
+      resolve({ extractedLayers: result, symlinks });
     });
 
     tarExtractor.on("error", (error) => reject(error));
 
     layerTarStream.pipe(decompressMaybe()).pipe(tarExtractor);
   });
+}
+
+/**
+ * Resolve a tar symlink target to an absolute path within the image.
+ * A relative target resolves against the symlink's own directory; tar entry
+ * names always use forward slashes, so this is posix math on every platform.
+ */
+function absoluteLinkTarget(entryName: string, linkTarget: string): string {
+  if (linkTarget.startsWith("/")) {
+    return path.posix.normalize(linkTarget);
+  }
+  const linkDir = path.posix.dirname(path.posix.normalize("/" + entryName));
+  return path.posix.normalize(path.posix.join(linkDir, linkTarget));
 }

--- a/lib/extractor/oci-archive/layer.ts
+++ b/lib/extractor/oci-archive/layer.ts
@@ -8,10 +8,12 @@ import { getErrorMessage } from "../../error-utils";
 import { streamToJson } from "../../stream-utils";
 import { PluginOptions } from "../../types";
 import { decompressMaybe } from "../decompress-maybe";
-import { extractImageLayer } from "../layer";
+import {
+  extractImageLayer,
+  LayerExtractionResult as ImageLayerExtractionResult,
+} from "../layer";
 import {
   ExtractAction,
-  ExtractedLayers,
   ExtractedLayersAndManifest,
   ImageConfig,
   OciArchiveManifest,
@@ -80,10 +82,11 @@ export async function extractArchive(
   }
 
   // Build the result
-  const filteredLayers = manifest.layers
+  const filteredLayerResults = manifest.layers
     .filter((layer) => layers[layer.digest])
     .map((layer) => layers[layer.digest])
     .reverse();
+  const filteredLayers = filteredLayerResults.map((r) => r.extractedLayers);
 
   if (filteredLayers.length === 0) {
     // Provide more context about why extraction failed
@@ -113,6 +116,7 @@ export async function extractArchive(
 
   return {
     layers: filteredLayers,
+    symlinkLayers: filteredLayerResults.map((r) => r.symlinks),
     manifest,
     imageConfig,
   };
@@ -263,8 +267,8 @@ async function tryParseJsonMetadata(stream: Readable): Promise<unknown> {
   });
 }
 
-interface LayerExtractionResult {
-  layers: Record<string, ExtractedLayers>;
+interface OciLayerExtractionPassResult {
+  layers: Record<string, ImageLayerExtractionResult>;
   failedDigests: Map<string, string>;
 }
 
@@ -278,10 +282,10 @@ async function extractLayers(
   ociArchiveFilesystemPath: string,
   requiredDigests: Set<string>,
   extractActions: ExtractAction[],
-): Promise<LayerExtractionResult> {
+): Promise<OciLayerExtractionPassResult> {
   return new Promise((resolve, reject) => {
     const tarExtractor: Extract = extract();
-    const layers: Record<string, ExtractedLayers> = {};
+    const layers: Record<string, ImageLayerExtractionResult> = {};
     const failedDigests: Map<string, string> = new Map();
 
     tarExtractor.on("entry", async (header, stream, next) => {

--- a/lib/extractor/types.ts
+++ b/lib/extractor/types.ts
@@ -25,6 +25,8 @@ export interface Extractor {
   ): string[];
 }
 
+export type SymlinkMap = Record<string, string>;
+
 export interface ExtractionResult {
   imageId: string;
   manifestLayers: string[];
@@ -37,6 +39,7 @@ export interface ExtractionResult {
    * Populated only when the `layer-attribution` option is enabled.
    */
   orderedLayers?: ExtractedLayers[];
+  symlinks?: SymlinkMap;
   rootFsLayers?: string[];
   autoDetectedUserInstructions?: AutoDetectedUserInstructions;
   platform?: string;
@@ -66,6 +69,7 @@ export interface KanikoArchiveManifest extends TarArchiveManifest {}
 
 export interface ExtractedLayersAndManifest {
   layers: ExtractedLayers[];
+  symlinkLayers?: SymlinkMap[];
   manifest: TarArchiveManifest | OciArchiveManifest;
   imageConfig: ImageConfig;
 }

--- a/test/lib/extractor/docker-archive-symlinks.spec.ts
+++ b/test/lib/extractor/docker-archive-symlinks.spec.ts
@@ -1,0 +1,150 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as tar from "tar-stream";
+import { extractImageContent } from "../../../lib/extractor";
+import { ImageType } from "../../../lib/types";
+
+interface LayerEntry {
+  name: string;
+  type?: "file" | "symlink" | "link";
+  linkname?: string;
+  content?: string;
+}
+
+const CONFIG_FILE_NAME = `${"a".repeat(64)}.json`;
+
+async function packToBuffer(
+  addEntries: (pack: tar.Pack) => void,
+): Promise<Buffer> {
+  const pack = tar.pack();
+  const chunks: Buffer[] = [];
+  const done = new Promise<Buffer>((resolve, reject) => {
+    pack.on("data", (chunk: Buffer) => chunks.push(chunk));
+    pack.on("end", () => resolve(Buffer.concat(chunks)));
+    pack.on("error", reject);
+  });
+  addEntries(pack);
+  pack.finalize();
+  return done;
+}
+
+function createLayerTarball(entries: LayerEntry[]): Promise<Buffer> {
+  return packToBuffer((pack) => {
+    for (const entry of entries) {
+      if (entry.type === "symlink" || entry.type === "link") {
+        pack.entry({
+          name: entry.name,
+          type: entry.type,
+          linkname: entry.linkname,
+        });
+      } else {
+        pack.entry({ name: entry.name, type: "file" }, entry.content ?? "");
+      }
+    }
+  });
+}
+
+/**
+ * Builds a minimal docker-archive tar in memory: manifest.json, a config
+ * file, and one tarball per layer. Layers are given base-first, matching
+ * the order of manifest.json's Layers field in a real docker save archive.
+ */
+async function createTestDockerArchive(
+  layers: LayerEntry[][],
+): Promise<string> {
+  const layerTarballs = await Promise.all(layers.map(createLayerTarball));
+  const layerNames = layers.map((_, i) => `layer${i}.tar`);
+  const manifest = [
+    { Config: CONFIG_FILE_NAME, RepoTags: [], Layers: layerNames },
+  ];
+  const config = {
+    rootfs: {
+      type: "layers",
+      diff_ids: layers.map((_, i) => `sha256:${"b".repeat(63)}${i}`),
+    },
+  };
+
+  const archive = await packToBuffer((pack) => {
+    pack.entry({ name: "manifest.json" }, JSON.stringify(manifest));
+    pack.entry({ name: CONFIG_FILE_NAME }, JSON.stringify(config));
+    layerTarballs.forEach((tarball, i) => {
+      pack.entry({ name: layerNames[i] }, tarball);
+    });
+  });
+
+  const archivePath = path.join(tempDir, `test-image-${Date.now()}.tar`);
+  fs.writeFileSync(archivePath, archive);
+  return archivePath;
+}
+
+let tempDir: string;
+
+describe("docker-archive symlink extraction across layers", () => {
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "docker-archive-test-"));
+  });
+
+  afterAll(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the upper layer's symlink when it replaces a base-layer symlink", async () => {
+    const archivePath = await createTestDockerArchive([
+      // base layer
+      [{ name: "bin", type: "symlink", linkname: "usr/old-bin" }],
+      // upper layer
+      [{ name: "bin", type: "symlink", linkname: "usr/new-bin" }],
+    ]);
+
+    const result = await extractImageContent(
+      ImageType.DockerArchive,
+      archivePath,
+      [],
+      {},
+    );
+
+    expect(result.symlinks).toEqual({ "/bin": "/usr/new-bin" });
+  });
+
+  it("drops a base-layer symlink deleted by an upper-layer whiteout", async () => {
+    const archivePath = await createTestDockerArchive([
+      // base layer
+      [
+        { name: "bin", type: "symlink", linkname: "usr/bin" },
+        { name: "lib", type: "symlink", linkname: "usr/lib" },
+      ],
+      // upper layer deletes /bin
+      [{ name: ".wh.bin", type: "file" }],
+    ]);
+
+    const result = await extractImageContent(
+      ImageType.DockerArchive,
+      archivePath,
+      [],
+      {},
+    );
+
+    expect(result.symlinks).toEqual({ "/lib": "/usr/lib" });
+  });
+
+  it("keeps a base-layer symlink untouched by upper layers", async () => {
+    const archivePath = await createTestDockerArchive([
+      // base layer
+      [{ name: "lib", type: "symlink", linkname: "usr/lib" }],
+      // upper layer adds an unrelated file
+      [{ name: "etc/hostname", type: "file", content: "myhost\n" }],
+    ]);
+
+    const result = await extractImageContent(
+      ImageType.DockerArchive,
+      archivePath,
+      [],
+      {},
+    );
+
+    expect(result.symlinks).toEqual({ "/lib": "/usr/lib" });
+  });
+});

--- a/test/lib/extractor/layer.spec.ts
+++ b/test/lib/extractor/layer.spec.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as tar from "tar-stream";
 import { extractImageLayer } from "../../../lib/extractor/layer";
 import { ExtractAction } from "../../../lib/extractor/types";
 import { getGoModulesContentAction } from "../../../lib/go-parser";
@@ -14,7 +15,7 @@ describe("layer extractor: layer contain bad elf file", () => {
       getFixture("extracted-layers/layer_with_bad_elf_file.tar"),
     );
     const p = extractImageLayer(stream, staticAnalysisActions);
-    expect(p).toMatchObject({});
+    expect(p).resolves.toMatchObject({ extractedLayers: {}, symlinks: {} });
   });
 });
 
@@ -26,6 +27,44 @@ describe("layer extractor: layer contain cgo compiled go file", () => {
       getFixture("extracted-layers/cgo-compiled-file.tar"),
     );
     const p = extractImageLayer(stream, staticAnalysisActions);
-    expect(p).toMatchObject({});
+    expect(p).resolves.toMatchObject({ extractedLayers: {}, symlinks: {} });
+  });
+});
+
+describe("layer extractor: symlink capture", () => {
+  it("records symlinks with absolute targets and ignores other entry types", async () => {
+    const pack = tar.pack();
+    // relative target resolves against the symlink's own directory
+    pack.entry({
+      name: "usr/bin/python3",
+      type: "symlink",
+      linkname: "python3.12",
+    });
+    // ".." segments in relative targets resolve too
+    pack.entry({
+      name: "usr/lib/libfoo.so",
+      type: "symlink",
+      linkname: "../share/foo/libfoo.so",
+    });
+    // absolute targets are stored normalized
+    pack.entry({ name: "bin", type: "symlink", linkname: "/usr//bin" });
+    // hard links are alternate names for the same inode, not redirects
+    pack.entry({
+      name: "usr/bin/[",
+      type: "link",
+      linkname: "usr/bin/busybox",
+    });
+    // regular files are not symlinks
+    pack.entry({ name: "etc/hostname", type: "file" }, "myhost\n");
+    pack.finalize();
+
+    const { symlinks } = await extractImageLayer(pack, []);
+
+    expect(symlinks).toEqual({
+      [path.join(path.sep, "usr", "bin", "python3")]: "/usr/bin/python3.12",
+      [path.join(path.sep, "usr", "lib", "libfoo.so")]:
+        "/usr/share/foo/libfoo.so",
+      [path.join(path.sep, "bin")]: "/usr/bin",
+    });
   });
 });

--- a/test/lib/extractor/symlink-merge.spec.ts
+++ b/test/lib/extractor/symlink-merge.spec.ts
@@ -1,0 +1,104 @@
+import { symlinksWithLatestModifications } from "../../../lib/extractor";
+import { ExtractedLayers, SymlinkMap } from "../../../lib/extractor/types";
+
+describe("symlinksWithLatestModifications", () => {
+  it("uses the newest layer when the same path appears in multiple layers", () => {
+    const symlinkLayers: SymlinkMap[] = [
+      { "/bin": "usr/local/bin" },
+      { "/bin": "usr/bin" },
+    ];
+
+    expect(symlinksWithLatestModifications(symlinkLayers, [{}, {}])).toEqual({
+      "/bin": "usr/local/bin",
+    });
+  });
+
+  it("merges symlinks from all layers when there is no conflict", () => {
+    const symlinkLayers: SymlinkMap[] = [
+      { "/bin": "usr/bin" },
+      { "/lib": "usr/lib" },
+      { "/etc": "usr/etc" },
+    ];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, [{}, {}, {}]),
+    ).toEqual({
+      "/bin": "usr/bin",
+      "/lib": "usr/lib",
+      "/etc": "usr/etc",
+    });
+  });
+
+  it("removes a symlink when a newer layer whiteouts the path", () => {
+    const symlinkLayers: SymlinkMap[] = [{}, { "/bin": "usr/bin" }];
+    const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, fileLayers),
+    ).toBeUndefined();
+  });
+
+  it("does not re-add a whiteouted symlink from an older layer", () => {
+    const symlinkLayers: SymlinkMap[] = [
+      {},
+      { "/bin": "usr/bin" },
+      { "/bin": "usr/old/bin" },
+    ];
+    const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}, {}];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, fileLayers),
+    ).toBeUndefined();
+  });
+
+  it("keeps a symlink re-created in a newer layer after an older layer deleted it", () => {
+    // Newest layer re-creates /bin after the middle layer deleted it; the
+    // middle layer's whiteout must only hide the oldest layer's symlink.
+    const symlinkLayers: SymlinkMap[] = [
+      { "/bin": "usr/bin" },
+      {},
+      { "/bin": "usr/old/bin" },
+    ];
+    const fileLayers: ExtractedLayers[] = [{}, { "/.wh.bin": {} }, {}];
+
+    expect(symlinksWithLatestModifications(symlinkLayers, fileLayers)).toEqual({
+      "/bin": "usr/bin",
+    });
+  });
+
+  it("keeps a symlink created in the same layer that whiteouts the path", () => {
+    // usrmerge pattern: one layer deletes the /bin directory and creates the
+    // /bin symlink; per the OCI spec a whiteout only hides lower layers.
+    const symlinkLayers: SymlinkMap[] = [
+      { "/bin": "usr/bin" },
+      { "/bin": "old/bin" },
+    ];
+    const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}];
+
+    expect(symlinksWithLatestModifications(symlinkLayers, fileLayers)).toEqual({
+      "/bin": "usr/bin",
+    });
+  });
+
+  it("keeps a base-layer symlink untouched by newer layers", () => {
+    const symlinkLayers: SymlinkMap[] = [{}, {}, { "/lib": "usr/lib" }];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, [{}, {}, {}]),
+    ).toEqual({
+      "/lib": "usr/lib",
+    });
+  });
+
+  it("removes symlinks under a folder whited out by a newer layer", () => {
+    const symlinkLayers: SymlinkMap[] = [
+      {},
+      { "/opt/app/current": "releases/1" },
+    ];
+    const fileLayers: ExtractedLayers[] = [{ "/.wh.opt": {} }, {}];
+
+    expect(
+      symlinksWithLatestModifications(symlinkLayers, fileLayers),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
[CN-1395](https://snyksec.atlassian.net/browse/CN-1395)

**Stack 2/5** — `main` ← apk file lists ← **this PR** ← ownership library ← ownership fact ← prettyName. Replaces the extractor portion of #861.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Records every symlink while the extractor streams each layer's tar entries, and merges the per-layer maps into a single view of the running container, exposed as `ExtractionResult.symlinks` → `StaticAnalysis.symlinks`.

**Why:** Chainguard images are usr-merged — the APK database declares `/usr/bin/node` while app evidence may say `/bin/node`, because `/bin → usr/bin` is a symlink. Ownership resolution (next PR in the stack) needs the image's symlink map to canonicalize both sides to the same form.

Design decisions, each from #861 review feedback:

- **Hard links are excluded** ([thread](https://github.com/snyk/snyk-docker-plugin/pull/861#discussion_r3390090719)): a hard link is an alternate name for the same inode, not a redirect — both names are real files and both appear in APK file lists, so they don't belong in a redirect map. Symlink targets are resolved to **absolute image paths at extraction time**, while the entry type and its directory are still known (relative targets resolve against the link's own directory; tar names are always forward-slash, so this is posix math on every platform).
- **Merge semantics mirror `layersWithLatestFileModifications`** ([thread](https://github.com/snyk/snyk-docker-plugin/pull/861#discussion_r3389610095)): layers arrive newest-first, first-seen wins. A whiteout hides paths only in *lower* (older) layers per the OCI spec — so a symlink re-created above a deletion survives, and a layer that whiteouts a directory while creating a symlink at the same path (the usrmerge pattern, exactly the `/bin → usr/bin` case this feature exists for) keeps its own symlink. A separate merge (rather than riding through `ExtractedLayers`) is deliberate: that structure only records files matching extract-action patterns, while symlinks must be collected for every path, and `getContent()` iterates all of its keys.

#### Where should the reviewer start?

`lib/extractor/layer.ts` (capture + `absoluteLinkTarget`), then `symlinksWithLatestModifications` in `lib/extractor/index.ts` (merge semantics). The rest is plumbing the per-layer maps through both archive extractors.

#### How should this be manually tested?

`npx jest test/lib/extractor/` — includes in-memory merge tests for replace/delete/re-create/same-layer-whiteout/folder-whiteout, an in-memory tar test for capture (absolute targets, hard links ignored), and synthetic two-layer docker-archive tests asserting the merged map end to end.

#### Any background context you want to provide?

Nothing consumes `StaticAnalysis.symlinks` until the ownership-fact PR higher in the stack; existing output (including all snapshots) is unchanged.

#### What are the relevant tickets?

CN-1395

#### Screenshots

N/A

#### Additional questions

N/A


[CN-1395]: https://snyksec.atlassian.net/browse/CN-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ