### PR TITLE
docs: add Cursor Cloud setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,3 +156,27 @@ target Node major (`20`) when validating locally.
 - How a scan flows end-to-end: start at `lib/scan.ts`.
 - How to add support for a new ecosystem: look at an existing one under
   `lib/inputs/` + `lib/analyzer/applications/` + `lib/parser/` as a template.
+
+## Cursor Cloud specific instructions
+
+This is a library, not a runnable app — there is no server/dev process to start.
+"Running it" means calling `scan(...)` (exported from `lib/index.ts`) against an
+image archive, e.g. a fixture under `test/fixtures/oci-archives/`. See the
+standard `Commands` table above for build/lint/test; only the non-obvious
+caveats below are Cloud-specific.
+
+- **Node version:** `.nvmrc` pins Node 20 and CI uses `20.19`. The VM's default
+  `node` may be a newer major (e.g. 22) from the agent runtime; it satisfies
+  `engines >=20.19` and build/lint/unit all pass on it, but to match CI run
+  `nvm use 20` (Node 20 is preinstalled via nvm; `nvm alias default 20` is set).
+- **Unit-test color gotcha:** the 4 tests in `test/lib/display.spec.ts` compare
+  against ANSI-colored fixtures. `chalk` only emits color when it detects color
+  support, so in a non-TTY shell those 4 tests fail spuriously with a
+  color-vs-plain diff. Run unit tests with `FORCE_COLOR=1`
+  (`FORCE_COLOR=1 npm run test:unit`) and they all pass.
+- **System tests need secrets + Docker:** `npm run test:system` requires a
+  running Docker daemon plus the private creds `DOCKER_HUB_PRIVATE_IMAGE`,
+  `DOCKER_HUB_USERNAME`, `DOCKER_HUB_PASSWORD` (and at runtime the plugin reads
+  `SNYK_REGISTRY_USERNAME` / `SNYK_REGISTRY_PASSWORD`). Neither Docker nor those
+  secrets are present by default here, so system tests cannot run until they are
+  provided. Unit tests and archive-based `scan()` calls need neither.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Cloud development environment for `snyk-docker-plugin` and documents the non-obvious caveats for future agents in a new `## Cursor Cloud specific instructions` section of `AGENTS.md`. No library code changed.

## Environment setup verified

- Node 20 (via nvm; `.nvmrc` pins `20`), `npm install` (runs `prepare` → `tsc` build).
- `npm run build` — TypeScript compiles to `dist/`.
- `npm run lint` — prettier + eslint + commitlint all pass.
- `npm run test:unit` — 873 unit tests pass (requires `FORCE_COLOR=1` in non-TTY shells; see note below).
- Hello-world: `scan()` on `oci-archive:test/fixtures/oci-archives/alpine-3.12.0.tar` extracted the `apk` dep graph (14 packages), OS `Alpine Linux v3.12`, image id and layers.

## Non-obvious caveats documented

- **Node:** VM default `node` may be v22 (satisfies `engines >=20.19`); use `nvm use 20` to match CI.
- **Unit-test color gotcha:** `test/lib/display.spec.ts` compares ANSI-colored fixtures; without `FORCE_COLOR=1` four tests fail spuriously in a non-TTY shell.
- **System tests:** `npm run test:system` needs Docker + private Docker Hub creds (`DOCKER_HUB_PRIVATE_IMAGE` / `DOCKER_HUB_USERNAME` / `DOCKER_HUB_PASSWORD`), which are not present by default.

[Hello-world scan output](https://cursor.com/agents/bc-db6fdbcb-649e-4e03-a785-3d67e30eb9b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_scan_output.log)
[lint_and_unit_tests.log](https://cursor.com/agents/bc-db6fdbcb-649e-4e03-a785-3d67e30eb9b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flint_and_unit_tests.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db6fdbcb-649e-4e03-a785-3d67e30eb9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db6fdbcb-649e-4e03-a785-3d67e30eb9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

