### PR TITLE
feat: cn-1395 add apk ownership resolution library

### DIFF
--- a/lib/analyzer/applications/evidence-paths.ts
+++ b/lib/analyzer/applications/evidence-paths.ts
@@ -1,0 +1,33 @@
+import { JarFingerprintsFact, TestedFilesFact } from "../../facts";
+import { AppDepsScanResultWithoutTarget } from "./types";
+
+/** Collect filesystem paths from an app scan result used to resolve APK ownership. */
+export function extractEvidencePaths(
+  scanResult: AppDepsScanResultWithoutTarget,
+): string[] {
+  const paths = new Set<string>();
+
+  if (scanResult.identity.targetFile) {
+    paths.add(scanResult.identity.targetFile);
+  }
+
+  for (const fact of scanResult.facts) {
+    if (fact.type === "testedFiles") {
+      const testedFilesFact = fact as TestedFilesFact;
+      for (const filePath of testedFilesFact.data) {
+        paths.add(filePath);
+      }
+    }
+
+    if (fact.type === "jarFingerprints") {
+      const jarFact = fact as JarFingerprintsFact;
+      for (const fingerprint of jarFact.data.fingerprints) {
+        if (fingerprint.location) {
+          paths.add(fingerprint.location);
+        }
+      }
+    }
+  }
+
+  return [...paths];
+}

--- a/lib/analyzer/package-managers/apk-ownership.ts
+++ b/lib/analyzer/package-managers/apk-ownership.ts
@@ -1,0 +1,263 @@
+import * as Debug from "debug";
+import { SymlinkMap } from "../../extractor/types";
+import {
+  AnalysisType,
+  AnalyzedPackageWithVersion,
+  ImageAnalysis,
+  ImagePackagesAnalysis,
+  OSRelease,
+} from "../types";
+import {
+  canonicalizePath,
+  normalizeAbsolutePath,
+  SymlinkGraph,
+} from "./path-canonicalization";
+
+export interface ApkPackageOwnership {
+  distroId: string;
+  packageName: string;
+  packageVersion: string;
+  originPackage: string;
+  evidencePaths: string[];
+}
+
+export type MatchKind = "exact" | "directory";
+
+export interface PathOwnerMatch {
+  owner: AnalyzedPackageWithVersion;
+  matchKind: MatchKind;
+  /** Number of matched path segments; a deeper directory match outranks a shallower one. */
+  prefixLength: number;
+}
+
+interface DirectoryTrieNode {
+  owners: AnalyzedPackageWithVersion[];
+  children: Map<string, DirectoryTrieNode>;
+}
+
+export interface ApkPathIndex {
+  exactFileOwners: Map<string, AnalyzedPackageWithVersion[]>;
+  directoryTrie: DirectoryTrieNode;
+}
+
+const debug = Debug("snyk");
+
+const CHAINGUARD_DISTROS = new Set(["wolfi", "chainguard"]);
+
+export function isChainguardDistro(osRelease: OSRelease): boolean {
+  return CHAINGUARD_DISTROS.has(osRelease.name);
+}
+
+export function toSymlinkGraph(symlinks?: SymlinkMap): SymlinkGraph {
+  const graph: SymlinkGraph = new Map();
+  if (!symlinks) {
+    return graph;
+  }
+  for (const [symlinkPath, target] of Object.entries(symlinks)) {
+    graph.set(normalizeAbsolutePath(symlinkPath), target);
+  }
+  return graph;
+}
+
+export function buildApkPathIndex(
+  packages: AnalyzedPackageWithVersion[],
+  symlinkGraph: SymlinkGraph,
+): ApkPathIndex {
+  const exactFileOwners = new Map<string, AnalyzedPackageWithVersion[]>();
+  const directoryTrie: DirectoryTrieNode = { owners: [], children: new Map() };
+
+  for (const pkg of packages) {
+    for (const filePath of pkg.Files ?? []) {
+      const canonical = canonicalizePath(filePath, symlinkGraph);
+      addToOwnerMap(exactFileOwners, canonical, pkg);
+    }
+
+    for (const dirPath of pkg.Directories ?? []) {
+      const canonical = canonicalizePath(dirPath, symlinkGraph);
+      insertDirectoryOwner(directoryTrie, canonical, pkg);
+    }
+  }
+
+  return { exactFileOwners, directoryTrie };
+}
+
+export function resolveOwnerForEvidencePath(
+  evidencePath: string,
+  index: ApkPathIndex,
+  symlinkGraph: SymlinkGraph,
+): PathOwnerMatch | undefined {
+  const canonical = canonicalizePath(evidencePath, symlinkGraph);
+  const exactOwners = index.exactFileOwners.get(canonical);
+  if (exactOwners && exactOwners.length > 0) {
+    return {
+      owner: pickExactOwner(exactOwners),
+      matchKind: "exact",
+      prefixLength: canonical.split("/").filter(Boolean).length,
+    };
+  }
+
+  return resolveDirectoryOwner(canonical, index);
+}
+
+function resolveDirectoryOwner(
+  canonicalPath: string,
+  index: ApkPathIndex,
+): PathOwnerMatch | undefined {
+  const segments = canonicalPath.split("/").filter(Boolean);
+  let node = index.directoryTrie;
+  let best: PathOwnerMatch | undefined;
+
+  for (let i = 0; i < segments.length; i++) {
+    const child = node.children.get(segments[i]);
+    if (!child) {
+      break;
+    }
+    node = child;
+    if (node.owners.length > 0) {
+      best = {
+        owner: pickExactOwner(node.owners),
+        matchKind: "directory",
+        prefixLength: i + 1,
+      };
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Resolve APK package ownership for app evidence paths on Wolfi/Chainguard images.
+ *
+ * Per Chainguard's scanner spec, an app dependency is owned by an APK package
+ * only when its evidence paths are wholly contained in that package's declared
+ * paths; a dependency with any unowned path is not covered by Chainguard's
+ * advisory data and must keep its findings. This fact drives downstream
+ * suppression, so we skip it rather than guess and risk suppressing real
+ * vulnerabilities in user-added software.
+ * https://github.com/chainguard-dev/vulnerability-scanner-support/blob/main/docs/scanning_implementation.md
+ */
+export function resolveApkOwnership(
+  evidencePaths: string[],
+  packages: AnalyzedPackageWithVersion[],
+  osRelease: OSRelease,
+  symlinkGraph: SymlinkGraph,
+): ApkPackageOwnership | undefined {
+  if (!isChainguardDistro(osRelease) || evidencePaths.length === 0) {
+    return undefined;
+  }
+
+  const index = buildApkPathIndex(packages, symlinkGraph);
+  const perPathMatches: PathOwnerMatch[] = [];
+
+  for (const evidencePath of evidencePaths) {
+    const normalized = normalizeAbsolutePath(evidencePath);
+    const match = resolveOwnerForEvidencePath(normalized, index, symlinkGraph);
+    if (!match) {
+      debug(
+        `apk ownership skipped: no owning package for evidence path ${normalized}`,
+      );
+      return undefined;
+    }
+    perPathMatches.push(match);
+  }
+
+  const owner = pickConsistentOwner(perPathMatches);
+  if (!owner) {
+    return undefined;
+  }
+
+  return {
+    distroId: osRelease.name,
+    packageName: owner.Name,
+    packageVersion: owner.Version,
+    originPackage: owner.Source ?? owner.Name,
+    evidencePaths,
+  };
+}
+
+function ownerKey(pkg: AnalyzedPackageWithVersion): string {
+  return `${pkg.Name}@${pkg.Version}`;
+}
+
+function pickConsistentOwner(
+  matches: PathOwnerMatch[],
+): AnalyzedPackageWithVersion | undefined {
+  return uniqueOwner(matches) ?? pickBestOwnerAcrossPaths(matches);
+}
+
+/**
+ * When evidence paths disagree on an owner, an owner backed by an exact file
+ * match outranks owners only inferred from a parent directory; among
+ * directory-only matches, the deepest prefix wins. Evidence that is still
+ * split between owners yields no owner.
+ */
+function pickBestOwnerAcrossPaths(
+  matches: PathOwnerMatch[],
+): AnalyzedPackageWithVersion | undefined {
+  const exactMatches = matches.filter((m) => m.matchKind === "exact");
+  if (exactMatches.length > 0) {
+    return uniqueOwner(exactMatches);
+  }
+
+  const deepest = Math.max(...matches.map((m) => m.prefixLength));
+  return uniqueOwner(matches.filter((m) => m.prefixLength === deepest));
+}
+
+function uniqueOwner(
+  matches: PathOwnerMatch[],
+): AnalyzedPackageWithVersion | undefined {
+  const first = matches[0].owner;
+  return matches.every((m) => ownerKey(m.owner) === ownerKey(first))
+    ? first
+    : undefined;
+}
+
+function pickExactOwner(
+  owners: AnalyzedPackageWithVersion[],
+): AnalyzedPackageWithVersion {
+  if (owners.length === 1) {
+    return owners[0];
+  }
+  const originMatch = owners.find((o) => o.Name === o.Source);
+  return originMatch ?? owners[0];
+}
+
+function addToOwnerMap(
+  map: Map<string, AnalyzedPackageWithVersion[]>,
+  canonicalPath: string,
+  pkg: AnalyzedPackageWithVersion,
+): void {
+  const existing = map.get(canonicalPath) ?? [];
+  existing.push(pkg);
+  map.set(canonicalPath, existing);
+}
+
+function insertDirectoryOwner(
+  root: DirectoryTrieNode,
+  dirPath: string,
+  pkg: AnalyzedPackageWithVersion,
+): void {
+  const segments = dirPath.split("/").filter(Boolean);
+  let node = root;
+  for (const segment of segments) {
+    let child = node.children.get(segment);
+    if (!child) {
+      child = { owners: [], children: new Map() };
+      node.children.set(segment, child);
+    }
+    node = child;
+  }
+  node.owners.push(pkg);
+}
+
+export function getApkPackagesFromResults(
+  results?: ImageAnalysis[],
+): AnalyzedPackageWithVersion[] {
+  if (!results) {
+    return [];
+  }
+  const apkResult = results.find((r) => r.AnalyzeType === AnalysisType.Apk) as
+    | ImagePackagesAnalysis
+    | undefined;
+  return apkResult?.Analysis ?? [];
+}

--- a/lib/analyzer/package-managers/path-canonicalization.ts
+++ b/lib/analyzer/package-managers/path-canonicalization.ts
@@ -1,0 +1,76 @@
+import { posix as path } from "path";
+
+export type SymlinkGraph = Map<string, string>;
+
+const MAX_SYMLINK_DEPTH = 40;
+
+/**
+ * Normalize a filesystem path to a POSIX absolute path without resolving symlinks.
+ */
+export function normalizeAbsolutePath(filePath: string): string {
+  const normalized = path.normalize(filePath.replace(/\\/g, "/"));
+  return normalized.startsWith("/") ? normalized : `/${normalized}`;
+}
+
+/**
+ * Resolve symlinks in a path using the extracted image symlink graph.
+ * Used so evidence paths like /bin/node match APK file lists recorded at /usr/bin/node.
+ */
+export function canonicalizePath(
+  filePath: string,
+  symlinkGraph: SymlinkGraph,
+): string {
+  const normalized = normalizeAbsolutePath(filePath);
+  const segments = normalized.split("/").filter(Boolean);
+  const resolvedSegments: string[] = [];
+
+  for (const segment of segments) {
+    resolvedSegments.push(segment);
+    const currentPath = `/${resolvedSegments.join("/")}`;
+    const linkTarget = symlinkGraph.get(currentPath);
+    if (!linkTarget) {
+      continue;
+    }
+
+    const resolvedTarget = resolveSymlinkChain(
+      normalizeSymlinkTarget(currentPath, linkTarget),
+      symlinkGraph,
+    );
+    const targetSegments = resolvedTarget.split("/").filter(Boolean);
+    resolvedSegments.length = 0;
+    resolvedSegments.push(...targetSegments);
+  }
+
+  return resolvedSegments.length === 0 ? "/" : `/${resolvedSegments.join("/")}`;
+}
+
+function normalizeSymlinkTarget(basePath: string, linkTarget: string): string {
+  const target = linkTarget.replace(/\\/g, "/");
+  if (target.startsWith("/")) {
+    return path.normalize(target);
+  }
+  const baseDir = path.dirname(basePath);
+  return path.normalize(path.join(baseDir, target));
+}
+
+function resolveSymlinkChain(
+  filePath: string,
+  symlinkGraph: SymlinkGraph,
+): string {
+  let current = normalizeAbsolutePath(filePath);
+  const visited = new Set<string>();
+
+  for (let depth = 0; depth < MAX_SYMLINK_DEPTH; depth++) {
+    const linkTarget = symlinkGraph.get(current);
+    if (!linkTarget) {
+      return current;
+    }
+    if (visited.has(current)) {
+      return current;
+    }
+    visited.add(current);
+    current = normalizeSymlinkTarget(current, linkTarget);
+  }
+
+  return current;
+}

--- a/test/unit/apk-ownership.spec.ts
+++ b/test/unit/apk-ownership.spec.ts
@@ -1,0 +1,225 @@
+import {
+  buildApkPathIndex,
+  resolveApkOwnership,
+  resolveOwnerForEvidencePath,
+} from "../../lib/analyzer/package-managers/apk-ownership";
+import { canonicalizePath } from "../../lib/analyzer/package-managers/path-canonicalization";
+import { AnalyzedPackageWithVersion } from "../../lib/analyzer/types";
+
+function makePackage(
+  name: string,
+  version: string,
+  origin: string,
+  files: string[],
+  directories: string[],
+): AnalyzedPackageWithVersion {
+  return {
+    Name: name,
+    Version: version,
+    Source: origin,
+    Provides: [],
+    Deps: {},
+    Files: files,
+    Directories: directories,
+  };
+}
+
+describe("apk-ownership", () => {
+  const symlinkGraph = new Map<string, string>([["/bin", "usr/bin"]]);
+
+  it("resolves exact file owners via O(1) lookup", () => {
+    const packages = [
+      makePackage("git", "2.43-r1", "git", ["/usr/bin/git"], ["/usr/bin"]),
+      makePackage("git-base", "2.43-r1", "git", [], ["/usr", "/usr/bin"]),
+    ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
+
+    const match = resolveOwnerForEvidencePath(
+      "/usr/bin/git",
+      index,
+      symlinkGraph,
+    );
+    expect(match?.owner.Name).toBe("git");
+    expect(match?.matchKind).toBe("exact");
+  });
+
+  it("canonicalizes evidence paths before matching APK file owners", () => {
+    const packages = [
+      makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/bin/node"],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toEqual({
+      distroId: "wolfi",
+      packageName: "nodejs",
+      packageVersion: "20-r1",
+      originPackage: "nodejs",
+      evidencePaths: ["/bin/node"],
+    });
+  });
+
+  it("returns undefined when evidence is not owned by any APK package", () => {
+    const packages = [
+      makePackage("bash", "5.2-r1", "bash", ["/bin/bash"], ["/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/opt/custom/app"],
+      packages,
+      { name: "chainguard", version: "20230214", prettyName: "Chainguard" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("does not run ownership resolution for non-Chainguard distros", () => {
+    const packages = [
+      makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/usr/bin/node"],
+      packages,
+      { name: "alpine", version: "3.19", prettyName: "Alpine" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("uses directory prefix only when exact file match is unavailable", () => {
+    const packages = [
+      makePackage("git-base", "2.43-r1", "git", [], ["/usr", "/usr/libexec"]),
+      makePackage(
+        "git",
+        "2.43-r1",
+        "git",
+        ["/usr/libexec/git-core/git"],
+        ["/usr/libexec"],
+      ),
+    ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
+    const exact = resolveOwnerForEvidencePath(
+      "/usr/libexec/git-core/git",
+      index,
+      symlinkGraph,
+    );
+    expect(exact?.owner.Name).toBe("git");
+    expect(exact?.matchKind).toBe("exact");
+  });
+
+  it("returns undefined when only some evidence paths are owned", () => {
+    // Chainguard spec: evidence paths must be wholly contained in the owning
+    // package's declared paths; a partially-owned app keeps its findings.
+    const packages = [
+      makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/usr/bin/node", "/opt/custom/app.jar"],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("prefers an exactly matched owner over a directory-matched owner", () => {
+    const packages = [
+      makePackage(
+        "gradle",
+        "8.5-r0",
+        "gradle",
+        ["/usr/share/java/gradle/lib/gradle.jar"],
+        ["/usr/share/java/gradle"],
+      ),
+      makePackage(
+        "java-common",
+        "1-r0",
+        "java-common",
+        [],
+        ["/usr/share/java"],
+      ),
+    ];
+    const ownership = resolveApkOwnership(
+      [
+        "/usr/share/java/gradle/lib/gradle.jar", // exact: gradle
+        "/usr/share/java/other.jar", // directory: java-common
+      ],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership?.packageName).toBe("gradle");
+  });
+
+  it("returns undefined when different owners each have exact matches", () => {
+    const packages = [
+      makePackage("pkg-a", "1-r0", "pkg-a", ["/usr/bin/a"], ["/usr/bin"]),
+      makePackage("pkg-b", "1-r0", "pkg-b", ["/usr/bin/some-b"], ["/usr/bin"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/usr/bin/a", "/usr/bin/some-b"],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("prefers the deepest directory match when no exact matches exist", () => {
+    const packages = [
+      makePackage("python", "3.12-r1", "python", [], ["/usr/lib/python3.12"]),
+      makePackage(
+        "py-foo",
+        "1.0-r0",
+        "py-foo",
+        [],
+        ["/usr/lib/python3.12/site-packages/foo"],
+      ),
+    ];
+    const ownership = resolveApkOwnership(
+      [
+        "/usr/lib/python3.12/site-packages/foo/mod.py", // directory: py-foo (deeper)
+        "/usr/lib/python3.12/abc.py", // directory: python (shallower)
+      ],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership?.packageName).toBe("py-foo");
+  });
+
+  it("returns undefined for a directory-depth tie between different owners", () => {
+    const packages = [
+      makePackage("pkg-a", "1-r0", "pkg-a", [], ["/usr/lib/a"]),
+      makePackage("pkg-b", "1-r0", "pkg-b", [], ["/usr/lib/b"]),
+    ];
+    const ownership = resolveApkOwnership(
+      ["/usr/lib/a/x.so", "/usr/lib/b/y.so"],
+      packages,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      symlinkGraph,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("canonicalizes APK declared paths consistently", () => {
+    const packages = [
+      makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], []),
+    ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
+    const canonicalApkPath = canonicalizePath("/usr/bin/node", symlinkGraph);
+    expect(index.exactFileOwners.get(canonicalApkPath)?.[0].Name).toBe(
+      "nodejs",
+    );
+  });
+});

--- a/test/unit/evidence-paths.spec.ts
+++ b/test/unit/evidence-paths.spec.ts
@@ -1,0 +1,29 @@
+import { extractEvidencePaths } from "../../lib/analyzer/applications/evidence-paths";
+import { AppDepsScanResultWithoutTarget } from "../../lib/analyzer/applications/types";
+
+describe("evidence-paths", () => {
+  it("collects targetFile, testedFiles, and jar fingerprint locations", () => {
+    const scanResult: AppDepsScanResultWithoutTarget = {
+      identity: { type: "npm", targetFile: "/app/package.json" },
+      facts: [
+        { type: "testedFiles", data: ["package-lock.json"] },
+        {
+          type: "jarFingerprints",
+          data: {
+            origin: "image",
+            path: "/app/lib",
+            fingerprints: [{ location: "/app/lib/foo.jar" } as any],
+          },
+        },
+      ],
+    };
+
+    expect(extractEvidencePaths(scanResult)).toEqual(
+      expect.arrayContaining([
+        "/app/package.json",
+        "package-lock.json",
+        "/app/lib/foo.jar",
+      ]),
+    );
+  });
+});

--- a/test/unit/path-canonicalization.spec.ts
+++ b/test/unit/path-canonicalization.spec.ts
@@ -1,0 +1,30 @@
+import {
+  canonicalizePath,
+  normalizeAbsolutePath,
+} from "../../lib/analyzer/package-managers/path-canonicalization";
+
+describe("path-canonicalization", () => {
+  it("normalizes paths to POSIX absolute form", () => {
+    expect(normalizeAbsolutePath("usr/bin/node")).toBe("/usr/bin/node");
+    expect(normalizeAbsolutePath("/bin/node")).toBe("/bin/node");
+  });
+
+  it("resolves symlinks when canonicalizing evidence paths", () => {
+    const symlinkGraph = new Map<string, string>([
+      ["/bin", "usr/bin"],
+      ["/lib", "usr/lib"],
+    ]);
+
+    expect(canonicalizePath("/bin/node", symlinkGraph)).toBe("/usr/bin/node");
+    expect(canonicalizePath("/lib/libc.so", symlinkGraph)).toBe(
+      "/usr/lib/libc.so",
+    );
+  });
+
+  it("returns the original path when no symlink exists", () => {
+    const symlinkGraph = new Map<string, string>();
+    expect(canonicalizePath("/opt/app/binary", symlinkGraph)).toBe(
+      "/opt/app/binary",
+    );
+  });
+});


### PR DESCRIPTION
[CN-1395](https://snyksec.atlassian.net/browse/CN-1395)

**Stack 3/5** — `main` ← apk file lists ← layer symlinks ← **this PR** ← ownership fact ← prettyName. Replaces the ownership-model portion of #861.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds the ownership resolution library — three new files, nothing wired in yet:

- `lib/analyzer/applications/evidence-paths.ts` — collects an app scan result's filesystem evidence: `identity.targetFile`, `testedFiles` facts, jar fingerprint locations.
- `lib/analyzer/package-managers/path-canonicalization.ts` — resolves paths through the image symlink map (chains, cycles, relative targets) so `/bin/node` matches APK records at `/usr/bin/node` on usr-merged images.
- `lib/analyzer/package-managers/apk-ownership.ts` — indexes APK `Files`/`Directories` (exact-file map + directory trie) and resolves which package owns a set of evidence paths.

**Why the rules are what they are:**

- **All-or-nothing containment** ([thread](https://github.com/snyk/snyk-docker-plugin/pull/861#discussion_r3389057732)): per [Chainguard's scanner spec](https://github.com/chainguard-dev/vulnerability-scanner-support/blob/main/docs/scanning_implementation.md), evidence paths must be *wholly contained* in the owning package's declared paths, and unowned dependencies "should be included in the final scan result". The result drives downstream finding **suppression**, so a partially-owned app (e.g. one jar apk-managed, one COPY'd in by the user) must keep its findings — guessing would hide real vulnerabilities in user-added software. Skipped paths are debug-logged.
- **Explicit disagreement rules** ([thread](https://github.com/snyk/snyk-docker-plugin/pull/861#discussion_r3389071739)): when evidence paths point at different packages, an owner backed by an exact file match outranks owners inferred from a parent directory; among directory-only matches the deepest prefix wins; still-split evidence yields no owner. (This replaces an earlier score-based tiebreak with a magic exact-match bonus.)

#### Where should the reviewer start?

`apk-ownership.ts` top to bottom — `buildApkPathIndex`, `resolveOwnerForEvidencePath`, then `resolveApkOwnership` and the selection helpers. Then `canonicalizePath` in `path-canonicalization.ts`.

#### How should this be manually tested?

`npx jest test/unit/apk-ownership.spec.ts test/unit/path-canonicalization.spec.ts test/unit/evidence-paths.spec.ts` — covers exact/directory resolution, symlink canonicalization, partial-match refusal, exact-over-directory preference, split exact matches, depth ties.

#### Any background context you want to provide?

Inert until the next PR wires it into `buildResponse`. Only consumes types introduced lower in the stack (`Files`/`Directories`, `SymlinkMap`).

#### What are the relevant tickets?

CN-1395

#### Screenshots

N/A

#### Additional questions

N/A


[CN-1395]: https://snyksec.atlassian.net/browse/CN-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ