### PR TITLE
feat(provenance): surface source repository for local builds via vcs.source [PRIM-100]

### DIFF
--- a/lib/extractor/provenance-parser.ts
+++ b/lib/extractor/provenance-parser.ts
@@ -68,7 +68,7 @@ interface SlsaPredicateV1_0 {
     metadata?: {
       startedOn?: string;
       buildkit_metadata?: {
-        vcs?: { revision?: string };
+        vcs?: { source?: string; revision?: string };
         source?: {
           infos?: BuildkitSourceInfo[];
         };
@@ -121,7 +121,11 @@ async function extractFieldsSlsaV0_2(
     ? "local"
     : null;
 
-  const buildConfigSourceUri = predicate.invocation?.configSource?.uri || null;
+  // configSource.uri is only set for remote (git-context) builds. For local
+  // builds (`docker buildx build .`), fall back to the git remote recorded by
+  // BuildKit in vcs.source so the source repository is still surfaced.
+  const buildConfigSourceUri =
+    predicate.invocation?.configSource?.uri || buildkitMeta?.vcs?.source || null;
 
   const builderId = predicate.builder?.id || "";
   const buildType = predicate.buildType || "";
@@ -171,8 +175,12 @@ async function extractFieldsSlsaV1_0(
     ? "local"
     : null;
 
+  // configSource.uri is only set for remote (git-context) builds. For local
+  // builds, fall back to the git remote recorded by BuildKit in vcs.source.
   const buildConfigSourceUri =
-    buildDefinition?.externalParameters?.configSource?.uri || null;
+    buildDefinition?.externalParameters?.configSource?.uri ||
+    runDetails?.metadata?.buildkit_metadata?.vcs?.source ||
+    null;
 
   const builderId = runDetails?.builder?.id || "";
   const buildType = buildDefinition?.buildType || "";

--- a/lib/extractor/provenance-parser.ts
+++ b/lib/extractor/provenance-parser.ts
@@ -121,11 +121,10 @@ async function extractFieldsSlsaV0_2(
     ? "local"
     : null;
 
-  // configSource.uri is only set for remote (git-context) builds. For local
-  // builds (`docker buildx build .`), fall back to the git remote recorded by
-  // BuildKit in vcs.source so the source repository is still surfaced.
   const buildConfigSourceUri =
-    predicate.invocation?.configSource?.uri || buildkitMeta?.vcs?.source || null;
+    predicate.invocation?.configSource?.uri ||
+    buildkitMeta?.vcs?.source ||
+    null;
 
   const builderId = predicate.builder?.id || "";
   const buildType = predicate.buildType || "";
@@ -175,8 +174,6 @@ async function extractFieldsSlsaV1_0(
     ? "local"
     : null;
 
-  // configSource.uri is only set for remote (git-context) builds. For local
-  // builds, fall back to the git remote recorded by BuildKit in vcs.source.
   const buildConfigSourceUri =
     buildDefinition?.externalParameters?.configSource?.uri ||
     runDetails?.metadata?.buildkit_metadata?.vcs?.source ||

--- a/test/lib/extractor/provenance-parser.spec.ts
+++ b/test/lib/extractor/provenance-parser.spec.ts
@@ -109,6 +109,10 @@ describe("provenance-parser", () => {
       expect(result).toHaveLength(1);
       expect(result[0].buildConfigDigest).toBe("localcommitsha");
       expect(result[0].buildConfigDigestSource).toBe("local");
+      // Local builds have no configSource.uri; the source repo falls back to vcs.source.
+      expect(result[0].buildConfigSourceUri).toBe(
+        "https://github.com/org/repo.git",
+      );
       expect(result[0].dockerfileMetadata.name).toBe("docker/Dockerfile.prod");
     });
 
@@ -283,6 +287,7 @@ describe("provenance-parser", () => {
               startedOn: "2025-07-01T09:00:00Z",
               buildkit_metadata: {
                 vcs: {
+                  source: "https://github.com/team/project.git",
                   revision: "localv1commit",
                 },
               },
@@ -296,6 +301,10 @@ describe("provenance-parser", () => {
       expect(result).toHaveLength(1);
       expect(result[0].buildConfigDigest).toBe("localv1commit");
       expect(result[0].buildConfigDigestSource).toBe("local");
+      // Local builds have no configSource.uri; the source repo falls back to vcs.source.
+      expect(result[0].buildConfigSourceUri).toBe(
+        "https://github.com/team/project.git",
+      );
     });
 
     it("decodes and parses dockerfile contents from a mode=max build", async () => {


### PR DESCRIPTION
## What

  configSource.uri is only set for remote (git-context) builds. For local builds, fall back to the git remote recorded by BuildKit in vcs.source.

This falls back to `vcs.source` when `configSource.uri` is absent.

## Change

- `lib/extractor/provenance-parser.ts`:
  - v0.2: `buildConfigSourceUri = configSource.uri || buildkitMeta.vcs.source || null`
  - v1: `buildConfigSourceUri = configSource.uri || buildkit_metadata.vcs.source || null` 
- `test/lib/extractor/provenance-parser.spec.ts`: extend the existing "local build VCS metadata" cases (v0.2 + v1) to assert `buildConfigSourceUri` now resolves to `vcs.source`.

## Why
Provenance from a locally-built image should still identify the repository it came from. Remote/git-context builds are unchanged.

## Test
`npx jest test/lib/extractor/provenance-parser.spec.ts`