### PR TITLE
feat: parse provenance attestations

### DIFF
--- a/lib/extractor/provenance-parser.ts
+++ b/lib/extractor/provenance-parser.ts
@@ -1,6 +1,4 @@
 import * as Debug from "debug";
-import { analyseDockerfile } from "../dockerfile";
-import { DockerFileAnalysis } from "../dockerfile/types";
 import { InTotoStatement, ResolvedAttestationManifest } from "./types";
 
 const debug = Debug("snyk");
@@ -13,7 +11,7 @@ type SlsaProvenanceVersion =
 
 export interface DockerfileMetadata {
   name: string;
-  analysis: DockerFileAnalysis | null;
+  contents: string | null;
 }
 
 export interface ProvenanceMetadata {
@@ -79,26 +77,12 @@ interface SlsaPredicateV1_0 {
   };
 }
 
-function getDecodedDockerfileContents(
+function getEncodedDockerfileContents(
   infos: BuildkitSourceInfo[] | undefined,
   dockerfileName: string,
 ): string | null {
   const match = infos?.find((info) => info.filename === dockerfileName);
-  if (!match?.data) {
-    return null;
-  }
-  return Buffer.from(match.data, "base64").toString("utf8");
-}
-
-async function analyseDecodedDockerfile(
-  infos: BuildkitSourceInfo[] | undefined,
-  dockerfileName: string,
-): Promise<DockerFileAnalysis | null> {
-  const contents = getDecodedDockerfileContents(infos, dockerfileName);
-  if (contents === null) {
-    return null;
-  }
-  return analyseDockerfile(contents);
+  return match?.data ?? null;
 }
 
 function getConfigSourceCommit(digest?: {
@@ -145,7 +129,7 @@ async function extractFieldsSlsaV0_2(
   const dockerfileName =
     predicate.invocation?.configSource?.entryPoint || "Dockerfile";
 
-  const dockerfileAnalysis = await analyseDecodedDockerfile(
+  const dockerfileContents = getEncodedDockerfileContents(
     buildkitMeta?.source?.infos,
     dockerfileName,
   );
@@ -161,7 +145,7 @@ async function extractFieldsSlsaV0_2(
     buildType,
     dockerfileMetadata: {
       name: dockerfileName,
-      analysis: dockerfileAnalysis,
+      contents: dockerfileContents,
     },
   };
 }
@@ -196,7 +180,7 @@ async function extractFieldsSlsaV1_0(
   const dockerfileName =
     buildDefinition?.externalParameters?.configSource?.path || "Dockerfile";
 
-  const dockerfileAnalysis = await analyseDecodedDockerfile(
+  const dockerfileContents = getEncodedDockerfileContents(
     runDetails?.metadata?.buildkit_metadata?.source?.infos,
     dockerfileName,
   );
@@ -212,7 +196,7 @@ async function extractFieldsSlsaV1_0(
     buildType,
     dockerfileMetadata: {
       name: dockerfileName,
-      analysis: dockerfileAnalysis,
+      contents: dockerfileContents,
     },
   };
 }

--- a/test/lib/extractor/provenance-parser.spec.ts
+++ b/test/lib/extractor/provenance-parser.spec.ts
@@ -74,7 +74,7 @@ describe("provenance-parser", () => {
           "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md",
         dockerfileMetadata: {
           name: "Dockerfile",
-          analysis: null,
+          contents: null,
         },
       });
     });
@@ -145,10 +145,8 @@ describe("provenance-parser", () => {
       expect(result).toHaveLength(1);
       expect(result[0].dockerfileMetadata.name).toBe("Dockerfile");
 
-      // The base64 contents are decoded and parsed into a DockerFileAnalysis;
-      // no raw base64 is surfaced.
-      expect(result[0].dockerfileMetadata.analysis?.baseImage).toBe("node:18");
-      expect(JSON.stringify(result[0])).not.toContain(dockerfileBase64);
+      // The raw base64 contents are surfaced verbatim.
+      expect(result[0].dockerfileMetadata.contents).toBe(dockerfileBase64);
     });
 
     it("selects dockerfile contents by filename when multiple sources exist", async () => {
@@ -180,10 +178,10 @@ describe("provenance-parser", () => {
       const result = await parseProvenanceAttestations([attestation]);
 
       expect(result).toHaveLength(1);
-      expect(result[0].dockerfileMetadata.analysis?.baseImage).toBe("alpine");
+      expect(result[0].dockerfileMetadata.contents).toBe(wanted);
     });
 
-    it("produces null analysis when no source matches the dockerfile name", async () => {
+    it("produces null contents when no source matches the dockerfile name", async () => {
       const a = Buffer.from("FROM alpine\n").toString("base64");
       const b = Buffer.from("FROM scratch\n").toString("base64");
 
@@ -213,7 +211,7 @@ describe("provenance-parser", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].dockerfileMetadata.name).toBe("Dockerfile");
-      expect(result[0].dockerfileMetadata.analysis).toBeNull();
+      expect(result[0].dockerfileMetadata.contents).toBeNull();
     });
   });
 
@@ -264,7 +262,7 @@ describe("provenance-parser", () => {
           "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md",
         dockerfileMetadata: {
           name: "build/Dockerfile",
-          analysis: null,
+          contents: null,
         },
       });
     });
@@ -336,9 +334,7 @@ describe("provenance-parser", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].dockerfileMetadata.name).toBe("Dockerfile");
-      expect(result[0].dockerfileMetadata.analysis?.baseImage).toBe(
-        "python:3.11",
-      );
+      expect(result[0].dockerfileMetadata.contents).toBe(dockerfileBase64);
     });
   });
 
@@ -526,7 +522,7 @@ describe("provenance-parser", () => {
         buildType: "",
         dockerfileMetadata: {
           name: "Dockerfile",
-          analysis: null,
+          contents: null,
         },
       });
     });

--- a/test/windows/__snapshots__/application-scans.spec.ts.snap
+++ b/test/windows/__snapshots__/application-scans.spec.ts.snap
@@ -2455,7 +2455,7 @@ exports[`go binaries scanning with esbuild npm path that previously failed exten
               "buildType": "https://mobyproject.org/buildkit@v1",
               "builderId": "",
               "dockerfileMetadata": {
-                "analysis": null,
+                "contents": null,
                 "name": "esbuild-test-dockerfile",
               },
             },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Surfaces the raw, base64-encoded Dockerfile contents in the `provenanceMetadata`
fact. `DockerfileMetadata` changes from `{ name, analysis }` to `{ name, contents }`:

App ui will decode for display.

#### Where should the reviewer start?

`lib/extractor/provenance-parser.ts`:
- `DockerfileMetadata` interface (`{ name, contents }`).
- `getEncodedDockerfileContents()` (returns raw base64; replaces the
  decode+analyse helpers).
- The `dockerfileMetadata` construction in `extractFieldsSlsaV0_2` /
  `extractFieldsSlsaV1_0`.

#### How should this be manually tested?

Scan an image built with provenance in max mode
(`docker buildx build --attest type=provenance,mode=max`), e.g. the test image
`snykgoof/alpine-provenance:latest`, and inspect the emitted `provenanceMetadata`
fact:

#### Any background context you want to provide?

keeping contents base64 encoded end-to-end
to match the DB contract

#### What are the relevant tickets?

- https://snyksec.atlassian.net/browse/PRIM-100

#### Screenshots

N/A — internal fact shape only.

#### Additional questions