### PR TITLE
chore(ci): add manually-triggered jest snapshot update jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ slack-snapshot-notify: &slack-snapshot-notify
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "*snyk-docker-plugin*\n\n:camera_with_flash: Snapshot update job finished!\nAuthor: *${CIRCLE_USERNAME}*"
+              "text": "*snyk-docker-plugin*\n\n:camera_with_flash: Snapshot update jobs finished!"
             }
           },
           {
@@ -62,8 +62,12 @@ slack-snapshot-notify: &slack-snapshot-notify
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "To complete the snapshot update:\n\n1. <${CIRCLE_BUILD_URL}|View the job on CircleCI>.\n2. Navigate to the 'Artifacts' tab.\n3. Download the patch artifact (`snapshots.patch` or `snapshots-windows.patch`).\n4. Apply the patch(es) with:\n```git apply snapshots.patch snapshots-windows.patch```"
+              "text": "Download the patch from each job's *Artifacts* tab:\n\n• <${LINUX_JOB_URL}|Linux snapshots> → `snapshots.patch`\n• <${WINDOWS_JOB_URL}|Windows snapshots> → `snapshots-windows.patch`"
             }
+          },
+          {
+            "type": "markdown",
+            "text": "Apply the patches locally with:\n\n```bash\ngit apply snapshots.patch snapshots-windows.patch\n```"
           }
         ]
       }
@@ -275,6 +279,15 @@ jobs:
       - store_artifacts:
           path: snapshots.patch
           destination: snapshots.patch
+      - run:
+          name: Record job URL
+          command: |
+            mkdir -p /tmp/snapshot-meta
+            echo "$CIRCLE_BUILD_URL" > /tmp/snapshot-meta/linux-job-url.txt
+      - persist_to_workspace:
+          root: /tmp/snapshot-meta
+          paths:
+            - linux-job-url.txt
   update_snapshots_windows:
     <<: *windows_big
     steps:
@@ -301,6 +314,26 @@ jobs:
       - store_artifacts:
           path: snapshots-windows.patch
           destination: snapshots-windows.patch
+      - run:
+          name: Record job URL
+          command: |
+            mkdir -p /tmp/snapshot-meta
+            echo "$CIRCLE_BUILD_URL" > /tmp/snapshot-meta/windows-job-url.txt
+      - persist_to_workspace:
+          root: /tmp/snapshot-meta
+          paths:
+            - windows-job-url.txt
+  notify_snapshots:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /tmp/snapshot-meta
+      - run:
+          name: Load job URLs into environment
+          command: |
+            echo "export LINUX_JOB_URL=$(cat /tmp/snapshot-meta/linux-job-url.txt)" >> "$BASH_ENV"
+            echo "export WINDOWS_JOB_URL=$(cat /tmp/snapshot-meta/windows-job-url.txt)" >> "$BASH_ENV"
+      - *slack-snapshot-notify
   release:
     <<: *release_defaults
     steps:
@@ -459,14 +492,16 @@ workflows:
           name: Update Snapshots
           context:
             - nodejs-install
-            - snyk-bot-slack
-          post-steps:
-            - *slack-snapshot-notify
       - update_snapshots_windows:
           name: Update Windows Snapshots
           node_version: *windows_node_version
           context:
             - nodejs-install
+      - notify_snapshots:
+          name: Notify Snapshots
+          context:
+            - nodejs-install
             - snyk-bot-slack
-          post-steps:
-            - *slack-snapshot-notify
+          requires:
+            - Update Snapshots: terminal
+            - Update Windows Snapshots: terminal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ orbs:
   slack: circleci/slack@5
   prodsec: snyk/prodsec-orb@1
 
+parameters:
+  run_snapshot_update:
+    type: boolean
+    default: false
+
 defaults: &defaults
   resource_class: small
   docker:
@@ -35,6 +40,33 @@ slack-success-notify: &slack-success-notify
     channel: team-container-pipeline-info
     branch_pattern: "main"
     template: basic_success_1
+
+slack-snapshot-notify: &slack-snapshot-notify
+  slack/notify:
+    event: always
+    channel: team-container-pipeline-info
+    custom: |
+      {
+        "blocks": [
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "*snyk-docker-plugin*\n\n:camera_with_flash: Snapshot update job finished!\nAuthor: *${CIRCLE_USERNAME}*"
+            }
+          },
+          {
+            "type": "divider"
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "To complete the snapshot update:\n\n1. <${CIRCLE_BUILD_URL}|View the job on CircleCI>.\n2. Navigate to the 'Artifacts' tab.\n3. Download the patch artifact (`snapshots.patch` or `snapshots-windows.patch`).\n4. Apply the patch(es) with:\n```git apply snapshots.patch snapshots-windows.patch```"
+            }
+          }
+        ]
+      }
 
 windows_big: &windows_big
   executor:
@@ -223,6 +255,52 @@ jobs:
       - run:
           name: Run Go binaries unit test
           command: npx jest test/unit/go-binaries.spec.ts
+  update_snapshots:
+    <<: *defaults
+    resource_class: medium
+    steps:
+      - install_deps
+      - setup_remote_docker
+      - run:
+          name: Regenerate Jest snapshots
+          command: npx jest -u --maxWorkers=3 --testPathPattern='test/(lib|system)/'
+          no_output_timeout: 20m
+      - run:
+          name: Build snapshot patch
+          when: always
+          command: |
+            git add -A -- '*.snap'
+            git diff --cached -- '*.snap' > snapshots.patch
+            git diff --cached --stat -- '*.snap'
+      - store_artifacts:
+          path: snapshots.patch
+          destination: snapshots.patch
+  update_snapshots_windows:
+    <<: *windows_big
+    steps:
+      - checkout
+      - install_node_npm:
+          node_version: << parameters.node_version >>
+      - setup_npm_user
+      - restore_cache:
+          keys:
+            - v1-windows-npm-cache-{{ checksum "package-lock.json" }}
+            - v1-windows-npm-cache-
+      - run: npm ci
+      - run:
+          name: Regenerate Windows Jest snapshots
+          command: npx jest -u --config test/windows/jest.config.js
+          no_output_timeout: 20m
+      - run:
+          name: Build snapshot patch
+          when: always
+          command: |
+            git add -A -- '*.snap'
+            git diff --cached -- '*.snap' > snapshots-windows.patch
+            git diff --cached --stat -- '*.snap'
+      - store_artifacts:
+          path: snapshots-windows.patch
+          destination: snapshots-windows.patch
   release:
     <<: *release_defaults
     steps:
@@ -248,6 +326,8 @@ workflows:
             matches:
               pattern: "^graphite-base/.*"
               value: << pipeline.git.branch >>
+        # do not run when manually triggered to update snapshots
+        - equal: [false, << pipeline.parameters.run_snapshot_update >>]
     jobs:
       - prodsec/secrets-scan:
           name: Scan repository for secrets
@@ -372,3 +452,21 @@ workflows:
             - Install
           post-steps:
             - *slack-fail-notify
+  update_snapshots:
+    when: << pipeline.parameters.run_snapshot_update >>
+    jobs:
+      - update_snapshots:
+          name: Update Snapshots
+          context:
+            - nodejs-install
+            - snyk-bot-slack
+          post-steps:
+            - *slack-snapshot-notify
+      - update_snapshots_windows:
+          name: Update Windows Snapshots
+          node_version: *windows_node_version
+          context:
+            - nodejs-install
+            - snyk-bot-slack
+          post-steps:
+            - *slack-snapshot-notify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,13 +281,15 @@ jobs:
           destination: snapshots.patch
       - run:
           name: Record job URL
+          when: always
           command: |
-            mkdir -p /tmp/snapshot-meta
-            echo "$CIRCLE_BUILD_URL" > /tmp/snapshot-meta/linux-job-url.txt
+            mkdir -p snapshot-meta
+            echo "$CIRCLE_BUILD_URL" > snapshot-meta/linux-job-url.txt
       - persist_to_workspace:
-          root: /tmp/snapshot-meta
+          when: always
+          root: .
           paths:
-            - linux-job-url.txt
+            - snapshot-meta/linux-job-url.txt
   update_snapshots_windows:
     <<: *windows_big
     steps:
@@ -316,23 +318,25 @@ jobs:
           destination: snapshots-windows.patch
       - run:
           name: Record job URL
+          when: always
           command: |
-            mkdir -p /tmp/snapshot-meta
-            echo "$CIRCLE_BUILD_URL" > /tmp/snapshot-meta/windows-job-url.txt
+            mkdir -p snapshot-meta
+            echo "$CIRCLE_BUILD_URL" > snapshot-meta/windows-job-url.txt
       - persist_to_workspace:
-          root: /tmp/snapshot-meta
+          when: always
+          root: .
           paths:
-            - windows-job-url.txt
+            - snapshot-meta/windows-job-url.txt
   notify_snapshots:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /tmp/snapshot-meta
+          at: ~/snyk-docker-plugin
       - run:
           name: Load job URLs into environment
           command: |
-            echo "export LINUX_JOB_URL=$(cat /tmp/snapshot-meta/linux-job-url.txt)" >> "$BASH_ENV"
-            echo "export WINDOWS_JOB_URL=$(cat /tmp/snapshot-meta/windows-job-url.txt)" >> "$BASH_ENV"
+            echo "export LINUX_JOB_URL=$(cat snapshot-meta/linux-job-url.txt)" >> "$BASH_ENV"
+            echo "export WINDOWS_JOB_URL=$(cat snapshot-meta/windows-job-url.txt)" >> "$BASH_ENV"
       - *slack-snapshot-notify
   release:
     <<: *release_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Regenerate Jest snapshots
-          command: npx jest -u --maxWorkers=3 --testPathPattern='test/(lib|system)/'
+          command: npx jest -u --colors --maxWorkers=3 --testPathPattern='test/(lib|system)/'
           no_output_timeout: 20m
       - run:
           name: Build snapshot patch

--- a/.circleci/trigger-snapshot-update.sh
+++ b/.circleci/trigger-snapshot-update.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Manually trigger the Jest snapshot-update jobs on CircleCI.
+#
+# The run_snapshot_update pipeline parameter cannot be set from the CircleCI UI;
+# it must be passed via the API. This script does that for the current (or a
+# given) branch.
+#
+# Usage:
+#   CIRCLE_TOKEN=<personal-api-token> ./.circleci/trigger-snapshot-update.sh [branch]
+#
+# Get a token at: CircleCI -> User Settings -> Personal API Tokens.
+set -euo pipefail
+
+: "${CIRCLE_TOKEN:?Set CIRCLE_TOKEN to a CircleCI personal API token}"
+
+branch="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+project="gh/snyk/snyk-docker-plugin"
+
+echo "Triggering snapshot update on branch: ${branch}"
+curl -fsS -X POST "https://circleci.com/api/v2/project/${project}/pipeline" \
+  -H "Circle-Token: ${CIRCLE_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"branch\":\"${branch}\",\"parameters\":{\"run_snapshot_update\":true}}"
+echo


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

### What does this PR do?

Updating Jest snapshots today requires running tests locally and committing the .snap diffs by hand, which requires Docker, credentials, and a matching environment for both Linux and Windows. This PR adds a CI-driven alternative.

- Adds two new CircleCI jobs (`update_snapshots`, `update_snapshots_windows`) that run `jest -u` to update snapshots. The changes are captured as [git patches](https://git-scm.com/docs/git-apply) and saved as test artifacts. These patch files can then be downloaded from the job and applied locally.
- Adds a `notify_snapshots` fan-in job that fires after both finish (regardless of outcome) and posts a single Slack message to #team-container-pipeline-info with direct links to each job's artifact.
- Gates the new workflow behind a `run_snapshot_update` pipeline parameter (default false) so it never runs on normal pushes/merges.
- Adds `.circleci/trigger-snapshot-update.sh`: a one-liner script to fire the pipeline via the CircleCI API.

### Run it manually 

- [ ] Trigger the workflow on this branch with CIRCLE_TOKEN=... ./.circleci/trigger-snapshot-update.sh d3vco/feat-update-snapshots-job and confirm both jobs run and produce patch artifacts.
- [ ] Confirm the Slack notification fires once (not twice) with links to both job artifacts.
- [ ] Confirm a normal push to this branch does not trigger the update_snapshots workflow.
- [ ] (Optional) Apply snapshots.patch locally with git apply and verify the diff looks correct. To create a patch, run against a branch with a change that impacts the snapshots.