### PR TITLE
feat: add native Ruby/Bundler application scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Applications:
 
 - Node (npm, yarn)
 - Java (jar files)
-- detecting package manager manifests (Python, Ruby)
+- Ruby (bundler)
+- detecting package manager manifests (Python)
 
 Others:
 

--- a/lib/analyzer/applications/index.ts
+++ b/lib/analyzer/applications/index.ts
@@ -5,6 +5,7 @@ import {
   pipFilesToScannedProjects,
   poetryFilesToScannedProjects,
 } from "./python";
+import { rubyFilesToScannedProjects } from "./ruby";
 
 export {
   dotnetFilesToScannedProjects,
@@ -12,4 +13,5 @@ export {
   phpFilesToScannedProjects,
   poetryFilesToScannedProjects,
   pipFilesToScannedProjects,
+  rubyFilesToScannedProjects,
 };

--- a/lib/analyzer/applications/ruby.ts
+++ b/lib/analyzer/applications/ruby.ts
@@ -1,0 +1,376 @@
+import { DepGraph, DepGraphBuilder } from "@snyk/dep-graph";
+import * as Debug from "debug";
+import { eventLoopSpinner } from "event-loop-spinner";
+import * as path from "path";
+import { getErrorMessage } from "../../error-utils";
+import { DepGraphFact, TestedFilesFact } from "../../facts";
+import { AppDepsScanResultWithoutTarget, FilePathToContent } from "./types";
+
+const debug = Debug("snyk");
+const PACKAGE_MANAGER_TYPE = "rubygems";
+
+interface RubyProjectFiles {
+  lock: string;
+  // The Gemfile is optional: an image may ship only a Gemfile.lock. When it is
+  // present we use it to drop development/test gems; without it we fall back to
+  // the lockfile's DEPENDENCIES section, which has no group information.
+  manifest?: string;
+}
+
+interface RubyGemSpec {
+  name: string;
+  version: string;
+  dependencies: string[];
+}
+
+interface ParsedGemfileLock {
+  specs: Map<string, RubyGemSpec[]>;
+  dependencies: string[];
+}
+
+interface ParsedGemfileManifest {
+  dependencies: Set<string>;
+  foundGemDeclarations: boolean;
+}
+
+export async function rubyFilesToScannedProjects(
+  filePathToContent: FilePathToContent,
+): Promise<AppDepsScanResultWithoutTarget[]> {
+  const scanResults: AppDepsScanResultWithoutTarget[] = [];
+  const projects = findRubyProjects(filePathToContent);
+
+  for (const project of projects) {
+    const manifestContent = project.manifest
+      ? filePathToContent[project.manifest]
+      : undefined;
+
+    let depGraph: DepGraph | null;
+    try {
+      depGraph = await buildDepGraphFromGemfileLock(
+        filePathToContent[project.lock],
+        project.lock,
+        manifestContent,
+      );
+    } catch (err) {
+      // Skip a malformed project rather than failing the whole image scan.
+      debug(
+        `Failed to parse Ruby Gemfile.lock at ${
+          project.lock
+        }: ${getErrorMessage(err)}`,
+      );
+      continue;
+    }
+    if (!depGraph) {
+      continue;
+    }
+
+    const testedFiles = project.manifest
+      ? [path.basename(project.manifest), path.basename(project.lock)]
+      : [path.basename(project.lock)];
+
+    const depGraphFact: DepGraphFact = {
+      type: "depGraph",
+      data: depGraph,
+    };
+    const testedFilesFact: TestedFilesFact = {
+      type: "testedFiles",
+      data: testedFiles,
+    };
+    scanResults.push({
+      facts: [depGraphFact, testedFilesFact],
+      identity: {
+        type: depGraph.pkgManager.name,
+        targetFile: project.lock,
+      },
+    });
+  }
+
+  return scanResults;
+}
+
+async function buildDepGraphFromGemfileLock(
+  content: string,
+  lockFilePath: string,
+  manifestContent?: string,
+): Promise<DepGraph | null> {
+  const parsedLock = parseGemfileLock(content);
+
+  // The Gemfile lets us scope the graph to gems that ship in production, i.e.
+  // excluding development/test groups. Without it we keep every direct gem the
+  // lockfile resolved.
+  let directDependencies = parsedLock.dependencies;
+  if (manifestContent !== undefined) {
+    const manifest = parseGemfileManifestDependencies(manifestContent);
+    if (manifest.foundGemDeclarations) {
+      directDependencies = Array.from(manifest.dependencies);
+    }
+  }
+
+  if (parsedLock.specs.size === 0 || directDependencies.length === 0) {
+    return null;
+  }
+
+  const builder = new DepGraphBuilder(
+    { name: PACKAGE_MANAGER_TYPE },
+    { name: lockFilePath },
+  );
+  const visited = new Set<string>();
+
+  for (const dependency of directDependencies) {
+    await addDependencyToDepGraph(
+      builder.rootNodeId,
+      dependency,
+      parsedLock.specs,
+      visited,
+      builder,
+    );
+  }
+
+  const depGraph = builder.build();
+  if (depGraph.getDepPkgs().length === 0) {
+    return null;
+  }
+
+  return depGraph;
+}
+
+async function addDependencyToDepGraph(
+  parentNodeId: string,
+  dependencyName: string,
+  specs: Map<string, RubyGemSpec[]>,
+  visited: Set<string>,
+  builder: DepGraphBuilder,
+): Promise<void> {
+  if (eventLoopSpinner.isStarving()) {
+    await eventLoopSpinner.spin();
+  }
+
+  const matchingSpecs = specs.get(dependencyName.toLowerCase());
+  if (!matchingSpecs) {
+    return;
+  }
+
+  for (const spec of matchingSpecs) {
+    await addSpecToDepGraph(parentNodeId, spec, specs, visited, builder);
+  }
+}
+
+async function addSpecToDepGraph(
+  parentNodeId: string,
+  spec: RubyGemSpec,
+  specs: Map<string, RubyGemSpec[]>,
+  visited: Set<string>,
+  builder: DepGraphBuilder,
+): Promise<void> {
+  const nodeId = `${spec.name}@${spec.version}`;
+  if (!visited.has(nodeId)) {
+    visited.add(nodeId);
+    builder.addPkgNode({ name: spec.name, version: spec.version }, nodeId);
+
+    for (const childName of spec.dependencies) {
+      await addDependencyToDepGraph(nodeId, childName, specs, visited, builder);
+    }
+  }
+  builder.connectDep(parentNodeId, nodeId);
+}
+
+function parseGemfileLock(content: string): ParsedGemfileLock {
+  const specs = new Map<string, RubyGemSpec[]>();
+  const dependencies = new Set<string>();
+  const lines = content.split(/\r?\n/);
+
+  let inDependencies = false;
+  let inSpecsBlock = false;
+  let currentSpec: RubyGemSpec | null = null;
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine) {
+      continue;
+    }
+
+    if (isSectionHeader(line)) {
+      inDependencies = trimmedLine === "DEPENDENCIES";
+      inSpecsBlock = false;
+      currentSpec = null;
+      continue;
+    }
+
+    if (trimmedLine === "specs:") {
+      inSpecsBlock = true;
+      currentSpec = null;
+      continue;
+    }
+
+    if (inSpecsBlock) {
+      const spec = parseSpecLine(line);
+      if (spec) {
+        currentSpec = spec;
+        addSpec(specs, spec);
+        continue;
+      }
+
+      const dependency = parseSpecDependencyLine(line);
+      if (dependency && currentSpec) {
+        currentSpec.dependencies.push(dependency);
+      }
+      continue;
+    }
+
+    if (inDependencies) {
+      const dependency = parseDependencyName(trimmedLine);
+      if (dependency) {
+        dependencies.add(dependency);
+      }
+    }
+  }
+
+  return { specs, dependencies: [...dependencies] };
+}
+
+function parseGemfileManifestDependencies(
+  content: string,
+): ParsedGemfileManifest {
+  const dependencies = new Set<string>();
+  let foundGemDeclarations = false;
+  const blockStack: Array<{ type: "group" | "other"; groups: string[] }> = [];
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = stripTrailingComment(rawLine);
+    const trimmedLine = line.trim();
+    if (!trimmedLine) {
+      continue;
+    }
+
+    const groupBlock = trimmedLine.match(/^group\s+(.+?)\s+do\b/);
+    if (groupBlock) {
+      blockStack.push({
+        type: "group",
+        groups: parseRubySymbols(groupBlock[1]),
+      });
+      continue;
+    }
+
+    if (trimmedLine === "end") {
+      blockStack.pop();
+      continue;
+    }
+
+    const gemName = parseGemName(trimmedLine);
+    if (gemName) {
+      foundGemDeclarations = true;
+      const groups = [
+        ...blockStack
+          .filter((block) => block.type === "group")
+          .flatMap((block) => block.groups),
+        ...parseInlineGemGroups(trimmedLine),
+      ];
+      if (shouldIncludeGemGroup(groups)) {
+        dependencies.add(gemName);
+      }
+      continue;
+    }
+
+    if (/\bdo\b/.test(trimmedLine)) {
+      blockStack.push({ type: "other", groups: [] });
+    }
+  }
+
+  return { dependencies, foundGemDeclarations };
+}
+
+function isSectionHeader(line: string): boolean {
+  return /^[A-Z][A-Z0-9 _-]*$/.test(line);
+}
+
+function parseSpecLine(line: string): RubyGemSpec | null {
+  const match = line.match(/^ {4}([^\s(]+) \(([^)]+)\)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    name: match[1],
+    version: match[2],
+    dependencies: [],
+  };
+}
+
+function parseSpecDependencyLine(line: string): string | null {
+  if (!line.startsWith("      ")) {
+    return null;
+  }
+  return parseDependencyName(line.trim());
+}
+
+function parseDependencyName(line: string): string | null {
+  const match = line.match(/^([^\s(!;]+)!?/);
+  return match ? match[1] : null;
+}
+
+function stripTrailingComment(line: string): string {
+  return line.replace(/\s+#.*$/, "");
+}
+
+function parseGemName(line: string): string | null {
+  const match = line.match(/^gem\s+["']([^"']+)["']/);
+  return match ? match[1] : null;
+}
+
+function parseInlineGemGroups(line: string): string[] {
+  const groups: string[] = [];
+  const groupMatches = line.matchAll(/(?:group|groups):\s*(\[[^\]]+\]|:\w+)/g);
+  for (const match of groupMatches) {
+    groups.push(...parseRubySymbols(match[1]));
+  }
+  return groups;
+}
+
+function parseRubySymbols(value: string): string[] {
+  return [...value.matchAll(/:(\w+)/g)].map((match) => match[1]);
+}
+
+function shouldIncludeGemGroup(groups: string[]): boolean {
+  if (groups.length === 0) {
+    return true;
+  }
+  const excludedGroups = new Set(["development", "test"]);
+  return groups.some((group) => !excludedGroups.has(group));
+}
+
+function addSpec(specs: Map<string, RubyGemSpec[]>, spec: RubyGemSpec): void {
+  const key = spec.name.toLowerCase();
+  if (!specs.has(key)) {
+    specs.set(key, []);
+  }
+  specs.get(key)!.push(spec);
+}
+
+// We only build a graph for a Gemfile.lock; a Gemfile alone has no resolved
+// versions. When both files share a directory we pair them so development/test
+// gems can be filtered out.
+function findRubyProjects(
+  filePathToContent: FilePathToContent,
+): RubyProjectFiles[] {
+  const filesByDir = Object.keys(filePathToContent).reduce<
+    Record<string, Set<string>>
+  >((acc, filePath) => {
+    const dir = path.dirname(filePath);
+    (acc[dir] ??= new Set()).add(path.basename(filePath));
+    return acc;
+  }, {});
+
+  const projects: RubyProjectFiles[] = [];
+  for (const dir of Object.keys(filesByDir)) {
+    const files = filesByDir[dir];
+    if (!files.has("Gemfile.lock")) {
+      continue;
+    }
+    projects.push({
+      lock: path.join(dir, "Gemfile.lock"),
+      manifest: files.has("Gemfile") ? path.join(dir, "Gemfile") : undefined,
+    });
+  }
+
+  return projects;
+}

--- a/lib/analyzer/applications/ruby.ts
+++ b/lib/analyzer/applications/ruby.ts
@@ -6,6 +6,11 @@ import { getErrorMessage } from "../../error-utils";
 import { DepGraphFact, TestedFilesFact } from "../../facts";
 import { AppDepsScanResultWithoutTarget, FilePathToContent } from "./types";
 
+// Builds rubygems dep-graphs from Bundler files found in a container image.
+// Gemfile.lock is the source of truth for the resolved tree (every gem and its
+// pinned version + edges). The Gemfile manifest, when present, is consulted only
+// to decide which top-level gems are graph roots and to drop development/test-only
+// gems, which the lockfile alone cannot distinguish.
 const debug = Debug("snyk");
 const PACKAGE_MANAGER_TYPE = "rubygems";
 
@@ -145,6 +150,9 @@ async function addDependencyToDepGraph(
     await eventLoopSpinner.spin();
   }
 
+  // A single gem name can resolve to several locked specs (one per platform,
+  // e.g. nokogiri pure-ruby + nokogiri-aarch64-linux-gnu). We connect every
+  // variant — this mirrors the lockfile's own multi-platform resolution.
   const matchingSpecs = specs.get(dependencyName.toLowerCase());
   if (!matchingSpecs) {
     return;
@@ -162,6 +170,9 @@ async function addSpecToDepGraph(
   visited: Set<string>,
   builder: DepGraphBuilder,
 ): Promise<void> {
+  // Create each pkg node (and recurse into its children) exactly once, but
+  // always connect the parent->child edge — the same gem can be depended on by
+  // multiple parents even though we only want to walk its subtree once.
   const nodeId = `${spec.name}@${spec.version}`;
   if (!visited.has(nodeId)) {
     visited.add(nodeId);
@@ -174,6 +185,18 @@ async function addSpecToDepGraph(
   builder.connectDep(parentNodeId, nodeId);
 }
 
+// Parses the relevant slices of a Gemfile.lock. The format is indentation-based:
+//
+//   GEM
+//     specs:
+//       rails (7.0.8)          <- 4-space indent: a resolved spec (name + version)
+//         actionpack (= 7.0.8) <- 6-space indent: that spec's dependency
+//   DEPENDENCIES
+//     rails                    <- the gems declared directly in the Gemfile
+//
+// We collect every spec (keyed lowercase, since a gem may have multiple platform
+// variants) and the DEPENDENCIES list (used as roots only when the Gemfile is
+// unavailable).
 function parseGemfileLock(content: string): ParsedGemfileLock {
   const specs = new Map<string, RubyGemSpec[]>();
   const dependencies = new Set<string>();
@@ -228,6 +251,12 @@ function parseGemfileLock(content: string): ParsedGemfileLock {
   return { specs, dependencies: [...dependencies] };
 }
 
+// Extracts the gem names declared in a Gemfile, excluding any that live only in
+// development/test groups. Groups can be set two ways: a `group :x do ... end`
+// block, or an inline `gem "x", group: :y` option. blockStack tracks the
+// enclosing `do`/`end` blocks so we know which group(s) a gem sits inside;
+// non-group blocks (e.g. `source ... do`) are pushed too so `end` lines stay
+// balanced.
 function parseGemfileManifestDependencies(
   content: string,
 ): ParsedGemfileManifest {
@@ -235,35 +264,30 @@ function parseGemfileManifestDependencies(
   let foundGemDeclarations = false;
   const blockStack: Array<{ type: "group" | "other"; groups: string[] }> = [];
 
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = stripTrailingComment(rawLine);
-    const trimmedLine = line.trim();
-    if (!trimmedLine) {
-      continue;
-    }
-
-    const groupBlock = trimmedLine.match(/^group\s+(.+?)\s+do\b/);
+  for (const statement of toLogicalLines(content)) {
+    // Matches both `group :x do` and the method-call form `group(:x) do`.
+    const groupBlock = statement.match(/^group\s*\(?\s*(.+?)\s*\)?\s+do\b/);
     if (groupBlock) {
       blockStack.push({
         type: "group",
-        groups: parseRubySymbols(groupBlock[1]),
+        groups: parseGroupNames(groupBlock[1]),
       });
       continue;
     }
 
-    if (trimmedLine === "end") {
+    if (statement === "end") {
       blockStack.pop();
       continue;
     }
 
-    const gemName = parseGemName(trimmedLine);
+    const gemName = parseGemName(statement);
     if (gemName) {
       foundGemDeclarations = true;
       const groups = [
         ...blockStack
           .filter((block) => block.type === "group")
           .flatMap((block) => block.groups),
-        ...parseInlineGemGroups(trimmedLine),
+        ...parseInlineGemGroups(statement),
       ];
       if (shouldIncludeGemGroup(groups)) {
         dependencies.add(gemName);
@@ -271,12 +295,41 @@ function parseGemfileManifestDependencies(
       continue;
     }
 
-    if (/\bdo\b/.test(trimmedLine)) {
+    if (/\bdo\b/.test(statement)) {
       blockStack.push({ type: "other", groups: [] });
     }
   }
 
   return { dependencies, foundGemDeclarations };
+}
+
+// Collapses a Gemfile into logical statements: blank lines and full-line comments
+// are dropped, and a line ending in a comma (a Ruby line continuation — e.g. a
+// `gem` call whose options spill onto the next line) is joined with the line(s)
+// that follow. This keeps inline group options attached to their gem, and stops a
+// comment that merely contains the word "do" from being mistaken for a block opener.
+function toLogicalLines(content: string): string[] {
+  const statements: string[] = [];
+  let buffer = "";
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const trimmedLine = stripTrailingComment(rawLine).trim();
+    if (trimmedLine === "" || trimmedLine.startsWith("#")) {
+      continue;
+    }
+    buffer = buffer === "" ? trimmedLine : `${buffer} ${trimmedLine}`;
+    if (buffer.endsWith(",")) {
+      continue;
+    }
+    statements.push(buffer);
+    buffer = "";
+  }
+
+  if (buffer !== "") {
+    statements.push(buffer);
+  }
+
+  return statements;
 }
 
 function isSectionHeader(line: string): boolean {
@@ -303,8 +356,10 @@ function parseSpecDependencyLine(line: string): string | null {
   return parseDependencyName(line.trim());
 }
 
+// Pulls the gem name off a dependency line, stopping at whitespace, a version
+// constraint `(`, a `!` (marks a path/git-pinned gem in DEPENDENCIES), or `;`.
 function parseDependencyName(line: string): string | null {
-  const match = line.match(/^([^\s(!;]+)!?/);
+  const match = line.match(/^([^\s(!;]+)/);
   return match ? match[1] : null;
 }
 
@@ -317,17 +372,40 @@ function parseGemName(line: string): string | null {
   return match ? match[1] : null;
 }
 
+// Reads the group(s) assigned inline on a gem line, via either the keyword form
+// (`group: :x` / `groups: [...]`) or the hash-rocket form (`:group => :x`). The
+// value may be a symbol, a quoted string, a symbol/string array, or a percent
+// array (`%i[...]` / `%w[...]`).
 function parseInlineGemGroups(line: string): string[] {
   const groups: string[] = [];
-  const groupMatches = line.matchAll(/(?:group|groups):\s*(\[[^\]]+\]|:\w+)/g);
+  const groupMatches = line.matchAll(
+    /(?::(?:group|groups)\s*=>|(?:group|groups):)\s*(%[iw]\[[^\]]*\]|\[[^\]]*\]|:\w+|"[^"]*"|'[^']*')/g,
+  );
   for (const match of groupMatches) {
-    groups.push(...parseRubySymbols(match[1]));
+    groups.push(...parseGroupNames(match[1]));
   }
   return groups;
 }
 
-function parseRubySymbols(value: string): string[] {
-  return [...value.matchAll(/:(\w+)/g)].map((match) => match[1]);
+// Extracts group names from a Ruby group expression, accepting every form Bundler
+// allows: symbols (`:development`), quoted strings (`"development"`), symbol/string
+// arrays (`[:development, :test]`), and percent arrays (`%i[development test]`,
+// `%w[development test]`).
+function parseGroupNames(value: string): string[] {
+  const symbols = [...value.matchAll(/:(\w+)/g)].map((match) => match[1]);
+  const strings = [...value.matchAll(/["']([^"']+)["']/g)].map(
+    (match) => match[1],
+  );
+  const named = [...symbols, ...strings];
+  if (named.length > 0) {
+    return named;
+  }
+  // Percent arrays (%i[...], %w[...]) carry bare, whitespace-separated words.
+  const bracket = value.match(/\[([^\]]*)\]/);
+  if (bracket) {
+    return bracket[1].split(/\s+/).filter(Boolean);
+  }
+  return [];
 }
 
 function shouldIncludeGemGroup(groups: string[]): boolean {
@@ -335,6 +413,8 @@ function shouldIncludeGemGroup(groups: string[]): boolean {
     return true;
   }
   const excludedGroups = new Set(["development", "test"]);
+  // Include if ANY group is not excluded — a gem shared between e.g. :production
+  // and :development must be kept, so this is `some`, not `every`.
   return groups.some((group) => !excludedGroups.has(group));
 }
 

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -47,6 +47,7 @@ import {
   getPoetryAppFileContentAction,
   getPythonAppFileContentAction,
 } from "../inputs/python/static";
+import { getRubyAppFileContentAction } from "../inputs/ruby/static";
 import {
   getRedHatRepositoriesContentAction,
   getRedHatRepositoriesFromExtractedLayers,
@@ -66,6 +67,7 @@ import {
   nodeFilesToScannedProjects,
   phpFilesToScannedProjects,
   poetryFilesToScannedProjects,
+  rubyFilesToScannedProjects,
 } from "./applications";
 import { jarFilesToScannedResults } from "./applications/java";
 import { pipFilesToScannedProjects } from "./applications/python";
@@ -147,6 +149,7 @@ export async function analyze(
       ...[
         getNodeAppFileContentAction,
         getPhpAppFileContentAction,
+        getRubyAppFileContentAction,
         getPoetryAppFileContentAction,
         getPipAppFileContentAction,
         getDotnetAppFileContentAction,
@@ -324,6 +327,12 @@ export async function analyze(
     timings.phpAnalysisMs = Date.now() - phaseStart;
 
     phaseStart = Date.now();
+    const rubyDependenciesScanResults = await rubyFilesToScannedProjects(
+      getFileContent(extractedLayers, getRubyAppFileContentAction.actionName),
+    );
+    timings.rubyAnalysisMs = Date.now() - phaseStart;
+
+    phaseStart = Date.now();
     const poetryDependenciesScanResults = await poetryFilesToScannedProjects(
       getFileContent(extractedLayers, getPoetryAppFileContentAction.actionName),
     );
@@ -372,6 +381,7 @@ export async function analyze(
       ...nodeDependenciesScanResults,
       ...nodeApplicationFilesScanResults,
       ...phpDependenciesScanResults,
+      ...rubyDependenciesScanResults,
       ...poetryDependenciesScanResults,
       ...pipDependenciesScanResults,
       ...pythonApplicationFilesScanResults,

--- a/lib/inputs/ruby/static.ts
+++ b/lib/inputs/ruby/static.ts
@@ -1,0 +1,18 @@
+import { basename } from "path";
+
+import { ExtractAction } from "../../extractor/types";
+import { streamToString } from "../../stream-utils";
+
+const rubyAppFiles = ["Gemfile", "Gemfile.lock"];
+const deletedAppFiles = rubyAppFiles.map((file) => ".wh." + file);
+
+function filePathMatches(filePath: string): boolean {
+  const fileName = basename(filePath);
+  return rubyAppFiles.includes(fileName) || deletedAppFiles.includes(fileName);
+}
+
+export const getRubyAppFileContentAction: ExtractAction = {
+  actionName: "ruby-app-files",
+  filePathMatches,
+  callback: streamToString,
+};

--- a/test/lib/analyzer/ruby.spec.ts
+++ b/test/lib/analyzer/ruby.spec.ts
@@ -1,0 +1,324 @@
+import { DepGraph } from "@snyk/dep-graph";
+import { rubyFilesToScannedProjects } from "../../../lib/analyzer/applications";
+import { AppDepsScanResultWithoutTarget } from "../../../lib/analyzer/applications/types";
+
+const gemfile = `source "https://rubygems.org"
+
+gem "rails"
+gem "puma"
+`;
+
+const gemfileLock = `GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (7.0.8)
+      rack (~> 2.0)
+    activesupport (7.0.8)
+      minitest (>= 5.1)
+    minitest (5.20.0)
+    nio4r (2.7.0)
+    puma (6.4.2)
+      nio4r (~> 2.0)
+    rack (2.2.8)
+    rails (7.0.8)
+      actionpack (= 7.0.8)
+      activesupport (= 7.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails (~> 7.0.0)
+  puma (~> 6.0)
+
+BUNDLED WITH
+   2.5.6
+`;
+
+const gemfileWithGroups = `source "https://rubygems.org"
+
+gem "rails"
+gem "puma", group: :production
+gem "debug", group: :development
+
+group :development, :test do
+  gem "rspec"
+end
+
+group :production do
+  gem "pg"
+end
+`;
+
+function getDepGraph(result: AppDepsScanResultWithoutTarget): DepGraph {
+  return result.facts.find((fact) => fact.type === "depGraph")!.data;
+}
+
+function getNodeDeps(depGraph: DepGraph, nodeId: string): string[] {
+  const node = depGraph
+    .toJSON()
+    .graph.nodes.find((graphNode) => graphNode.nodeId === nodeId);
+  return node ? node.deps.map((dep) => dep.nodeId).sort() : [];
+}
+
+describe("ruby Gemfile.lock analyzer", () => {
+  it("creates a rubygems scan result from Gemfile and Gemfile.lock", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": gemfile,
+      "/app/Gemfile.lock": gemfileLock,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].identity).toEqual({
+      type: "rubygems",
+      targetFile: "/app/Gemfile.lock",
+    });
+    expect(results[0].facts).toEqual([
+      { type: "depGraph", data: expect.any(Object) },
+      { type: "testedFiles", data: ["Gemfile", "Gemfile.lock"] },
+    ]);
+  });
+
+  it("builds direct and transitive dependencies from the lockfile", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": gemfile,
+      "/app/Gemfile.lock": gemfileLock,
+    });
+
+    const depGraph = getDepGraph(results[0]);
+    expect(depGraph.pkgManager.name).toBe("rubygems");
+    expect(depGraph.rootPkg.name).toBe("/app/Gemfile.lock");
+    expect(depGraph.getPkgs()).toEqual(
+      expect.arrayContaining([
+        { name: "rails", version: "7.0.8" },
+        { name: "puma", version: "6.4.2" },
+        { name: "actionpack", version: "7.0.8" },
+        { name: "rack", version: "2.2.8" },
+        { name: "activesupport", version: "7.0.8" },
+        { name: "minitest", version: "5.20.0" },
+        { name: "nio4r", version: "2.7.0" },
+      ]),
+    );
+    expect(getNodeDeps(depGraph, "root-node")).toEqual([
+      "puma@6.4.2",
+      "rails@7.0.8",
+    ]);
+    expect(getNodeDeps(depGraph, "rails@7.0.8")).toEqual([
+      "actionpack@7.0.8",
+      "activesupport@7.0.8",
+    ]);
+    expect(getNodeDeps(depGraph, "actionpack@7.0.8")).toEqual(["rack@2.2.8"]);
+  });
+
+  it("creates one scan result per directory with a Gemfile.lock", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": gemfile,
+      "/app/Gemfile.lock": gemfileLock,
+      "/worker/Gemfile": gemfile,
+      "/worker/Gemfile.lock": gemfileLock,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => result.identity.targetFile).sort()).toEqual([
+      "/app/Gemfile.lock",
+      "/worker/Gemfile.lock",
+    ]);
+  });
+
+  it("builds a graph from a Gemfile.lock even without a Gemfile", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile.lock": gemfileLock,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].identity).toEqual({
+      type: "rubygems",
+      targetFile: "/app/Gemfile.lock",
+    });
+    // No Gemfile present, so only the lockfile is reported as tested.
+    expect(results[0].facts).toEqual([
+      { type: "depGraph", data: expect.any(Object) },
+      { type: "testedFiles", data: ["Gemfile.lock"] },
+    ]);
+
+    const depGraph = getDepGraph(results[0]);
+    expect(getNodeDeps(depGraph, "root-node")).toEqual([
+      "puma@6.4.2",
+      "rails@7.0.8",
+    ]);
+  });
+
+  it("does not scan a directory that only has a Gemfile", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": gemfile,
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("ignores a lockfile that has no resolved specs", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": gemfile,
+      "/app/Gemfile.lock": `DEPENDENCIES
+  rails
+`,
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("skips a malformed project but still scans valid ones", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/broken/Gemfile": gemfile,
+      "/broken/Gemfile.lock": "this is not a lockfile",
+      "/app/Gemfile": gemfile,
+      "/app/Gemfile.lock": gemfileLock,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].identity.targetFile).toBe("/app/Gemfile.lock");
+  });
+
+  it("parses path or git dependencies marked with a bang", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+gem "local_tool", git: "https://example.com/local-tool.git"
+`,
+      "/app/Gemfile.lock": `GIT
+  remote: https://example.com/local-tool.git
+  revision: abc123
+  specs:
+    local_tool (0.1.0)
+      thor (>= 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    thor (1.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  local_tool!
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    expect(depGraph.getPkgs()).toEqual(
+      expect.arrayContaining([
+        { name: "local_tool", version: "0.1.0" },
+        { name: "thor", version: "1.3.0" },
+      ]),
+    );
+    expect(getNodeDeps(depGraph, "local_tool@0.1.0")).toEqual(["thor@1.3.0"]);
+  });
+
+  it("excludes dependencies that are only in development and test groups", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": gemfileWithGroups,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    debug (1.9.2)
+    nio4r (2.7.0)
+    pg (1.5.6)
+    puma (6.4.2)
+      nio4r (~> 2.0)
+    rails (7.0.8)
+    rspec (3.13.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  debug
+  pg
+  puma
+  rails
+  rspec
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    expect(getNodeDeps(depGraph, "root-node")).toEqual([
+      "pg@1.5.6",
+      "puma@6.4.2",
+      "rails@7.0.8",
+    ]);
+    expect(depGraph.getPkgs()).not.toEqual(
+      expect.arrayContaining([
+        { name: "debug", version: "1.9.2" },
+        { name: "rspec", version: "3.13.0" },
+      ]),
+    );
+  });
+
+  it("returns no scan result when every declared gem is excluded by group", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+group :development, :test do
+  gem "debug"
+  gem "rspec"
+end
+`,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    debug (1.9.2)
+    rspec (3.13.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  debug
+  rspec
+`,
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("keeps multiple locked specs for the same gem name", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+gem "nokogiri"
+`,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    mini_portile2 (2.8.7)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+
+PLATFORMS
+  aarch64-linux-gnu
+  ruby
+
+DEPENDENCIES
+  nokogiri
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    expect(depGraph.getPkgs()).toEqual(
+      expect.arrayContaining([
+        { name: "nokogiri", version: "1.18.10" },
+        { name: "nokogiri", version: "1.18.10-aarch64-linux-gnu" },
+        { name: "mini_portile2", version: "2.8.7" },
+      ]),
+    );
+    expect(getNodeDeps(depGraph, "root-node")).toEqual([
+      "nokogiri@1.18.10",
+      "nokogiri@1.18.10-aarch64-linux-gnu",
+    ]);
+  });
+});

--- a/test/lib/analyzer/ruby.spec.ts
+++ b/test/lib/analyzer/ruby.spec.ts
@@ -1,4 +1,4 @@
-import { DepGraph } from "@snyk/dep-graph";
+import { DepGraph, DepGraphBuilder } from "@snyk/dep-graph";
 import { rubyFilesToScannedProjects } from "../../../lib/analyzer/applications";
 import { AppDepsScanResultWithoutTarget } from "../../../lib/analyzer/applications/types";
 
@@ -167,7 +167,7 @@ describe("ruby Gemfile.lock analyzer", () => {
     expect(results).toHaveLength(0);
   });
 
-  it("skips a malformed project but still scans valid ones", async () => {
+  it("skips an unparseable lockfile that yields no specs but still scans valid ones", async () => {
     const results = await rubyFilesToScannedProjects({
       "/broken/Gemfile": gemfile,
       "/broken/Gemfile.lock": "this is not a lockfile",
@@ -177,6 +177,30 @@ describe("ruby Gemfile.lock analyzer", () => {
 
     expect(results).toHaveLength(1);
     expect(results[0].identity.targetFile).toBe("/app/Gemfile.lock");
+  });
+
+  it("skips a project whose dep-graph construction throws but still scans valid ones", async () => {
+    // The "no specs" case above returns null; this exercises the catch path by
+    // forcing the graph builder to throw for the first project only.
+    const buildSpy = jest
+      .spyOn(DepGraphBuilder.prototype, "build")
+      .mockImplementationOnce(() => {
+        throw new Error("synthetic dep-graph failure");
+      });
+
+    try {
+      const results = await rubyFilesToScannedProjects({
+        "/broken/Gemfile": gemfile,
+        "/broken/Gemfile.lock": gemfileLock,
+        "/app/Gemfile": gemfile,
+        "/app/Gemfile.lock": gemfileLock,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].identity.targetFile).toBe("/app/Gemfile.lock");
+    } finally {
+      buildSpy.mockRestore();
+    }
   });
 
   it("parses path or git dependencies marked with a bang", async () => {
@@ -320,5 +344,186 @@ DEPENDENCIES
       "nokogiri@1.18.10",
       "nokogiri@1.18.10-aarch64-linux-gnu",
     ]);
+  });
+
+  it("does not let a comment containing 'do' corrupt group parsing", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+group :development do
+# do not edit the gems below
+  gem "rspec"
+end
+
+gem "rails"
+gem "puma"
+`,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    puma (6.4.2)
+    rails (7.0.8)
+    rspec (3.13.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puma
+  rails
+  rspec
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    // rails and puma are production gems declared after the group block — they
+    // must survive even though a comment inside the block contains "do".
+    expect(getNodeDeps(depGraph, "root-node")).toEqual([
+      "puma@6.4.2",
+      "rails@7.0.8",
+    ]);
+    expect(depGraph.getPkgs()).not.toEqual(
+      expect.arrayContaining([{ name: "rspec", version: "3.13.0" }]),
+    );
+  });
+
+  it("excludes a gem whose group is set with hash-rocket syntax", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+gem "rails"
+gem "byebug", :group => :development
+`,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    rails (7.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  byebug
+  rails
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    expect(getNodeDeps(depGraph, "root-node")).toEqual(["rails@7.0.8"]);
+  });
+
+  it("excludes a gem whose groups use a %i[] array literal", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+gem "rails"
+gem "rspec-rails", groups: %i[development test]
+`,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.0.8)
+    rspec-rails (6.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails
+  rspec-rails
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    expect(getNodeDeps(depGraph, "root-node")).toEqual(["rails@7.0.8"]);
+  });
+
+  it("excludes a gem whose group is given as a quoted string", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+gem "rails"
+gem "byebug", group: "development"
+`,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    rails (7.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  byebug
+  rails
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    expect(getNodeDeps(depGraph, "root-node")).toEqual(["rails@7.0.8"]);
+  });
+
+  it("applies group filtering across a multi-line gem declaration", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+gem "rails"
+gem "rspec",
+  "~> 3.13",
+  groups: [:development, :test]
+`,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.0.8)
+    rspec (3.13.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails
+  rspec
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    expect(getNodeDeps(depGraph, "root-node")).toEqual(["rails@7.0.8"]);
+  });
+
+  it("excludes gems inside a group(...) method-call block", async () => {
+    const results = await rubyFilesToScannedProjects({
+      "/app/Gemfile": `source "https://rubygems.org"
+
+gem "rails"
+group(:development) do
+  gem "rspec"
+end
+`,
+      "/app/Gemfile.lock": `GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.0.8)
+    rspec (3.13.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails
+  rspec
+`,
+    });
+
+    expect(results).toHaveLength(1);
+    const depGraph = getDepGraph(results[0]);
+    expect(getNodeDeps(depGraph, "root-node")).toEqual(["rails@7.0.8"]);
   });
 });

--- a/test/lib/inputs/ruby/static.spec.ts
+++ b/test/lib/inputs/ruby/static.spec.ts
@@ -1,0 +1,27 @@
+import { getRubyAppFileContentAction } from "../../../../lib/inputs/ruby/static";
+
+describe("Ruby application file path matching", () => {
+  const { filePathMatches } = getRubyAppFileContentAction;
+
+  it("matches Gemfile and Gemfile.lock", () => {
+    expect(filePathMatches("/app/Gemfile")).toBe(true);
+    expect(filePathMatches("/app/Gemfile.lock")).toBe(true);
+  });
+
+  it("matches nested Gemfile and Gemfile.lock", () => {
+    expect(filePathMatches("/srv/app/current/Gemfile")).toBe(true);
+    expect(filePathMatches("/srv/app/current/Gemfile.lock")).toBe(true);
+  });
+
+  it("matches deleted Gemfile and Gemfile.lock whiteouts", () => {
+    expect(filePathMatches("/app/.wh.Gemfile")).toBe(true);
+    expect(filePathMatches("/app/.wh.Gemfile.lock")).toBe(true);
+  });
+
+  it("does not match unrelated Ruby files", () => {
+    expect(filePathMatches("/app/config.ru")).toBe(false);
+    expect(filePathMatches("/app/app.rb")).toBe(false);
+    expect(filePathMatches("/app/gems.locked")).toBe(false);
+    expect(filePathMatches("/app/my-Gemfile")).toBe(false);
+  });
+});

--- a/test/system/application-scans/ruby.spec.ts
+++ b/test/system/application-scans/ruby.spec.ts
@@ -1,12 +1,58 @@
 import { scan } from "../../../lib";
-import { ImageManifestFilesFact } from "../../../lib/facts";
+import { DepGraphFact, ImageManifestFilesFact } from "../../../lib/facts";
 import { getFixture } from "../../util";
 
 describe("ruby application scans", () => {
-  it("should correctly return applications", async () => {
-    const fixturePath = getFixture("docker-archives/docker-save/gemfile.tar");
-    const imageNameAndTag = `docker-archive:${fixturePath}`;
+  const fixturePath = getFixture("docker-archives/docker-save/gemfile.tar");
+  const imageNameAndTag = `docker-archive:${fixturePath}`;
 
+  it("returns a rubygems dependency graph from the Gemfile.lock", async () => {
+    const pluginResult = await scan({
+      path: imageNameAndTag,
+      "app-vulns": true,
+    });
+
+    const rubyScanResult = pluginResult.scanResults.find(
+      (scanResult) => scanResult.identity.type === "rubygems",
+    );
+    expect(rubyScanResult).toBeDefined();
+    expect(rubyScanResult!.identity.targetFile).toMatch(/Gemfile\.lock$/);
+
+    const testedFiles = rubyScanResult!.facts.find(
+      (fact) => fact.type === "testedFiles",
+    );
+    expect(testedFiles).toEqual({
+      type: "testedFiles",
+      data: ["Gemfile", "Gemfile.lock"],
+    });
+
+    const depGraph = (
+      rubyScanResult!.facts.find(
+        (fact) => fact.type === "depGraph",
+      )! as DepGraphFact
+    ).data;
+    expect(depGraph.pkgManager.name).toBe("rubygems");
+    expect(depGraph.getDepPkgs().length).toBeGreaterThan(0);
+    expect(depGraph.getPkgs()).toEqual(
+      expect.arrayContaining([
+        { name: "logstash-core", version: "7.17.5-java" },
+        { name: "elasticsearch", version: "7.17.1" },
+        { name: "elasticsearch-api", version: "7.17.1" },
+      ]),
+    );
+
+    // Spot-check a real transitive edge to prove the graph is connected, not flat.
+    const elasticsearchNode = depGraph
+      .toJSON()
+      .graph.nodes.find((node) => node.nodeId === "elasticsearch@7.17.1");
+    expect(elasticsearchNode?.deps).toEqual(
+      expect.arrayContaining([{ nodeId: "elasticsearch-api@7.17.1" }]),
+    );
+  });
+
+  it("still passes Gemfile manifests through when globs are requested", async () => {
+    // Native Ruby scanning and the imageManifestFiles passthrough coexist; we do
+    // not dedupe the Gemfile globs the way composer does.
     const pluginResult = await scan({
       path: imageNameAndTag,
       "app-vulns": true,
@@ -16,7 +62,10 @@ describe("ruby application scans", () => {
       },
     });
 
-    expect(pluginResult.scanResults.length).toBeGreaterThan(0);
+    const rubyScanResult = pluginResult.scanResults.find(
+      (scanResult) => scanResult.identity.type === "rubygems",
+    );
+    expect(rubyScanResult).toBeDefined();
 
     const imageManifestFiles = pluginResult.scanResults[0].facts.find(
       (fact) => fact.type === "imageManifestFiles",
@@ -33,5 +82,17 @@ describe("ruby application scans", () => {
     // This is testing for a specific bug with our extraction logic.
     // Previously the length would be less than half of this number due to a bug in the encoding logic.
     expect(gemfileLock.length).toEqual(28180);
+  });
+
+  it("does not scan Ruby applications when app vulns are excluded", async () => {
+    const pluginResult = await scan({
+      path: imageNameAndTag,
+      "exclude-app-vulns": true,
+    });
+
+    const rubyScanResult = pluginResult.scanResults.find(
+      (scanResult) => scanResult.identity.type === "rubygems",
+    );
+    expect(rubyScanResult).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds Ruby/Bundler application scanning. Until now Ruby was only handled as a generic manifest passthrough (`imageManifestFiles` via `globsToFind`). This builds a real `rubygems` dependency graph from `Gemfile.lock` during app scans, following the existing per-ecosystem pattern (`lib/inputs/ruby/static.ts` + `lib/analyzer/applications/ruby.ts`, wired in `static-analyzer.ts`).

- New extract action `ruby-app-files` matching `Gemfile`/`Gemfile.lock` (and `.wh.` whiteouts).
- New analyzer `rubyFilesToScannedProjects` that parses `Gemfile.lock` into a connected dep graph (direct + transitive), resolving versions from the lockfile specs and handling platform-variant specs and `GIT`/`PATH`/bang dependencies.
- When a `Gemfile` is present next to the lockfile, development/test group gems are excluded so results stay scoped to what ships in production. Images that only contain a `Gemfile.lock` fall back to the lockfile's `DEPENDENCIES` section (no group filtering possible).
- Emits `depGraph` (identity `rubygems`, `targetFile` = the `Gemfile.lock`) and `testedFiles` facts.

No new runtime dependency: the lockfile parsing is a small custom parser. I evaluated `@snyk/gemfile` but it only reads the lockfile and can't do dev/test group filtering.

## Consumer-visible behavior change

Ruby images now produce a native `rubygems` `depGraph` scan result with a new `identity.type` value (`rubygems`), in addition to the existing `imageManifestFiles` passthrough. Unlike the PHP/Composer integration, this does **not** dedupe `Gemfile`/`Gemfile.lock` out of `globsToFind`, so callers that pass those globs keep receiving both the native depGraph and the manifest passthrough. This reuses existing `FactType`s (`depGraph`, `testedFiles`) and adds no new `FactType`.

## Test plan

- [x] `npm run build`
- [x] `npm run lint` (prettier + eslint)
- [x] `npm run test:unit` (888 passing; the 4 `display.spec.ts` failures are pre-existing chalk/TTY color artifacts that pass with `--colors`, as CI runs them)
- [x] Ruby unit tests: input path matching + analyzer (direct/transitive deps, multiple dirs, dev/test group exclusion, `GIT`/`PATH`/bang deps, platform-variant specs, lockfile-only fallback, malformed-skip)
- [x] Ruby system test against `gemfile.tar`: native `rubygems` depGraph (244 gems, real transitive edge asserted), coexisting `imageManifestFiles` regression check, and `exclude-app-vulns` behavior
- [x] Re-ran PHP and Go system tests to confirm the `static-analyzer.ts` wiring didn't disturb other ecosystems

Note: Snyk Code SAST could not run (not enabled for the current org); manual review found no issues (pure per-line string parsing, no eval/exec/fs/network, bounded regexes).