### PR TITLE
feat: cn-1395 emit apkPackageOwnership fact for chainguard images

### DIFF
--- a/lib/analyzer/applications/evidence-paths.ts
+++ b/lib/analyzer/applications/evidence-paths.ts
@@ -1,3 +1,4 @@
+import { posix as path } from "path";
 import { JarFingerprintsFact, TestedFilesFact } from "../../facts";
 import { AppDepsScanResultWithoutTarget } from "./types";
 
@@ -7,15 +8,36 @@ export function extractEvidencePaths(
 ): string[] {
   const paths = new Set<string>();
 
+  // Some analyzers emit testedFiles as bare basenames (e.g. "composer.json").
+  // Anchor those to the app directory so they become real image paths instead
+  // of being rooted at "/" downstream, which never matches an APK file list.
+  const baseDir = scanResult.identity.targetFile
+    ? path.dirname(scanResult.identity.targetFile)
+    : undefined;
+  const addPath = (filePath: string) => {
+    if (filePath.startsWith("/")) {
+      paths.add(filePath);
+    } else if (baseDir) {
+      paths.add(path.join(baseDir, filePath));
+    }
+  };
+
   if (scanResult.identity.targetFile) {
-    paths.add(scanResult.identity.targetFile);
+    addPath(scanResult.identity.targetFile);
   }
 
   for (const fact of scanResult.facts) {
     if (fact.type === "testedFiles") {
       const testedFilesFact = fact as TestedFilesFact;
-      for (const filePath of testedFilesFact.data) {
-        paths.add(filePath);
+      // Some analyzers (node, pnpm) emit data as a bare string rather than the
+      // declared string[]. Treat a string as a single path so it isn't iterated
+      // character-by-character into bogus paths.
+      const testedFiles =
+        typeof testedFilesFact.data === "string"
+          ? [testedFilesFact.data as string]
+          : testedFilesFact.data;
+      for (const filePath of testedFiles) {
+        addPath(filePath);
       }
     }
 
@@ -23,7 +45,7 @@ export function extractEvidencePaths(
       const jarFact = fact as JarFingerprintsFact;
       for (const fingerprint of jarFact.data.fingerprints) {
         if (fingerprint.location) {
-          paths.add(fingerprint.location);
+          addPath(fingerprint.location);
         }
       }
     }

--- a/lib/analyzer/package-managers/apk-ownership.ts
+++ b/lib/analyzer/package-managers/apk-ownership.ts
@@ -44,8 +44,8 @@ const debug = Debug("snyk");
 
 const CHAINGUARD_DISTROS = new Set(["wolfi", "chainguard"]);
 
-export function isChainguardDistro(osRelease: OSRelease): boolean {
-  return CHAINGUARD_DISTROS.has(osRelease.name);
+export function isChainguardDistro(osRelease?: OSRelease): boolean {
+  return !!osRelease && CHAINGUARD_DISTROS.has(osRelease.name.toLowerCase());
 }
 
 export function toSymlinkGraph(symlinks?: SymlinkMap): SymlinkGraph {
@@ -105,7 +105,8 @@ function resolveDirectoryOwner(
 ): PathOwnerMatch | undefined {
   const segments = canonicalPath.split("/").filter(Boolean);
   let node = index.directoryTrie;
-  let best: PathOwnerMatch | undefined;
+  let deepestOwners: AnalyzedPackageWithVersion[] | undefined;
+  let deepestPrefix = 0;
 
   for (let i = 0; i < segments.length; i++) {
     const child = node.children.get(segments[i]);
@@ -114,15 +115,32 @@ function resolveDirectoryOwner(
     }
     node = child;
     if (node.owners.length > 0) {
-      best = {
-        owner: pickExactOwner(node.owners),
-        matchKind: "directory",
-        prefixLength: i + 1,
-      };
+      deepestOwners = node.owners;
+      deepestPrefix = i + 1;
     }
   }
 
-  return best;
+  if (!deepestOwners) {
+    return undefined;
+  }
+
+  // A directory declared by more than one distinct package is shared, so no
+  // single package wholly owns its contents. Fail closed rather than guess.
+  const owner = uniqueDeclaredOwner(deepestOwners);
+  if (!owner) {
+    return undefined;
+  }
+
+  return { owner, matchKind: "directory", prefixLength: deepestPrefix };
+}
+
+function uniqueDeclaredOwner(
+  owners: AnalyzedPackageWithVersion[],
+): AnalyzedPackageWithVersion | undefined {
+  const first = owners[0];
+  return owners.every((o) => ownerKey(o) === ownerKey(first))
+    ? first
+    : undefined;
 }
 
 /**
@@ -138,15 +156,14 @@ function resolveDirectoryOwner(
  */
 export function resolveApkOwnership(
   evidencePaths: string[],
-  packages: AnalyzedPackageWithVersion[],
-  osRelease: OSRelease,
+  index: ApkPathIndex,
   symlinkGraph: SymlinkGraph,
+  osRelease: OSRelease,
 ): ApkPackageOwnership | undefined {
   if (!isChainguardDistro(osRelease) || evidencePaths.length === 0) {
     return undefined;
   }
 
-  const index = buildApkPathIndex(packages, symlinkGraph);
   const perPathMatches: PathOwnerMatch[] = [];
 
   for (const evidencePath of evidencePaths) {

--- a/lib/analyzer/package-managers/path-canonicalization.ts
+++ b/lib/analyzer/package-managers/path-canonicalization.ts
@@ -20,28 +20,46 @@ export function canonicalizePath(
   filePath: string,
   symlinkGraph: SymlinkGraph,
 ): string {
-  const normalized = normalizeAbsolutePath(filePath);
-  const segments = normalized.split("/").filter(Boolean);
-  const resolvedSegments: string[] = [];
+  let current = normalizeAbsolutePath(filePath);
+  const visited = new Set<string>();
 
-  for (const segment of segments) {
-    resolvedSegments.push(segment);
-    const currentPath = `/${resolvedSegments.join("/")}`;
-    const linkTarget = symlinkGraph.get(currentPath);
-    if (!linkTarget) {
-      continue;
+  // Re-scan from the start after each substitution so that a resolved target
+  // whose own parent is a symlink (e.g. /lib64 -> /lib/x with /lib -> /usr/lib)
+  // is fully resolved. MAX_SYMLINK_DEPTH and the visited set guard against cycles.
+  for (let depth = 0; depth < MAX_SYMLINK_DEPTH; depth++) {
+    if (visited.has(current)) {
+      return current;
+    }
+    visited.add(current);
+
+    const segments = current.split("/").filter(Boolean);
+    const prefix: string[] = [];
+    let rewritten = false;
+
+    for (const segment of segments) {
+      prefix.push(segment);
+      const linkTarget = symlinkGraph.get(`/${prefix.join("/")}`);
+      if (!linkTarget) {
+        continue;
+      }
+      const resolvedPrefix = normalizeSymlinkTarget(
+        `/${prefix.join("/")}`,
+        linkTarget,
+      );
+      const rest = segments.slice(prefix.length).join("/");
+      current = normalizeAbsolutePath(
+        rest ? `${resolvedPrefix}/${rest}` : resolvedPrefix,
+      );
+      rewritten = true;
+      break;
     }
 
-    const resolvedTarget = resolveSymlinkChain(
-      normalizeSymlinkTarget(currentPath, linkTarget),
-      symlinkGraph,
-    );
-    const targetSegments = resolvedTarget.split("/").filter(Boolean);
-    resolvedSegments.length = 0;
-    resolvedSegments.push(...targetSegments);
+    if (!rewritten) {
+      return current;
+    }
   }
 
-  return resolvedSegments.length === 0 ? "/" : `/${resolvedSegments.join("/")}`;
+  return current;
 }
 
 function normalizeSymlinkTarget(basePath: string, linkTarget: string): string {
@@ -51,26 +69,4 @@ function normalizeSymlinkTarget(basePath: string, linkTarget: string): string {
   }
   const baseDir = path.dirname(basePath);
   return path.normalize(path.join(baseDir, target));
-}
-
-function resolveSymlinkChain(
-  filePath: string,
-  symlinkGraph: SymlinkGraph,
-): string {
-  let current = normalizeAbsolutePath(filePath);
-  const visited = new Set<string>();
-
-  for (let depth = 0; depth < MAX_SYMLINK_DEPTH; depth++) {
-    const linkTarget = symlinkGraph.get(current);
-    if (!linkTarget) {
-      return current;
-    }
-    if (visited.has(current)) {
-      return current;
-    }
-    visited.add(current);
-    current = normalizeSymlinkTarget(current, linkTarget);
-  }
-
-  return current;
 }

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -172,3 +172,14 @@ export interface BaseRuntimesFact {
   type: "baseRuntimes";
   data: BaseRuntime[];
 }
+
+export interface ApkPackageOwnershipFact {
+  type: "apkPackageOwnership";
+  data: {
+    distroId: string;
+    packageName: string;
+    packageVersion: string;
+    originPackage: string;
+    evidencePaths: string[];
+  };
+}

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -1,4 +1,11 @@
 import { legacy } from "@snyk/dep-graph";
+import { extractEvidencePaths } from "./analyzer/applications/evidence-paths";
+import {
+  buildApkPathIndex,
+  getApkPackagesFromResults,
+  resolveApkOwnership,
+  toSymlinkGraph,
+} from "./analyzer/package-managers/apk-ownership";
 import { IntroducingLayerByPackage, StaticAnalysis } from "./analyzer/types";
 import * as facts from "./facts";
 // Module that provides functions to collect and build response after all
@@ -240,6 +247,16 @@ async function buildResponse(
     additionalFacts.push(autoDetectedUserInstructionsFact);
   }
 
+  // The APK ownership inputs are image-global, so build the path index once
+  // here rather than rebuilding it for every application scan result below.
+  // resolveApkOwnership decides which distros the index actually applies to.
+  const osRelease = depsAnalysis.osRelease;
+  const apkSymlinkGraph = toSymlinkGraph(depsAnalysis.symlinks);
+  const apkPathIndex = buildApkPathIndex(
+    getApkPackagesFromResults(depsAnalysis.results),
+    apkSymlinkGraph,
+  );
+
   const applicationDependenciesScanResults: types.ScanResult[] = (
     depsAnalysis.applicationDependenciesScanResults || []
   ).map((appDepsScanResult) => {
@@ -291,6 +308,20 @@ async function buildResponse(
     //     appDepsScanResult.facts.push(historyFact);
     //   }
     // }
+
+    const ownership = resolveApkOwnership(
+      extractEvidencePaths(appDepsScanResult),
+      apkPathIndex,
+      apkSymlinkGraph,
+      osRelease,
+    );
+    if (ownership) {
+      const ownershipFact: facts.ApkPackageOwnershipFact = {
+        type: "apkPackageOwnership",
+        data: ownership,
+      };
+      appDepsScanResult.facts.push(ownershipFact);
+    }
 
     return {
       ...appDepsScanResult,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -82,7 +82,9 @@ export type FactType =
   // Used for application dependencies scanning; shows which files were used in the analysis of the dependencies.
   | "testedFiles"
   // Application files observed in the image
-  | "applicationFiles";
+  | "applicationFiles"
+  // Chainguard/Wolfi: APK package that owns application dependency evidence paths
+  | "apkPackageOwnership";
 
 export interface PluginAnalytics {
   name: string;

--- a/test/system/application-scans/chainguard-ownership.spec.ts
+++ b/test/system/application-scans/chainguard-ownership.spec.ts
@@ -1,0 +1,32 @@
+import { scan } from "../../../lib/index";
+
+describe("chainguard app ownership", () => {
+  afterAll(async () => {
+    // Best-effort cleanup if the image was pulled during the test.
+    try {
+      const { execute } = await import("../../../lib/sub-process");
+      await execute("docker", [
+        "image",
+        "rm",
+        "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a",
+      ]);
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  it("does not attach apkPackageOwnership on OS-only Chainguard images", async () => {
+    const image =
+      "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a";
+    const pluginResult = await scan({
+      path: image,
+      platform: "linux/amd64",
+    });
+
+    const appResults = pluginResult.scanResults.slice(1);
+    const ownershipFacts = appResults.flatMap((result) =>
+      result.facts.filter((fact) => fact.type === "apkPackageOwnership"),
+    );
+    expect(ownershipFacts).toHaveLength(0);
+  });
+});

--- a/test/unit/apk-ownership.spec.ts
+++ b/test/unit/apk-ownership.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildApkPathIndex,
+  isChainguardDistro,
   resolveApkOwnership,
   resolveOwnerForEvidencePath,
 } from "../../lib/analyzer/package-managers/apk-ownership";
@@ -47,12 +48,12 @@ describe("apk-ownership", () => {
     const packages = [
       makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
     ];
-    const ownership = resolveApkOwnership(
-      ["/bin/node"],
-      packages,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
-      symlinkGraph,
-    );
+    const index = buildApkPathIndex(packages, symlinkGraph);
+    const ownership = resolveApkOwnership(["/bin/node"], index, symlinkGraph, {
+      name: "wolfi",
+      version: "20230201",
+      prettyName: "Wolfi",
+    });
 
     expect(ownership).toEqual({
       distroId: "wolfi",
@@ -67,11 +68,12 @@ describe("apk-ownership", () => {
     const packages = [
       makePackage("bash", "5.2-r1", "bash", ["/bin/bash"], ["/bin"]),
     ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       ["/opt/custom/app"],
-      packages,
-      { name: "chainguard", version: "20230214", prettyName: "Chainguard" },
+      index,
       symlinkGraph,
+      { name: "chainguard", version: "20230214", prettyName: "Chainguard" },
     );
 
     expect(ownership).toBeUndefined();
@@ -81,11 +83,12 @@ describe("apk-ownership", () => {
     const packages = [
       makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
     ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       ["/usr/bin/node"],
-      packages,
-      { name: "alpine", version: "3.19", prettyName: "Alpine" },
+      index,
       symlinkGraph,
+      { name: "alpine", version: "3.19", prettyName: "Alpine" },
     );
 
     expect(ownership).toBeUndefined();
@@ -118,11 +121,12 @@ describe("apk-ownership", () => {
     const packages = [
       makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
     ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       ["/usr/bin/node", "/opt/custom/app.jar"],
-      packages,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      index,
       symlinkGraph,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
     );
 
     expect(ownership).toBeUndefined();
@@ -145,14 +149,15 @@ describe("apk-ownership", () => {
         ["/usr/share/java"],
       ),
     ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       [
         "/usr/share/java/gradle/lib/gradle.jar", // exact: gradle
         "/usr/share/java/other.jar", // directory: java-common
       ],
-      packages,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      index,
       symlinkGraph,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
     );
 
     expect(ownership?.packageName).toBe("gradle");
@@ -163,11 +168,12 @@ describe("apk-ownership", () => {
       makePackage("pkg-a", "1-r0", "pkg-a", ["/usr/bin/a"], ["/usr/bin"]),
       makePackage("pkg-b", "1-r0", "pkg-b", ["/usr/bin/some-b"], ["/usr/bin"]),
     ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       ["/usr/bin/a", "/usr/bin/some-b"],
-      packages,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      index,
       symlinkGraph,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
     );
 
     expect(ownership).toBeUndefined();
@@ -184,17 +190,43 @@ describe("apk-ownership", () => {
         ["/usr/lib/python3.12/site-packages/foo"],
       ),
     ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       [
         "/usr/lib/python3.12/site-packages/foo/mod.py", // directory: py-foo (deeper)
         "/usr/lib/python3.12/abc.py", // directory: python (shallower)
       ],
-      packages,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      index,
       symlinkGraph,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
     );
 
     expect(ownership?.packageName).toBe("py-foo");
+  });
+
+  it("returns undefined when one directory is declared by multiple packages", () => {
+    // On Chainguard node images, /usr/lib/node_modules is declared by both
+    // node-gyp and npm. Neither wholly owns it, so ownership is ambiguous and
+    // must fail closed rather than attributing the whole tree to an arbitrary one.
+    const packages = [
+      makePackage(
+        "node-gyp",
+        "13.0.0-r0",
+        "node-gyp",
+        [],
+        ["/usr/lib/node_modules"],
+      ),
+      makePackage("npm", "10.9.0-r0", "npm", [], ["/usr/lib/node_modules"]),
+    ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
+    const ownership = resolveApkOwnership(
+      ["/usr/lib/node_modules"],
+      index,
+      symlinkGraph,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+    );
+
+    expect(ownership).toBeUndefined();
   });
 
   it("returns undefined for a directory-depth tie between different owners", () => {
@@ -202,11 +234,12 @@ describe("apk-ownership", () => {
       makePackage("pkg-a", "1-r0", "pkg-a", [], ["/usr/lib/a"]),
       makePackage("pkg-b", "1-r0", "pkg-b", [], ["/usr/lib/b"]),
     ];
+    const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       ["/usr/lib/a/x.so", "/usr/lib/b/y.so"],
-      packages,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      index,
       symlinkGraph,
+      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
     );
 
     expect(ownership).toBeUndefined();
@@ -221,5 +254,26 @@ describe("apk-ownership", () => {
     expect(index.exactFileOwners.get(canonicalApkPath)?.[0].Name).toBe(
       "nodejs",
     );
+  });
+
+  it("matches the distro id case-insensitively", () => {
+    expect(
+      isChainguardDistro({
+        name: "Wolfi",
+        version: "20230201",
+        prettyName: "",
+      }),
+    ).toBe(true);
+    expect(
+      isChainguardDistro({
+        name: "CHAINGUARD",
+        version: "20230214",
+        prettyName: "",
+      }),
+    ).toBe(true);
+    expect(
+      isChainguardDistro({ name: "alpine", version: "3.19", prettyName: "" }),
+    ).toBe(false);
+    expect(isChainguardDistro(undefined)).toBe(false);
   });
 });

--- a/test/unit/evidence-paths.spec.ts
+++ b/test/unit/evidence-paths.spec.ts
@@ -21,9 +21,47 @@ describe("evidence-paths", () => {
     expect(extractEvidencePaths(scanResult)).toEqual(
       expect.arrayContaining([
         "/app/package.json",
-        "package-lock.json",
+        // basename testedFiles are anchored to the app directory, not "/"
+        "/app/package-lock.json",
         "/app/lib/foo.jar",
       ]),
     );
+  });
+
+  it("anchors basename testedFiles to the app directory of targetFile", () => {
+    const scanResult: AppDepsScanResultWithoutTarget = {
+      identity: { type: "composer", targetFile: "/srv/app/composer.lock" },
+      facts: [
+        { type: "testedFiles", data: ["composer.json", "composer.lock"] },
+      ],
+    };
+
+    expect(extractEvidencePaths(scanResult).sort()).toEqual([
+      "/srv/app/composer.json",
+      "/srv/app/composer.lock",
+    ]);
+  });
+
+  it("treats a string testedFiles value as a single path, not characters", () => {
+    // The npm/pnpm analyzers emit testedFiles.data as a bare string (the global
+    // node_modules dir), violating the string[] contract. It must be read as one
+    // path, not iterated character-by-character into garbage like "/", "/usr/lib/u".
+    const scanResult: AppDepsScanResultWithoutTarget = {
+      identity: { type: "npm", targetFile: "/usr/lib/node_modules" },
+      facts: [{ type: "testedFiles", data: "/usr/lib/node_modules" as any }],
+    };
+
+    expect(extractEvidencePaths(scanResult)).toEqual(["/usr/lib/node_modules"]);
+  });
+
+  it("skips relative testedFiles when there is no targetFile to anchor to", () => {
+    const scanResult: AppDepsScanResultWithoutTarget = {
+      identity: { type: "composer" },
+      facts: [
+        { type: "testedFiles", data: ["composer.json", "/abs/path.jar"] },
+      ],
+    };
+
+    expect(extractEvidencePaths(scanResult)).toEqual(["/abs/path.jar"]);
   });
 });

--- a/test/unit/path-canonicalization.spec.ts
+++ b/test/unit/path-canonicalization.spec.ts
@@ -27,4 +27,22 @@ describe("path-canonicalization", () => {
       "/opt/app/binary",
     );
   });
+
+  it("resolves a symlink whose target sits under another symlinked directory", () => {
+    const symlinkGraph = new Map<string, string>([
+      ["/lib64", "/lib/x"],
+      ["/lib", "/usr/lib"],
+    ]);
+
+    expect(canonicalizePath("/lib64/foo", symlinkGraph)).toBe("/usr/lib/x/foo");
+  });
+
+  it("terminates on a symlink cycle instead of looping forever", () => {
+    const symlinkGraph = new Map<string, string>([
+      ["/a", "/b"],
+      ["/b", "/a"],
+    ]);
+
+    expect(canonicalizePath("/a/foo", symlinkGraph)).toMatch(/^\/(a|b)\/foo$/);
+  });
 });

--- a/test/unit/response-builder-ownership.spec.ts
+++ b/test/unit/response-builder-ownership.spec.ts
@@ -1,0 +1,76 @@
+import { AnalysisType } from "../../lib/analyzer/types";
+import { buildResponse } from "../../lib/response-builder";
+
+describe("buildResponse apkPackageOwnership", () => {
+  it("attaches an ownership fact to application ScanResults on Wolfi", async () => {
+    const response = await buildResponse(
+      {
+        depTree: {
+          name: "docker-image|chainguard-node",
+          version: "latest",
+          packageFormatVersion: "apk:0.0.1",
+          targetOS: {
+            name: "wolfi",
+            version: "20230201",
+            prettyName: "Wolfi",
+          },
+          dependencies: {},
+        },
+        packageFormat: "apk",
+        imageId: "sha256:abc",
+        osRelease: {
+          name: "wolfi",
+          version: "20230201",
+          prettyName: "Wolfi",
+        },
+        results: [
+          {
+            Image: "chainguard-node",
+            AnalyzeType: AnalysisType.Apk,
+            Analysis: [
+              {
+                Name: "nodejs",
+                Version: "20-r1",
+                Source: "nodejs",
+                Provides: [],
+                Deps: {},
+                Files: ["/usr/bin/node"],
+                Directories: ["/usr/bin"],
+              },
+            ],
+          },
+        ],
+        binaries: [],
+        imageLayers: [],
+        applicationDependenciesScanResults: [
+          {
+            identity: { type: "gomodules", targetFile: "/usr/bin/node" },
+            facts: [
+              {
+                type: "testedFiles",
+                data: ["/usr/bin/node"],
+              },
+            ],
+          },
+        ],
+        manifestFiles: [],
+        symlinks: {
+          "/bin": "usr/bin",
+        },
+      },
+      undefined,
+      false,
+    );
+
+    const appResult = response.scanResults[1];
+    const ownershipFact = appResult.facts.find(
+      (f) => f.type === "apkPackageOwnership",
+    );
+    expect(ownershipFact).toBeDefined();
+    expect(ownershipFact!.data).toMatchObject({
+      distroId: "wolfi",
+      originPackage: "nodejs",
+      packageName: "nodejs",
+    });
+  });
+});


### PR DESCRIPTION
[CN-1395](https://snyksec.atlassian.net/browse/CN-1395)

**Stack 4/5** — `main` ← apk file lists ← layer symlinks ← ownership library ← **this PR** ← prettyName.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Wires the ownership library into `buildResponse`: every application ScanResult on a Chainguard/Wolfi image whose evidence paths are wholly owned by one APK package gains an `apkPackageOwnership` fact (distro, package name, installed version, **origin**). The origin is the key into Chainguard's advisory feed — it lets downstream matching reconcile app findings against the owning package's fixed-version data instead of reporting raw upstream-range matches.

⚠️ **Public API note:** `apkPackageOwnership` is a new `FactType` — a contract change visible to all plugin consumers (CLI, kubernetes-monitor, registry agents). The fact is only *emitted* for Chainguard distros with fully resolved evidence, so existing scan output is unchanged — zero snapshot churn in this PR (verified: no `.snap` in the repo contains the fact).

Also removes the unreachable `?? depsAnalysis.depTree.targetOS` fallback on the `osRelease` read — `StaticAnalysis.osRelease` is a required field, so the fallback could never fire.

#### Where should the reviewer start?

The single block added to `lib/response-builder.ts`, then the fact shape in `lib/facts.ts`. The heavy algorithmic review happened one PR down.

#### How should this be manually tested?

`npx jest test/unit/response-builder-ownership.spec.ts` (full `buildResponse` pass on a synthetic Wolfi analysis asserting the fact and its data) and `npx jest test/system/application-scans/chainguard-ownership.spec.ts` (pulls `chainguard/bash`, asserts an OS-only Chainguard image emits **no** ownership facts — the fail-closed direction). `test/system/package-managers/apk.spec.ts` snapshots stay byte-identical.

#### Any background context you want to provide?

Downstream consumption is follow-up work in `registry` (thread the fact through) and `@snyk/vuln` (subtract findings when installed ≥ fixed for the owning origin). Until those land, the fact rides along in scan results unconsumed.

#### What are the relevant tickets?

CN-1395

#### Screenshots

N/A

#### Additional questions

N/A


[CN-1395]: https://snyksec.atlassian.net/browse/CN-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ