### PR TITLE
chore: circle ci store test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,13 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/snyk-docker-plugin
-      - run: npm run test:unit
+      - run:
+          command: npm run test:unit
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./test/reports
+            JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
+      - store_test_results:
+          path: ./test/reports
   test_system:
     <<: *defaults
     steps:
@@ -186,6 +192,11 @@ jobs:
       - run:
           command: npm run test:system
           no_output_timeout: 20m
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./test/reports
+            JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
+      - store_test_results:
+          path: ./test/reports
   test_windows_with_docker:
     <<: *windows_big
     steps:
@@ -206,6 +217,11 @@ jobs:
       - run:
           command: npm run test:windows:docker
           no_output_timeout: 20m
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./test/reports
+            JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
+      - store_test_results:
+          path: ./test/reports
   test_windows_no_docker:
     <<: *windows_big
     steps:
@@ -227,6 +243,11 @@ jobs:
       - run:
           command: npm run test:windows
           no_output_timeout: 20m
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./test/reports
+            JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
+      - store_test_results:
+          path: ./test/reports
   build:
     <<: *defaults
     steps:

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,10 +23,15 @@ module.exports = {
   // https://github.com/facebook/jest/issues/10550
   // https://snyk.slack.com/archives/CLW30N31V/p1602232569018000?thread_ts=1602230753.017500&cid=CLW30N31V
   transform: {
-    '^.+\\.tsx?$': [
-      'ts-jest', {
-        isolatedModules: true
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        isolatedModules: true,
       },
     ],
   },
+  // Use 3 of 4 CircleCI cores
+  // https://github.com/jestjs/jest/issues/11956#issuecomment-1212925677
+  maxWorkers: 3,
+  reporters: ["default", ["jest-junit", { outputDirectory: "test/reports" }]],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   setupFilesAfterEnv: [
-    // "<rootDir>/test/jest-snapshot-strip-analytics.cjs",
+    "<rootDir>/test/jest-snapshot-strip-analytics.cjs",
     "<rootDir>/test/matchers/setup.ts",
   ],
   testEnvironment: "node",

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   setupFilesAfterEnv: [
-    "<rootDir>/test/jest-snapshot-strip-analytics.cjs",
+    // "<rootDir>/test/jest-snapshot-strip-analytics.cjs",
     "<rootDir>/test/matchers/setup.ts",
   ],
   testEnvironment: "node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.0.0",
         "jest": "^29.7.0",
+        "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
         "semantic-release": "^25.0.3",
@@ -9309,6 +9310,36 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-17.0.0.tgz",
+      "integrity": "sha512-RYWCkq4j59gUXj5DsgbIE7xFBZzu1gtibPhyjSjMmGaOTLnqlXhg7x9zuGCwgbCuMAyoyvk0Mi8wSrRR5uOeLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^14.0.0",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -11202,6 +11233,19 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -17430,6 +17474,13 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "test": "jest --logHeapUsage --colors",
     "test:unit": "jest --logHeapUsage --colors --testPathPattern='test/(lib|unit)/'",
     "test:system": "jest --logHeapUsage --colors --testPathPattern='test/system/'",
-    "test:windows": "jest --config test/windows/jest.config.js --logHeapUsage",
-    "test:windows:docker": "jest --config test/windows/jest.docker.config.js",
+    "test:windows": "jest --logHeapUsage --config test/windows/jest.config.js",
+    "test:windows:docker": "jest --logHeapUsage --config test/windows/jest.docker.config.js",
     "prepare": "npm run build"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "lint:eslint": "eslint \"{lib,test}/**/*.ts\"",
     "lint:commit": "commitlint --from=HEAD~1",
     "format": "prettier --loglevel warn --write '{lib,test}/**/*.ts' && eslint --fix '{lib,test}/**/*.ts'",
-    "test": "jest --ci --maxWorkers=3 --logHeapUsage --colors",
-    "test:unit": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/(lib|unit)/'",
-    "test:system": "jest --ci --maxWorkers=3 --logHeapUsage --colors --testPathPattern='test/system/'",
-    "test:windows": "jest --ci --maxWorkers=3 --config test/windows/jest.config.js --logHeapUsage",
-    "test:windows:docker": "jest --ci --maxWorkers=3 --config test/windows/jest.docker.config.js --logHeapUsage",
+    "test": "jest --logHeapUsage --colors",
+    "test:unit": "jest --logHeapUsage --colors --testPathPattern='test/(lib|unit)/'",
+    "test:system": "jest --logHeapUsage --colors --testPathPattern='test/system/'",
+    "test:windows": "jest --config test/windows/jest.config.js --logHeapUsage",
+    "test:windows:docker": "jest --config test/windows/jest.docker.config.js",
     "prepare": "npm run build"
   },
   "engines": {
@@ -59,25 +59,26 @@
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",
     "@commitlint/config-conventional": "^17.0.2",
+    "@eslint/js": "^10.0.0",
     "@mongodb-js/zstd": "^2.0.1",
     "@semantic-release/exec": "^7.1.0",
-    "semantic-release": "^25.0.3",
     "@types/adm-zip": "^0.4.34",
     "@types/debug": "^4.1.5",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.19.1",
     "@types/tar-stream": "^1.6.1",
-    "@eslint/js": "^10.0.0",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.0.0",
-    "typescript-eslint": "^8.56.0",
     "jest": "^29.7.0",
+    "jest-junit": "^17.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
+    "semantic-release": "^25.0.3",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.2.1",
     "tsc-watch": "^4.2.8",
-    "typescript": "~5.4.2"
+    "typescript": "~5.4.2",
+    "typescript-eslint": "^8.56.0"
   },
   "release": {
     "branches": [

--- a/test/lib/response-builder.spec.ts
+++ b/test/lib/response-builder.spec.ts
@@ -1740,7 +1740,6 @@ describe("buildResponse", () => {
       );
 
       const pkgNames = getDepPkgs(result.scanResults[0]).map((p) => p.name);
-      console.dir(pkgNames, { depth: null });
       expect(pkgNames).toEqual(
         expect.arrayContaining([
           "foo/foo",

--- a/test/reports/.gitignore
+++ b/test/reports/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds JUnit reporting to enable CircleCI [test report collection](https://circleci.com/docs/guides/test/collect-test-data/#jest).

Requires new devDependency `jest-junit` (note: NPM shuffled some of the other deps but this is the only real change)

To streamline the package.json scripts, I:
1. Moved `maxWorkers` to the config file
2. Removed the `--ci` flag (this is already set by CircleCI, test [here](https://app.circleci.com/pipelines/github/snyk/snyk-docker-plugin/4834/workflows/41ee54e0-24a1-4704-a557-19f56b2bc826) confirms)

I also removed a stray console log from local testing that was accidentally committed.
