### PR TITLE
feat: cn-1395 resolve per-dependency apk ownership for npm global modules

### DIFF
--- a/lib/analyzer/applications/evidence-paths.ts
+++ b/lib/analyzer/applications/evidence-paths.ts
@@ -63,7 +63,7 @@ export function extractEvidencePaths(
  *   package's own dir resolves to a single owner.
  * - Java jars, Go binaries, everything else: a single whole-result unit over the
  *   result's evidence paths — owned only when one apk package owns them all
- *   (fail closed), matching the pre-merge whole-result behavior.
+ *   (fail closed), the same whole-result behavior #872 introduced.
  */
 export function buildOwnershipCandidates(
   scanResult: AppDepsScanResultWithoutTarget,

--- a/lib/analyzer/applications/evidence-paths.ts
+++ b/lib/analyzer/applications/evidence-paths.ts
@@ -1,5 +1,6 @@
 import { posix as path } from "path";
 import { JarFingerprintsFact, TestedFilesFact } from "../../facts";
+import { OwnershipCandidate } from "../package-managers/apk-ownership";
 import { AppDepsScanResultWithoutTarget } from "./types";
 
 /** Collect filesystem paths from an app scan result used to resolve APK ownership. */
@@ -52,4 +53,30 @@ export function extractEvidencePaths(
   }
 
   return [...paths];
+}
+
+/**
+ * Build the ownership units for an app scan result, each resolved independently
+ * by resolveApkOwnership:
+ * - npm global modules: one unit per package, keyed by its own install dir. The
+ *   shared node_modules root is declared by several apk packages, so only each
+ *   package's own dir resolves to a single owner.
+ * - Java jars, Go binaries, everything else: a single whole-result unit over the
+ *   result's evidence paths — owned only when one apk package owns them all
+ *   (fail closed), matching the pre-merge whole-result behavior.
+ */
+export function buildOwnershipCandidates(
+  scanResult: AppDepsScanResultWithoutTarget,
+): OwnershipCandidate[] {
+  const npmPackages = scanResult.nodeModulesPackagePaths;
+  if (npmPackages && npmPackages.length > 0) {
+    return npmPackages.map((pkg) => ({
+      evidencePaths: [pkg.installDir],
+      name: pkg.name,
+      version: pkg.version,
+    }));
+  }
+
+  const evidencePaths = extractEvidencePaths(scanResult);
+  return evidencePaths.length > 0 ? [{ evidencePaths }] : [];
 }

--- a/lib/analyzer/applications/node.ts
+++ b/lib/analyzer/applications/node.ts
@@ -23,6 +23,7 @@ import {
   groupNodeModulesFilesByDirectory,
   persistNodeModules,
 } from "./node-modules-utils";
+import { NodeModulesPackagePath } from "../types";
 import {
   AppDepsScanResultWithoutTarget,
   FilePathToContent,
@@ -38,6 +39,10 @@ interface ManifestLockPathPair {
 export async function nodeFilesToScannedProjects(
   filePathToContent: FilePathToContent,
   shouldIncludeNodeModules: boolean,
+  // Per-package install paths are only consumed for APK ownership on
+  // Chainguard/Wolfi images, so collection is gated to avoid parsing every
+  // node_modules package.json on images that will never use it.
+  collectOwnershipPaths = false,
 ): Promise<AppDepsScanResultWithoutTarget[]> {
   const scanResults: AppDepsScanResultWithoutTarget[] = [];
   /**
@@ -81,6 +86,7 @@ export async function nodeFilesToScannedProjects(
           filePathToContent,
           nodeProjects,
           appNodeModulesGroupedByDirectory,
+          collectOwnershipPaths,
         )),
       );
     }
@@ -89,10 +95,68 @@ export async function nodeFilesToScannedProjects(
   return scanResults;
 }
 
+const nodeModulesPackageJsonRegex = /\/node_modules\/.+\/package\.json$/;
+
+/**
+ * Collect the on-disk install directory of each package under a project's
+ * node_modules, from the image paths already gathered for the scan. Used to
+ * resolve per-package APK ownership downstream (response-builder), since the
+ * scan result itself only records the shared node_modules root. Skips pnpm/.bin
+ * virtual entries and any package.json without a name+version.
+ */
+export function collectNodeModulesPackagePaths(
+  project: string,
+  fileNamesGroupedByDirectory: FilesByDirMap,
+  filePathToContent: FilePathToContent,
+): NodeModulesPackagePath[] {
+  const files = fileNamesGroupedByDirectory.get(project);
+  if (!files) {
+    return [];
+  }
+
+  const packages: NodeModulesPackagePath[] = [];
+  for (const filePath of files) {
+    // Skip dot-prefixed node_modules entries (.pnpm virtual store, .bin, .cache).
+    // Safe because npm package names cannot begin with ".", so a real package
+    // dir is never excluded by this guard.
+    if (
+      !nodeModulesPackageJsonRegex.test(filePath) ||
+      filePath.includes("/node_modules/.")
+    ) {
+      continue;
+    }
+
+    const content = filePathToContent[filePath];
+    if (!content) {
+      continue;
+    }
+
+    let parsed: { name?: string; version?: string };
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      continue;
+    }
+
+    if (!parsed.name || !parsed.version) {
+      continue;
+    }
+
+    packages.push({
+      name: parsed.name,
+      version: parsed.version,
+      installDir: path.posix.dirname(filePath),
+    });
+  }
+
+  return packages;
+}
+
 async function depGraphFromNodeModules(
   filePathToContent: FilePathToContent,
   nodeProjects: string[],
   fileNamesGroupedByDirectory: FilesByDirMap,
+  collectOwnershipPaths: boolean,
 ): Promise<AppDepsScanResultWithoutTarget[]> {
   const scanResults: AppDepsScanResultWithoutTarget[] = [];
   for (const project of nodeProjects) {
@@ -141,6 +205,16 @@ async function depGraphFromNodeModules(
         pkgTree.type || "npm",
       );
 
+      // Only collected on Chainguard/Wolfi (the caller passes the distro gate),
+      // since per-package ownership is the only consumer.
+      const nodeModulesPackages = collectOwnershipPaths
+        ? collectNodeModulesPackagePaths(
+            project,
+            fileNamesGroupedByDirectory,
+            filePathToContent,
+          )
+        : [];
+
       scanResults.push({
         facts: [
           {
@@ -160,6 +234,9 @@ async function depGraphFromNodeModules(
             ? manifestPath
             : path.join(project, "node_modules"),
         },
+        ...(nodeModulesPackages.length > 0
+          ? { nodeModulesPackagePaths: nodeModulesPackages }
+          : {}),
       });
     } catch (error) {
       debug(

--- a/lib/analyzer/applications/node.ts
+++ b/lib/analyzer/applications/node.ts
@@ -23,6 +23,7 @@ import {
   groupNodeModulesFilesByDirectory,
   persistNodeModules,
 } from "./node-modules-utils";
+import { normalizeAbsolutePath } from "../package-managers/path-canonicalization";
 import { NodeModulesPackagePath } from "../types";
 import {
   AppDepsScanResultWithoutTarget,
@@ -95,7 +96,12 @@ export async function nodeFilesToScannedProjects(
   return scanResults;
 }
 
-const nodeModulesPackageJsonRegex = /\/node_modules\/.+\/package\.json$/;
+// Match a package.json only at a real package root (parent is an immediate
+// child of node_modules, optional @scope/), so bundled fixtures nested deeper
+// aren't collected as packages. [\\/] handles both POSIX and Windows paths.
+const nodeModulesPackageJsonRegex =
+  /[\\/]node_modules[\\/](?:@[^\\/]+[\\/])?[^\\/]+[\\/]package\.json$/;
+const nodeModulesDotDirRegex = /[\\/]node_modules[\\/]\./;
 
 /**
  * Collect the on-disk install directory of each package under a project's
@@ -116,12 +122,11 @@ export function collectNodeModulesPackagePaths(
 
   const packages: NodeModulesPackagePath[] = [];
   for (const filePath of files) {
-    // Skip dot-prefixed node_modules entries (.pnpm virtual store, .bin, .cache).
-    // Safe because npm package names cannot begin with ".", so a real package
-    // dir is never excluded by this guard.
+    // Skip dot-prefixed node_modules entries (.pnpm, .bin, .cache); npm package
+    // names never start with ".", so no real package dir is excluded.
     if (
       !nodeModulesPackageJsonRegex.test(filePath) ||
-      filePath.includes("/node_modules/.")
+      nodeModulesDotDirRegex.test(filePath)
     ) {
       continue;
     }
@@ -131,21 +136,29 @@ export function collectNodeModulesPackagePaths(
       continue;
     }
 
-    let parsed: { name?: string; version?: string };
+    let parsed: { name?: unknown; version?: unknown };
     try {
       parsed = JSON.parse(content);
     } catch {
       continue;
     }
 
-    if (!parsed.name || !parsed.version) {
+    // JSON.parse returns any; require non-empty strings since the coordinate
+    // flows into the apkPackageOwnership fact as name/version.
+    if (
+      typeof parsed.name !== "string" ||
+      typeof parsed.version !== "string" ||
+      !parsed.name ||
+      !parsed.version
+    ) {
       continue;
     }
 
     packages.push({
       name: parsed.name,
       version: parsed.version,
-      installDir: path.posix.dirname(filePath),
+      // Normalize first so posix.dirname works on Windows backslash paths.
+      installDir: path.posix.dirname(normalizeAbsolutePath(filePath)),
     });
   }
 

--- a/lib/analyzer/applications/types.ts
+++ b/lib/analyzer/applications/types.ts
@@ -1,8 +1,14 @@
 import { Elf } from "../../go-parser/types";
 import { ScanResult } from "../../types";
+import type { NodeModulesPackagePath } from "../types";
 
 export interface AppDepsScanResultWithoutTarget
-  extends Omit<ScanResult, "target"> {}
+  extends Omit<ScanResult, "target"> {
+  // Internal-only: per-package node_modules install dirs used to resolve
+  // per-dependency APK ownership. Destructured out before the result becomes a
+  // public ScanResult, so it never reaches the wire.
+  nodeModulesPackagePaths?: NodeModulesPackagePath[];
+}
 
 export interface FilePathToContent {
   [filePath: string]: string;

--- a/lib/analyzer/package-managers/apk-ownership.ts
+++ b/lib/analyzer/package-managers/apk-ownership.ts
@@ -1,4 +1,3 @@
-import * as Debug from "debug";
 import { SymlinkMap } from "../../extractor/types";
 import {
   AnalysisType,
@@ -13,12 +12,35 @@ import {
   SymlinkGraph,
 } from "./path-canonicalization";
 
+export interface OwnedPackage {
+  // The file(s)/dir(s) that justify this ownership. Always present — the
+  // universal key across ecosystems (jar files, npm install dirs, Go binaries).
+  evidencePaths: string[];
+  // The apk package that owns the evidence paths.
+  apkPackageName: string;
+  apkPackageVersion: string;
+  // apk Source package (falls back to apkPackageName).
+  originPackage: string;
+  // Dependency coordinate (name@version) for per-package ecosystems where only
+  // some of a result's dependencies are owned — npm global modules. Absent for
+  // whole-result entries (Go binaries, Java jar dirs), where the entire result
+  // is owned and downstream relabels every dependency it produced.
+  name?: string;
+  version?: string;
+}
+
 export interface ApkPackageOwnership {
   distroId: string;
-  packageName: string;
-  packageVersion: string;
-  originPackage: string;
+  ownedPackages: OwnedPackage[];
+}
+
+// A unit of evidence to resolve ownership for. Each candidate is resolved
+// independently (fail closed per candidate): all of its evidence paths must
+// resolve to one consistent apk package, or it is omitted.
+export interface OwnershipCandidate {
   evidencePaths: string[];
+  name?: string;
+  version?: string;
 }
 
 export type MatchKind = "exact" | "directory";
@@ -39,8 +61,6 @@ export interface ApkPathIndex {
   exactFileOwners: Map<string, AnalyzedPackageWithVersion[]>;
   directoryTrie: DirectoryTrieNode;
 }
-
-const debug = Debug("snyk");
 
 const CHAINGUARD_DISTROS = new Set(["wolfi", "chainguard"]);
 
@@ -144,52 +164,104 @@ function uniqueDeclaredOwner(
 }
 
 /**
- * Resolve APK package ownership for app evidence paths on Wolfi/Chainguard images.
- *
- * Per Chainguard's scanner spec, an app dependency is owned by an APK package
- * only when its evidence paths are wholly contained in that package's declared
- * paths; a dependency with any unowned path is not covered by Chainguard's
- * advisory data and must keep its findings. This fact drives downstream
- * suppression, so we skip it rather than guess and risk suppressing real
- * vulnerabilities in user-added software.
+ * Resolve APK package ownership for a set of candidates on Wolfi/Chainguard
+ * images. Each candidate (a single npm package, or a whole Go/Java result) is
+ * resolved independently: all of its evidence paths must be wholly owned by one
+ * consistent APK package, or the candidate is omitted (fail closed per
+ * candidate). Per Chainguard's scanner spec, a dependency with any unowned path
+ * is not covered by advisory data and must keep its findings — we skip rather
+ * than guess and risk suppressing real vulnerabilities in user-added software.
+ * Candidates carrying a coordinate (name@version) are deduplicated, keeping an
+ * owned occurrence over an unowned one.
  * https://github.com/chainguard-dev/vulnerability-scanner-support/blob/main/docs/scanning_implementation.md
  */
 export function resolveApkOwnership(
-  evidencePaths: string[],
+  candidates: OwnershipCandidate[],
   index: ApkPathIndex,
   symlinkGraph: SymlinkGraph,
   osRelease: OSRelease,
 ): ApkPackageOwnership | undefined {
-  if (!isChainguardDistro(osRelease) || evidencePaths.length === 0) {
+  if (!isChainguardDistro(osRelease) || candidates.length === 0) {
     return undefined;
   }
 
-  const perPathMatches: PathOwnerMatch[] = [];
+  const ownedPackages: OwnedPackage[] = [];
+  // `seen` holds matched coordinates only, so an owned occurrence always wins
+  // over an unowned one. It must NOT include unmatched coordinates, or a later
+  // owned copy of the same coordinate would be skipped.
+  const seen = new Set<string>();
+  // Memoize per-path owner lookups so a path shared by several candidates (or an
+  // unmatched coordinate seen repeatedly) is resolved only once.
+  const resolvedByPath = new Map<
+    string,
+    ReturnType<typeof resolveOwnerForEvidencePath>
+  >();
+  // Sort by first evidence path so coordinate dedup is deterministic regardless
+  // of discovery order: when a coordinate is bundled under more than one apk
+  // package, the lexicographically-first evidence path wins. Which origin is
+  // "correct" in that case is a downstream (@snyk/vuln) question.
+  const ordered = [...candidates].sort((a, b) =>
+    (a.evidencePaths[0] ?? "").localeCompare(b.evidencePaths[0] ?? ""),
+  );
 
-  for (const evidencePath of evidencePaths) {
-    const normalized = normalizeAbsolutePath(evidencePath);
-    const match = resolveOwnerForEvidencePath(normalized, index, symlinkGraph);
-    if (!match) {
-      debug(
-        `apk ownership skipped: no owning package for evidence path ${normalized}`,
-      );
-      return undefined;
+  for (const candidate of ordered) {
+    if (candidate.evidencePaths.length === 0) {
+      continue;
     }
-    perPathMatches.push(match);
+    const coordinate =
+      candidate.name && candidate.version
+        ? `${candidate.name}@${candidate.version}`
+        : undefined;
+    if (coordinate && seen.has(coordinate)) {
+      continue;
+    }
+
+    // Fail closed per candidate: every evidence path must resolve to one
+    // consistent owner, else the candidate keeps its findings.
+    const matches: PathOwnerMatch[] = [];
+    let allOwned = true;
+    for (const evidencePath of candidate.evidencePaths) {
+      const normalized = normalizeAbsolutePath(evidencePath);
+      if (!resolvedByPath.has(normalized)) {
+        resolvedByPath.set(
+          normalized,
+          resolveOwnerForEvidencePath(normalized, index, symlinkGraph),
+        );
+      }
+      const match = resolvedByPath.get(normalized);
+      if (!match) {
+        allOwned = false;
+        break;
+      }
+      matches.push(match);
+    }
+    if (!allOwned) {
+      continue;
+    }
+
+    const owner = pickConsistentOwner(matches);
+    if (!owner) {
+      continue;
+    }
+
+    if (coordinate) {
+      seen.add(coordinate);
+    }
+    ownedPackages.push({
+      evidencePaths: candidate.evidencePaths,
+      apkPackageName: owner.Name,
+      apkPackageVersion: owner.Version,
+      originPackage: owner.Source ?? owner.Name,
+      ...(candidate.name ? { name: candidate.name } : {}),
+      ...(candidate.version ? { version: candidate.version } : {}),
+    });
   }
 
-  const owner = pickConsistentOwner(perPathMatches);
-  if (!owner) {
+  if (ownedPackages.length === 0) {
     return undefined;
   }
 
-  return {
-    distroId: osRelease.name,
-    packageName: owner.Name,
-    packageVersion: owner.Version,
-    originPackage: owner.Source ?? owner.Name,
-    evidencePaths,
-  };
+  return { distroId: osRelease.name, ownedPackages };
 }
 
 function ownerKey(pkg: AnalyzedPackageWithVersion): string {

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -78,6 +78,7 @@ import {
 } from "./layer-attribution";
 import * as osReleaseDetector from "./os-release";
 import { analyze as apkAnalyze } from "./package-managers/apk";
+import { isChainguardDistro } from "./package-managers/apk-ownership";
 import {
   analyze as aptAnalyze,
   analyzeDistroless as aptDistrolessAnalyze,
@@ -303,6 +304,7 @@ export async function analyze(
     const nodeDependenciesScanResults = await nodeFilesToScannedProjects(
       getFileContent(extractedLayers, getNodeAppFileContentAction.actionName),
       nodeModulesScan,
+      isChainguardDistro(osRelease),
     );
     let nodeApplicationFilesScanResults: AppDepsScanResultWithoutTarget[] = [];
     if (collectApplicationFiles) {

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -90,6 +90,14 @@ export interface JarFingerprint {
   version?: string;
   dependencies: JarCoords[];
 }
+// Per-package install directory under a node_modules root. Carried internally
+// from the node scanner to response-builder to resolve per-dependency APK
+// ownership; never serialized into the public scan output.
+export interface NodeModulesPackagePath {
+  name: string;
+  version: string;
+  installDir: string;
+}
 export interface StaticAnalysis {
   imageId: string;
   platform?: string;

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -1,5 +1,6 @@
 import { DepGraph } from "@snyk/dep-graph";
 import { ApplicationFiles } from "./analyzer/applications/types";
+import { ApkPackageOwnership } from "./analyzer/package-managers/apk-ownership";
 import { JarFingerprint } from "./analyzer/types";
 import { DockerFileAnalysis } from "./dockerfile/types";
 import { OCIDistributionMetadata } from "./extractor/oci-distribution-metadata";
@@ -175,11 +176,6 @@ export interface BaseRuntimesFact {
 
 export interface ApkPackageOwnershipFact {
   type: "apkPackageOwnership";
-  data: {
-    distroId: string;
-    packageName: string;
-    packageVersion: string;
-    originPackage: string;
-    evidencePaths: string[];
-  };
+  // Shape owned by the resolver so the contract and the lib stay in lockstep.
+  data: ApkPackageOwnership;
 }

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -315,7 +315,7 @@ async function buildResponse(
 
     if (ownershipEnabled && apkPathIndex) {
       // One ownership fact per app-dep result. buildOwnershipCandidates shapes
-      // the units per ecosystem (npm: per package; Java: per jar; Go/other: one
+      // the units per ecosystem (npm: one per package; Java/Go/other: a single
       // whole-result unit) and resolveApkOwnership attributes each to its owning
       // APK package, failing closed per candidate.
       const ownership = resolveApkOwnership(

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -314,10 +314,7 @@ async function buildResponse(
     // }
 
     if (ownershipEnabled && apkPathIndex) {
-      // One ownership fact per app-dep result. buildOwnershipCandidates shapes
-      // the units per ecosystem (npm: one per package; Java/Go/other: a single
-      // whole-result unit) and resolveApkOwnership attributes each to its owning
-      // APK package, failing closed per candidate.
+      // One ownership fact per app-dep result; candidates fail closed independently.
       const ownership = resolveApkOwnership(
         buildOwnershipCandidates(appDepsScanResult),
         apkPathIndex,

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -1,8 +1,9 @@
 import { legacy } from "@snyk/dep-graph";
-import { extractEvidencePaths } from "./analyzer/applications/evidence-paths";
+import { buildOwnershipCandidates } from "./analyzer/applications/evidence-paths";
 import {
   buildApkPathIndex,
   getApkPackagesFromResults,
+  isChainguardDistro,
   resolveApkOwnership,
   toSymlinkGraph,
 } from "./analyzer/package-managers/apk-ownership";
@@ -247,15 +248,18 @@ async function buildResponse(
     additionalFacts.push(autoDetectedUserInstructionsFact);
   }
 
-  // The APK ownership inputs are image-global, so build the path index once
-  // here rather than rebuilding it for every application scan result below.
-  // resolveApkOwnership decides which distros the index actually applies to.
+  // APK package ownership only applies to Chainguard/Wolfi images, so the
+  // image-global path index is built once here and only when it will be used;
+  // non-Chainguard images skip the build (and all resolution below) entirely.
   const osRelease = depsAnalysis.osRelease;
+  const ownershipEnabled = isChainguardDistro(osRelease);
   const apkSymlinkGraph = toSymlinkGraph(depsAnalysis.symlinks);
-  const apkPathIndex = buildApkPathIndex(
-    getApkPackagesFromResults(depsAnalysis.results),
-    apkSymlinkGraph,
-  );
+  const apkPathIndex = ownershipEnabled
+    ? buildApkPathIndex(
+        getApkPackagesFromResults(depsAnalysis.results),
+        apkSymlinkGraph,
+      )
+    : undefined;
 
   const applicationDependenciesScanResults: types.ScanResult[] = (
     depsAnalysis.applicationDependenciesScanResults || []
@@ -309,22 +313,32 @@ async function buildResponse(
     //   }
     // }
 
-    const ownership = resolveApkOwnership(
-      extractEvidencePaths(appDepsScanResult),
-      apkPathIndex,
-      apkSymlinkGraph,
-      osRelease,
-    );
-    if (ownership) {
-      const ownershipFact: facts.ApkPackageOwnershipFact = {
-        type: "apkPackageOwnership",
-        data: ownership,
-      };
-      appDepsScanResult.facts.push(ownershipFact);
+    if (ownershipEnabled && apkPathIndex) {
+      // One ownership fact per app-dep result. buildOwnershipCandidates shapes
+      // the units per ecosystem (npm: per package; Java: per jar; Go/other: one
+      // whole-result unit) and resolveApkOwnership attributes each to its owning
+      // APK package, failing closed per candidate.
+      const ownership = resolveApkOwnership(
+        buildOwnershipCandidates(appDepsScanResult),
+        apkPathIndex,
+        apkSymlinkGraph,
+        osRelease,
+      );
+      if (ownership) {
+        const ownershipFact: facts.ApkPackageOwnershipFact = {
+          type: "apkPackageOwnership",
+          data: ownership,
+        };
+        appDepsScanResult.facts.push(ownershipFact);
+      }
     }
 
+    // Drop the internal-only install-dir data so it never reaches the wire.
+    const { nodeModulesPackagePaths: _internal, ...publicResult } =
+      appDepsScanResult;
+
     return {
-      ...appDepsScanResult,
+      ...publicResult,
       target: {
         image: depGraph.rootPkg.name,
       },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -83,7 +83,8 @@ export type FactType =
   | "testedFiles"
   // Application files observed in the image
   | "applicationFiles"
-  // Chainguard/Wolfi: APK package that owns application dependency evidence paths
+  // Chainguard/Wolfi: APK packages that own application dependency evidence
+  // (per-dependency for npm, whole-result for Go/Java)
   | "apkPackageOwnership";
 
 export interface PluginAnalytics {

--- a/test/system/application-scans/chainguard-ownership.spec.ts
+++ b/test/system/application-scans/chainguard-ownership.spec.ts
@@ -60,12 +60,7 @@ describe("chainguard app ownership", () => {
     );
     expect(npmOwned.length).toBeGreaterThan(0);
 
-    // The internal install-dir data must never reach the public output —
-    // neither as a fact nor as a field on the ScanResult.
-    const carrierFacts = appResults.flatMap((result) =>
-      result.facts.filter((fact) => fact.type === "nodeModulesPackagePaths"),
-    );
-    expect(carrierFacts).toHaveLength(0);
+    // The internal install-dir data must never reach the public ScanResult.
     appResults.forEach((result) => {
       expect((result as any).nodeModulesPackagePaths).toBeUndefined();
     });

--- a/test/system/application-scans/chainguard-ownership.spec.ts
+++ b/test/system/application-scans/chainguard-ownership.spec.ts
@@ -1,25 +1,26 @@
 import { scan } from "../../../lib/index";
 
+const BASH_IMAGE =
+  "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a";
+// Digest-pinned for reproducibility (mirrors BASH_IMAGE) and pulled from
+// docker.io to match the registry the rest of the system suite already uses.
+const NODE_IMAGE =
+  "chainguard/node@sha256:27bf957bdf6d189108c8908c958fd966d9814f78e7172c2d791940f4e208a334";
+
 describe("chainguard app ownership", () => {
   afterAll(async () => {
-    // Best-effort cleanup if the image was pulled during the test.
+    // Best-effort cleanup if the images were pulled during the test.
     try {
       const { execute } = await import("../../../lib/sub-process");
-      await execute("docker", [
-        "image",
-        "rm",
-        "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a",
-      ]);
+      await execute("docker", ["image", "rm", BASH_IMAGE, NODE_IMAGE]);
     } catch {
       // ignore teardown errors
     }
   });
 
   it("does not attach apkPackageOwnership on OS-only Chainguard images", async () => {
-    const image =
-      "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a";
     const pluginResult = await scan({
-      path: image,
+      path: BASH_IMAGE,
       platform: "linux/amd64",
     });
 
@@ -28,5 +29,40 @@ describe("chainguard app ownership", () => {
       result.facts.filter((fact) => fact.type === "apkPackageOwnership"),
     );
     expect(ownershipFacts).toHaveLength(0);
+  });
+
+  it("attaches per-dependency npm ownership for apk-bundled node packages", async () => {
+    // npm bundles its own dependency tree under
+    // /usr/lib/node_modules/npm/node_modules, owned by the `npm` apk package.
+    // Those deps must be reconciled to origin `npm` rather than reported as
+    // unqualified upstream npm findings. Assert the invariant (at least one npm
+    // owned dependency) rather than a specific package, which can change across
+    // npm releases.
+    const pluginResult = await scan({
+      path: NODE_IMAGE,
+      platform: "linux/amd64",
+    });
+
+    const appResults = pluginResult.scanResults.slice(1);
+    const ownedPackages = appResults.flatMap((result) =>
+      result.facts
+        .filter((fact) => fact.type === "apkPackageOwnership")
+        .flatMap((fact) => (fact.data as any).ownedPackages),
+    );
+
+    const npmOwned = ownedPackages.filter(
+      (pkg: any) => pkg.originPackage === "npm",
+    );
+    expect(npmOwned.length).toBeGreaterThan(0);
+
+    // The internal install-dir data must never reach the public output —
+    // neither as a fact nor as a field on the ScanResult.
+    const carrierFacts = appResults.flatMap((result) =>
+      result.facts.filter((fact) => fact.type === "nodeModulesPackagePaths"),
+    );
+    expect(carrierFacts).toHaveLength(0);
+    appResults.forEach((result) => {
+      expect((result as any).nodeModulesPackagePaths).toBeUndefined();
+    });
   });
 });

--- a/test/system/application-scans/chainguard-ownership.spec.ts
+++ b/test/system/application-scans/chainguard-ownership.spec.ts
@@ -2,8 +2,8 @@ import { scan } from "../../../lib/index";
 
 const BASH_IMAGE =
   "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a";
-// Digest-pinned for reproducibility (mirrors BASH_IMAGE) and pulled from
-// docker.io to match the registry the rest of the system suite already uses.
+// Both images are digest-pinned for reproducibility and pulled from docker.io,
+// matching the registry the rest of the system suite already uses.
 const NODE_IMAGE =
   "chainguard/node@sha256:27bf957bdf6d189108c8908c958fd966d9814f78e7172c2d791940f4e208a334";
 

--- a/test/system/application-scans/chainguard-ownership.spec.ts
+++ b/test/system/application-scans/chainguard-ownership.spec.ts
@@ -5,10 +5,10 @@ import { scan } from "../../../lib/index";
 // break this in CI.
 const BASH_IMAGE =
   "snykgoof/chainguard-bash@sha256:bf932e4dc71966dcab75dae6ec518ff3d1dde8f473ddb7bbaebdaab52b5efae8";
-// Digest-pinned for reproducibility and pulled from docker.io, matching the
-// registry the rest of the system suite already uses.
+// Self-hosted on the snykgoof Docker Hub org (mirrored from chainguard/node)
+// for the same reason as BASH_IMAGE above.
 const NODE_IMAGE =
-  "chainguard/node@sha256:27bf957bdf6d189108c8908c958fd966d9814f78e7172c2d791940f4e208a334";
+  "snykgoof/chainguard-node@sha256:858d431f75ac714496d61ad63da99152ce884d58367234d9b82fe79cf4e16f2c";
 
 describe("chainguard app ownership", () => {
   afterAll(async () => {

--- a/test/system/application-scans/chainguard-ownership.spec.ts
+++ b/test/system/application-scans/chainguard-ownership.spec.ts
@@ -1,14 +1,16 @@
 import { scan } from "../../../lib/index";
 
-// Self-hosted on the snykgoof Docker Hub org (mirrored from chainguard/bash)
-// since chainguard.dev requires auth to pull non-`latest` tags, which would
-// break this in CI.
+// Self-hosted on the snykgoof Docker Hub org (mirrored from chainguard/bash,
+// preserving the original multi-arch amd64+arm64 manifest index) since
+// chainguard.dev requires auth to pull non-`latest` tags, which would break
+// this in CI. The mirror was pushed with `docker buildx imagetools create`,
+// which copies the manifest index verbatim, so the digest is unchanged.
 const BASH_IMAGE =
-  "snykgoof/chainguard-bash@sha256:bf932e4dc71966dcab75dae6ec518ff3d1dde8f473ddb7bbaebdaab52b5efae8";
+  "snykgoof/chainguard-bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a";
 // Self-hosted on the snykgoof Docker Hub org (mirrored from chainguard/node)
 // for the same reason as BASH_IMAGE above.
 const NODE_IMAGE =
-  "snykgoof/chainguard-node@sha256:858d431f75ac714496d61ad63da99152ce884d58367234d9b82fe79cf4e16f2c";
+  "snykgoof/chainguard-node@sha256:27bf957bdf6d189108c8908c958fd966d9814f78e7172c2d791940f4e208a334";
 
 describe("chainguard app ownership", () => {
   afterAll(async () => {

--- a/test/system/application-scans/chainguard-ownership.spec.ts
+++ b/test/system/application-scans/chainguard-ownership.spec.ts
@@ -1,9 +1,12 @@
 import { scan } from "../../../lib/index";
 
+// Self-hosted on the snykgoof Docker Hub org (mirrored from chainguard/bash)
+// since chainguard.dev requires auth to pull non-`latest` tags, which would
+// break this in CI.
 const BASH_IMAGE =
-  "chainguard/bash@sha256:642933df66209814502599053ca3dfa97cccf847badc4219d2b1fd6565f6559a";
-// Both images are digest-pinned for reproducibility and pulled from docker.io,
-// matching the registry the rest of the system suite already uses.
+  "snykgoof/chainguard-bash@sha256:bf932e4dc71966dcab75dae6ec518ff3d1dde8f473ddb7bbaebdaab52b5efae8";
+// Digest-pinned for reproducibility and pulled from docker.io, matching the
+// registry the rest of the system suite already uses.
 const NODE_IMAGE =
   "chainguard/node@sha256:27bf957bdf6d189108c8908c958fd966d9814f78e7172c2d791940f4e208a334";
 

--- a/test/unit/apk-ownership.spec.ts
+++ b/test/unit/apk-ownership.spec.ts
@@ -25,6 +25,8 @@ function makePackage(
   };
 }
 
+const wolfi = { name: "wolfi", version: "20230201", prettyName: "Wolfi" };
+
 describe("apk-ownership", () => {
   const symlinkGraph = new Map<string, string>([["/bin", "usr/bin"]]);
 
@@ -49,18 +51,23 @@ describe("apk-ownership", () => {
       makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
     ];
     const index = buildApkPathIndex(packages, symlinkGraph);
-    const ownership = resolveApkOwnership(["/bin/node"], index, symlinkGraph, {
-      name: "wolfi",
-      version: "20230201",
-      prettyName: "Wolfi",
-    });
+    const ownership = resolveApkOwnership(
+      [{ evidencePaths: ["/bin/node"] }],
+      index,
+      symlinkGraph,
+      wolfi,
+    );
 
     expect(ownership).toEqual({
       distroId: "wolfi",
-      packageName: "nodejs",
-      packageVersion: "20-r1",
-      originPackage: "nodejs",
-      evidencePaths: ["/bin/node"],
+      ownedPackages: [
+        {
+          evidencePaths: ["/bin/node"],
+          apkPackageName: "nodejs",
+          apkPackageVersion: "20-r1",
+          originPackage: "nodejs",
+        },
+      ],
     });
   });
 
@@ -70,7 +77,7 @@ describe("apk-ownership", () => {
     ];
     const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
-      ["/opt/custom/app"],
+      [{ evidencePaths: ["/opt/custom/app"] }],
       index,
       symlinkGraph,
       { name: "chainguard", version: "20230214", prettyName: "Chainguard" },
@@ -85,7 +92,7 @@ describe("apk-ownership", () => {
     ];
     const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
-      ["/usr/bin/node"],
+      [{ evidencePaths: ["/usr/bin/node"] }],
       index,
       symlinkGraph,
       { name: "alpine", version: "3.19", prettyName: "Alpine" },
@@ -115,18 +122,18 @@ describe("apk-ownership", () => {
     expect(exact?.matchKind).toBe("exact");
   });
 
-  it("returns undefined when only some evidence paths are owned", () => {
-    // Chainguard spec: evidence paths must be wholly contained in the owning
-    // package's declared paths; a partially-owned app keeps its findings.
+  it("omits a candidate when only some of its evidence paths are owned", () => {
+    // Chainguard spec: a candidate's evidence paths must be wholly contained in
+    // the owning package's declared paths; a partially-owned unit keeps findings.
     const packages = [
       makePackage("nodejs", "20-r1", "nodejs", ["/usr/bin/node"], ["/usr/bin"]),
     ];
     const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
-      ["/usr/bin/node", "/opt/custom/app.jar"],
+      [{ evidencePaths: ["/usr/bin/node", "/opt/custom/app.jar"] }],
       index,
       symlinkGraph,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      wolfi,
     );
 
     expect(ownership).toBeUndefined();
@@ -152,15 +159,19 @@ describe("apk-ownership", () => {
     const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       [
-        "/usr/share/java/gradle/lib/gradle.jar", // exact: gradle
-        "/usr/share/java/other.jar", // directory: java-common
+        {
+          evidencePaths: [
+            "/usr/share/java/gradle/lib/gradle.jar", // exact: gradle
+            "/usr/share/java/other.jar", // directory: java-common
+          ],
+        },
       ],
       index,
       symlinkGraph,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      wolfi,
     );
 
-    expect(ownership?.packageName).toBe("gradle");
+    expect(ownership?.ownedPackages[0].apkPackageName).toBe("gradle");
   });
 
   it("returns undefined when different owners each have exact matches", () => {
@@ -170,10 +181,10 @@ describe("apk-ownership", () => {
     ];
     const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
-      ["/usr/bin/a", "/usr/bin/some-b"],
+      [{ evidencePaths: ["/usr/bin/a", "/usr/bin/some-b"] }],
       index,
       symlinkGraph,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      wolfi,
     );
 
     expect(ownership).toBeUndefined();
@@ -193,15 +204,19 @@ describe("apk-ownership", () => {
     const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
       [
-        "/usr/lib/python3.12/site-packages/foo/mod.py", // directory: py-foo (deeper)
-        "/usr/lib/python3.12/abc.py", // directory: python (shallower)
+        {
+          evidencePaths: [
+            "/usr/lib/python3.12/site-packages/foo/mod.py", // directory: py-foo (deeper)
+            "/usr/lib/python3.12/abc.py", // directory: python (shallower)
+          ],
+        },
       ],
       index,
       symlinkGraph,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      wolfi,
     );
 
-    expect(ownership?.packageName).toBe("py-foo");
+    expect(ownership?.ownedPackages[0].apkPackageName).toBe("py-foo");
   });
 
   it("returns undefined when one directory is declared by multiple packages", () => {
@@ -220,10 +235,10 @@ describe("apk-ownership", () => {
     ];
     const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
-      ["/usr/lib/node_modules"],
+      [{ evidencePaths: ["/usr/lib/node_modules"] }],
       index,
       symlinkGraph,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      wolfi,
     );
 
     expect(ownership).toBeUndefined();
@@ -236,10 +251,10 @@ describe("apk-ownership", () => {
     ];
     const index = buildApkPathIndex(packages, symlinkGraph);
     const ownership = resolveApkOwnership(
-      ["/usr/lib/a/x.so", "/usr/lib/b/y.so"],
+      [{ evidencePaths: ["/usr/lib/a/x.so", "/usr/lib/b/y.so"] }],
       index,
       symlinkGraph,
-      { name: "wolfi", version: "20230201", prettyName: "Wolfi" },
+      wolfi,
     );
 
     expect(ownership).toBeUndefined();
@@ -275,5 +290,183 @@ describe("apk-ownership", () => {
       isChainguardDistro({ name: "alpine", version: "3.19", prettyName: "" }),
     ).toBe(false);
     expect(isChainguardDistro(undefined)).toBe(false);
+  });
+});
+
+describe("resolveApkOwnership per-package (npm)", () => {
+  const symlinkGraph = new Map<string, string>();
+
+  // The npm apk package bundles its own dependencies under its subtree, so each
+  // bundled package's directory is owned even though the node_modules root is not.
+  const npmPackage = makePackage(
+    "npm",
+    "10.9.0-r0",
+    "npm",
+    [],
+    [
+      "/usr/lib/node_modules/npm",
+      "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+    ],
+  );
+
+  it("resolves a coordinate-bearing candidate to its owning APK origin", () => {
+    const index = buildApkPathIndex([npmPackage], symlinkGraph);
+    const ownership = resolveApkOwnership(
+      [
+        {
+          evidencePaths: [
+            "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+          ],
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+      ],
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+
+    expect(ownership).toEqual({
+      distroId: "wolfi",
+      ownedPackages: [
+        {
+          evidencePaths: [
+            "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+          ],
+          apkPackageName: "npm",
+          apkPackageVersion: "10.9.0-r0",
+          originPackage: "npm",
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+      ],
+    });
+  });
+
+  it("resolves each candidate independently, omitting unowned ones", () => {
+    const index = buildApkPathIndex([npmPackage], symlinkGraph);
+    const ownership = resolveApkOwnership(
+      [
+        {
+          evidencePaths: [
+            "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+          ],
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+        {
+          evidencePaths: ["/usr/local/lib/node_modules/left-pad"],
+          name: "left-pad",
+          version: "1.3.0",
+        },
+      ],
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+
+    expect(ownership?.ownedPackages.map((p) => p.name)).toEqual([
+      "brace-expansion",
+    ]);
+  });
+
+  it("does not resolve ownership for the shared node_modules root", () => {
+    const sharedRoot = [
+      npmPackage,
+      makePackage(
+        "node-gyp",
+        "13.0.0-r0",
+        "node-gyp",
+        [],
+        ["/usr/lib/node_modules"],
+      ),
+      makePackage("npm", "10.9.0-r0", "npm", [], ["/usr/lib/node_modules"]),
+    ];
+    const index = buildApkPathIndex(sharedRoot, symlinkGraph);
+    const ownership = resolveApkOwnership(
+      [
+        {
+          evidencePaths: ["/usr/lib/node_modules"],
+          name: "root",
+          version: "0",
+        },
+      ],
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("dedupes a coordinate by name@version, keeping the owned occurrence", () => {
+    const index = buildApkPathIndex([npmPackage], symlinkGraph);
+    const ownership = resolveApkOwnership(
+      [
+        // unowned copy
+        {
+          evidencePaths: ["/app/node_modules/brace-expansion"],
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+        // owned copy
+        {
+          evidencePaths: [
+            "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+          ],
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+      ],
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+
+    expect(ownership?.ownedPackages).toHaveLength(1);
+    expect(ownership?.ownedPackages[0].originPackage).toBe("npm");
+  });
+
+  it("returns undefined for non-Chainguard distros", () => {
+    const index = buildApkPathIndex([npmPackage], symlinkGraph);
+    const ownership = resolveApkOwnership(
+      [
+        {
+          evidencePaths: [
+            "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+          ],
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+      ],
+      index,
+      symlinkGraph,
+      { name: "alpine", version: "3.19", prettyName: "Alpine" },
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("returns undefined when no candidate is owned", () => {
+    const index = buildApkPathIndex([npmPackage], symlinkGraph);
+    const ownership = resolveApkOwnership(
+      [
+        {
+          evidencePaths: ["/app/left-pad"],
+          name: "left-pad",
+          version: "1.3.0",
+        },
+      ],
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+
+    expect(ownership).toBeUndefined();
+  });
+
+  it("returns undefined for empty input", () => {
+    const index = buildApkPathIndex([npmPackage], symlinkGraph);
+    expect(resolveApkOwnership([], index, symlinkGraph, wolfi)).toBeUndefined();
   });
 });

--- a/test/unit/apk-ownership.spec.ts
+++ b/test/unit/apk-ownership.spec.ts
@@ -427,6 +427,105 @@ describe("resolveApkOwnership per-package (npm)", () => {
     expect(ownership?.ownedPackages[0].originPackage).toBe("npm");
   });
 
+  it("dedupes a coordinate when the owned occurrence is resolved first", () => {
+    // Owned copy sorts first ("/usr" < "/zzz"), so it fills `seen` and the later
+    // duplicate hits the seen.has skip — the reverse order of the test above.
+    const index = buildApkPathIndex([npmPackage], symlinkGraph);
+    const ownership = resolveApkOwnership(
+      [
+        {
+          evidencePaths: [
+            "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+          ],
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+        {
+          evidencePaths: ["/zzz/node_modules/brace-expansion"],
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+      ],
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+
+    expect(ownership?.ownedPackages).toHaveLength(1);
+    expect(ownership?.ownedPackages[0].originPackage).toBe("npm");
+  });
+
+  it("deterministically resolves a coordinate bundled by two different apk packages", () => {
+    // Same coordinate under two apk packages: the localeCompare sort picks the
+    // lexicographically-first evidence path ("aaa" < "npm") regardless of order.
+    const aaaPackage = makePackage(
+      "aaa",
+      "1.0.0-r0",
+      "aaa",
+      [],
+      ["/usr/lib/node_modules/aaa/node_modules/brace-expansion"],
+    );
+    const index = buildApkPathIndex([npmPackage, aaaPackage], symlinkGraph);
+
+    const candidates = [
+      {
+        evidencePaths: [
+          "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+        ],
+        name: "brace-expansion",
+        version: "2.0.1",
+      },
+      {
+        evidencePaths: [
+          "/usr/lib/node_modules/aaa/node_modules/brace-expansion",
+        ],
+        name: "brace-expansion",
+        version: "2.0.1",
+      },
+    ];
+
+    const ownership = resolveApkOwnership(
+      candidates,
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+    const reversed = resolveApkOwnership(
+      [...candidates].reverse(),
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+
+    expect(ownership?.ownedPackages).toHaveLength(1);
+    expect(ownership?.ownedPackages[0].originPackage).toBe("aaa");
+    // Input order must not change the winner.
+    expect(reversed?.ownedPackages[0].originPackage).toBe("aaa");
+  });
+
+  it("skips a candidate whose evidencePaths is empty", () => {
+    const index = buildApkPathIndex([npmPackage], symlinkGraph);
+    const ownership = resolveApkOwnership(
+      [
+        { evidencePaths: [], name: "phantom", version: "0.0.0" },
+        {
+          evidencePaths: [
+            "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+          ],
+          name: "brace-expansion",
+          version: "2.0.1",
+        },
+      ],
+      index,
+      symlinkGraph,
+      wolfi,
+    );
+
+    expect(ownership?.ownedPackages.map((p) => p.name)).toEqual([
+      "brace-expansion",
+    ]);
+  });
+
   it("returns undefined for non-Chainguard distros", () => {
     const index = buildApkPathIndex([npmPackage], symlinkGraph);
     const ownership = resolveApkOwnership(

--- a/test/unit/evidence-paths.spec.ts
+++ b/test/unit/evidence-paths.spec.ts
@@ -21,14 +21,15 @@ describe("evidence-paths", () => {
       ],
     };
 
-    expect(extractEvidencePaths(scanResult)).toEqual(
-      expect.arrayContaining([
-        "/app/package.json",
-        // basename testedFiles are anchored to the app directory, not "/"
-        "/app/package-lock.json",
-        "/app/lib/foo.jar",
-      ]),
-    );
+    // Exact match, not arrayContaining, so extra bogus paths would fail here.
+    const result = extractEvidencePaths(scanResult);
+    expect(result).toEqual([
+      "/app/package.json",
+      // basename testedFiles are anchored to the app directory, not "/"
+      "/app/package-lock.json",
+      "/app/lib/foo.jar",
+    ]);
+    expect(result).toHaveLength(3);
   });
 
   it("anchors basename testedFiles to the app directory of targetFile", () => {

--- a/test/unit/evidence-paths.spec.ts
+++ b/test/unit/evidence-paths.spec.ts
@@ -1,4 +1,7 @@
-import { extractEvidencePaths } from "../../lib/analyzer/applications/evidence-paths";
+import {
+  buildOwnershipCandidates,
+  extractEvidencePaths,
+} from "../../lib/analyzer/applications/evidence-paths";
 import { AppDepsScanResultWithoutTarget } from "../../lib/analyzer/applications/types";
 
 describe("evidence-paths", () => {
@@ -63,5 +66,80 @@ describe("evidence-paths", () => {
     };
 
     expect(extractEvidencePaths(scanResult)).toEqual(["/abs/path.jar"]);
+  });
+});
+
+describe("buildOwnershipCandidates", () => {
+  it("emits one coordinate-bearing candidate per npm global package", () => {
+    const scanResult: AppDepsScanResultWithoutTarget = {
+      identity: { type: "npm", targetFile: "/usr/lib/node_modules" },
+      facts: [{ type: "testedFiles", data: "/usr/lib/node_modules" as any }],
+      nodeModulesPackagePaths: [
+        {
+          name: "brace-expansion",
+          version: "2.0.1",
+          installDir: "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+        },
+        {
+          name: "semver",
+          version: "7.6.0",
+          installDir: "/usr/lib/node_modules/npm/node_modules/semver",
+        },
+      ],
+    };
+
+    expect(buildOwnershipCandidates(scanResult)).toEqual([
+      {
+        evidencePaths: [
+          "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+        ],
+        name: "brace-expansion",
+        version: "2.0.1",
+      },
+      {
+        evidencePaths: ["/usr/lib/node_modules/npm/node_modules/semver"],
+        name: "semver",
+        version: "7.6.0",
+      },
+    ]);
+  });
+
+  it("emits a single whole-result candidate (no coordinate) for jars/Go/other", () => {
+    // Java jars and Go binaries resolve as one whole-result unit — owned only
+    // when one apk package owns every evidence path. No per-coordinate split.
+    const scanResult: AppDepsScanResultWithoutTarget = {
+      identity: { type: "gomodules", targetFile: "/usr/bin/manager" },
+      facts: [
+        { type: "testedFiles", data: ["/usr/bin/manager"] },
+        {
+          type: "jarFingerprints",
+          data: {
+            origin: "image",
+            path: "/usr/share/java/maven/lib",
+            fingerprints: [
+              { location: "/usr/share/java/maven/lib/asm-9.9.1.jar" } as any,
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(buildOwnershipCandidates(scanResult)).toEqual([
+      {
+        evidencePaths: [
+          "/usr/bin/manager",
+          "/usr/share/java/maven/lib/asm-9.9.1.jar",
+        ],
+      },
+    ]);
+  });
+
+  it("returns no candidates when there is no ownership evidence", () => {
+    const scanResult: AppDepsScanResultWithoutTarget = {
+      identity: { type: "composer" },
+      facts: [{ type: "testedFiles", data: ["composer.json"] }],
+    };
+
+    expect(buildOwnershipCandidates(scanResult)).toEqual([]);
   });
 });

--- a/test/unit/node-package-paths.spec.ts
+++ b/test/unit/node-package-paths.spec.ts
@@ -1,0 +1,134 @@
+import { collectNodeModulesPackagePaths } from "../../lib/analyzer/applications/node";
+import {
+  FilePathToContent,
+  FilesByDirMap,
+} from "../../lib/analyzer/applications/types";
+
+describe("collectNodeModulesPackagePaths", () => {
+  const project = "/usr/lib";
+
+  function pkgJson(name: string, version: string): string {
+    return JSON.stringify({ name, version });
+  }
+
+  it("collects name/version/installDir for each node_modules package.json", () => {
+    const braceDir = "/usr/lib/node_modules/npm/node_modules/brace-expansion";
+    const semverDir = "/usr/lib/node_modules/npm/node_modules/semver";
+    const files: FilesByDirMap = new Map([
+      [
+        project,
+        new Set([
+          `${braceDir}/package.json`,
+          `${semverDir}/package.json`,
+          "/usr/lib/node_modules/npm/package.json",
+        ]),
+      ],
+    ]);
+    const contents: FilePathToContent = {
+      [`${braceDir}/package.json`]: pkgJson("brace-expansion", "2.0.1"),
+      [`${semverDir}/package.json`]: pkgJson("semver", "7.6.0"),
+      ["/usr/lib/node_modules/npm/package.json"]: pkgJson("npm", "10.9.0"),
+    };
+
+    const result = collectNodeModulesPackagePaths(project, files, contents);
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { name: "brace-expansion", version: "2.0.1", installDir: braceDir },
+        { name: "semver", version: "7.6.0", installDir: semverDir },
+        {
+          name: "npm",
+          version: "10.9.0",
+          installDir: "/usr/lib/node_modules/npm",
+        },
+      ]),
+    );
+    expect(result).toHaveLength(3);
+  });
+
+  it("skips pnpm/.bin virtual entries and root manifests outside node_modules", () => {
+    const files: FilesByDirMap = new Map([
+      [
+        project,
+        new Set([
+          "/usr/lib/node_modules/.pnpm/foo@1.0.0/node_modules/foo/package.json",
+          "/usr/lib/node_modules/.bin/whatever/package.json",
+          "/usr/lib/package.json", // root manifest, not under node_modules
+        ]),
+      ],
+    ]);
+    const contents: FilePathToContent = {
+      "/usr/lib/node_modules/.pnpm/foo@1.0.0/node_modules/foo/package.json":
+        pkgJson("foo", "1.0.0"),
+      "/usr/lib/node_modules/.bin/whatever/package.json": pkgJson("x", "1"),
+      "/usr/lib/package.json": pkgJson("root", "1.0.0"),
+    };
+
+    expect(collectNodeModulesPackagePaths(project, files, contents)).toEqual(
+      [],
+    );
+  });
+
+  it("skips package.json with missing name/version or invalid JSON", () => {
+    const files: FilesByDirMap = new Map([
+      [
+        project,
+        new Set([
+          "/usr/lib/node_modules/no-version/package.json",
+          "/usr/lib/node_modules/broken/package.json",
+        ]),
+      ],
+    ]);
+    const contents: FilePathToContent = {
+      "/usr/lib/node_modules/no-version/package.json": JSON.stringify({
+        name: "no-version",
+      }),
+      "/usr/lib/node_modules/broken/package.json": "{ not json",
+    };
+
+    expect(collectNodeModulesPackagePaths(project, files, contents)).toEqual(
+      [],
+    );
+  });
+
+  it("handles scoped packages (@scope/name)", () => {
+    const scopedDir = "/usr/lib/node_modules/npm/node_modules/@npmcli/agent";
+    const files: FilesByDirMap = new Map([
+      [project, new Set([`${scopedDir}/package.json`])],
+    ]);
+    const contents: FilePathToContent = {
+      [`${scopedDir}/package.json`]: pkgJson("@npmcli/agent", "4.0.2"),
+    };
+
+    expect(collectNodeModulesPackagePaths(project, files, contents)).toEqual([
+      { name: "@npmcli/agent", version: "4.0.2", installDir: scopedDir },
+    ]);
+  });
+
+  it("returns one entry per install path for a coordinate at multiple depths", () => {
+    // Collection does not dedup; the resolver dedups by coordinate. This keeps
+    // both install locations available so ownership can be resolved per path.
+    const hoisted = "/usr/lib/node_modules/npm/node_modules/semver";
+    const nested =
+      "/usr/lib/node_modules/npm/node_modules/foo/node_modules/semver";
+    const files: FilesByDirMap = new Map([
+      [project, new Set([`${hoisted}/package.json`, `${nested}/package.json`])],
+    ]);
+    const contents: FilePathToContent = {
+      [`${hoisted}/package.json`]: pkgJson("semver", "7.6.0"),
+      [`${nested}/package.json`]: pkgJson("semver", "7.6.0"),
+    };
+
+    const result = collectNodeModulesPackagePaths(project, files, contents);
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.installDir).sort()).toEqual(
+      [hoisted, nested].sort(),
+    );
+  });
+
+  it("returns empty when the project has no grouped files", () => {
+    expect(collectNodeModulesPackagePaths("/missing", new Map(), {})).toEqual(
+      [],
+    );
+  });
+});

--- a/test/unit/node-package-paths.spec.ts
+++ b/test/unit/node-package-paths.spec.ts
@@ -126,6 +126,60 @@ describe("collectNodeModulesPackagePaths", () => {
     );
   });
 
+  it("excludes bundled fixtures/examples that are not real package roots", () => {
+    // Nested below a package root, so it must not be collected even though it
+    // declares a real-looking coordinate that would collide with the real dep.
+    const fixture =
+      "/usr/lib/node_modules/npm/node_modules/brace-expansion/test/fixtures/package.json";
+    const files: FilesByDirMap = new Map([[project, new Set([fixture])]]);
+    const contents: FilePathToContent = {
+      [fixture]: pkgJson("lodash", "4.17.21"),
+    };
+
+    expect(collectNodeModulesPackagePaths(project, files, contents)).toEqual(
+      [],
+    );
+  });
+
+  it("collects packages from Windows-style backslash paths", () => {
+    // On Windows the extractor emits backslash paths; they must still match and
+    // installDir must be normalized to POSIX for the resolver.
+    const winProject = "\\usr\\lib";
+    const braceJson =
+      "\\usr\\lib\\node_modules\\npm\\node_modules\\brace-expansion\\package.json";
+    const files: FilesByDirMap = new Map([[winProject, new Set([braceJson])]]);
+    const contents: FilePathToContent = {
+      [braceJson]: pkgJson("brace-expansion", "2.0.1"),
+    };
+
+    expect(collectNodeModulesPackagePaths(winProject, files, contents)).toEqual(
+      [
+        {
+          name: "brace-expansion",
+          version: "2.0.1",
+          installDir: "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+        },
+      ],
+    );
+  });
+
+  it("skips a manifest whose name/version are not strings", () => {
+    // Numeric or empty name/version must not reach the coordinate.
+    const numeric = "/usr/lib/node_modules/numeric/package.json";
+    const emptyName = "/usr/lib/node_modules/empty/package.json";
+    const files: FilesByDirMap = new Map([
+      [project, new Set([numeric, emptyName])],
+    ]);
+    const contents: FilePathToContent = {
+      [numeric]: JSON.stringify({ name: 123, version: 4.5 }),
+      [emptyName]: JSON.stringify({ name: "", version: "1.0.0" }),
+    };
+
+    expect(collectNodeModulesPackagePaths(project, files, contents)).toEqual(
+      [],
+    );
+  });
+
   it("returns empty when the project has no grouped files", () => {
     expect(collectNodeModulesPackagePaths("/missing", new Map(), {})).toEqual(
       [],

--- a/test/unit/response-builder-ownership.spec.ts
+++ b/test/unit/response-builder-ownership.spec.ts
@@ -1,7 +1,7 @@
 import { AnalysisType } from "../../lib/analyzer/types";
 import { buildResponse } from "../../lib/response-builder";
 
-describe("buildResponse apkPackageOwnership", () => {
+describe("buildResponse apkPackageOwnership — whole-result (Go)", () => {
   it("attaches an ownership fact to application ScanResults on Wolfi", async () => {
     const response = await buildResponse(
       {
@@ -69,8 +69,139 @@ describe("buildResponse apkPackageOwnership", () => {
     expect(ownershipFact).toBeDefined();
     expect(ownershipFact!.data).toMatchObject({
       distroId: "wolfi",
-      originPackage: "nodejs",
-      packageName: "nodejs",
+      ownedPackages: [{ apkPackageName: "nodejs", originPackage: "nodejs" }],
     });
+  });
+});
+
+describe("buildResponse apkPackageOwnership — per-dependency (npm)", () => {
+  const npmAnalysis = {
+    Image: "chainguard-node",
+    AnalyzeType: AnalysisType.Apk,
+    Analysis: [
+      {
+        Name: "npm",
+        Version: "10.9.0-r0",
+        Source: "npm",
+        Provides: [],
+        Deps: {},
+        Files: [],
+        Directories: ["/usr/lib/node_modules/npm/node_modules/brace-expansion"],
+      },
+    ],
+  };
+
+  function wolfiAnalysisWithNpmResult(
+    nodeModulesPackagePaths: any[],
+    osName = "wolfi",
+  ) {
+    const targetOS = { name: osName, version: "20230201", prettyName: osName };
+    return {
+      depTree: {
+        name: "docker-image|chainguard-node",
+        version: "latest",
+        packageFormatVersion: "apk:0.0.1",
+        targetOS,
+        dependencies: {},
+      },
+      packageFormat: "apk",
+      imageId: "sha256:abc",
+      osRelease: targetOS,
+      results: [npmAnalysis],
+      binaries: [],
+      imageLayers: [],
+      applicationDependenciesScanResults: [
+        {
+          identity: { type: "npm", targetFile: "/usr/lib/node_modules" },
+          facts: [{ type: "testedFiles", data: "/usr/lib/node_modules" }],
+          // Internal carrier: install dirs the node scanner recorded, never a fact.
+          nodeModulesPackagePaths,
+        },
+      ],
+      manifestFiles: [],
+      symlinks: {},
+    };
+  }
+
+  it("attaches a per-dependency ownership fact and never leaks the install dirs", async () => {
+    const response = await buildResponse(
+      wolfiAnalysisWithNpmResult([
+        {
+          name: "brace-expansion",
+          version: "2.0.1",
+          installDir: "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+        },
+      ]) as any,
+      undefined,
+      false,
+    );
+
+    const appResult = response.scanResults[1];
+    const ownershipFact = appResult.facts.find(
+      (f) => f.type === "apkPackageOwnership",
+    );
+    expect(ownershipFact).toBeDefined();
+    expect(ownershipFact!.data).toMatchObject({
+      distroId: "wolfi",
+      ownedPackages: [
+        {
+          name: "brace-expansion",
+          version: "2.0.1",
+          originPackage: "npm",
+          apkPackageName: "npm",
+        },
+      ],
+    });
+
+    // The internal install-dir data must never reach the public ScanResult.
+    expect((appResult as any).nodeModulesPackagePaths).toBeUndefined();
+    expect(
+      appResult.facts.find((f) => f.type === "nodeModulesPackagePaths"),
+    ).toBeUndefined();
+  });
+
+  it("emits no ownership fact when nothing is owned", async () => {
+    const response = await buildResponse(
+      wolfiAnalysisWithNpmResult([
+        {
+          name: "left-pad",
+          version: "1.3.0",
+          installDir: "/usr/local/lib/node_modules/left-pad",
+        },
+      ]) as any,
+      undefined,
+      false,
+    );
+
+    const appResult = response.scanResults[1];
+    expect(
+      appResult.facts.find((f) => f.type === "apkPackageOwnership"),
+    ).toBeUndefined();
+    expect((appResult as any).nodeModulesPackagePaths).toBeUndefined();
+  });
+
+  it("does no ownership work on non-Chainguard distros and never leaks install dirs", async () => {
+    const response = await buildResponse(
+      wolfiAnalysisWithNpmResult(
+        [
+          {
+            name: "brace-expansion",
+            version: "2.0.1",
+            installDir:
+              "/usr/lib/node_modules/npm/node_modules/brace-expansion",
+          },
+        ],
+        "alpine",
+      ) as any,
+      undefined,
+      false,
+    );
+
+    const appResult = response.scanResults[1];
+    // Gated off on non-Chainguard: no ownership fact even though the dir is owned.
+    expect(
+      appResult.facts.find((f) => f.type === "apkPackageOwnership"),
+    ).toBeUndefined();
+    expect((appResult as any).nodeModulesPackagePaths).toBeUndefined();
   });
 });

--- a/test/unit/response-builder-ownership.spec.ts
+++ b/test/unit/response-builder-ownership.spec.ts
@@ -155,9 +155,6 @@ describe("buildResponse apkPackageOwnership — per-dependency (npm)", () => {
 
     // The internal install-dir data must never reach the public ScanResult.
     expect((appResult as any).nodeModulesPackagePaths).toBeUndefined();
-    expect(
-      appResult.facts.find((f) => f.type === "nodeModulesPackagePaths"),
-    ).toBeUndefined();
   });
 
   it("emits no ownership fact when nothing is owned", async () => {


### PR DESCRIPTION
[CN-1395](https://snyksec.atlassian.net/browse/CN-1395)

**Follow-up to #872.** Stacked on `feat/cn-1395-apk-ownership-fact`.

#### What does this PR do?

#872 emits an `apkPackageOwnership` fact only when **all** of an application-dependency ScanResult's evidence paths are owned by a single apk package. That works for Java (jar paths) and Go (binaries), but **npm global modules fail closed**: their only evidence path is the shared `/usr/lib/node_modules` root, which is declared by multiple apk packages (`npm`, `node-gyp`), so nothing resolves — even though individual bundled packages **are** owned.

Concretely, `brace-expansion` (a CN-1395 example finding) lives at `/usr/lib/node_modules/npm/node_modules/brace-expansion` and is owned by the `npm` apk package, but #872 never reconciles it.

This PR unifies ownership resolution across all three ecosystems behind a single **ownership-candidate** model, resolving npm per-package while preserving whole-result resolution for Java and Go:

- **`node.ts`** — `collectNodeModulesPackagePaths()` parses each `package.json` under `node_modules/` to derive `{name, version, installDir}` per installed package, attached as an internal `nodeModulesPackagePaths` field. Gated by `isChainguardDistro()`, so non-Chainguard images skip the parsing entirely.
- **`evidence-paths.ts`** — `buildOwnershipCandidates()` produces one `OwnershipCandidate` per npm package, keyed by that package's own install dir and carrying a `name@version` coordinate. Java/Go fall through to the existing path: a single whole-result candidate over all evidence paths, with no coordinate. `.pnpm`, `.bin`, and `.cache` entries are skipped.
- **`apk-ownership.ts`** — `resolveApkOwnership()` now takes `OwnershipCandidate[]` and resolves each candidate independently (fail closed per candidate, so user-installed packages keep their findings). Candidates with coordinates are deduped by `name@version` — keeping an owned occurrence over an unowned one — sorted by first evidence path for deterministic output, with memoized per-path lookups.
- **`response-builder.ts`** — emits a **single** `apkPackageOwnership` fact and strips the internal `nodeModulesPackagePaths` field before the result becomes a public `ScanResult`, so it never reaches the wire.

#### ⚠️ Public API note

The `apkPackageOwnership` `FactType` string is **unchanged**, but its data shape changes from flat `packageName`/`packageVersion`/`originPackage` fields to:

```ts
{ distroId, ownedPackages: OwnedPackage[] }
// OwnedPackage: { evidencePaths, apkPackageName, apkPackageVersion, originPackage, name?, version? }
```

`name`/`version` are present only for per-dependency entries (npm); they're absent for whole-result entries (Go, Java). The fact only emits on Chainguard/Wolfi images → **zero snapshot churn**.

#### Where should the reviewer start?

`buildOwnershipCandidates` in `lib/analyzer/applications/evidence-paths.ts`, then `resolveApkOwnership` in `lib/analyzer/package-managers/apk-ownership.ts`, then the wiring in `lib/response-builder.ts`.

#### How was this tested?

- Unit: `npx jest test/unit/apk-ownership.spec.ts test/unit/evidence-paths.spec.ts test/unit/node-package-paths.spec.ts test/unit/response-builder-ownership.spec.ts`
- System (Docker + cgr.dev): `npx jest test/system/application-scans/chainguard-ownership.spec.ts` — scans `cgr.dev/chainguard/node:latest` and asserts `brace-expansion` → origin `npm`. **Verified passing.**
- Full `npm run test:unit` + `npm run build` + `npm run lint` all green, no snapshot churn.

#### Out of scope (follow-ups)

- pnpm virtual store (`.pnpm`) — skipped.
- Java multi-jar mixed-owner results — separate concern.

#### Relevant tickets
CN-1395

[CN-1395]: https://snyksec.atlassian.net/browse/CN-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ