### PR TITLE
fix(provenance): only fetch attestations for images pulled from a registry

### DIFF
--- a/lib/analyzer/image-inspector.ts
+++ b/lib/analyzer/image-inspector.ts
@@ -246,6 +246,7 @@ async function getImageArchive(
     return {
       imageName,
       path: saveLocation,
+      pulledFromRegistry: true,
       removeArchive: destination.removeCallback,
     };
   }
@@ -267,6 +268,7 @@ async function getImageArchive(
     return {
       imageName,
       path: saveLocation,
+      pulledFromRegistry: true,
       removeArchive: destination.removeCallback,
     };
   } else {
@@ -275,6 +277,7 @@ async function getImageArchive(
     return {
       imageName,
       path: saveLocation,
+      pulledFromRegistry: false,
       removeArchive: destination.removeCallback,
     };
   }

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -162,6 +162,14 @@ export interface StaticPackagesAnalysis extends StaticAnalysis {
 export interface ArchiveResult {
   imageName: ImageName;
   path: string;
+  /**
+   * True when the archive came from pulling the image out of its registry, false
+   * when it was saved from an image already present on the local daemon. Callers
+   * that want to reach back out to the registry for optional extras need to know
+   * the difference: a reference can look like a registry one and still have never
+   * come from a registry, so the registry may not exist or be reachable at all.
+   */
+  pulledFromRegistry: boolean;
   removeArchive(): void;
 }
 

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -228,6 +228,7 @@ async function imageIdentifierAnalysis(
       globToFind,
       options,
       imageName,
+      archiveResult.pulledFromRegistry,
     );
   } finally {
     archiveResult.removeArchive();

--- a/lib/static.ts
+++ b/lib/static.ts
@@ -29,6 +29,7 @@ export async function analyzeStatically(
   globsToFind: { include: string[]; exclude: string[] },
   options: Partial<PluginOptions>,
   imageName?: ImageName,
+  pulledFromRegistry = false,
 ): Promise<PluginResponse> {
   const totalStart = Date.now();
 
@@ -67,8 +68,17 @@ export async function analyzeStatically(
     packageFormat: parsedAnalysisResult.packageFormat,
   };
 
+  // Only reach back out to the registry for an image that actually came from one.
+  // An Identifier reference merely *looks* like a registry reference: an image that
+  // was built or loaded locally and tagged `my-registry.local/app:tag` never touched
+  // a registry, and that host may not resolve at all. Attempting it there produces a
+  // transport failure rather than a "no attestations" answer, and while this function
+  // swallows that error, the failed request is still visible to the HTTP layer that
+  // carried it -- which can append a second error document to an otherwise successful
+  // `--json` result. Skipping the request avoids the failure instead of handling it.
   if (
     imageType === ImageType.Identifier &&
+    pulledFromRegistry &&
     (!analysis.attestations || analysis.attestations.length === 0)
   ) {
     try {

--- a/test/lib/static.spec.ts
+++ b/test/lib/static.spec.ts
@@ -1,0 +1,86 @@
+import { ImageType } from "../../lib/types";
+
+jest.mock("../../lib/analyzer");
+jest.mock("../../lib/parser");
+jest.mock("../../lib/dependency-tree");
+jest.mock("../../lib/response-builder");
+jest.mock("../../lib/extractor/fetch-registry-provenance-attestations");
+
+import * as analyzer from "../../lib/analyzer";
+import { buildTree } from "../../lib/dependency-tree";
+import { fetchAttestationsFromRegistry } from "../../lib/extractor/fetch-registry-provenance-attestations";
+import { parseAnalysisResults } from "../../lib/parser";
+import { buildResponse } from "../../lib/response-builder";
+import { analyzeStatically } from "../../lib/static";
+
+const mockedAnalyzer = analyzer.analyzeStatically as jest.Mock;
+const mockedParse = parseAnalysisResults as jest.Mock;
+const mockedBuildTree = buildTree as jest.Mock;
+const mockedBuildResponse = buildResponse as jest.Mock;
+const mockedFetch = fetchAttestationsFromRegistry as jest.Mock;
+
+describe("analyzeStatically provenance registry fetch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // No attestations found inside the image, which is what makes the code consider
+    // asking the registry for them.
+    mockedAnalyzer.mockResolvedValue({ attestations: [], timings: {} });
+    mockedParse.mockReturnValue({
+      imageId: "sha256:abc",
+      imageLayers: [],
+      packageFormat: "apk",
+      depInfosList: [],
+      targetOS: { name: "alpine", version: "3.19", prettyName: "" },
+    });
+    mockedBuildTree.mockReturnValue({});
+    mockedBuildResponse.mockResolvedValue({ scanResults: [] });
+    mockedFetch.mockResolvedValue([]);
+  });
+
+  async function run(pulledFromRegistry?: boolean) {
+    return analyzeStatically(
+      "my-registry.local/app:latest",
+      undefined,
+      ImageType.Identifier,
+      "/tmp/image.tar",
+      { include: [], exclude: [] },
+      {},
+      undefined,
+      pulledFromRegistry,
+    );
+  }
+
+  it("does not call the registry for an image that was not pulled from one", async () => {
+    await run(false);
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it("does not call the registry when the caller says nothing", async () => {
+    // Defaulting to false keeps every existing caller on the safe side: an omitted
+    // argument must not produce an outbound request.
+    await run(undefined);
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it("calls the registry for an image that really was pulled from one", async () => {
+    await run(true);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registryBase: "my-registry.local",
+        repo: "app",
+        imageReference: "latest",
+      }),
+    );
+  });
+
+  it("does not call the registry when the image already carries attestations", async () => {
+    mockedAnalyzer.mockResolvedValue({
+      attestations: [{ some: "attestation" }],
+      timings: {},
+    });
+    await run(true);
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

#891 asks the registry for provenance attestations whenever the reference is an `Identifier` and the image carried none itself:

```ts
if (
  imageType === ImageType.Identifier &&
  (!analysis.attestations || analysis.attestations.length === 0)
)
```

That condition looks at the **shape of the reference**, not at where the image actually came from. This adds the missing condition.

## Why

An image built or loaded locally and tagged `my-registry.local/app:tag` is an `Identifier` reference that never touched a registry — and that hostname may not resolve at all. The request then fails at the **transport** layer instead of returning "no attestations".

`fetchAttestationsFromRegistry` swallows that error and returns `[]`, so the scan result is correct. But the failed request is still visible to the HTTP layer that carried it, which reports it independently. In the CLI that surfaces as a **second JSON document appended to an otherwise successful `--json` result**, breaking any consumer that parses stdout.

Observed in snyk/cli#7047, on `snyk container test private-registry.local/test-node-slim:latest --json`:

```
    }
  ]
}
{
  "ok": false,
  "error": "dial tcp: lookup private-registry.local on 127.0.0.11:53: no such host",
  "path": "private-registry.local/test-node-slim:latest"
}
```

The plugin's own log line confirms it handled the error and moved on:

```
snyk [provenance] failed to fetch attestation manifest for test-node-slim@latest: socket hang up
```

### The underlying assumption this broke

Every registry call before this one was **load-bearing**: if it failed there was no image, the scan failed, and you got a single coherent error document. This is the first *optional* request in that path, so it's the first that can fail while the command succeeds. Nothing downstream expects a successful result and a failure on the same stream.

Note the distinction — reachable registry with no attestation returns HTTP 404, which is handled cleanly and produces one document. Only an unreachable host produces the extra one. Verified: `snyk container test alpine:3.6 --json` (registry reference, no attestations, resolves fine) returns a single clean document.

## How

- `ArchiveResult` gains `pulledFromRegistry: boolean`. `getImageArchive` has three exits — two `pullImage` (→ `true`) and one `docker.save` of an image already on the daemon (→ `false`).
- Threaded through `scan.ts` into `analyzeStatically`, defaulting to `false`, so a caller that says nothing makes no outbound request.
- `static.ts` requires it before reaching out.

This **removes** the failure rather than handling it. For an image that genuinely came from a registry, that registry is reachable by definition, so the fetch still runs wherever it can succeed.

## Tests

New `test/lib/static.spec.ts` — the file had no coverage before:

| Case | Expectation |
|---|---|
| not pulled from registry | no fetch |
| caller omits the argument | no fetch (safe default) |
| genuinely pulled from registry | fetch called with the right registry/repo/tag |
| image already carries attestations | no fetch (existing behaviour preserved) |

Verified the test actually catches the bug — removing the new condition fails 2 of the 4:

```
✕ does not call the registry for an image that was not pulled from one
✕ does not call the registry when the caller says nothing
✓ calls the registry for an image that really was pulled from one
✓ does not call the registry when the image already carries attestations
```

`tsc --noEmit` clean, `eslint` clean, prettier-formatted.

`npx jest test/lib` → **534 passed**. 4 failures in `display.spec.ts`, `decompress-maybe.spec.ts` and `inputs/chisel/static.spec.ts` are **pre-existing** — confirmed identical on clean `origin/main`.

## Notes for the reviewer

- I did not gate this behind a feature flag. SDP has no flag client and shouldn't; and a flag would only hide the problem while it's off. This fixes the actual mistake and holds whether the flag is on or off.
- **Not fixed here:** the HTTP layer reporting a failed *optional* sub-request as a command-level error. This PR means the request isn't attempted where it would fail, but a customer with the flag enabled and a genuinely unreachable or firewalled registry could still hit it. Worth raising with the CLI team separately.
- `snyk/cli#7047` should go green on a release containing this, with no change needed on the CLI side.
