### PR TITLE
docs: add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,3 +156,59 @@ target Node major (`20`) when validating locally.
 - How a scan flows end-to-end: start at `lib/scan.ts`.
 - How to add support for a new ecosystem: look at an existing one under
   `lib/inputs/` + `lib/analyzer/applications/` + `lib/parser/` as a template.
+
+## Cursor Cloud specific instructions
+
+These notes are specific to the Cursor Cloud Agent VM. Standard commands live in
+the tables above and in `package.json` — only the non-obvious caveats are here.
+
+### Running unit tests — set `FORCE_COLOR`
+
+`npm run test:unit` passes, but you **must** export `FORCE_COLOR=1` (or higher),
+e.g. `FORCE_COLOR=3 npm run test:unit`. Without it, the 4 `display` tests in
+`test/lib/display.spec.ts` fail: their expected fixtures embed ANSI color
+escapes, and `chalk` strips colors when stdout is not a TTY (as in the cloud
+shell). This is an environment artifact, not a code bug — do not "fix" the
+fixtures.
+
+### Docker is installed but Docker Hub pulls are blocked
+
+- The Docker engine is installed and configured for docker-in-docker
+  (`fuse-overlayfs` storage driver in `/etc/docker/daemon.json`). It is **not**
+  auto-started: run `sudo dockerd >/tmp/dockerd.log 2>&1 &` once per VM if you
+  need it. The socket is left world-readable/writable so `docker` works without
+  `sudo`.
+- Network egress to Docker Hub **blob storage** (`*.s3...amazonaws.com` /
+  `production.cloudflare.docker.com`) is blocked, so `docker pull <docker.io image>`
+  fails with TLS/`EOF` errors after the manifest fetch. Pull Docker official
+  images from the AWS public mirror instead, e.g.
+  `docker pull public.ecr.aws/docker/library/node:18-alpine`.
+- Consequently `npm run test:system` (and the sibling `snyk-docker-pull` repo's
+  tests) cannot pull their target images here and will fail on network — run
+  `npm run test:unit` for the inner loop and rely on CI for system tests, unless
+  the user widens network access and provides the `DOCKER_HUB_*` creds.
+
+### Quick end-to-end smoke of the library
+
+`scan()` works fully offline against a saved archive — no daemon or network
+needed once the tar exists:
+
+```bash
+docker pull public.ecr.aws/docker/library/node:18-alpine
+docker save public.ecr.aws/docker/library/node:18-alpine -o /tmp/img.tar
+node -e 'require("./dist").scan({path:"docker-archive:/tmp/img.tar"}).then(r=>console.log(r.scanResults[0].facts.map(f=>f.type)))'
+```
+
+(`npm run build` first so `dist/` exists.)
+
+### Workspace-wide credential note
+
+This VM contains several sibling Snyk repos under `repos/`. The public libraries
+(`snyk-docker-plugin`, `snyk-docker-pull`, `docker-registry-v2-client`) install
+from the public npm registry with no auth. The service repos
+(`docker-deps`, `container-image-collector`, `docker-registry-agent`, `registry`)
+depend on **private `@snyk/*` npm packages** and need an `NPM_TOKEN`; the Go
+services (`container-image-service`, `container-importer`, `container-monitor-data`)
+depend on **private `github.com/snyk/*` modules** (`GOPRIVATE=github.com/snyk`)
+and need a GitHub credential with access to the Snyk org. Without those secrets
+their dependency installs fail with 404 / "repository not found".


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing the non-obvious caveats discovered while setting up this repo in a Cursor Cloud Agent VM:

- **`FORCE_COLOR` is required for `npm run test:unit`** — without it the 4 `display` tests in `test/lib/display.spec.ts` fail because their fixtures embed ANSI color escapes and `chalk` strips colors when stdout is not a TTY.
- **Docker Hub pulls are blocked** by the VM's network egress (blob storage on S3/Cloudflare CDN); Docker official images must be pulled from the `public.ecr.aws/docker/library/*` mirror. The Docker engine is installed (docker-in-docker via `fuse-overlayfs`) but not auto-started.
- `npm run test:system` (and the sibling `snyk-docker-pull` tests) can't pull their target images here and rely on CI.
- A quick offline end-to-end smoke recipe for `scan()` against a saved archive.
- A workspace-wide note on which sibling repos need private `NPM_TOKEN` / `GOPRIVATE` GitHub credentials.

#### Where should the reviewer start?

`AGENTS.md` → `## Cursor Cloud specific instructions`.

#### How should this be manually tested?

`FORCE_COLOR=3 npm run test:unit` → 873/873 pass. Documentation-only change.

#### Any background context you want to provide?

Produced during automated dev-environment setup. No source/test code changed.

#### What are the relevant tickets?

N/A

#### Screenshots

N/A — docs only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89618d1f-1171-4001-90a6-82e0dea560e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89618d1f-1171-4001-90a6-82e0dea560e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

