### PR TITLE
docs: add Cursor Cloud agent testing notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,27 @@ target Node major (`20`) when validating locally.
 - How a scan flows end-to-end: start at `lib/scan.ts`.
 - How to add support for a new ecosystem: look at an existing one under
   `lib/inputs/` + `lib/analyzer/applications/` + `lib/parser/` as a template.
+
+## Cursor Cloud specific instructions
+
+Cloud Agent shells run with `NO_COLOR=1` (and `FORCE_COLOR=0`) injected by the
+runtime. The four `test/lib/display.spec.ts` cases compare `display()` output
+against fixtures that contain ANSI color codes, so they fail under `NO_COLOR`
+even though the code is fine. CircleCI doesn't hit this because `supports-color`
+treats the `CIRCLECI` env var as color-capable.
+
+Run the unit suite with color forced on to match CI:
+
+```sh
+FORCE_COLOR=1 npm run test:unit
+```
+
+The `install` step (`npm ci`) doesn't run tests, so environment builds aren't
+affected — this only matters when you run the tests yourself.
+
+System tests (`npm run test:system`) additionally need a running Docker daemon
+plus the Docker Hub private-image credentials (`DOCKER_HUB_PRIVATE_IMAGE`,
+`DOCKER_HUB_USERNAME`, `DOCKER_HUB_PASSWORD`, from 1Password). Neither is
+provisioned by default in Cloud Agents, so that layer is skipped unless you add
+them. Build, lint, unit tests, and calling `scan()` on a `docker-archive:` /
+`oci-archive:` fixture under `test/fixtures/` all work without Docker.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting one non-obvious quirk that trips up the test suite in Cursor Cloud Agents.

## Why

Cloud Agent shells run with `NO_COLOR=1` / `FORCE_COLOR=0` injected by the runtime. The four `test/lib/display.spec.ts` cases compare `display()` output against fixtures containing ANSI color codes, so they fail under `NO_COLOR` even though the code is correct. CircleCI doesn't hit this because `supports-color` treats the `CIRCLECI` env var as color-capable.

Running `FORCE_COLOR=1 npm run test:unit` makes the full suite pass (920/920), matching CI behavior. The note also records that system tests need a Docker daemon plus Docker Hub private credentials, which aren't provisioned in Cloud Agents by default.

## Scope

Documentation only — no code or test changes. `npm ci` (the environment install step) doesn't run tests, so environment builds are unaffected.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67139e2c-0606-497c-b3af-45ac15160fe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67139e2c-0606-497c-b3af-45ac15160fe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

