### PR TITLE
feat(go-parser): add pure go.mod/go.sum dependency parser

### DIFF
--- a/lib/go-parser/go-mod-parser.ts
+++ b/lib/go-parser/go-mod-parser.ts
@@ -1,0 +1,257 @@
+export interface GoModuleDependency {
+  name: string;
+  version: string;
+}
+
+export interface ParseGoModulesResult {
+  modulePath: string;
+  dependencies: GoModuleDependency[];
+}
+
+interface ReplaceDirective {
+  oldModule: string;
+  oldVersion?: string;
+  newModule?: string;
+  newVersion?: string;
+  isLocal: boolean;
+}
+
+const VERSION_REGEX = /^v\d/;
+
+export function parseGoModules(
+  goModContent: string,
+  goSumContent?: string,
+): ParseGoModulesResult {
+  const sumVersions = goSumContent ? parseGoSum(goSumContent) : new Map();
+  const { modulePath, requires, replaces } = parseGoMod(goModContent);
+
+  let dependencies = resolveDependencies(requires, sumVersions);
+  dependencies = applyReplaces(dependencies, replaces);
+
+  return { modulePath, dependencies };
+}
+
+function parseGoSum(content: string): Map<string, string[]> {
+  const versions = new Map<string, string[]>();
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("//")) {
+      continue;
+    }
+
+    const parts = line.split(/\s+/);
+    if (parts.length < 2) {
+      continue;
+    }
+
+    const modulePath = parts[0];
+    let version = parts[1];
+    if (version.endsWith("/go.mod")) {
+      version = version.slice(0, -"/go.mod".length);
+    }
+
+    const existing = versions.get(modulePath) ?? [];
+    if (!existing.includes(version)) {
+      existing.push(version);
+      versions.set(modulePath, existing);
+    }
+  }
+
+  return versions;
+}
+
+function parseGoMod(content: string): {
+  modulePath: string;
+  requires: Map<string, string | undefined>;
+  replaces: ReplaceDirective[];
+} {
+  let modulePath = "";
+  const requires = new Map<string, string | undefined>();
+  const replaces: ReplaceDirective[] = [];
+  let inRequireBlock = false;
+
+  for (const rawLine of content.split("\n")) {
+    const line = stripComment(rawLine).trim();
+    if (!line) {
+      continue;
+    }
+
+    if (line.startsWith("module ")) {
+      modulePath = line.slice("module ".length).trim();
+      continue;
+    }
+
+    if (line === "require (" || line.startsWith("require(")) {
+      inRequireBlock = true;
+      continue;
+    }
+
+    if (inRequireBlock) {
+      if (line === ")") {
+        inRequireBlock = false;
+        continue;
+      }
+      parseRequireEntry(line, requires);
+      continue;
+    }
+
+    if (line.startsWith("require ")) {
+      parseRequireEntry(line.slice("require ".length).trim(), requires);
+      continue;
+    }
+
+    if (line.startsWith("replace ")) {
+      const replace = parseReplaceEntry(line.slice("replace ".length).trim());
+      if (replace) {
+        replaces.push(replace);
+      }
+    }
+  }
+
+  return { modulePath, requires, replaces };
+}
+
+function stripComment(line: string): string {
+  const commentIndex = line.indexOf("//");
+  if (commentIndex >= 0) {
+    return line.slice(0, commentIndex);
+  }
+  return line;
+}
+
+function parseRequireEntry(
+  line: string,
+  requires: Map<string, string | undefined>,
+): void {
+  const parsed = parseModuleVersionLine(line);
+  if (!parsed) {
+    return;
+  }
+  requires.set(parsed.module, parsed.version);
+}
+
+function parseModuleVersionLine(
+  line: string,
+): { module: string; version?: string } | null {
+  const parts = line.trim().split(/\s+/);
+  if (parts.length === 0) {
+    return null;
+  }
+
+  if (parts.length === 1) {
+    return { module: parts[0] };
+  }
+
+  const lastPart = parts[parts.length - 1];
+  if (VERSION_REGEX.test(lastPart)) {
+    return {
+      module: parts.slice(0, -1).join(" "),
+      version: lastPart,
+    };
+  }
+
+  return { module: parts.join(" ") };
+}
+
+function parseReplaceEntry(line: string): ReplaceDirective | null {
+  const arrowIndex = line.indexOf("=>");
+  if (arrowIndex < 0) {
+    return null;
+  }
+
+  const left = line.slice(0, arrowIndex).trim();
+  const right = line.slice(arrowIndex + 2).trim();
+  if (!left || !right) {
+    return null;
+  }
+
+  const leftParsed = parseModuleVersionLine(left);
+  if (!leftParsed) {
+    return null;
+  }
+
+  const rightParts = right.split(/\s+/);
+  if (rightParts.length === 1 && isLocalPath(rightParts[0])) {
+    return {
+      oldModule: leftParsed.module,
+      oldVersion: leftParsed.version,
+      isLocal: true,
+    };
+  }
+
+  const rightParsed = parseModuleVersionLine(right);
+  if (!rightParsed?.version) {
+    return null;
+  }
+
+  return {
+    oldModule: leftParsed.module,
+    oldVersion: leftParsed.version,
+    newModule: rightParsed.module,
+    newVersion: rightParsed.version,
+    isLocal: false,
+  };
+}
+
+function isLocalPath(path: string): boolean {
+  return (
+    path.startsWith("./") || path.startsWith("../") || path.startsWith("/")
+  );
+}
+
+function resolveDependencies(
+  requires: Map<string, string | undefined>,
+  sumVersions: Map<string, string[]>,
+): GoModuleDependency[] {
+  const dependencies: GoModuleDependency[] = [];
+
+  for (const [name, modVersion] of requires) {
+    let version = modVersion;
+
+    if (!version) {
+      const sumEntries = sumVersions.get(name);
+      if (sumEntries && sumEntries.length > 0) {
+        version = sumEntries[0];
+      }
+    }
+
+    if (version) {
+      dependencies.push({ name, version });
+    }
+  }
+
+  return dependencies;
+}
+
+function applyReplaces(
+  dependencies: GoModuleDependency[],
+  replaces: ReplaceDirective[],
+): GoModuleDependency[] {
+  let result = dependencies;
+
+  for (const replace of replaces) {
+    result = result.flatMap((dep) => {
+      if (dep.name !== replace.oldModule) {
+        return [dep];
+      }
+
+      if (replace.oldVersion && dep.version !== replace.oldVersion) {
+        return [dep];
+      }
+
+      if (replace.isLocal) {
+        return [];
+      }
+
+      return [
+        {
+          name: replace.newModule!,
+          version: replace.newVersion!,
+        },
+      ];
+    });
+  }
+
+  return result;
+}

--- a/lib/go-parser/go-mod-parser.ts
+++ b/lib/go-parser/go-mod-parser.ts
@@ -69,11 +69,27 @@ function parseGoMod(content: string): {
   let modulePath = "";
   const requires = new Map<string, string | undefined>();
   const replaces: ReplaceDirective[] = [];
-  let inRequireBlock = false;
+  let blockType: "require" | "replace" | undefined;
 
   for (const rawLine of content.split("\n")) {
     const line = stripComment(rawLine).trim();
     if (!line) {
+      continue;
+    }
+
+    if (blockType) {
+      if (line === ")") {
+        blockType = undefined;
+        continue;
+      }
+      if (blockType === "require") {
+        parseRequireEntry(line, requires);
+      } else {
+        const replace = parseReplaceEntry(line);
+        if (replace) {
+          replaces.push(replace);
+        }
+      }
       continue;
     }
 
@@ -83,16 +99,12 @@ function parseGoMod(content: string): {
     }
 
     if (line === "require (" || line.startsWith("require(")) {
-      inRequireBlock = true;
+      blockType = "require";
       continue;
     }
 
-    if (inRequireBlock) {
-      if (line === ")") {
-        inRequireBlock = false;
-        continue;
-      }
-      parseRequireEntry(line, requires);
+    if (line === "replace (" || line.startsWith("replace(")) {
+      blockType = "replace";
       continue;
     }
 

--- a/test/fixtures/go-modules/malformed/go.mod
+++ b/test/fixtures/go-modules/malformed/go.mod
@@ -1,0 +1,10 @@
+module example.com/malformed
+
+go 1.21
+
+require github.com/good/module v1.0.0
+
+require (
+	github.com/also/good v2.0.0
+	STRAY_TOKEN_HERE
+	github.com/block/good v3.0.0

--- a/test/fixtures/go-modules/malformed/go.sum
+++ b/test/fixtures/go-modules/malformed/go.sum
@@ -1,0 +1,4 @@
+github.com/good/module v1.0.0 h1:abc123
+github.com/also/good v2.0.0 h1:def456
+truncated line without hash
+github.com/block/good v3.0.0 h1:ghi789

--- a/test/fixtures/go-modules/no-sum/go.mod
+++ b/test/fixtures/go-modules/no-sum/go.mod
@@ -1,0 +1,8 @@
+module example.com/no-sum
+
+go 1.21
+
+require (
+	github.com/stretchr/testify v1.8.0
+	github.com/davecgh/go-spew v1.1.1
+)

--- a/test/fixtures/go-modules/replace-block/go.mod
+++ b/test/fixtures/go-modules/replace-block/go.mod
@@ -1,0 +1,14 @@
+module example.com/replace-block
+
+go 1.21
+
+require (
+	github.com/old/module v1.0.0
+	github.com/local/drop v1.0.0
+	github.com/another/old v2.0.0
+)
+
+replace (
+	github.com/old/module v1.0.0 => github.com/new/module v2.0.0
+	github.com/local/drop v1.0.0 => ../local
+)

--- a/test/fixtures/go-modules/replace-block/go.sum
+++ b/test/fixtures/go-modules/replace-block/go.sum
@@ -1,0 +1,8 @@
+github.com/another/old v2.0.0 h1:abc123another=
+github.com/another/old v2.0.0/go.mod h1:anothermod=
+github.com/local/drop v1.0.0 h1:localdrop=
+github.com/local/drop v1.0.0/go.mod h1:localmod=
+github.com/new/module v2.0.0 h1:newmodule=
+github.com/new/module v2.0.0/go.mod h1:newmod=
+github.com/old/module v1.0.0 h1:oldmodule=
+github.com/old/module v1.0.0/go.mod h1:oldmod=

--- a/test/fixtures/go-modules/replace-no-version/go.mod
+++ b/test/fixtures/go-modules/replace-no-version/go.mod
@@ -1,0 +1,7 @@
+module example.com/replace-no-version
+
+go 1.21
+
+require github.com/old/module v1.5.0
+
+replace github.com/old/module => github.com/new/module v1.2.3

--- a/test/fixtures/go-modules/replace/go.mod
+++ b/test/fixtures/go-modules/replace/go.mod
@@ -1,0 +1,13 @@
+module example.com/replace
+
+go 1.21
+
+require (
+	github.com/old/module v1.0.0
+	github.com/another/old v2.0.0
+	github.com/local/drop v1.0.0
+)
+
+replace github.com/old/module v1.0.0 => github.com/new/module v2.0.0
+
+replace github.com/local/drop v1.0.0 => ../local

--- a/test/fixtures/go-modules/replace/go.sum
+++ b/test/fixtures/go-modules/replace/go.sum
@@ -1,0 +1,8 @@
+github.com/another/old v2.0.0 h1:abc123another=
+github.com/another/old v2.0.0/go.mod h1:anothermod=
+github.com/local/drop v1.0.0 h1:localdrop=
+github.com/local/drop v1.0.0/go.mod h1:localmod=
+github.com/new/module v2.0.0 h1:newmodule=
+github.com/new/module v2.0.0/go.mod h1:newmod=
+github.com/old/module v1.0.0 h1:oldmodule=
+github.com/old/module v1.0.0/go.mod h1:oldmod=

--- a/test/fixtures/go-modules/standard/go.mod
+++ b/test/fixtures/go-modules/standard/go.mod
@@ -1,0 +1,10 @@
+module example.com/standard
+
+go 1.21
+
+require github.com/gorilla/mux v1.8.0
+
+require (
+	github.com/spf13/cobra v1.7.0
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+)

--- a/test/fixtures/go-modules/standard/go.sum
+++ b/test/fixtures/go-modules/standard/go.sum
@@ -1,0 +1,6 @@
+github.com/gorilla/mux v1.8.0 h1:329qvw05ZWFXj9j1RW1Q8sH3Lq2D7QZ8J6dY3b5n5k=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/inconshreveable/mousetrap v1.1.0 h1:7N4XaHzgXzZ6RqMtCboDVwAA7B+1ztCfnq4g+Jtj/vZ=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:OpnC5Un0jUg2icV5DJ+8tI03Ohcq7KnFafIXT+1K5Rg=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShMdxk0U8Re5V+KFzrrY9aXhXS8HZS1YM=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxWILGyhQT5TKcUXi0swQsQfDdDbS8U0pELokm5gok=

--- a/test/fixtures/go-modules/sum-fallback/go.mod
+++ b/test/fixtures/go-modules/sum-fallback/go.mod
@@ -1,0 +1,5 @@
+module example.com/sum-fallback
+
+go 1.21
+
+require github.com/no-version/module

--- a/test/fixtures/go-modules/sum-fallback/go.sum
+++ b/test/fixtures/go-modules/sum-fallback/go.sum
@@ -1,0 +1,2 @@
+github.com/no-version/module v1.2.3 h1:abc123=
+github.com/no-version/module v1.2.3/go.mod h1:abcmod=

--- a/test/unit/go-mod-parser.spec.ts
+++ b/test/unit/go-mod-parser.spec.ts
@@ -51,6 +51,51 @@ describe("go mod parser", () => {
     );
   });
 
+  it("applies block-form replace directives and drops local path replacements", () => {
+    const goMod = readFixture("replace-block/go.mod");
+    const goSum = readFixture("replace-block/go.sum");
+
+    const result = parseGoModules(goMod, goSum);
+
+    expect(result.modulePath).toBe("example.com/replace-block");
+    expect(result.dependencies).toEqual(
+      expect.arrayContaining([
+        { name: "github.com/new/module", version: "v2.0.0" },
+        { name: "github.com/another/old", version: "v2.0.0" },
+      ]),
+    );
+    expect(result.dependencies).toHaveLength(2);
+    expect(result.dependencies).not.toEqual(
+      expect.arrayContaining([
+        { name: "github.com/old/module", version: "v1.0.0" },
+        { name: "github.com/local/drop", version: "v1.0.0" },
+      ]),
+    );
+  });
+
+  it("falls back to the go.sum version when a require entry has no inline version", () => {
+    const goMod = readFixture("sum-fallback/go.mod");
+    const goSum = readFixture("sum-fallback/go.sum");
+
+    const result = parseGoModules(goMod, goSum);
+
+    expect(result.modulePath).toBe("example.com/sum-fallback");
+    expect(result.dependencies).toEqual([
+      { name: "github.com/no-version/module", version: "v1.2.3" },
+    ]);
+  });
+
+  it("applies a replace directive with no version on the left side regardless of the dep's resolved version", () => {
+    const goMod = readFixture("replace-no-version/go.mod");
+
+    const result = parseGoModules(goMod);
+
+    expect(result.modulePath).toBe("example.com/replace-no-version");
+    expect(result.dependencies).toEqual([
+      { name: "github.com/new/module", version: "v1.2.3" },
+    ]);
+  });
+
   it("parses go.mod without go.sum", () => {
     const goMod = readFixture("no-sum/go.mod");
 

--- a/test/unit/go-mod-parser.spec.ts
+++ b/test/unit/go-mod-parser.spec.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parseGoModules } from "../../lib/go-parser/go-mod-parser";
+
+const fixturesRoot = join(__dirname, "../fixtures/go-modules");
+
+function readFixture(relativePath: string): string {
+  return readFileSync(join(fixturesRoot, relativePath), "utf8");
+}
+
+describe("go mod parser", () => {
+  it("parses standard go.mod and go.sum with block and single-line requires", () => {
+    const goMod = readFixture("standard/go.mod");
+    const goSum = readFixture("standard/go.sum");
+
+    const result = parseGoModules(goMod, goSum);
+
+    expect(result.modulePath).toBe("example.com/standard");
+    expect(result.dependencies).toEqual(
+      expect.arrayContaining([
+        { name: "github.com/gorilla/mux", version: "v1.8.0" },
+        { name: "github.com/spf13/cobra", version: "v1.7.0" },
+        {
+          name: "github.com/inconshreveable/mousetrap",
+          version: "v1.1.0",
+        },
+      ]),
+    );
+    expect(result.dependencies).toHaveLength(3);
+  });
+
+  it("applies replace directives and drops local path replacements", () => {
+    const goMod = readFixture("replace/go.mod");
+    const goSum = readFixture("replace/go.sum");
+
+    const result = parseGoModules(goMod, goSum);
+
+    expect(result.modulePath).toBe("example.com/replace");
+    expect(result.dependencies).toEqual(
+      expect.arrayContaining([
+        { name: "github.com/new/module", version: "v2.0.0" },
+        { name: "github.com/another/old", version: "v2.0.0" },
+      ]),
+    );
+    expect(result.dependencies).toHaveLength(2);
+    expect(result.dependencies).not.toEqual(
+      expect.arrayContaining([
+        { name: "github.com/old/module", version: "v1.0.0" },
+        { name: "github.com/local/drop", version: "v1.0.0" },
+      ]),
+    );
+  });
+
+  it("parses go.mod without go.sum", () => {
+    const goMod = readFixture("no-sum/go.mod");
+
+    const result = parseGoModules(goMod);
+
+    expect(result.modulePath).toBe("example.com/no-sum");
+    expect(result.dependencies).toEqual(
+      expect.arrayContaining([
+        { name: "github.com/stretchr/testify", version: "v1.8.0" },
+        { name: "github.com/davecgh/go-spew", version: "v1.1.1" },
+      ]),
+    );
+    expect(result.dependencies).toHaveLength(2);
+  });
+
+  it("does not throw on malformed go.mod and go.sum", () => {
+    const goMod = readFixture("malformed/go.mod");
+    const goSum = readFixture("malformed/go.sum");
+
+    expect(() => parseGoModules(goMod, goSum)).not.toThrow();
+
+    const result = parseGoModules(goMod, goSum);
+
+    expect(result.modulePath).toBe("example.com/malformed");
+    expect(result.dependencies).toEqual(
+      expect.arrayContaining([
+        { name: "github.com/good/module", version: "v1.0.0" },
+        { name: "github.com/also/good", version: "v2.0.0" },
+        { name: "github.com/block/good", version: "v3.0.0" },
+      ]),
+    );
+    expect(result.dependencies).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a standalone, I/O-free parser for Go module manifests: `parseGoModules(goModContent, goSumContent?)` in `lib/go-parser/go-mod-parser.ts`. It returns the module path from `go.mod` along with a flat list of `{ name, version }` dependencies, handling both single-line and block-form `require` entries (including `// indirect` comments), falling back to `go.sum` when a `require` line omits a version, and applying `replace` directives last so a replaced module's new path and version take precedence. Local filesystem replacements (`./`, `../`) are dropped entirely since they have no resolvable registry version.

The parser skips unparseable lines in either file rather than raising, so malformed entries don't prevent well-formed ones nearby from being extracted.

Seven fixture directories under `test/fixtures/go-modules/` (standard, replace, replace-block, replace-no-version, no-sum, sum-fallback, malformed) back a unit spec covering each of these behaviors.

## Acceptance criteria

1. Given a container image containing a go.mod and go.sum file (e.g. from a compiled Go binary's embedded module info, or files left in the image filesystem), the plugin extracts a list of Go module dependencies with names and resolved versions.
2. The extracted dependency list is emitted in the same internal dependency-graph/tree format used by the plugin's other ecosystem detectors, so downstream vulnerability scanning can consume it without ecosystem-specific handling.
3. Given an image with no go.mod/go.sum present, the Go detector contributes no dependencies and does not error or fail the overall `snyk container test` run.
4. Given a go.sum with malformed or truncated entries, parsing does not throw an unhandled exception; it either skips the malformed entry or fails that ecosystem's detection gracefully without crashing the whole scan.
5. Given a go.mod with a `replace` directive, the resulting dependency list reflects the replaced module/version rather than the original one.
6. Unit tests exist covering: a standard go.mod+go.sum pair, a go.mod with replace directives, an empty/missing go.sum, and malformed input.
7. Fixture files (sample go.mod/go.sum) are added under the plugin's existing test fixtures structure for this ecosystem.

## Not in this branch

The plan had work this branch does not carry:

- `go-mod-extract-action` (done when: `npm run test:unit -- inputs/go/static` passes. `lib/inputs/go/static.ts` exports an `ExtractAction` (e.g. `getGoModFileContentAction`) whose `actionName` is a new unique string distinct from the existing `"gomodules"` action at `lib/go-parser/index.ts:53`, whose `callback` is `streamToString`, and whose `filePathMatches` is a `basename` check in the style of `lib/inputs/php/static.ts:9-12` combined with an ignore list in the style of `lib/go-parser/index.ts:20-34` / `lib/inputs/java/static.ts:6` covering GOROOT (`/usr/local/go`, `/usr/lib/go`, `/usr/share/go`) and the module cache (any path containing `/pkg/mod/`). The spec asserts `filePathMatches` returns true for `/app/go.mod`, `/app/go.sum`, `/app/.wh.go.mod`, `/app/.wh.go.sum`; and false for `/app/go.mod.bak`, `/app/main.go`, `/usr/bin/testgo`, `/usr/local/go/src/net/http/go.mod`, `/go/pkg/mod/github.com/x/y@v1.0.0/go.mod`, and `/root/go/pkg/mod/cache/download/x/@v/go.mod`. The ignore list is a prefix/substring comparison on the path, not a regex over the full path — this predicate runs against every entry in every layer.): the builder call itself failed: pipeline: builder:go-mod-extract-action:retry: exit: cursor create returned HTTP 400 (validation_error): [invalid_argument] Error
- `go-modules-analyzer-wiring` (done when: `npm run test:unit` passes with no new failures and no snapshot updates; `npm run build` succeeds; `npm run lint:prettier && npm run lint:eslint` succeed (do NOT run the full `npm run lint` — it includes `lint:commit`, which validates the checked-out HEAD commit message and is the coordinator's gate, not this task's). Additionally, run `npx jest --selectProjects system test/system/application-scans/gomodules.spec.ts test/system/application-scans/node.spec.ts` WITHOUT `-u` and report the outcome verbatim in the task report — pass, or the exact snapshot diff, or the exact error if the environment cannot run it; never regenerate a snapshot. Code: `lib/analyzer/applications/go-modules.ts` exports `goModFilesToScannedProjects(filePathToContent: FilePathToContent): Promise<AppDepsScanResultWithoutTarget[]>`, re-exported from `lib/analyzer/applications/index.ts`; the diff of `lib/analyzer/static-analyzer.ts` shows the new action pushed into the `appScan` action list next to `getPhpAppFileContentAction` (`:150`) and the consumer invoked via `getFileContent(extractedLayers, <actionName>)` alongside the other consumers (`:324-372`) with its results spread into `applicationDependenciesScanResults` (`:374-384`). Tests: `test/lib/analyzer/applications/go-modules.spec.ts` feeds the `test/fixtures/go-modules/` fixtures in as a `{ "/app/go.mod": ..., "/app/go.sum": ... }` map and asserts: the returned result has `identity.type === "gomodules"` and `identity.targetFile === "/app/go.mod"`; its `depGraph` fact is a real `DepGraph` whose `getDepPkgs()` contains the expected `{ name, version }` entries (the replace fixture shows the replaced module, not the original); a go.mod with no sibling go.sum still produces a result; an empty input map returns `[]` without throwing; and the malformed fixture returns without throwing and without an unhandled rejection. Docs: `docs/application-ecosystem-coverage.md` is self-consistent after the change in all six places this task falsifies — the Method line-range pins at `:7` (action list and consumer line ranges both shift), the barrel-registry claim at `:12` (`applications/index.ts` now also re-exports the Go manifest consumer, so the 'only dotnet, node, php, pip, and poetry' enumeration and the 'Go is wired in directly from its own module' claim must be corrected), the Detected-table Go row at `:26`, the partial-support gaps row at `:34`, the native-parsing list at `:49`, and the 'Runtime-only signal for Go' caveat at `:107` — each updated to name the new action and analyzer with correct file/line references. `lib/go-parser/go-mod-parser.ts` and `lib/inputs/go/static.ts` are listed in this task's files only because it imports them; they are not rewritten here.): not started: chained after task go-mod-extract-action, which did not land (the builder call itself failed: pipeline: builder:go-mod-extract-action:retry: exit: cursor create returned HTTP 400 (validation_error): [invalid_argument] Error)

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `go-mod-sum-parser`: Added parseGoModules(goModContent, goSumContent?) — a pure, no-I/O parser returning { modulePath, dependencies: { name, version }[] }. Parses go.mod module/require (single-line and block, // indirect tolerated) and replace directives; uses go.sum only to confirm or fill missing versions; applies replace last (version-specific replacements, local ./ or ../ paths dropped). Four fixture directories under test/fixtures/go-modules/ cover standard, replace, no-sum, and malformed inputs. All 4 unit tests pass (npx jest --selectProjects unit --testPathPattern go-mod-parser). Branch cursor/go-mod-sum-parser-fefc pushed to origin. | gate "npm run test:unit -- go-mod-parser" passed in 5343ms
- `final:build`: `npm run build` passed in 3733ms
- `final:test_unit`: `npm run test:unit` passed in 3326ms
- `final:lint`: `npm run lint` passed in 2550ms
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch, and nothing regressed against the base commit.

## Decisions taken without asking

- Should Go dependency detection also inspect compiled Go binaries' embedded module/version metadata (via debug/buildinfo), which is a common way Go dependencies show up in minimal/scratch container images that lack source files?
  - took: Out of scope for this slice — restrict to go.mod/go.sum file parsing, since the split rationale explicitly frames this as a self-contained parser for those two file formats.
  - alternative: Binary buildinfo extraction could be considered essential to the feature's practical value for container scanning (since many Go images ship only a compiled binary with no go.mod/go.sum), making it in-scope for 'dependency detection... for Go modules' even though it's a different parsing mechanism.

## Assumptions

- "Vulnerability scanning support" in this slice means making Go dependencies visible to the existing scanning pipeline in the correct data shape, not building a new scanning engine specific to Go.
- The plugin already has an established pattern/interface for per-ecosystem dependency detectors (e.g. for npm, pip) that this Go detector should conform to, since the request frames this as adding support to an existing system rather than building one from scratch.
- go.sum, when present alongside go.mod, is treated as the authoritative source of resolved versions, with go.mod used primarily for direct/indirect requirement and replace-directive information.
- Detection operates on files found via the same image-filesystem-scanning mechanism already used for other manifest-based ecosystems (e.g. package.json, requirements.txt), not on binary introspection.
- "Go modules" scope is limited to the module graph described by go.mod/go.sum; it does not include GOPATH-style (pre-modules) dependency layouts.

## Run

- Run: `20260810-161150-df9e`
- Origin: 
- Base: `95eb1c1c671973b4f5fef238f50a189d9098440b`
- Head: `ba7bf30da64d9995d14b96e636e5e2f396308206`

Human review is required. This automation never merges or marks a PR ready.
