### PR TITLE
refactor: optimize hot paths in docker image extraction pipeline

### DIFF
--- a/lib/extractor/callbacks.ts
+++ b/lib/extractor/callbacks.ts
@@ -8,6 +8,21 @@ export async function applyCallbacks(
   streamSize?: number,
 ): Promise<FileNameAndContent> {
   const result: FileNameAndContent = {};
+
+  if (matchedActions.length === 1) {
+    const action = matchedActions[0];
+    const content =
+      action.callback !== undefined
+        ? await action.callback(fileContentStream, streamSize)
+        : await streamToString(fileContentStream);
+
+    if (content) {
+      result[action.actionName] = content;
+    }
+
+    return result;
+  }
+
   const actionsToAwait = matchedActions.map((action) => {
     // Using a pass through allows us to read the stream multiple times.
     const streamCopy = new PassThrough();

--- a/lib/extractor/index.ts
+++ b/lib/extractor/index.ts
@@ -28,6 +28,12 @@ import {
 
 const debug = Debug("snyk");
 
+const WHITEOUT_PATH_PATTERN = /.wh./;
+
+function whiteoutToRemovedPath(filename: string): string {
+  return path.normalize(filename.replace(WHITEOUT_PATH_PATTERN, ""));
+}
+
 export { InvalidArchiveError } from "./generic-archive-extractor";
 class ArchiveExtractor {
   private extractor: Extractor;
@@ -277,7 +283,7 @@ export function symlinksWithLatestModifications(
     if (fileLayer) {
       for (const filename of Object.keys(fileLayer)) {
         if (isWhitedOutFile(filename)) {
-          removedPathsToIgnore.add(filename.replace(/.wh./, ""));
+          removedPathsToIgnore.add(whiteoutToRemovedPath(filename));
         }
       }
     }
@@ -290,9 +296,7 @@ function isSymlinkInARemovedFolder(
   symlinkPath: string,
   removedPathsToIgnore: Set<string>,
 ): boolean {
-  return Array.from(removedPathsToIgnore).some((removedPath) =>
-    isFileInFolder(symlinkPath, removedPath),
-  );
+  return isPathUnderAnyRemovedPath(symlinkPath, removedPathsToIgnore);
 }
 
 function layersWithLatestFileModifications(
@@ -308,7 +312,7 @@ function layersWithLatestFileModifications(
       // if finding a deleted file - trimming to its original file name for excluding it from extractedLayers
       // + not adding this file
       if (isWhitedOutFile(filename)) {
-        removedFilesToIgnore.add(filename.replace(/.wh./, ""));
+        removedFilesToIgnore.add(whiteoutToRemovedPath(filename));
         continue;
       }
       // not adding previously found to be whited out files to extractedLayers
@@ -358,32 +362,38 @@ function getContent(
   extractedLayers: ExtractedLayers,
   extractAction: ExtractAction,
 ): FileContent | undefined {
-  const fileNames = Object.keys(extractedLayers);
-  const fileNamesProducedByTheExtractAction = fileNames.filter(
-    (name) => extractAction.actionName in extractedLayers[name],
-  );
-
-  const firstFileNameMatch = fileNamesProducedByTheExtractAction.find((match) =>
-    extractAction.filePathMatches(match),
-  );
-
-  return firstFileNameMatch !== undefined
-    ? extractedLayers[firstFileNameMatch][extractAction.actionName]
-    : undefined;
+  for (const fileName of Object.keys(extractedLayers)) {
+    if (
+      extractAction.actionName in extractedLayers[fileName] &&
+      extractAction.filePathMatches(fileName)
+    ) {
+      return extractedLayers[fileName][extractAction.actionName];
+    }
+  }
+  return undefined;
 }
 
-function isFileInFolder(file: string, folder: string): boolean {
-  const folderPath = path.normalize(folder);
-  const filePath = path.normalize(file);
-
-  return filePath.startsWith(path.join(folderPath, path.sep));
+function isPathUnderAnyRemovedPath(
+  candidatePath: string,
+  removedPaths: Set<string>,
+): boolean {
+  let current = path.normalize(candidatePath);
+  while (true) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    if (removedPaths.has(parent)) {
+      return true;
+    }
+    current = parent;
+  }
+  return false;
 }
 
 function isFileInARemovedFolder(
   filename: string,
   removedFilesToIgnore: Set<string>,
 ): boolean {
-  return Array.from(removedFilesToIgnore).some((removedFile) =>
-    isFileInFolder(filename, removedFile),
-  );
+  return isPathUnderAnyRemovedPath(filename, removedFilesToIgnore);
 }

--- a/lib/extractor/layer.ts
+++ b/lib/extractor/layer.ts
@@ -7,8 +7,10 @@ import { applyCallbacks, isResultEmpty } from "./callbacks";
 import { decompressMaybe } from "./decompress-maybe";
 import { ExtractAction, ExtractedLayers, SymlinkMap } from "./types";
 
-export function isWhitedOutFile(filename: string) {
-  return filename.match(/.wh./gm);
+const WHITEOUT_PATTERN = /.wh./;
+
+export function isWhitedOutFile(filename: string): boolean {
+  return WHITEOUT_PATTERN.test(filename);
 }
 
 const debug = Debug("snyk");
@@ -37,11 +39,10 @@ export async function extractImageLayer(
     const tarExtractor: Extract = extract();
 
     tarExtractor.on("entry", async (headers, stream, next) => {
-      const absoluteFileName = path.join(path.sep, headers.name);
-
       // Symlinks are path redirects; hard links are alternate names for the same
       // inode and must not be treated as redirects during path canonicalization.
       if (headers.type === "symlink") {
+        const absoluteFileName = path.join(path.sep, headers.name);
         const linkTarget = headers.linkname;
         if (linkTarget) {
           symlinks[absoluteFileName] = absoluteLinkTarget(
@@ -50,10 +51,18 @@ export async function extractImageLayer(
           );
         }
       } else if (headers.type === "file") {
-        const matchedActions = extractActions.filter((action) =>
-          action.filePathMatches(absoluteFileName),
-        );
-        if (matchedActions.length > 0) {
+        const absoluteFileName = path.join(path.sep, headers.name);
+        let matchedActions: ExtractAction[] | undefined;
+        for (const action of extractActions) {
+          if (action.filePathMatches(absoluteFileName)) {
+            if (matchedActions === undefined) {
+              matchedActions = [action];
+            } else {
+              matchedActions.push(action);
+            }
+          }
+        }
+        if (matchedActions !== undefined && matchedActions.length > 0) {
           try {
             const callbackResult = await applyCallbacks(
               matchedActions,

--- a/lib/go-parser/index.ts
+++ b/lib/go-parser/index.ts
@@ -38,10 +38,13 @@ export const DEP_GRAPH_TYPE = "gomodules";
 function filePathMatches(filePath: string): boolean {
   const normalizedPath = path.normalize(filePath);
   const dirName = path.dirname(normalizedPath);
-  const forwardSlashedPath = filePath.replace(/\\/g, "/");
+  const forwardSlashedPath = filePath.includes("\\")
+    ? filePath.replace(/\\/g, "/")
+    : filePath;
 
-  // Fix backslash path extension detection false positives: path.parse().ext incorrectly detects extensions in paths with backslashes (usually on Windows)
-  const hasExtension = !!path.posix.parse(forwardSlashedPath).ext;
+  // Fix backslash path extension detection false positives: path.extname() on
+  // forward-slashed paths avoids false positives from backslashes on Windows.
+  const hasExtension = !!path.extname(forwardSlashedPath);
   const isInIgnoredPath = ignoredPaths.some((ignorePath) =>
     dirName.startsWith(ignorePath),
   );

--- a/lib/inputs/file-pattern/static.ts
+++ b/lib/inputs/file-pattern/static.ts
@@ -1,4 +1,4 @@
-import { minimatch, MinimatchOptions } from "minimatch";
+import { Minimatch, MinimatchOptions } from "minimatch";
 import * as path from "path";
 
 import { ExtractAction, ExtractedLayers } from "../../extractor/types";
@@ -18,12 +18,19 @@ function generatePathMatcher(
     optimizationLevel: 0,
   };
 
+  const excludeMatchers = globsExclude.map(
+    (glob) => new Minimatch(glob, matchOptions),
+  );
+  const includeMatchers = globsInclude.map(
+    (glob) => new Minimatch(glob, matchOptions),
+  );
+
   return (filePath: string): boolean => {
-    if (globsExclude.some((glob) => minimatch(filePath, glob, matchOptions))) {
+    if (excludeMatchers.some((matcher) => matcher.match(filePath))) {
       return false;
     }
 
-    return globsInclude.some((glob) => minimatch(filePath, glob, matchOptions));
+    return includeMatchers.some((matcher) => matcher.match(filePath));
   };
 }
 

--- a/test/lib/extractor/callbacks-performance.spec.ts
+++ b/test/lib/extractor/callbacks-performance.spec.ts
@@ -1,0 +1,255 @@
+import { PassThrough, Readable } from "stream";
+import { applyCallbacks } from "../../../lib/extractor/callbacks";
+import {
+  ExtractAction,
+  FileNameAndContent,
+} from "../../../lib/extractor/types";
+import { streamToString } from "../../../lib/stream-utils";
+
+const MEGABYTE = 1024 * 1024;
+const CHUNK_SIZE = 64 * 1024;
+
+function createMultiMegabyteStream(sizeMb: number): Readable {
+  const totalBytes = sizeMb * MEGABYTE;
+  let sent = 0;
+
+  return new Readable({
+    read() {
+      if (sent >= totalBytes) {
+        this.push(null);
+        return;
+      }
+      const remaining = totalBytes - sent;
+      const size = Math.min(CHUNK_SIZE, remaining);
+      this.push(Buffer.alloc(size, 0x42));
+      sent += size;
+    },
+  });
+}
+
+async function baselineApplyCallbacks(
+  matchedActions: ExtractAction[],
+  fileContentStream: Readable,
+  streamSize?: number,
+): Promise<FileNameAndContent> {
+  const result: FileNameAndContent = {};
+  const actionsToAwait = matchedActions.map((action) => {
+    // Using a pass through allows us to read the stream multiple times.
+    const streamCopy = new PassThrough();
+    fileContentStream.pipe(streamCopy);
+
+    // Queue the promise but don't await on it yet: we want consumers to start around the same time.
+    const promise =
+      action.callback !== undefined
+        ? action.callback(streamCopy, streamSize)
+        : // If no callback was provided for this action then return as string by default.
+          streamToString(streamCopy);
+
+    return promise.then((content) => {
+      // Assign the result once the Promise is complete.
+      if (content) {
+        result[action.actionName] = content;
+      }
+    });
+  });
+
+  await Promise.all(actionsToAwait);
+
+  return result;
+}
+
+function bufferAction(
+  actionName: string,
+  callback?: ExtractAction["callback"],
+): ExtractAction {
+  return {
+    actionName,
+    filePathMatches: () => true,
+    callback:
+      callback ??
+      (async (stream) => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of stream) {
+          chunks.push(Buffer.from(chunk));
+        }
+        return Buffer.concat(chunks);
+      }),
+  };
+}
+
+describe("applyCallbacks stream passthrough bypass", () => {
+  const streamSizeMb = 4;
+
+  it("matches baseline for a single matched action", async () => {
+    const action = bufferAction("content");
+
+    const optimizedStream = createMultiMegabyteStream(streamSizeMb);
+    const baselineStream = createMultiMegabyteStream(streamSizeMb);
+
+    const optimized = await applyCallbacks(
+      [action],
+      optimizedStream,
+      streamSizeMb,
+    );
+    const baseline = await baselineApplyCallbacks(
+      [action],
+      baselineStream,
+      streamSizeMb,
+    );
+
+    expect(optimized).toEqual(baseline);
+  });
+
+  it("matches baseline for two matched actions over the same stream size", async () => {
+    const actions = [
+      bufferAction("first"),
+      bufferAction("second", async (stream) => {
+        const text = await streamToString(stream);
+        return text.length.toString();
+      }),
+    ];
+
+    const optimizedStream = createMultiMegabyteStream(streamSizeMb);
+    const baselineStream = createMultiMegabyteStream(streamSizeMb);
+
+    const optimized = await applyCallbacks(
+      actions,
+      optimizedStream,
+      streamSizeMb,
+    );
+    const baseline = await baselineApplyCallbacks(
+      actions,
+      baselineStream,
+      streamSizeMb,
+    );
+
+    expect(optimized).toEqual(baseline);
+  });
+
+  it("omits the result key when a callback resolves undefined", async () => {
+    const action: ExtractAction = {
+      actionName: "empty",
+      filePathMatches: () => true,
+      callback: async () => undefined,
+    };
+
+    const optimizedStream = createMultiMegabyteStream(1);
+    const baselineStream = createMultiMegabyteStream(1);
+
+    const optimized = await applyCallbacks([action], optimizedStream);
+    const baseline = await baselineApplyCallbacks([action], baselineStream);
+
+    expect(optimized).toEqual({});
+    expect(baseline).toEqual({});
+    expect(Object.prototype.hasOwnProperty.call(optimized, "empty")).toBe(
+      false,
+    );
+  });
+
+  it("rejects with the same error as baseline when a callback rejects", async () => {
+    const expectedError = new Error("callback failed");
+    const action: ExtractAction = {
+      actionName: "failing",
+      filePathMatches: () => true,
+      callback: async () => {
+        throw expectedError;
+      },
+    };
+
+    const optimizedStream = createMultiMegabyteStream(1);
+    const baselineStream = createMultiMegabyteStream(1);
+
+    await expect(applyCallbacks([action], optimizedStream)).rejects.toBe(
+      expectedError,
+    );
+    await expect(baselineApplyCallbacks([action], baselineStream)).rejects.toBe(
+      expectedError,
+    );
+  });
+
+  it("leaves the source stream drainable via resume when callback resolves on first chunk", async () => {
+    const totalBytes = 2 * MEGABYTE;
+    let produced = 0;
+    let drained = 0;
+    let firstChunkSize = 0;
+
+    const stream = new Readable({
+      read() {
+        if (produced >= totalBytes) {
+          this.push(null);
+          return;
+        }
+        const size = Math.min(CHUNK_SIZE, totalBytes - produced);
+        this.push(Buffer.alloc(size, 0x42));
+        produced += size;
+      },
+    });
+    stream.pause();
+
+    const action: ExtractAction = {
+      actionName: "early",
+      filePathMatches: () => true,
+      callback: (dataStream) =>
+        new Promise((resolve) => {
+          dataStream.once("data", (chunk: Buffer) => {
+            firstChunkSize = chunk.length;
+            dataStream.pause();
+            resolve("partial");
+          });
+          dataStream.resume();
+        }),
+    };
+
+    const result = await applyCallbacks([action], stream);
+    expect(result).toEqual({ early: "partial" });
+
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (chunk: Buffer) => {
+        drained += chunk.length;
+      });
+      stream.on("end", resolve);
+      stream.on("error", reject);
+      stream.resume();
+    });
+
+    expect(firstChunkSize + drained).toBe(totalBytes);
+  });
+
+  it("is faster than baseline for the single-action path", async () => {
+    const action = bufferAction("content");
+    const benchmarkSizeMb = 8;
+    const runs = 5;
+
+    const measure = async (
+      fn: (
+        actions: ExtractAction[],
+        stream: Readable,
+        streamSize?: number,
+      ) => Promise<FileNameAndContent>,
+    ): Promise<number> => {
+      const times: number[] = [];
+      for (let i = 0; i < runs; i++) {
+        const stream = createMultiMegabyteStream(benchmarkSizeMb);
+        const start = process.hrtime.bigint();
+        await fn([action], stream, benchmarkSizeMb);
+        times.push(Number(process.hrtime.bigint() - start) / 1e6);
+      }
+      return Math.min(...times);
+    };
+
+    // Warmup
+    await measure(baselineApplyCallbacks);
+
+    const baselineMs = await measure(baselineApplyCallbacks);
+    const optimizedMs = await measure(applyCallbacks);
+
+     
+    console.log(
+      `applyCallbacks single-action: optimized=${optimizedMs.toFixed(
+        2,
+      )}ms baseline=${baselineMs.toFixed(2)}ms`,
+    );
+
+    expect(optimizedMs).toBeLessThan(baselineMs);
+  });
+});

--- a/test/lib/extractor/callbacks-performance.spec.ts
+++ b/test/lib/extractor/callbacks-performance.spec.ts
@@ -243,7 +243,6 @@ describe("applyCallbacks stream passthrough bypass", () => {
     const baselineMs = await measure(baselineApplyCallbacks);
     const optimizedMs = await measure(applyCallbacks);
 
-     
     console.log(
       `applyCallbacks single-action: optimized=${optimizedMs.toFixed(
         2,

--- a/test/lib/extractor/merge-hot-path-performance.spec.ts
+++ b/test/lib/extractor/merge-hot-path-performance.spec.ts
@@ -404,7 +404,6 @@ describe("merge hot path performance", () => {
         }
       }, 5);
 
-       
       console.log(
         `isWhitedOutFile timing: baseline=${baselineMs.toFixed(
           3,
@@ -440,7 +439,6 @@ describe("merge hot path performance", () => {
         runAllMerges(optimizedLayersWithLatestFileModifications);
       }, 5);
 
-       
       console.log(
         `file merge timing: baseline=${baselineMs.toFixed(
           3,
@@ -461,7 +459,6 @@ describe("merge hot path performance", () => {
       {},
     );
     const elapsedMs = performance.now() - start;
-     
     console.log(
       `extractImageContent(nginx.tar) elapsed=${elapsedMs.toFixed(3)}ms`,
     );

--- a/test/lib/extractor/merge-hot-path-performance.spec.ts
+++ b/test/lib/extractor/merge-hot-path-performance.spec.ts
@@ -1,0 +1,469 @@
+import * as path from "path";
+import {
+  extractImageContent,
+  getContentAsBuffer,
+  getContentAsString,
+  isWhitedOutFile,
+  symlinksWithLatestModifications,
+} from "../../../lib/extractor";
+import { extractArchive } from "../../../lib/extractor/docker-archive";
+import { InvalidArchiveError } from "../../../lib/extractor/generic-archive-extractor";
+import {
+  ExtractAction,
+  ExtractedLayers,
+  SymlinkMap,
+} from "../../../lib/extractor/types";
+import { ImageType } from "../../../lib/types";
+import { getFixture } from "../../util/index";
+
+function baselineIsWhitedOutFile(filename: string) {
+  return filename.match(/.wh./gm);
+}
+
+function baselineIsFileInFolder(file: string, folder: string): boolean {
+  const folderPath = path.normalize(folder);
+  const filePath = path.normalize(file);
+
+  return filePath.startsWith(path.join(folderPath, path.sep));
+}
+
+function baselineIsFileInARemovedFolder(
+  filename: string,
+  removedFilesToIgnore: Set<string>,
+): boolean {
+  return Array.from(removedFilesToIgnore).some((removedFile) =>
+    baselineIsFileInFolder(filename, removedFile),
+  );
+}
+
+function baselineLayersWithLatestFileModifications(
+  layers: ExtractedLayers[],
+): ExtractedLayers {
+  const extractedLayers: ExtractedLayers = {};
+  const removedFilesToIgnore: Set<string> = new Set();
+
+  for (const layer of layers) {
+    for (const filename of Object.keys(layer)) {
+      if (baselineIsWhitedOutFile(filename)) {
+        removedFilesToIgnore.add(filename.replace(/.wh./, ""));
+        continue;
+      }
+      if (removedFilesToIgnore.has(filename)) {
+        continue;
+      }
+      if (baselineIsFileInARemovedFolder(filename, removedFilesToIgnore)) {
+        continue;
+      }
+      if (!Reflect.has(extractedLayers, filename)) {
+        extractedLayers[filename] = layer[filename];
+      }
+    }
+  }
+  return extractedLayers;
+}
+
+function optimizedWhiteoutToRemovedPath(filename: string): string {
+  return path.normalize(filename.replace(/.wh./, ""));
+}
+
+function optimizedIsPathUnderAnyRemovedPath(
+  candidatePath: string,
+  removedPaths: Set<string>,
+): boolean {
+  let current = path.normalize(candidatePath);
+  while (true) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    if (removedPaths.has(parent)) {
+      return true;
+    }
+    current = parent;
+  }
+  return false;
+}
+
+function optimizedLayersWithLatestFileModifications(
+  layers: ExtractedLayers[],
+): ExtractedLayers {
+  const extractedLayers: ExtractedLayers = {};
+  const removedFilesToIgnore: Set<string> = new Set();
+
+  for (const layer of layers) {
+    for (const filename of Object.keys(layer)) {
+      if (isWhitedOutFile(filename)) {
+        removedFilesToIgnore.add(optimizedWhiteoutToRemovedPath(filename));
+        continue;
+      }
+      if (removedFilesToIgnore.has(filename)) {
+        continue;
+      }
+      if (optimizedIsPathUnderAnyRemovedPath(filename, removedFilesToIgnore)) {
+        continue;
+      }
+      if (!Reflect.has(extractedLayers, filename)) {
+        extractedLayers[filename] = layer[filename];
+      }
+    }
+  }
+  return extractedLayers;
+}
+
+const matchEverythingAction: ExtractAction = {
+  actionName: "record",
+  filePathMatches: () => true,
+  callback: async (stream) => {
+    stream.resume();
+    return Buffer.from("x");
+  },
+};
+
+async function extractUnmergedArchive(fixturePath: string) {
+  const fixture = getFixture(fixturePath);
+  try {
+    return await extractArchive(fixture, [matchEverythingAction], {});
+  } catch (error) {
+    if (error instanceof InvalidArchiveError) {
+      const { extractArchive: extractOciArchive } = await import(
+        "../../../lib/extractor/oci-archive"
+      );
+      return extractOciArchive(fixture, [matchEverythingAction], {});
+    }
+    throw error;
+  }
+}
+
+function bestOfRuns(fn: () => void, runs: number): number {
+  const times: number[] = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    fn();
+    times.push(performance.now() - start);
+  }
+  return Math.min(...times);
+}
+
+describe("merge hot path performance", () => {
+  describe("getContentAsString and getContentAsBuffer", () => {
+    const actionName = "test-action";
+    const extractAction: ExtractAction = {
+      actionName,
+      filePathMatches: (filePath) => filePath.endsWith("/target"),
+    };
+
+    it("returns undefined when there is no match", () => {
+      const extractedLayers: ExtractedLayers = {
+        "/other/file": { [actionName]: "content" },
+      };
+      expect(
+        getContentAsString(extractedLayers, extractAction),
+      ).toBeUndefined();
+      expect(
+        getContentAsBuffer(extractedLayers, extractAction),
+      ).toBeUndefined();
+    });
+
+    it("skips entries with matching actionName but failing filePathMatches", () => {
+      const extractedLayers: ExtractedLayers = {
+        "/wrong/path": { [actionName]: "wrong" },
+        "/also/wrong": { [actionName]: "also wrong" },
+      };
+      expect(
+        getContentAsString(extractedLayers, extractAction),
+      ).toBeUndefined();
+    });
+
+    it("returns the first key in Object.keys order when several candidates match", () => {
+      const extractedLayers: ExtractedLayers = {
+        "/z/target": { [actionName]: "z" },
+        "/a/target": { [actionName]: "a" },
+        "/m/target": { [actionName]: "m" },
+      };
+      const expectedKey = Object.keys(extractedLayers).find((name) =>
+        extractAction.filePathMatches(name),
+      );
+      expect(getContentAsString(extractedLayers, extractAction)).toEqual(
+        extractedLayers[expectedKey!][actionName],
+      );
+    });
+
+    it("returns string content via getContentAsString", () => {
+      const extractedLayers: ExtractedLayers = {
+        "/path/target": { [actionName]: "hello" },
+      };
+      expect(getContentAsString(extractedLayers, extractAction)).toEqual(
+        "hello",
+      );
+      expect(
+        getContentAsBuffer(extractedLayers, extractAction),
+      ).toBeUndefined();
+    });
+
+    it("returns buffer content via getContentAsBuffer", () => {
+      const buffer = Buffer.from("binary");
+      const extractedLayers: ExtractedLayers = {
+        "/path/target": { [actionName]: buffer },
+      };
+      expect(getContentAsBuffer(extractedLayers, extractAction)).toEqual(
+        buffer,
+      );
+      expect(
+        getContentAsString(extractedLayers, extractAction),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("symlinksWithLatestModifications", () => {
+    it("uses the newest layer when the same path appears in multiple layers", () => {
+      const symlinkLayers: SymlinkMap[] = [
+        { "/bin": "usr/local/bin" },
+        { "/bin": "usr/bin" },
+      ];
+      expect(symlinksWithLatestModifications(symlinkLayers, [{}, {}])).toEqual({
+        "/bin": "usr/local/bin",
+      });
+    });
+
+    it("merges symlinks from all layers when there is no conflict", () => {
+      const symlinkLayers: SymlinkMap[] = [
+        { "/bin": "usr/bin" },
+        { "/lib": "usr/lib" },
+        { "/etc": "usr/etc" },
+      ];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, [{}, {}, {}]),
+      ).toEqual({
+        "/bin": "usr/bin",
+        "/lib": "usr/lib",
+        "/etc": "usr/etc",
+      });
+    });
+
+    it("removes a symlink when a newer layer whiteouts the path", () => {
+      const symlinkLayers: SymlinkMap[] = [{}, { "/bin": "usr/bin" }];
+      const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, fileLayers),
+      ).toBeUndefined();
+    });
+
+    it("does not re-add a whiteouted symlink from an older layer", () => {
+      const symlinkLayers: SymlinkMap[] = [
+        {},
+        { "/bin": "usr/bin" },
+        { "/bin": "usr/old/bin" },
+      ];
+      const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}, {}];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, fileLayers),
+      ).toBeUndefined();
+    });
+
+    it("keeps a symlink re-created in a newer layer after an older layer deleted it", () => {
+      const symlinkLayers: SymlinkMap[] = [
+        { "/bin": "usr/bin" },
+        {},
+        { "/bin": "usr/old/bin" },
+      ];
+      const fileLayers: ExtractedLayers[] = [{}, { "/.wh.bin": {} }, {}];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, fileLayers),
+      ).toEqual({
+        "/bin": "usr/bin",
+      });
+    });
+
+    it("keeps a symlink created in the same layer that whiteouts the path", () => {
+      const symlinkLayers: SymlinkMap[] = [
+        { "/bin": "usr/bin" },
+        { "/bin": "old/bin" },
+      ];
+      const fileLayers: ExtractedLayers[] = [{ "/.wh.bin": {} }, {}];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, fileLayers),
+      ).toEqual({
+        "/bin": "usr/bin",
+      });
+    });
+
+    it("keeps a base-layer symlink untouched by newer layers", () => {
+      const symlinkLayers: SymlinkMap[] = [{}, {}, { "/lib": "usr/lib" }];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, [{}, {}, {}]),
+      ).toEqual({
+        "/lib": "usr/lib",
+      });
+    });
+
+    it("removes symlinks under a folder whited out by a newer layer", () => {
+      const symlinkLayers: SymlinkMap[] = [
+        {},
+        { "/opt/app/current": "releases/1" },
+      ];
+      const fileLayers: ExtractedLayers[] = [{ "/.wh.opt": {} }, {}];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, fileLayers),
+      ).toBeUndefined();
+    });
+
+    it("removes a symlink nested several levels under a whited-out folder", () => {
+      const symlinkLayers: SymlinkMap[] = [
+        {},
+        { "/opt/app/releases/current/bin": "releases/1/bin" },
+      ];
+      const fileLayers: ExtractedLayers[] = [{ "/.wh.opt": {} }, {}];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, fileLayers),
+      ).toBeUndefined();
+    });
+
+    it("keeps a symlink whose path merely shares a prefix with a removed path", () => {
+      const symlinkLayers: SymlinkMap[] = [{}, { "/opt/apple": "fruit/apple" }];
+      const fileLayers: ExtractedLayers[] = [{ "/.wh.opt/app": {} }, {}];
+      expect(
+        symlinksWithLatestModifications(symlinkLayers, fileLayers),
+      ).toEqual({
+        "/opt/apple": "fruit/apple",
+      });
+    });
+  });
+
+  describe("file merge equivalence via extractImageContent", () => {
+    const fixtures = [
+      "docker-archives/docker-save/deleted-folder.tar",
+      "docker-archives/docker-save/test-deleted.tar",
+      "docker-archives/docker-save/two-adds-one-file-rm.tar",
+    ];
+
+    it.each(fixtures)(
+      "merged keys match baseline for %s",
+      async (fixturePath) => {
+        const archiveContent = await extractUnmergedArchive(fixturePath);
+        const baselineKeys = Object.keys(
+          baselineLayersWithLatestFileModifications(archiveContent.layers),
+        ).sort();
+        const shipped = await extractImageContent(
+          ImageType.DockerArchive,
+          getFixture(fixturePath),
+          [matchEverythingAction],
+          {},
+        );
+        const shippedKeys = Object.keys(shipped.extractedLayers).sort();
+        expect(shippedKeys).toEqual(baselineKeys);
+      },
+    );
+  });
+
+  describe("timing benchmarks", () => {
+    let corpusPaths: string[] = [];
+    let mergeLayerSets: ExtractedLayers[][] = [];
+
+    beforeAll(async () => {
+      const fixturePaths = [
+        "docker-archives/docker-save/nginx.tar",
+        "docker-archives/docker-save/deleted-folder.tar",
+        "docker-archives/docker-save/test-deleted.tar",
+        "docker-archives/docker-save/two-adds-one-file-rm.tar",
+      ];
+      corpusPaths = [];
+      mergeLayerSets = [];
+      for (const fixturePath of fixturePaths) {
+        const content = await extractUnmergedArchive(fixturePath);
+        mergeLayerSets.push(content.layers);
+        for (const layer of content.layers) {
+          corpusPaths.push(...Object.keys(layer));
+        }
+      }
+    });
+
+    it("optimized isWhitedOutFile is faster than baseline on harvested corpus", () => {
+      const timingCorpus: string[] = [];
+      for (const p of corpusPaths) {
+        timingCorpus.push(p);
+        const baseName = path.basename(p);
+        timingCorpus.push(path.join(path.dirname(p), `.wh.${baseName}`));
+      }
+
+      baselineIsWhitedOutFile(timingCorpus[0]);
+      isWhitedOutFile(timingCorpus[0]);
+
+      const repetitions = 200;
+      const baselineMs = bestOfRuns(() => {
+        for (let rep = 0; rep < repetitions; rep++) {
+          for (const p of timingCorpus) {
+            baselineIsWhitedOutFile(p);
+          }
+        }
+      }, 5);
+      const optimizedMs = bestOfRuns(() => {
+        for (let rep = 0; rep < repetitions; rep++) {
+          for (const p of timingCorpus) {
+            isWhitedOutFile(p);
+          }
+        }
+      }, 5);
+
+       
+      console.log(
+        `isWhitedOutFile timing: baseline=${baselineMs.toFixed(
+          3,
+        )}ms optimized=${optimizedMs.toFixed(3)}ms (corpus=${
+          timingCorpus.length
+        } paths)`,
+      );
+      expect(optimizedMs).toBeLessThan(baselineMs);
+    });
+
+    it("optimized file merge is faster than baseline on harvested corpus", async () => {
+      baselineLayersWithLatestFileModifications(mergeLayerSets[0]);
+      optimizedLayersWithLatestFileModifications(mergeLayerSets[0]);
+      await extractImageContent(
+        ImageType.DockerArchive,
+        getFixture("docker-archives/docker-save/nginx.tar"),
+        [matchEverythingAction],
+        {},
+      );
+
+      const runAllMerges = (
+        mergeFn: (layers: ExtractedLayers[]) => ExtractedLayers,
+      ) => {
+        for (const layers of mergeLayerSets) {
+          mergeFn(layers);
+        }
+      };
+
+      const baselineMs = bestOfRuns(() => {
+        runAllMerges(baselineLayersWithLatestFileModifications);
+      }, 5);
+      const optimizedMs = bestOfRuns(() => {
+        runAllMerges(optimizedLayersWithLatestFileModifications);
+      }, 5);
+
+       
+      console.log(
+        `file merge timing: baseline=${baselineMs.toFixed(
+          3,
+        )}ms optimized=${optimizedMs.toFixed(3)}ms (${
+          mergeLayerSets.length
+        } layer sets)`,
+      );
+      expect(optimizedMs).toBeLessThan(baselineMs);
+    });
+  });
+
+  it("logs full extractImageContent timing for nginx.tar", async () => {
+    const start = performance.now();
+    await extractImageContent(
+      ImageType.DockerArchive,
+      getFixture("docker-archives/docker-save/nginx.tar"),
+      [matchEverythingAction],
+      {},
+    );
+    const elapsedMs = performance.now() - start;
+     
+    console.log(
+      `extractImageContent(nginx.tar) elapsed=${elapsedMs.toFixed(3)}ms`,
+    );
+  });
+});

--- a/test/unit/file-matching-performance.spec.ts
+++ b/test/unit/file-matching-performance.spec.ts
@@ -1,0 +1,305 @@
+import { minimatch, Minimatch } from "minimatch";
+import { posix as path } from "path";
+
+import { extractImageContent } from "../../lib/extractor";
+import { ExtractAction } from "../../lib/extractor/types";
+import { getGoModulesContentAction } from "../../lib/go-parser";
+import { generateExtractAction } from "../../lib/inputs/file-pattern/static";
+import { ImageType } from "../../lib/types";
+import { getFixture } from "../util";
+
+const nginxFixture = getFixture("docker-archives/docker-save/nginx.tar");
+
+const matchOptions = {
+  windowsPathsNoEscape: true,
+  optimizationLevel: 0,
+} as const;
+
+const ignoredPaths = [
+  path.normalize("/boot"),
+  path.normalize("/dev"),
+  path.normalize("/etc"),
+  path.normalize("/home"),
+  path.normalize("/media"),
+  path.normalize("/mnt"),
+  path.normalize("/proc"),
+  path.normalize("/root"),
+  path.normalize("/run"),
+  path.normalize("/sbin"),
+  path.normalize("/sys"),
+  path.normalize("/tmp"),
+  path.normalize("/var"),
+];
+
+function baselineGoFilePathMatches(filePath: string): boolean {
+  const normalizedPath = path.normalize(filePath);
+  const dirName = path.dirname(normalizedPath);
+  const forwardSlashedPath = filePath.replace(/\\/g, "/");
+  const hasExtension = !!path.parse(forwardSlashedPath).ext;
+  const isInIgnoredPath = ignoredPaths.some((ignorePath) =>
+    dirName.startsWith(ignorePath),
+  );
+
+  return !hasExtension && !isInIgnoredPath;
+}
+
+function baselineGeneratePathMatcher(
+  globsInclude: string[],
+  globsExclude: string[],
+): (filePath: string) => boolean {
+  return (filePath: string): boolean => {
+    if (globsExclude.some((glob) => minimatch(filePath, glob, matchOptions))) {
+      return false;
+    }
+
+    return globsInclude.some((glob) => minimatch(filePath, glob, matchOptions));
+  };
+}
+
+const cheapCallback = async () => "stub";
+
+const explicitGoPaths = [
+  "C:\\Windows\\System32\\kubectl",
+  "/app/foo.bar/baz",
+  "/etc/passwd",
+  "/var/log/app",
+];
+
+const explicitGlobPaths = [
+  "/etc/nginx/nginx.conf",
+  "/usr/share/nginx/html/index.html",
+];
+
+function bestOf(runs: number[], count: number): number {
+  return [...runs]
+    .sort((a, b) => a - b)
+    .slice(0, count)
+    .pop()!;
+}
+
+describe("file matching performance", () => {
+  let corpusPaths: string[];
+
+  beforeAll(async () => {
+    const harvestAction: ExtractAction = {
+      actionName: "harvest-paths",
+      filePathMatches: () => true,
+      callback: cheapCallback,
+    };
+
+    const harvested = await extractImageContent(
+      ImageType.DockerArchive,
+      nginxFixture,
+      [harvestAction],
+      {},
+    );
+
+    corpusPaths = [
+      ...new Set([
+        ...Object.keys(harvested.extractedLayers),
+        ...explicitGoPaths,
+        ...explicitGlobPaths,
+      ]),
+    ];
+  });
+
+  describe("Go filePathMatches equivalence", () => {
+    const shippedGoFilePathMatches = getGoModulesContentAction.filePathMatches;
+
+    it("matches the inlined baseline for every harvested corpus path", () => {
+      for (const filePath of corpusPaths) {
+        expect(shippedGoFilePathMatches(filePath)).toBe(
+          baselineGoFilePathMatches(filePath),
+        );
+      }
+    });
+
+    it("covers explicit Windows, dotted extension-less, and ignored-path cases", () => {
+      expect(shippedGoFilePathMatches("C:\\Windows\\System32\\kubectl")).toBe(
+        baselineGoFilePathMatches("C:\\Windows\\System32\\kubectl"),
+      );
+      expect(shippedGoFilePathMatches("/app/foo.bar/baz")).toBe(
+        baselineGoFilePathMatches("/app/foo.bar/baz"),
+      );
+      expect(shippedGoFilePathMatches("/etc/passwd")).toBe(false);
+      expect(shippedGoFilePathMatches("/var/log/app")).toBe(false);
+    });
+  });
+
+  describe("glob path matcher equivalence", () => {
+    const shippedGlobMatcher = generateExtractAction(
+      ["**/*.txt", "**/etc/**", "**/var/**"],
+      ["**/mock.txt"],
+    ).filePathMatches;
+    const baselineGlobMatcher = baselineGeneratePathMatcher(
+      ["**/*.txt", "**/etc/**", "**/var/**"],
+      ["**/mock.txt"],
+    );
+
+    it("matches the inlined baseline for every harvested corpus path", () => {
+      for (const filePath of corpusPaths) {
+        expect(shippedGlobMatcher(filePath)).toBe(
+          baselineGlobMatcher(filePath),
+        );
+      }
+    });
+
+    it("handles comment globs the same way as the baseline minimatch() form", () => {
+      const commentGlob = "#ignore-me";
+      const samplePath = "/etc/nginx/nginx.conf";
+      const baselineResult = minimatch(samplePath, commentGlob, matchOptions);
+      const compiledMatcher = new Minimatch(commentGlob, matchOptions);
+
+      expect(compiledMatcher.match(samplePath)).toBe(baselineResult);
+      expect(baselineGeneratePathMatcher([commentGlob], [])(samplePath)).toBe(
+        baselineResult,
+      );
+      expect(
+        generateExtractAction([commentGlob], []).filePathMatches(samplePath),
+      ).toBe(baselineResult);
+    });
+
+    it("handles exclude patterns that shadow includes", () => {
+      const matcher = generateExtractAction(
+        ["**/**"],
+        ["**/mock.txt"],
+      ).filePathMatches;
+      const baselineMatcher = baselineGeneratePathMatcher(
+        ["**/**"],
+        ["**/mock.txt"],
+      );
+
+      expect(matcher("/snyk/mock.txt")).toBe(false);
+      expect(baselineMatcher("/snyk/mock.txt")).toBe(false);
+      expect(matcher("/etc/os-release")).toBe(true);
+      expect(baselineMatcher("/etc/os-release")).toBe(true);
+    });
+
+    it("matches a non-empty subset of harvested corpus paths", () => {
+      const includeMatcher = generateExtractAction(
+        ["**/*.txt"],
+        [],
+      ).filePathMatches;
+      const matchedPaths = corpusPaths.filter((filePath) =>
+        includeMatcher(filePath),
+      );
+
+      expect(matchedPaths.length).toBeGreaterThan(0);
+      expect(matchedPaths).toContain("/snyk/mock.txt");
+    });
+  });
+
+  describe("extractImageContent end-to-end equivalence and timing", () => {
+    const e2eGlobsInclude = ["**/**"];
+    const e2eGlobsExclude: string[] = [];
+
+    function makeGlobAction(
+      filePathMatches: (filePath: string) => boolean,
+    ): ExtractAction {
+      return {
+        ...generateExtractAction(e2eGlobsInclude, e2eGlobsExclude),
+        filePathMatches,
+      };
+    }
+
+    const shippedGlobAction = makeGlobAction(
+      generateExtractAction(e2eGlobsInclude, e2eGlobsExclude).filePathMatches,
+    );
+    const baselineGlobAction = makeGlobAction(
+      baselineGeneratePathMatcher(e2eGlobsInclude, e2eGlobsExclude),
+    );
+
+    function makeGoAction(
+      filePathMatches: (filePath: string) => boolean,
+    ): ExtractAction {
+      return {
+        ...getGoModulesContentAction,
+        filePathMatches,
+        callback: cheapCallback,
+      };
+    }
+
+    async function runExtraction(
+      globAction: ExtractAction,
+      goFilePathMatches: (filePath: string) => boolean,
+    ): Promise<string[]> {
+      const result = await extractImageContent(
+        ImageType.DockerArchive,
+        nginxFixture,
+        [globAction, makeGoAction(goFilePathMatches)],
+        {},
+      );
+
+      return Object.keys(result.extractedLayers).sort();
+    }
+
+    it("produces identical extracted layer keys for baseline and shipped predicates", async () => {
+      const baselineKeys = await runExtraction(
+        baselineGlobAction,
+        baselineGoFilePathMatches,
+      );
+      const shippedKeys = await runExtraction(
+        shippedGlobAction,
+        getGoModulesContentAction.filePathMatches,
+      );
+
+      expect(shippedKeys).toEqual(baselineKeys);
+    });
+
+    it("runs faster with shipped predicates than with the baseline copy", async () => {
+      const timedRuns = async (
+        globAction: ExtractAction,
+        goFilePathMatches: (filePath: string) => boolean,
+      ): Promise<number[]> => {
+        await runExtraction(globAction, goFilePathMatches);
+
+        const runs: number[] = [];
+        for (let i = 0; i < 3; i++) {
+          const start = performance.now();
+          await runExtraction(globAction, goFilePathMatches);
+          runs.push(performance.now() - start);
+        }
+        return runs;
+      };
+
+      const baselineRuns = await timedRuns(
+        baselineGlobAction,
+        baselineGoFilePathMatches,
+      );
+      const shippedRuns = await timedRuns(
+        shippedGlobAction,
+        getGoModulesContentAction.filePathMatches,
+      );
+
+      const baselineBest = bestOf(baselineRuns, 1);
+      const shippedBest = bestOf(shippedRuns, 1);
+
+       
+      console.log(
+        `file matching e2e best-of-3 ms: baseline=${baselineBest.toFixed(
+          3,
+        )}, shipped=${shippedBest.toFixed(3)}`,
+      );
+
+      expect(shippedBest).toBeLessThan(baselineBest);
+    });
+
+    it("matches the baseline arm key set when using untouched shipped actions", async () => {
+      const baselineKeys = await runExtraction(
+        baselineGlobAction,
+        baselineGoFilePathMatches,
+      );
+
+      const shippedResult = await extractImageContent(
+        ImageType.DockerArchive,
+        nginxFixture,
+        [shippedGlobAction, getGoModulesContentAction],
+        {},
+      );
+
+      expect(Object.keys(shippedResult.extractedLayers).sort()).toEqual(
+        baselineKeys,
+      );
+    });
+  });
+});

--- a/test/unit/file-matching-performance.spec.ts
+++ b/test/unit/file-matching-performance.spec.ts
@@ -274,7 +274,6 @@ describe("file matching performance", () => {
       const baselineBest = bestOf(baselineRuns, 1);
       const shippedBest = bestOf(shippedRuns, 1);
 
-       
       console.log(
         `file matching e2e best-of-3 ms: baseline=${baselineBest.toFixed(
           3,


### PR DESCRIPTION
## Summary

Speeds up container image scanning without changing what gets reported, by removing allocations and redundant work from code that runs once per tar entry or per file across an entire image.

Three independent hotspots are addressed. Per-entry tar extraction and the whiteout/symlink merge in lib/extractor/layer.ts and lib/extractor/index.ts move from global-regex matching, per-entry array allocation, and quadratic Array.from(set).some() scans to a non-global RegExp.test(), a zero-allocation match loop, and a parent-directory walk against a Set. applyCallbacks in lib/extractor/callbacks.ts adds a fast path that skips the PassThrough stream fan-out when only one action matched a file, which is the overwhelmingly common case. The Go module path predicate and the glob-based file-pattern matcher avoid redundant string and object allocation per call, and the glob matcher now compiles each Minimatch once instead of once per file per call.

Each change is paired with a new performance spec that verifies correctness against an inlined copy of the prior implementation on real or harvested fixture data, including through extractImageContent end-to-end, and separately benchmarks the optimized code against that same baseline. No Fact, FactType, ScanResult, or PluginResponse shape changes, and no parser output changes.

## Acceptance criteria

1. A representative image scan (using an existing fixture/benchmark image from the test suite) takes measurably less wall-clock time after the change than before, demonstrated by a timing/benchmark test added or updated in the repo.
2. Scan output (detected packages, dependency graphs, layers, vulnerabilities surfaced downstream) is unchanged in content before and after the change — only speed differs, not results.
3. All changes are confined to the snyk-docker-plugin repository; no files in any other repository are modified.
4. The existing test suite passes without modification to expected test outcomes (only new/updated performance tests are added).
5. The performance change targets a real, identifiable hotspot in the plugin's scanning code path (e.g., redundant I/O, unnecessary re-parsing, sequential work that can be parallelized) rather than an unrelated or cosmetic change.

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `t3-per-entry-path-predicates`: Optimized Go filePathMatches to normalize backslashes only when present and to use path.extname instead of path.parse().ext. Hoisted Minimatch compilation in generatePathMatcher so include/exclude globs are compiled once and matched via .match() per file. Added test/unit/file-matching-performance.spec.ts harvesting nginx.tar paths, asserting baseline/shipped predicate equivalence (including Windows paths, dotted extension-less paths, /etc and /var ignores, comment globs, exclude-shadowing-include, and corpus-matching globs), end-to-end extractImageContent key-set parity, best-of-3 timing (baseline glob+go predicates vs shipped, with warmup), and untouched shipped actions matching the baseline key set. npm run test:unit passes for all task-owned specs; test/lib/display.spec.ts still fails pre-existing ANSI snapshot mismatches unrelated to this change. | gate "npm run test:unit" passed in 5388ms
- `t1-extraction-entry-and-merge-hot-path`: Optimized per-entry extraction in layer.ts (module-level RegExp.test for whiteouts, deferred absoluteFileName, zero-allocation action matching loop) and merge/content lookup in index.ts (single-pass getContent, normalized whiteout paths, parent-directory Set walks replacing Array.from().some). Added merge-hot-path-performance.spec.ts covering getContentAsString/Buffer, symlinksWithLatestModifications (including prefix-survival case), A/B merge equivalence on three whiteout fixtures via extractArchive + extractImageContent, and timing benchmarks. npm run test:unit passes (941/941 with FORCE_COLOR=1 as CI uses). Branch pushed to origin/cursor/extraction-layer-entry-merge-0da7. | gate "npm run test:unit" passed in 5478ms
- `t2-single-action-stream-passthrough-bypass`: applyCallbacks now fast-paths when matchedActions.length === 1: the tar entry stream goes straight to the action callback or streamToString with no PassThrough or .pipe(); the multi-action PassThrough fan-out and isResultEmpty are unchanged. New callbacks-performance.spec.ts inlines baselineApplyCallbacks (pre-change body) and asserts deep equality for 1- and 2-action runs over 4 MB streams, undefined-callback (key absent), rejection parity, early-resolve-then-resume drainability, and best-of-5 timing (optimized ~2.5–3.3 ms vs baseline ~3.3–4.2 ms on 8 MB). npm run test:unit: 926/926 passed with FORCE_COLOR=1; display.spec.ts also fails without color on the unchanged base commit. | gate "npm run test:unit" passed in 56109ms
- `final:build`: `npm run build` passed in 3762ms
- `final:test_unit`: `npm run test:unit` passed in 53054ms
- `final:lint`: `npm run lint` passed in 2659ms
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch, and nothing regressed against the base commit.

## Decisions taken without asking

- Should the performance work target reducing per-scan fixed overhead (startup, initialization, single small-image scans) or improving throughput/scaling for large, many-layer images?
  - took: Optimize hot paths that affect typical/representative scans broadly (e.g., layer processing and file traversal), since the request gives no indication the concern is specifically about large images or specifically about startup cost.
  - alternative: Focus exclusively on large-image/multi-layer scan throughput, treating small-image scan time as already acceptable.

## Assumptions

- "Container scanning" refers to the image-scanning logic implemented within the snyk-docker-plugin repository itself, not scanning performed by other Snyk components.
- "Faster" means reduced wall-clock/CPU time for a typical scan run; it does not mean reduced memory footprint, binary size, or install time.
- No numeric performance target was given, so any measurable, correctness-preserving speedup satisfies the request rather than a specific percentage or benchmark threshold.
- The optimization should focus on the plugin's own processing (e.g., layer extraction, parsing, file traversal) rather than rewriting or replacing third-party dependencies it calls into.
- "Only edit snyk-docker-plugin repo" is a hard constraint: even if a faster fix would be easier in an upstream dependency or sibling repo, the change must be made or worked around entirely inside this repo.
- Existing scan output format and semantics must remain byte-for-byte or semantically equivalent; performance work is not license to also refactor unrelated behavior.

## Run

- Run: `event-fa4050ebbf955658a6b8`
- Origin: https://app.slack.com/client/C0BPC0Z2048/p1786136509387019
- Base: `c8eadeebbb967d91f7a0e373c3d116e810bf7144`
- Head: `f05850d7d2427b64d894884ad305291433520a75`

Human review is required. This automation never merges or marks a PR ready.
