### PR TITLE
feat(scan): derive image name from OCI archive index for oci-archive scans [PRIM-100]

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { extract } from "tar-stream";
 
 import { getImageArchive } from "./analyzer/image-inspector";
 import { readDockerfileAndAnalyse } from "./dockerfile";
@@ -151,6 +152,48 @@ function getAndValidateArchivePath(targetImage: string) {
   return archivePath;
 }
 
+// Reads the image reference embedded in an OCI archive's index.json
+// (io.containerd.image.name, falling back to org.opencontainers.image.ref.name).
+// This lets an `oci-archive:` scan be attributed to the actual image name instead of
+// the tar filename, so the resulting asset has the correct registry/repository identity.
+async function getImageNameFromOciArchive(
+  archivePath: string,
+): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve) => {
+    let imageName: string | undefined;
+    const tarExtractor = extract();
+
+    tarExtractor.on("entry", (header, stream, next) => {
+      if (header.name === "index.json" || header.name === "./index.json") {
+        let contents = "";
+        stream.on("data", (chunk) => (contents += chunk.toString()));
+        stream.on("end", () => {
+          try {
+            const index = JSON.parse(contents);
+            const annotations = index?.manifests?.[0]?.annotations ?? {};
+            imageName =
+              annotations["io.containerd.image.name"] ||
+              annotations["org.opencontainers.image.ref.name"] ||
+              undefined;
+          } catch {
+            // Malformed index — fall back to the archive filename.
+          }
+          next();
+        });
+        stream.on("error", () => next());
+      } else {
+        stream.on("end", next);
+        stream.resume();
+      }
+    });
+
+    tarExtractor.on("finish", () => resolve(imageName));
+    tarExtractor.on("error", () => resolve(undefined));
+
+    fs.createReadStream(archivePath).pipe(tarExtractor);
+  });
+}
+
 async function localArchiveAnalysis(
   targetImage: string,
   imageType: ImageType,
@@ -163,8 +206,17 @@ async function localArchiveAnalysis(
   };
 
   const archivePath = getAndValidateArchivePath(targetImage);
+
+  // For OCI archives, prefer the image name embedded in the archive's index.json over
+  // the tar filename, so the asset gets the correct registry/repository identity.
+  const embeddedImageName =
+    !options.imageNameAndTag && imageType === ImageType.OciArchive
+      ? await getImageNameFromOciArchive(archivePath)
+      : undefined;
+
   const imageIdentifier =
     options.imageNameAndTag ||
+    embeddedImageName ||
     // The target image becomes the base of the path, e.g. "archive.tar" for "/var/tmp/archive.tar"
     path.basename(archivePath);
 
@@ -177,6 +229,8 @@ async function localArchiveAnalysis(
       manifest: options.digests?.manifest,
       index: options.digests?.index,
     });
+  } else if (embeddedImageName) {
+    imageName = new ImageName(embeddedImageName);
   }
 
   return await staticModule.analyzeStatically(


### PR DESCRIPTION
## What

Scanning `oci-archive:<tar>` currently names the asset after the **tar filename** (`path.basename`), so the resulting container-image asset has an **empty registry/repository identity** (nameless asset).

This reads the image reference embedded in the archive's `index.json` — `io.containerd.image.name` (falling back to `org.opencontainers.image.ref.name`) — and uses it as the image identity for OCI-archive scans.

## Why it matters

Provenance attestations are only preserved when the image is **not** round-tripped through the Docker daemon (`docker save`/`docker pull` flatten the attestation on the classic image store). The reliable way to scan with provenance intact is to build to an OCI archive and scan it directly:

```
docker buildx build --provenance=mode=max --output type=oci,dest=image.tar .
snyk container monitor oci-archive:image.tar
```

Before this change that produced a **nameless** asset. With it, the same flow yields a correctly-identified asset **with** provenance — and removes the need for the containerd-image-store workaround on the scanning machine.

## Change
- `lib/scan.ts`: add `getImageNameFromOciArchive` (reads `index.json` from the tar via `tar-stream`) and, in `localArchiveAnalysis`, use the embedded name for `imageIdentifier`/`ImageName` when scanning an `oci-archive` and no explicit `imageNameAndTag` was given. Docker-archive and explicit-name paths are unchanged.

## Test
- `tsc --noEmit` clean.
- Follow-up: add a unit test with an OCI-archive fixture asserting the derived identity (draft).

## Related
- #889 (`vcs.source → repository_uri`) — together these let a plain build → `oci-archive` scan produce full provenance (name + commit + source repo) with no daemon/containerd dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)