### PR TITLE
feat(dotnet): detect more NuGet manifest and lockfile formats

### DIFF
--- a/docs/application-ecosystem-coverage.md
+++ b/docs/application-ecosystem-coverage.md
@@ -21,7 +21,7 @@ Application-ecosystem extraction and analysis are gated on `exclude-app-vulns` b
 | **PHP / Composer** | Supported | `composer.json`, `composer.lock`, and `vendor/composer/installed.json` (anchored on the `vendor/composer/` path segment) ([`lib/inputs/php/static.ts:6-13`](../lib/inputs/php/static.ts)) | [`lib/inputs/php/static.ts`](../lib/inputs/php/static.ts), action `php-app-files` | [`lib/analyzer/applications/php.ts`](../lib/analyzer/applications/php.ts); `identity.type` = `depGraph.pkgManager.name` ([`:75`, `:140`](../lib/analyzer/applications/php.ts)) | **Delegated** for a `composer.json`+`composer.lock` pair — [`@snyk/composer-lockfile-parser`](https://www.npmjs.com/package/@snyk/composer-lockfile-parser) (`package.json:33`); **Native** fallback when only `composer.lock` or only `vendor/composer/installed.json` is present — in-repo [`lib/php-parser/composer-lock-parser.ts`](../lib/php-parser/composer-lock-parser.ts), consumed by `buildScanResultFromPackages` in `php.ts`. A `composer.json` with no `composer.lock` is not reported: it carries version constraints, not pinned versions |
 | **Python — Poetry** | Supported | `pyproject.toml`, `poetry.lock` ([`lib/inputs/python/static.ts:6`](../lib/inputs/python/static.ts)) | [`lib/inputs/python/static.ts`](../lib/inputs/python/static.ts), action `poetry-app-files` | [`lib/analyzer/applications/python/poetry.ts`](../lib/analyzer/applications/python/poetry.ts); `identity.type` = `depGraph.pkgManager.name` ([`:42`](../lib/analyzer/applications/python/poetry.ts)) | **Delegated** — [`snyk-poetry-lockfile-parser`](https://www.npmjs.com/package/snyk-poetry-lockfile-parser) (`package.json:53`) |
 | **Python — pip** | Supported | `requirements.txt`; installed-package `METADATA` under `lib/python*/site-packages/` or `dist-packages/` matching [`lib/inputs/python/static.ts:9–10`](../lib/inputs/python/static.ts) | [`lib/inputs/python/static.ts`](../lib/inputs/python/static.ts), action `pip-app-files` | [`lib/analyzer/applications/python/pip.ts`](../lib/analyzer/applications/python/pip.ts); literal `identity.type` `'pip'` ([`:172`](../lib/analyzer/applications/python/pip.ts)) | **Native** — in-repo [`lib/python-parser/metadata-parser`](../lib/python-parser/metadata-parser) and [`lib/python-parser/requirements-parser`](../lib/python-parser/requirements-parser) ([`pip.ts:8–10`](../lib/analyzer/applications/python/pip.ts)) |
-| **.NET / NuGet** | Partially supported | `*.deps.json` only, excluding paths containing `/dotnet/shared/` or `/dotnet/packs/` ([`lib/inputs/dotnet/static.ts:9–18`](../lib/inputs/dotnet/static.ts)) | [`lib/inputs/dotnet/static.ts`](../lib/inputs/dotnet/static.ts), action `dotnet-app-files` | [`lib/analyzer/applications/dotnet.ts`](../lib/analyzer/applications/dotnet.ts); literal `identity.type` `'nuget'` ([`:115`](../lib/analyzer/applications/dotnet.ts)) | **Native** — parsed in-repo from publish output `.deps.json` |
+| **.NET / NuGet** | Partially supported | `*.deps.json`, `packages.config`, `*.csproj` / `*.fsproj` / `*.vbproj`, `packages.lock.json`, and `obj/project.assets.json`, excluding paths containing `/dotnet/shared/`, `/dotnet/packs/`, `/dotnet/sdk/`, or `/.nuget/packages/` ([`lib/inputs/dotnet/static.ts`](../lib/inputs/dotnet/static.ts)) | [`lib/inputs/dotnet/static.ts`](../lib/inputs/dotnet/static.ts), action `dotnet-app-files` | [`lib/analyzer/applications/dotnet.ts`](../lib/analyzer/applications/dotnet.ts); literal `identity.type` `'nuget'` ([`:115`](../lib/analyzer/applications/dotnet.ts)) | **Native** — parsed in-repo from publish output `.deps.json` and from manifest/lockfile formats via [`lib/dotnet-parser/`](../lib/dotnet-parser/) |
 | **Java / Maven** | Partially supported | `.jar` and `.war` on the image filesystem ([`lib/inputs/java/static.ts:7`](../lib/inputs/java/static.ts)); `/usr/lib` and `gradle/cache` paths ignored at [`static.ts:6`](../lib/inputs/java/static.ts) (re-added for system JARs via `getUsrLibJarFileContentAction` when `include-system-jars` is set) | [`lib/inputs/java/static.ts`](../lib/inputs/java/static.ts), action `jar` | [`lib/analyzer/applications/java.ts`](../lib/analyzer/applications/java.ts); `identity.type` `'maven'` ([`:62`](../lib/analyzer/applications/java.ts)); emits `jarFingerprints` facts, not a dep graph | **Native** — in-repo [`adm-zip`](https://www.npmjs.com/package/adm-zip) archive traversal and `pom.properties` parsing ([`:135–154`](../lib/analyzer/applications/java.ts), [`getCoordsFromPomProperties` `:269–285`](../lib/analyzer/applications/java.ts), [`parsePomProperties` `:292–303`](../lib/analyzer/applications/java.ts)); SHA-1 fingerprint fallback when coordinates are absent ([`:227–236`](../lib/analyzer/applications/java.ts)). **Gap:** no `pom.xml` or `build.gradle` filesystem matcher anywhere in `lib/`; Maven coordinates are read only from `pom.properties` entries inside unpacked archives, never from build files on the image filesystem |
 | **Go modules** | Partially supported | Extension-less files outside a fixed ignore list ([`lib/go-parser/index.ts:38–50`](../lib/go-parser/index.ts)); callback `findGoBinaries` keeps only ELF binaries carrying `.go.buildinfo` or `.note.go.buildid` sections ([`:66–107`](../lib/go-parser/index.ts)); module data from embedded build info ([`lib/go-parser/go-binary.ts`](../lib/go-parser/go-binary.ts)) | [`lib/go-parser/index.ts`](../lib/go-parser/index.ts), action `gomodules` ([`:52–56`](../lib/go-parser/index.ts)) | [`goModulesToScannedProjects`](../lib/go-parser/index.ts); literal `identity.type` `'gomodules'` ([`:36`, `:205`](../lib/go-parser/index.ts)) | **Native** — in-repo ELF reader and Go build-info parser. **Gap:** no `go.mod` or `go.sum` filesystem matcher |
 
@@ -29,7 +29,7 @@ Application-ecosystem extraction and analysis are gated on `exclude-app-vulns` b
 
 | Ecosystem | What is detected | What is missing |
 | --- | --- | --- |
-| .NET / NuGet | Published `*.deps.json` (excluding shared runtime/pack paths) | No matcher for `.csproj`, `packages.config`, `paket.lock`, or `packages.lock.json` |
+| .NET / NuGet | Published `*.deps.json`, `packages.config`, PackageReference project files (`.csproj` / `.fsproj` / `.vbproj`), `packages.lock.json`, and `obj/project.assets.json` (excluding shared runtime, pack, SDK, and NuGet cache paths) | No matcher for `paket.lock` |
 | Java / Maven | `.jar`/`.war` archives; Maven coordinates from `pom.properties` inside unpacked archives; SHA-1 fallback for Maven Central lookup | No `pom.xml` or `build.gradle` matcher; no Gradle lockfile support; coordinates never read from build files on the image filesystem |
 | Go modules | ELF binaries with embedded Go module build info | No `go.mod` or `go.sum` matcher; only compiled binaries, not source-tree manifests |
 
@@ -64,7 +64,7 @@ The following ecosystems named in the request against Snyk Open Source's support
 | Hex / Elixir | `mix.exs`, `mix.lock` | No hits, no `ExtractAction`, no analyzer |
 | Dart / Pub | `pubspec.yaml`, `pubspec.lock` | No hits, no `ExtractAction`, no analyzer |
 | Scala / sbt | `build.sbt`, `*.sbt` | No hits, no `ExtractAction`, no analyzer |
-| NuGet — manifest half | `packages.config`, `paket.lock`, `packages.lock.json`, `*.csproj` | No hits for `paket` or `packages.config`; NuGet detection ([above](#detected)) is limited to published `*.deps.json` |
+| NuGet — manifest half | `paket.lock` | Only `paket.lock` remains unmatched; NuGet detection ([above](#detected)) now covers `packages.config`, PackageReference project files, `packages.lock.json`, `obj/project.assets.json`, and published `*.deps.json` |
 | Maven/Gradle — manifest half | `pom.xml`, `build.gradle` | No hits for `pom.xml` or `build.gradle` as filesystem matchers; Java/Maven detection ([above](#detected)) reads coordinates only from `pom.properties` inside already-extracted `.jar`/`.war` archives |
 
 `Pipfile` (Pipenv's manifest) is a partial exception: it appears once in `lib/`, in `pythonApplicationFileSuffixes` ([`lib/inputs/python/static.ts:13`](../lib/inputs/python/static.ts)). That list feeds `collect-application-files`, a source-file collection path used for reporting which application files exist on the image — it is not consumed by any dependency-graph analyzer, and no `Pipfile.lock` matcher or Pipenv analyzer exists. So Pipenv dependencies are not detected even though the bare filename `Pipfile` is recognised for an unrelated purpose.
@@ -75,19 +75,24 @@ This document could not fetch or verify Snyk Open Source's current supported-eco
 
 ## Evidence appendix
 
-Two greps against `lib/` were run to check whether any manifest-filename string for the "not detected" ecosystems appears anywhere in the source, including places that would not by themselves indicate real detection (comments, unrelated identifiers). Both are reproducible with the commands below; a reviewer re-running them should see the same hit counts and locations.
+Two greps against `lib/` were run to check whether any manifest-filename string for the "not detected" ecosystems appears anywhere in the source, including places that would not by themselves indicate real detection (comments, unrelated identifiers). Both are reproducible with the commands below; a reviewer re-running them should see the audit hits listed below plus the new NuGet matcher/parser hit sites named in each check.
 
 **Check A — narrow manifest-filename sweep.** Pattern (case-insensitive): `Gemfile|gemspec|Cargo\.toml|Podfile|packages\.config|paket|pubspec|mix\.exs|Package\.swift|\.sbt|pom\.xml|build\.gradle`
 
-This returns exactly **one** hit in the whole of `lib/`:
+As of the audit commit, before the NuGet matchers in this change landed, this returned exactly **one** hit in the whole of `lib/`:
 
 - [`lib/types.ts:64`](../lib/types.ts) — a code comment reading `// Package manager manifests (e.g. requirements.txt, Gemfile.lock) collected as part of an application scan.` This is a comment on a type describing collected manifest filenames for reporting purposes, not an `ExtractAction` matcher; it does not indicate Gemfile detection.
+
+After the NuGet matcher/parser change, re-running this pattern also hits:
+
+- [`lib/inputs/dotnet/static.ts`](../lib/inputs/dotnet/static.ts) — the widened `filePathMatches` for `packages.config`, project files, `packages.lock.json`, and `obj/project.assets.json`
+- [`lib/dotnet-parser/`](../lib/dotnet-parser/) — in-repo parsers for the newly matched NuGet manifest/lockfile formats
 
 Notably, this narrow pattern does **not** match [`lib/inputs/java/static.ts:6`](../lib/inputs/java/static.ts) (`const ignoredPaths = [usrLibPath, "gradle/cache"];`), because that line contains the bare substring `gradle` without `build.gradle`, and the pattern does not include bare `gradle`.
 
 **Check B — broadened sweep.** Pattern (case-insensitive), narrow pattern plus bare `gradle|maven|nuget`: `Gemfile|gemspec|Cargo\.toml|Podfile|packages\.config|paket|pubspec|mix\.exs|Package\.swift|\.sbt|pom\.xml|build\.gradle|gradle|maven|nuget`
 
-This returns **nine** hits in `lib/`, none of which are filesystem manifest matchers:
+As of the audit commit, before the NuGet matchers in this change landed, this returned **nine** hits in `lib/`, none of which are filesystem manifest matchers:
 
 - [`lib/types.ts:64`](../lib/types.ts) — the same comment as Check A
 - [`lib/inputs/java/static.ts:6`](../lib/inputs/java/static.ts) — `ignoredPaths` list excluding `gradle/cache` from `.jar`/`.war` matching, not a Gradle manifest matcher
@@ -99,12 +104,17 @@ This returns **nine** hits in `lib/`, none of which are filesystem manifest matc
 - [`lib/analyzer/applications/java.ts:230`](../lib/analyzer/applications/java.ts) — a comment about the sha1 fallback for Maven Central
 - [`lib/analyzer/applications/java.ts:258`](../lib/analyzer/applications/java.ts) — a comment about resolving JARs via "maven-deps"
 
-None of the nine hits is a `pom.xml`, `build.gradle`, `packages.config`, or `paket` filesystem matcher. This confirms the "manifest half" gaps stated in the [Detected](#detected) table and the [Not detected](#not-detected) table above.
+After the NuGet matcher/parser change, re-running this pattern also hits the same new sites as Check A:
+
+- [`lib/inputs/dotnet/static.ts`](../lib/inputs/dotnet/static.ts) — the widened `filePathMatches` for `packages.config`, project files, `packages.lock.json`, and `obj/project.assets.json`
+- [`lib/dotnet-parser/`](../lib/dotnet-parser/) — in-repo parsers for the newly matched NuGet manifest/lockfile formats
+
+None of the audit hits is a `pom.xml`, `build.gradle`, or `paket.lock` filesystem matcher. This confirms the "manifest half" gaps stated in the [Detected](#detected) table and the [Not detected](#not-detected) table above.
 
 ## Caveats
 
 - **No network access at audit time.** This document is built entirely from static inspection of this repository's source at the commit it was written against. It could not cross-check against Snyk Open Source's live supported-ecosystem documentation; see [Completeness against Snyk Open Source's supported ecosystems](#completeness-against-snyk-open-sources-supported-ecosystems).
 - **Gate assumed open.** All "Detected" rows assume `exclude-app-vulns` is unset/false. If a caller sets `exclude-app-vulns`, none of the application-ecosystem extraction or analysis described here runs, and every ecosystem — including the ones in the Detected table — behaves as "not detected" for that scan.
 - **Runtime-only signal for Go.** Go module detection depends on binaries retaining embedded build info (`.go.buildinfo` / `.note.go.buildid` ELF sections); a stripped binary or a Go source tree with only `go.mod`/`go.sum` on the image filesystem produces no detection, even though the ecosystem is nominally "supported" here.
-- **Partial support is not full support.** The "Partially supported" rows in the Detected table (.NET/NuGet, Java/Maven, Go modules) detect only the code paths named there. A manifest-only project (e.g. a `.csproj` with no published `*.deps.json`, or a Java source tree with a `pom.xml` but no built `.jar`/`.war`) is not detected despite the ecosystem having a row in that table.
-- **This document does not change plugin behavior.** It is an audit artifact only; none of the gaps identified here have been fixed as part of producing this document.
+- **Partial support is not full support.** The "Partially supported" rows in the Detected table (.NET/NuGet, Java/Maven, Go modules) detect only the code paths named there. A manifest-only project that lacks the matched artifacts (e.g. a Java source tree with a `pom.xml` but no built `.jar`/`.war`, or a Paket-only project with only `paket.lock` and no other matched NuGet manifest) is not detected despite the ecosystem having a row in that table.
+- **This document does not change plugin behavior.** It is an audit artifact only; the NuGet manifest gaps named here (except `paket.lock`) have since been addressed in the plugin source.

--- a/lib/analyzer/applications/dotnet.ts
+++ b/lib/analyzer/applications/dotnet.ts
@@ -1,10 +1,20 @@
-import { DepGraphBuilder } from "@snyk/dep-graph";
+import { DepGraph, DepGraphBuilder } from "@snyk/dep-graph";
 import * as Debug from "debug";
 import { eventLoopSpinner } from "event-loop-spinner";
 import * as path from "path";
 import { getErrorMessage } from "../../error-utils";
+import {
+  DotnetGraphParseResult,
+  DotnetPackage,
+  parsePackagesConfig,
+  parsePackagesLockJson,
+  parseProjectAssetsJson,
+  parseProjectFile,
+} from "../../dotnet-parser";
 import { DepGraphFact, TestedFilesFact } from "../../facts";
 import { AppDepsScanResultWithoutTarget, FilePathToContent } from "./types";
+
+const PACKAGE_MANAGER_TYPE = "nuget";
 
 const debug = Debug("snyk");
 
@@ -31,7 +41,7 @@ interface DepsJson {
 interface PackageInfo {
   name: string;
   version: string;
-  dependencies: { [name: string]: string };
+  dependencies: string[];
 }
 
 type PackageIndex = Map<string, PackageInfo>;
@@ -82,11 +92,36 @@ async function addDependency(
     visited.add(nodeId);
     builder.addPkgNode({ name: pkg.name, version: pkg.version }, nodeId);
 
-    for (const childName of Object.keys(pkg.dependencies)) {
+    for (const childName of pkg.dependencies) {
       await addDependency(nodeId, childName, packageIndex, visited, builder);
     }
   }
   builder.connectDep(parentNodeId, nodeId);
+}
+
+async function buildDepGraphFromPackageIndex(
+  packageIndex: PackageIndex,
+  directDependencyNames: string[],
+  rootName: string,
+  rootVersion: string,
+): Promise<DepGraph> {
+  const builder = new DepGraphBuilder(
+    { name: PACKAGE_MANAGER_TYPE },
+    { name: rootName, version: rootVersion },
+  );
+
+  const visited = new Set<string>();
+  for (const depName of directDependencyNames) {
+    await addDependency(
+      builder.rootNodeId,
+      depName,
+      packageIndex,
+      visited,
+      builder,
+    );
+  }
+
+  return builder.build();
 }
 
 export async function dotnetFilesToScannedProjects(
@@ -95,6 +130,10 @@ export async function dotnetFilesToScannedProjects(
   const scanResults: AppDepsScanResultWithoutTarget[] = [];
 
   for (const [filePath, content] of Object.entries(filePathToContent)) {
+    if (!filePath.replace(/\\/g, "/").endsWith(".deps.json")) {
+      continue;
+    }
+
     try {
       const depGraph = await buildDepGraphFromDepsJson(content, filePath);
       if (!depGraph) {
@@ -112,7 +151,7 @@ export async function dotnetFilesToScannedProjects(
       scanResults.push({
         facts: [depGraphFact, testedFilesFact],
         identity: {
-          type: "nuget",
+          type: PACKAGE_MANAGER_TYPE,
           targetFile: filePath,
         },
       });
@@ -124,6 +163,10 @@ export async function dotnetFilesToScannedProjects(
       );
     }
   }
+
+  scanResults.push(
+    ...(await newFormatDotnetFilesToScannedProjects(filePathToContent)),
+  );
 
   return scanResults;
 }
@@ -167,11 +210,6 @@ async function buildDepGraphFromDepsJson(content: string, filePath: string) {
     return null;
   }
 
-  const builder = new DepGraphBuilder(
-    { name: "nuget" },
-    { name: rootName, version: rootVersion },
-  );
-
   const packageIndex: PackageIndex = new Map();
   for (const key of allPackages) {
     const parsed = parsePackageKey(key);
@@ -182,22 +220,256 @@ async function buildDepGraphFromDepsJson(content: string, filePath: string) {
     packageIndex.set(name.toLowerCase(), {
       name,
       version: parsed.version,
-      dependencies: target[key]?.dependencies || {},
+      dependencies: Object.keys(target[key]?.dependencies || {}),
     });
   }
 
-  const visited = new Set<string>();
   const directDeps = Object.keys(rootDependencies);
 
-  for (const depName of directDeps) {
-    await addDependency(
-      builder.rootNodeId,
-      depName,
-      packageIndex,
-      visited,
-      builder,
-    );
+  return buildDepGraphFromPackageIndex(
+    packageIndex,
+    directDeps,
+    rootName,
+    rootVersion,
+  );
+}
+
+interface DotnetNewFormatProjectFiles {
+  projectAssetsJson?: string;
+  packagesLockJson?: string;
+  packagesConfig?: string;
+  projectFile?: string;
+}
+
+function normalizeSlashes(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+// Groups the new manifest/lockfile formats by project root so a directory
+// holding more than one of them (e.g. packages.config next to a .csproj)
+// contributes a single scan result rather than double-counting the project.
+// obj/project.assets.json belongs to the directory above obj/, mirroring
+// where `dotnet restore` writes it relative to the project file.
+function groupNewFormatFilesByProjectRoot(
+  filePathToContent: FilePathToContent,
+): Map<string, DotnetNewFormatProjectFiles> {
+  const projects = new Map<string, DotnetNewFormatProjectFiles>();
+
+  function projectFor(root: string): DotnetNewFormatProjectFiles {
+    let project = projects.get(root);
+    if (!project) {
+      project = {};
+      projects.set(root, project);
+    }
+    return project;
+  }
+
+  for (const filePath of Object.keys(filePathToContent)) {
+    const normalized = normalizeSlashes(filePath);
+    const fileName = path.posix.basename(normalized);
+
+    if (fileName === "project.assets.json") {
+      const objDir = path.posix.dirname(normalized);
+      const root = path.posix.dirname(objDir);
+      projectFor(root).projectAssetsJson = filePath;
+    } else if (fileName === "packages.lock.json") {
+      projectFor(path.posix.dirname(normalized)).packagesLockJson = filePath;
+    } else if (fileName === "packages.config") {
+      projectFor(path.posix.dirname(normalized)).packagesConfig = filePath;
+    } else if (
+      normalized.endsWith(".csproj") ||
+      normalized.endsWith(".fsproj") ||
+      normalized.endsWith(".vbproj")
+    ) {
+      projectFor(path.posix.dirname(normalized)).projectFile = filePath;
+    }
+  }
+
+  return projects;
+}
+
+// deps.json is the fully-resolved publish output; if one exists at or under
+// a project root, that root's manifest/lockfile is a duplicate view of the
+// same project and is suppressed so it isn't reported twice under two
+// differently-resolved graphs.
+function isProjectRootCoveredByDepsJson(
+  root: string,
+  depsJsonPaths: string[],
+): boolean {
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return depsJsonPaths.some((depsJsonPath) => depsJsonPath.startsWith(prefix));
+}
+
+function buildDepGraphFromFlatPackages(
+  packages: DotnetPackage[],
+  targetFile: string,
+): DepGraph {
+  const builder = new DepGraphBuilder(
+    { name: PACKAGE_MANAGER_TYPE },
+    { name: targetFile },
+  );
+
+  for (const pkg of packages) {
+    const nodeId = `${pkg.name}@${pkg.version}`;
+    builder.addPkgNode({ name: pkg.name, version: pkg.version }, nodeId);
+    builder.connectDep(builder.rootNodeId, nodeId);
   }
 
   return builder.build();
+}
+
+function buildScanResultFromFlatPackages(
+  packages: DotnetPackage[],
+  targetFile: string,
+): AppDepsScanResultWithoutTarget | undefined {
+  if (packages.length === 0) {
+    return undefined;
+  }
+
+  const depGraphFact: DepGraphFact = {
+    type: "depGraph",
+    data: buildDepGraphFromFlatPackages(packages, targetFile),
+  };
+  const testedFilesFact: TestedFilesFact = {
+    type: "testedFiles",
+    data: [path.basename(targetFile)],
+  };
+
+  return {
+    facts: [depGraphFact, testedFilesFact],
+    identity: {
+      type: PACKAGE_MANAGER_TYPE,
+      targetFile,
+    },
+  };
+}
+
+async function buildScanResultFromGraphResult(
+  result: DotnetGraphParseResult,
+  targetFile: string,
+): Promise<AppDepsScanResultWithoutTarget> {
+  const packageIndex: PackageIndex = new Map();
+  for (const pkg of result.packages) {
+    const name = normalizePackageName(pkg.name);
+    packageIndex.set(name.toLowerCase(), {
+      name,
+      version: pkg.version,
+      dependencies: pkg.dependencies,
+    });
+  }
+
+  const depGraph = await buildDepGraphFromPackageIndex(
+    packageIndex,
+    result.directDependencies,
+    result.rootName,
+    result.rootVersion,
+  );
+
+  const depGraphFact: DepGraphFact = {
+    type: "depGraph",
+    data: depGraph,
+  };
+  const testedFilesFact: TestedFilesFact = {
+    type: "testedFiles",
+    data: [path.basename(targetFile)],
+  };
+
+  return {
+    facts: [depGraphFact, testedFilesFact],
+    identity: {
+      type: PACKAGE_MANAGER_TYPE,
+      targetFile,
+    },
+  };
+}
+
+// Picks the richest available resolution per project root: fully-resolved
+// restore output beats a flat lockfile, which beats a flat manifest with no
+// transitive data at all.
+async function newFormatDotnetFilesToScannedProjects(
+  filePathToContent: FilePathToContent,
+): Promise<AppDepsScanResultWithoutTarget[]> {
+  const scanResults: AppDepsScanResultWithoutTarget[] = [];
+
+  const projects = groupNewFormatFilesByProjectRoot(filePathToContent);
+  if (projects.size === 0) {
+    return scanResults;
+  }
+
+  const depsJsonPaths = Object.keys(filePathToContent)
+    .map(normalizeSlashes)
+    .filter((filePath) => filePath.endsWith(".deps.json"));
+
+  for (const [root, project] of projects.entries()) {
+    if (isProjectRootCoveredByDepsJson(root, depsJsonPaths)) {
+      continue;
+    }
+
+    try {
+      if (project.projectAssetsJson) {
+        const result = parseProjectAssetsJson(
+          filePathToContent[project.projectAssetsJson],
+        );
+        if (result) {
+          scanResults.push(
+            await buildScanResultFromGraphResult(
+              result,
+              project.projectAssetsJson,
+            ),
+          );
+        }
+        continue;
+      }
+
+      if (project.packagesLockJson) {
+        const result = parsePackagesLockJson(
+          filePathToContent[project.packagesLockJson],
+        );
+        if (result) {
+          scanResults.push(
+            await buildScanResultFromGraphResult(
+              result,
+              project.packagesLockJson,
+            ),
+          );
+        }
+        continue;
+      }
+
+      if (project.packagesConfig) {
+        const packages = parsePackagesConfig(
+          filePathToContent[project.packagesConfig],
+        );
+        const result = buildScanResultFromFlatPackages(
+          packages,
+          project.packagesConfig,
+        );
+        if (result) {
+          scanResults.push(result);
+        }
+        continue;
+      }
+
+      if (project.projectFile) {
+        const packages = parseProjectFile(
+          filePathToContent[project.projectFile],
+        );
+        const result = buildScanResultFromFlatPackages(
+          packages,
+          project.projectFile,
+        );
+        if (result) {
+          scanResults.push(result);
+        }
+      }
+    } catch (err) {
+      debug(
+        `Failed to parse .NET NuGet manifest under ${root}: ${getErrorMessage(
+          err,
+        )}`,
+      );
+    }
+  }
+
+  return scanResults;
 }

--- a/lib/dotnet-parser/index.ts
+++ b/lib/dotnet-parser/index.ts
@@ -1,0 +1,9 @@
+export { parsePackagesConfig } from "./packages-config-parser";
+export { parseProjectFile } from "./project-file-parser";
+export { parsePackagesLockJson } from "./packages-lock-parser";
+export { parseProjectAssetsJson } from "./project-assets-parser";
+export {
+  DotnetPackage,
+  DotnetPackageWithDependencies,
+  DotnetGraphParseResult,
+} from "./types";

--- a/lib/dotnet-parser/packages-config-parser.ts
+++ b/lib/dotnet-parser/packages-config-parser.ts
@@ -1,0 +1,33 @@
+import { DotnetPackage } from "./types";
+
+const PACKAGE_TAG_REGEX =
+  /<package\b[^>]*\bid\s*=\s*["']([^"']+)["'][^>]*\bversion\s*=\s*["']([^"']+)["'][^>]*\/?>/gi;
+
+function isDevelopmentDependency(tag: string): boolean {
+  const match = tag.match(/\bdevelopmentDependency\s*=\s*["']([^"']+)["']/i);
+  return match !== null && match[1].toLowerCase() === "true";
+}
+
+export function parsePackagesConfig(content: string): DotnetPackage[] {
+  if (!content || typeof content !== "string") {
+    return [];
+  }
+
+  const packages: DotnetPackage[] = [];
+  let match: RegExpExecArray | null;
+
+  PACKAGE_TAG_REGEX.lastIndex = 0;
+  while ((match = PACKAGE_TAG_REGEX.exec(content)) !== null) {
+    const fullTag = match[0];
+    if (isDevelopmentDependency(fullTag)) {
+      continue;
+    }
+
+    packages.push({
+      name: match[1],
+      version: match[2],
+    });
+  }
+
+  return packages;
+}

--- a/lib/dotnet-parser/packages-lock-parser.ts
+++ b/lib/dotnet-parser/packages-lock-parser.ts
@@ -1,0 +1,98 @@
+import { DotnetGraphParseResult, DotnetPackageWithDependencies } from "./types";
+
+interface LockDependencyEntry {
+  type?: string;
+  resolved?: string;
+  dependencies?: Record<string, string>;
+}
+
+interface PackagesLockJson {
+  dependencies?: Record<string, Record<string, LockDependencyEntry>>;
+}
+
+export function parsePackagesLockJson(
+  content: string,
+): DotnetGraphParseResult | null {
+  if (!content || typeof content !== "string") {
+    return null;
+  }
+
+  let parsed: PackagesLockJson;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const tfmEntries = parsed.dependencies;
+  if (!tfmEntries || typeof tfmEntries !== "object") {
+    return null;
+  }
+
+  const tfmKeys = Object.keys(tfmEntries);
+  if (tfmKeys.length === 0) {
+    return null;
+  }
+
+  const target = tfmEntries[tfmKeys[0]];
+  if (!target || typeof target !== "object") {
+    return null;
+  }
+
+  let rootName = "project";
+  const rootVersion = "0.0.0";
+  const packageMap = new Map<string, DotnetPackageWithDependencies>();
+  const directDependencyNames = new Set<string>();
+
+  for (const [pkgName, entry] of Object.entries(target)) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+
+    const entryType = entry.type ?? "";
+
+    if (entryType === "Project") {
+      rootName = pkgName;
+      if (entry.dependencies) {
+        for (const depName of Object.keys(entry.dependencies)) {
+          directDependencyNames.add(depName);
+        }
+      }
+      continue;
+    }
+
+    if (entryType === "Direct") {
+      directDependencyNames.add(pkgName);
+    }
+
+    const resolved = entry.resolved;
+    if (!resolved || typeof resolved !== "string") {
+      continue;
+    }
+
+    const dependencies = entry.dependencies
+      ? Object.keys(entry.dependencies)
+      : [];
+
+    packageMap.set(pkgName.toLowerCase(), {
+      name: pkgName,
+      version: resolved,
+      dependencies,
+    });
+  }
+
+  if (packageMap.size === 0 && directDependencyNames.size === 0) {
+    return null;
+  }
+
+  return {
+    rootName,
+    rootVersion,
+    directDependencies: Array.from(directDependencyNames),
+    packages: Array.from(packageMap.values()),
+  };
+}

--- a/lib/dotnet-parser/project-assets-parser.ts
+++ b/lib/dotnet-parser/project-assets-parser.ts
@@ -1,0 +1,120 @@
+import { DotnetGraphParseResult, DotnetPackageWithDependencies } from "./types";
+
+interface AssetsTargetEntry {
+  dependencies?: Record<string, string>;
+}
+
+interface AssetsLibraryEntry {
+  type?: string;
+}
+
+interface ProjectAssetsJson {
+  project?: {
+    restore?: {
+      projectName?: string;
+    };
+    frameworks?: Record<
+      string,
+      {
+        dependencies?: Record<string, string>;
+      }
+    >;
+  };
+  targets?: Record<string, Record<string, AssetsTargetEntry>>;
+  libraries?: Record<string, AssetsLibraryEntry>;
+}
+
+function parsePackageKey(
+  key: string,
+): { name: string; version: string } | null {
+  const slashIndex = key.indexOf("/");
+  if (slashIndex === -1) {
+    return null;
+  }
+  return {
+    name: key.substring(0, slashIndex),
+    version: key.substring(slashIndex + 1),
+  };
+}
+
+export function parseProjectAssetsJson(
+  content: string,
+): DotnetGraphParseResult | null {
+  if (!content || typeof content !== "string") {
+    return null;
+  }
+
+  let parsed: ProjectAssetsJson;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const targets = parsed.targets;
+  const libraries = parsed.libraries;
+  if (!targets || !libraries) {
+    return null;
+  }
+
+  const tfmKeys = Object.keys(targets);
+  if (tfmKeys.length === 0) {
+    return null;
+  }
+
+  const target = targets[tfmKeys[0]];
+  if (!target || typeof target !== "object") {
+    return null;
+  }
+
+  const rootName = parsed.project?.restore?.projectName ?? "project";
+  const rootVersion = "0.0.0";
+
+  const frameworkKeys = Object.keys(parsed.project?.frameworks ?? {});
+  const frameworkDeps =
+    frameworkKeys.length > 0
+      ? parsed.project!.frameworks![frameworkKeys[0]].dependencies
+      : undefined;
+
+  const directDependencies = frameworkDeps ? Object.keys(frameworkDeps) : [];
+
+  const packageMap = new Map<string, DotnetPackageWithDependencies>();
+
+  for (const key of Object.keys(target)) {
+    const library = libraries[key];
+    if (library?.type === "project") {
+      continue;
+    }
+
+    const parsedKey = parsePackageKey(key);
+    if (!parsedKey) {
+      continue;
+    }
+
+    const entry = target[key];
+    const dependencies = entry?.dependencies
+      ? Object.keys(entry.dependencies)
+      : [];
+
+    packageMap.set(parsedKey.name.toLowerCase(), {
+      name: parsedKey.name,
+      version: parsedKey.version,
+      dependencies,
+    });
+  }
+
+  if (packageMap.size === 0 && directDependencies.length === 0) {
+    return null;
+  }
+
+  return {
+    rootName,
+    rootVersion,
+    directDependencies,
+    packages: Array.from(packageMap.values()),
+  };
+}

--- a/lib/dotnet-parser/project-file-parser.ts
+++ b/lib/dotnet-parser/project-file-parser.ts
@@ -1,0 +1,78 @@
+import { DotnetPackage } from "./types";
+
+function stripXmlComments(content: string): string {
+  return content.replace(/<!--[\s\S]*?-->/g, "");
+}
+
+function isExactVersion(version: string): boolean {
+  if (!version || version.includes("$(")) {
+    return false;
+  }
+  if (version.includes("*")) {
+    return false;
+  }
+  if (version.startsWith("[") || version.startsWith("(")) {
+    return false;
+  }
+  return true;
+}
+
+function parsePackageReferenceTag(
+  tagContent: string,
+  packages: DotnetPackage[],
+): void {
+  if (/\bUpdate\s*=/i.test(tagContent)) {
+    return;
+  }
+
+  const includeMatch = tagContent.match(/\bInclude\s*=\s*["']([^"']+)["']/i);
+  if (!includeMatch) {
+    return;
+  }
+
+  const name = includeMatch[1];
+  let version: string | undefined;
+
+  const versionAttrMatch = tagContent.match(
+    /\bVersion\s*=\s*["']([^"']+)["']/i,
+  );
+  if (versionAttrMatch) {
+    version = versionAttrMatch[1];
+  } else {
+    const childVersionMatch = tagContent.match(
+      /<Version>\s*([^<]+?)\s*<\/Version>/i,
+    );
+    if (childVersionMatch) {
+      version = childVersionMatch[1].trim();
+    }
+  }
+
+  if (!version || !isExactVersion(version)) {
+    return;
+  }
+
+  packages.push({ name, version });
+}
+
+export function parseProjectFile(content: string): DotnetPackage[] {
+  if (!content || typeof content !== "string") {
+    return [];
+  }
+
+  const stripped = stripXmlComments(content);
+  const packages: DotnetPackage[] = [];
+
+  const selfClosingRegex = /<PackageReference\b([^>]*)\/>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = selfClosingRegex.exec(stripped)) !== null) {
+    parsePackageReferenceTag(match[1], packages);
+  }
+
+  const elementRegex =
+    /<PackageReference\b([^>]*[^/])>([\s\S]*?)<\/PackageReference>/gi;
+  while ((match = elementRegex.exec(stripped)) !== null) {
+    parsePackageReferenceTag(`${match[1]}>${match[2]}`, packages);
+  }
+
+  return packages;
+}

--- a/lib/dotnet-parser/types.ts
+++ b/lib/dotnet-parser/types.ts
@@ -1,0 +1,15 @@
+export interface DotnetPackage {
+  name: string;
+  version: string;
+}
+
+export interface DotnetPackageWithDependencies extends DotnetPackage {
+  dependencies: string[];
+}
+
+export interface DotnetGraphParseResult {
+  rootName: string;
+  rootVersion: string;
+  directDependencies: string[];
+  packages: DotnetPackageWithDependencies[];
+}

--- a/lib/inputs/dotnet/static.ts
+++ b/lib/inputs/dotnet/static.ts
@@ -1,20 +1,64 @@
 import { ExtractAction } from "../../extractor/types";
 import { streamToString } from "../../stream-utils";
 
-/**
- * Matches *.deps.json files produced by `dotnet publish`.
- * Excludes framework deps.json files under the shared runtime directory
- * (e.g. /usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.0/).
- */
-function filePathMatches(filePath: string): boolean {
-  if (
-    !filePath.endsWith(".deps.json") ||
-    filePath.includes("/dotnet/shared/") ||
-    filePath.includes("/dotnet/packs/")
-  ) {
+const DOTNET_EXCLUSIONS = [
+  "/dotnet/shared/",
+  "/dotnet/packs/",
+  "/dotnet/sdk/",
+  "/.nuget/packages/",
+];
+
+function isExcluded(normalizedPath: string): boolean {
+  return DOTNET_EXCLUSIONS.some((segment) => normalizedPath.includes(segment));
+}
+
+function matchesProjectAssetsJson(normalizedPath: string): boolean {
+  if (!normalizedPath.endsWith("project.assets.json")) {
     return false;
   }
-  return true;
+  return normalizedPath.includes("/obj/");
+}
+
+/**
+ * Matches NuGet manifest and lockfile formats used by application projects:
+ * *.deps.json (publish output), packages.config, *.csproj/*.fsproj/*.vbproj,
+ * packages.lock.json, and obj/project.assets.json (restore output).
+ *
+ * Excludes framework/runtime files under the shared dotnet install and NuGet
+ * cache paths (shared, packs, sdk, and restored package contentFiles).
+ */
+function filePathMatches(filePath: string): boolean {
+  const normalizedPath = filePath.replace(/\\/g, "/");
+
+  if (isExcluded(normalizedPath)) {
+    return false;
+  }
+
+  if (normalizedPath.endsWith(".deps.json")) {
+    return true;
+  }
+
+  if (normalizedPath.endsWith("packages.config")) {
+    return true;
+  }
+
+  if (
+    normalizedPath.endsWith(".csproj") ||
+    normalizedPath.endsWith(".fsproj") ||
+    normalizedPath.endsWith(".vbproj")
+  ) {
+    return true;
+  }
+
+  if (normalizedPath.endsWith("packages.lock.json")) {
+    return true;
+  }
+
+  if (matchesProjectAssetsJson(normalizedPath)) {
+    return true;
+  }
+
+  return false;
 }
 
 export const getDotnetAppFileContentAction: ExtractAction = {

--- a/test/fixtures/dotnet/VulnApp.csproj
+++ b/test/fixtures/dotnet/VulnApp.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="ExactSibling" Version="1.0.0" />
+    <PackageReference Include="PropRef" Version="$(SomeProperty)" />
+    <PackageReference Include="WildcardRef" Version="1.2.*" />
+    <PackageReference Include="RangeRef" Version="[1.0,2.0)" />
+    <!-- <PackageReference Include="CommentedOut" Version="9.9.9" /> -->
+    <PackageReference Update="UpdateRef" Version="2.0.0" />
+    <PackageReference Include="ChildElementRef">
+      <Version>3.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnet/packages.config
+++ b/test/fixtures/dotnet/packages.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AutoMapper" version="13.0.1" />
+  <package id="Newtonsoft.Json" version="13.0.3" />
+  <package id="DevOnly" version="1.0.0" developmentDependency="true" />
+</packages>

--- a/test/fixtures/dotnet/packages.lock.json
+++ b/test/fixtures/dotnet/packages.lock.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "VulnApp": {
+        "type": "Project",
+        "dependencies": {
+          "AutoMapper": "13.0.1"
+        }
+      },
+      "AutoMapper": {
+        "type": "Direct",
+        "requested": "13.0.1",
+        "resolved": "13.0.1",
+        "contentHash": "abc123",
+        "dependencies": {
+          "Microsoft.Extensions.Options": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0"
+      }
+    }
+  }
+}

--- a/test/fixtures/dotnet/project.assets.json
+++ b/test/fixtures/dotnet/project.assets.json
@@ -1,0 +1,71 @@
+{
+  "version": 3,
+  "targets": {
+    "net8.0": {
+      "VulnApp/1.0.0": {
+        "dependencies": {
+          "AutoMapper": "13.0.1"
+        }
+      },
+      "AutoMapper/13.0.1": {
+        "dependencies": {
+          "Microsoft.Extensions.Options": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options/6.0.0": {
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {}
+    }
+  },
+  "libraries": {
+    "VulnApp/1.0.0": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "AutoMapper/13.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-abc123==",
+      "path": "automapper/13.0.1",
+      "hashPath": "automapper.13.0.1.nupkg.sha512"
+    },
+    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-def456==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Options/6.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ghi789==",
+      "path": "microsoft.extensions.options/6.0.0",
+      "hashPath": "microsoft.extensions.options.6.0.0.nupkg.sha512"
+    }
+  },
+  "projectFileDependencyGroups": {
+    "net8.0": [
+      "AutoMapper >= 13.0.1"
+    ]
+  },
+  "project": {
+    "restore": {
+      "projectName": "VulnApp"
+    },
+    "frameworks": {
+      "net8.0": {
+        "dependencies": {
+          "AutoMapper": {
+            "target": "Package",
+            "version": "[13.0.1, )"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/lib/analyzer/dotnet.spec.ts
+++ b/test/lib/analyzer/dotnet.spec.ts
@@ -161,4 +161,137 @@ describe("dotnet deps.json analyzer", () => {
       expect(results).toHaveLength(2);
     });
   });
+
+  describe("new NuGet manifest/lockfile formats reach the scan pipeline", () => {
+    it("parses packages.config into a nuget scan result", async () => {
+      const filePathToContent = {
+        "/app/packages.config": loadFixture("packages.config"),
+      };
+
+      const results = await dotnetFilesToScannedProjects(filePathToContent);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].identity.type).toBe("nuget");
+      expect(results[0].identity.targetFile).toBe("/app/packages.config");
+
+      const pkgs = results[0].facts
+        .find((f) => f.type === "depGraph")!
+        .data.getPkgs();
+      expect(
+        pkgs.some((p) => p.name === "AutoMapper" && p.version === "13.0.1"),
+      ).toBe(true);
+      expect(pkgs.some((p) => p.name === "DevOnly")).toBe(false);
+    });
+
+    it("parses a .csproj into a nuget scan result", async () => {
+      const filePathToContent = {
+        "/app/VulnApp.csproj": loadFixture("VulnApp.csproj"),
+      };
+
+      const results = await dotnetFilesToScannedProjects(filePathToContent);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].identity.type).toBe("nuget");
+
+      const pkgs = results[0].facts
+        .find((f) => f.type === "depGraph")!
+        .data.getPkgs();
+      expect(
+        pkgs.some((p) => p.name === "AutoMapper" && p.version === "13.0.1"),
+      ).toBe(true);
+    });
+
+    it("parses packages.lock.json into a nuget scan result with transitive deps", async () => {
+      const filePathToContent = {
+        "/app/packages.lock.json": loadFixture("packages.lock.json"),
+      };
+
+      const results = await dotnetFilesToScannedProjects(filePathToContent);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].identity.type).toBe("nuget");
+
+      const pkgs = results[0].facts
+        .find((f) => f.type === "depGraph")!
+        .data.getPkgs();
+      expect(
+        pkgs.some((p) => p.name === "AutoMapper" && p.version === "13.0.1"),
+      ).toBe(true);
+      expect(
+        pkgs.some(
+          (p) =>
+            p.name === "Microsoft.Extensions.DependencyInjection.Abstractions",
+        ),
+      ).toBe(true);
+    });
+
+    it("parses obj/project.assets.json into a nuget scan result", async () => {
+      const filePathToContent = {
+        "/app/obj/project.assets.json": loadFixture("project.assets.json"),
+      };
+
+      const results = await dotnetFilesToScannedProjects(filePathToContent);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].identity.type).toBe("nuget");
+      expect(results[0].identity.targetFile).toBe(
+        "/app/obj/project.assets.json",
+      );
+
+      const depGraph = results[0].facts.find(
+        (f) => f.type === "depGraph",
+      )!.data;
+      expect(depGraph.rootPkg.name).toBe("VulnApp");
+      const pkgs = depGraph.getPkgs();
+      expect(
+        pkgs.some((p) => p.name === "AutoMapper" && p.version === "13.0.1"),
+      ).toBe(true);
+    });
+
+    it("prefers project.assets.json over packages.lock.json, packages.config, and a project file in the same root", async () => {
+      const filePathToContent = {
+        "/app/obj/project.assets.json": loadFixture("project.assets.json"),
+        "/app/packages.lock.json": loadFixture("packages.lock.json"),
+        "/app/packages.config": loadFixture("packages.config"),
+        "/app/VulnApp.csproj": loadFixture("VulnApp.csproj"),
+      };
+
+      const results = await dotnetFilesToScannedProjects(filePathToContent);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].identity.targetFile).toBe(
+        "/app/obj/project.assets.json",
+      );
+    });
+
+    it("suppresses the new-format result when a deps.json exists under the same project root", async () => {
+      const filePathToContent = {
+        "/app/VulnApp.csproj": loadFixture("VulnApp.csproj"),
+        "/app/bin/publish/VulnApp.deps.json": loadFixture("VulnApp.deps.json"),
+      };
+
+      const results = await dotnetFilesToScannedProjects(filePathToContent);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].identity.targetFile).toBe(
+        "/app/bin/publish/VulnApp.deps.json",
+      );
+    });
+
+    it("does not suppress a new-format result when deps.json belongs to an unrelated root", async () => {
+      const filePathToContent = {
+        "/app1/VulnApp.csproj": loadFixture("VulnApp.csproj"),
+        "/app2/VulnApp.deps.json": loadFixture("VulnApp.deps.json"),
+      };
+
+      const results = await dotnetFilesToScannedProjects(filePathToContent);
+
+      expect(results).toHaveLength(2);
+      const targetFiles = results.map((r) => r.identity.targetFile).sort();
+      expect(targetFiles).toEqual([
+        "/app1/VulnApp.csproj",
+        "/app2/VulnApp.deps.json",
+      ]);
+    });
+  });
 });

--- a/test/lib/inputs/dotnet/static.spec.ts
+++ b/test/lib/inputs/dotnet/static.spec.ts
@@ -1,0 +1,64 @@
+import { getDotnetAppFileContentAction } from "../../../../lib/inputs/dotnet/static";
+import { streamToString } from "../../../../lib/stream-utils";
+
+describe(".NET application file path matching", () => {
+  const { filePathMatches, actionName, callback } =
+    getDotnetAppFileContentAction;
+
+  it("exports getDotnetAppFileContentAction with expected actionName and callback", () => {
+    expect(actionName).toBe("dotnet-app-files");
+    expect(callback).toBe(streamToString);
+  });
+
+  describe("application manifest paths (forward slashes)", () => {
+    it.each([
+      "/app/packages.config",
+      "/app/App.csproj",
+      "/app/App.fsproj",
+      "/app/App.vbproj",
+      "/app/obj/project.assets.json",
+      "/app/packages.lock.json",
+      "/app/App.deps.json",
+    ])("matches %s", (filePath) => {
+      expect(filePathMatches(filePath)).toBe(true);
+    });
+  });
+
+  describe("application manifest paths (backslashes)", () => {
+    it.each([
+      "\\app\\packages.config",
+      "\\app\\App.csproj",
+      "\\app\\App.fsproj",
+      "\\app\\App.vbproj",
+      "\\app\\obj\\project.assets.json",
+      "\\app\\packages.lock.json",
+      "\\app\\App.deps.json",
+    ])("matches %s", (filePath) => {
+      expect(filePathMatches(filePath)).toBe(true);
+    });
+  });
+
+  describe("framework, SDK, and cache paths (forward slashes)", () => {
+    it.each([
+      "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.0/x.deps.json",
+      "/usr/share/dotnet/packs/x.deps.json",
+      "/usr/share/dotnet/sdk/8.0.100/x.csproj",
+      "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.0/x.csproj",
+      "/root/.nuget/packages/foo/1.0.0/contentFiles/any/net8.0/x.csproj",
+      "/app/project.assets.json",
+      "/app/foo.json",
+    ])("does not match %s", (filePath) => {
+      expect(filePathMatches(filePath)).toBe(false);
+    });
+  });
+
+  describe("framework, SDK, and cache paths (backslashes)", () => {
+    it.each([
+      "\\usr\\share\\dotnet\\shared\\Microsoft.NETCore.App\\8.0.0\\x.deps.json",
+      "\\usr\\share\\dotnet\\packs\\x.deps.json",
+      "\\root\\.nuget\\packages\\foo\\1.0.0\\contentFiles\\any\\net8.0\\x.csproj",
+    ])("does not match %s", (filePath) => {
+      expect(filePathMatches(filePath)).toBe(false);
+    });
+  });
+});

--- a/test/unit/dotnet-parsers.spec.ts
+++ b/test/unit/dotnet-parsers.spec.ts
@@ -1,0 +1,222 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  parsePackagesConfig,
+  parseProjectFile,
+  parsePackagesLockJson,
+  parseProjectAssetsJson,
+} from "../../lib/dotnet-parser";
+
+const fixturesRoot = join(__dirname, "../fixtures/dotnet");
+
+function readFixture(relativePath: string): string {
+  return readFileSync(join(fixturesRoot, relativePath), "utf8");
+}
+
+function packageNamesAndVersions(
+  packages: { name: string; version: string }[],
+): { name: string; version: string }[] {
+  return packages.map(({ name, version }) => ({ name, version }));
+}
+
+describe("dotnet parsers", () => {
+  describe("parsePackagesConfig", () => {
+    it("returns exact package names and versions from the fixture", () => {
+      const content = readFixture("packages.config");
+
+      const packages = parsePackagesConfig(content);
+
+      expect(packageNamesAndVersions(packages)).toEqual([
+        { name: "AutoMapper", version: "13.0.1" },
+        { name: "Newtonsoft.Json", version: "13.0.3" },
+      ]);
+    });
+
+    it('excludes packages with developmentDependency="true"', () => {
+      const content = readFixture("packages.config");
+
+      const packages = parsePackagesConfig(content);
+
+      expect(packages).not.toEqual(
+        expect.arrayContaining([{ name: "DevOnly", version: "1.0.0" }]),
+      );
+    });
+
+    it("returns an empty list for malformed or truncated content instead of throwing", () => {
+      expect(() => parsePackagesConfig("<packages><package id=")).not.toThrow();
+      expect(parsePackagesConfig("<packages><package id=")).toEqual([]);
+
+      expect(() => parsePackagesConfig("")).not.toThrow();
+      expect(parsePackagesConfig("")).toEqual([]);
+    });
+  });
+
+  describe("parseProjectFile", () => {
+    it("returns exact package names and versions from the fixture", () => {
+      const content = readFixture("VulnApp.csproj");
+
+      const packages = parseProjectFile(content);
+
+      expect(packageNamesAndVersions(packages)).toEqual([
+        { name: "AutoMapper", version: "13.0.1" },
+        { name: "ExactSibling", version: "1.0.0" },
+        { name: "ChildElementRef", version: "3.0.0" },
+      ]);
+    });
+
+    it("excludes PackageReference entries inside XML comments", () => {
+      const content = readFixture("VulnApp.csproj");
+
+      const packages = parseProjectFile(content);
+
+      expect(packages).not.toEqual(
+        expect.arrayContaining([{ name: "CommentedOut", version: "9.9.9" }]),
+      );
+    });
+
+    it("skips PackageReference versions that are MSBuild properties, wildcards, or ranges", () => {
+      const content = readFixture("VulnApp.csproj");
+
+      const packages = parseProjectFile(content);
+
+      expect(packages).not.toEqual(
+        expect.arrayContaining([
+          { name: "PropRef", version: "$(SomeProperty)" },
+          { name: "WildcardRef", version: "1.2.*" },
+          { name: "RangeRef", version: "[1.0,2.0)" },
+        ]),
+      );
+      expect(packages).toEqual(
+        expect.arrayContaining([{ name: "ExactSibling", version: "1.0.0" }]),
+      );
+    });
+
+    it("excludes PackageReference entries using Update= instead of Include=", () => {
+      const content = readFixture("VulnApp.csproj");
+
+      const packages = parseProjectFile(content);
+
+      expect(packages).not.toEqual(
+        expect.arrayContaining([{ name: "UpdateRef", version: "2.0.0" }]),
+      );
+    });
+
+    it("parses the child-element <Version> form", () => {
+      const content = readFixture("VulnApp.csproj");
+
+      const packages = parseProjectFile(content);
+
+      expect(packages).toEqual(
+        expect.arrayContaining([{ name: "ChildElementRef", version: "3.0.0" }]),
+      );
+    });
+
+    it("returns an empty list for malformed or truncated content instead of throwing", () => {
+      expect(() =>
+        parseProjectFile("<Project><PackageReference Include="),
+      ).not.toThrow();
+      expect(parseProjectFile("<Project><PackageReference Include=")).toEqual(
+        [],
+      );
+
+      expect(() => parseProjectFile("")).not.toThrow();
+      expect(parseProjectFile("")).toEqual([]);
+    });
+  });
+
+  describe("parsePackagesLockJson", () => {
+    it("returns exact package names and versions from the fixture", () => {
+      const content = readFixture("packages.lock.json");
+
+      const result = parsePackagesLockJson(content);
+
+      expect(result).not.toBeNull();
+      expect(packageNamesAndVersions(result!.packages)).toEqual(
+        expect.arrayContaining([
+          { name: "AutoMapper", version: "13.0.1" },
+          { name: "Microsoft.Extensions.Options", version: "6.0.0" },
+          {
+            name: "Microsoft.Extensions.DependencyInjection.Abstractions",
+            version: "6.0.0",
+          },
+        ]),
+      );
+      expect(result!.packages).toHaveLength(3);
+    });
+
+    it("traverses Project-type entries for dependencies but does not emit them as packages", () => {
+      const content = readFixture("packages.lock.json");
+
+      const result = parsePackagesLockJson(content);
+
+      expect(result).not.toBeNull();
+      expect(result!.rootName).toBe("VulnApp");
+      expect(result!.packages).not.toEqual(
+        expect.arrayContaining([
+          { name: "VulnApp", version: expect.any(String) },
+        ]),
+      );
+      expect(result!.directDependencies).toEqual(
+        expect.arrayContaining(["AutoMapper"]),
+      );
+    });
+
+    it("returns null for malformed or truncated content instead of throwing", () => {
+      expect(() => parsePackagesLockJson("{")).not.toThrow();
+      expect(parsePackagesLockJson("{")).toBeNull();
+
+      expect(() => parsePackagesLockJson("not json")).not.toThrow();
+      expect(parsePackagesLockJson("not json")).toBeNull();
+
+      expect(() => parsePackagesLockJson("")).not.toThrow();
+      expect(parsePackagesLockJson("")).toBeNull();
+    });
+  });
+
+  describe("parseProjectAssetsJson", () => {
+    it("returns exact package names and versions from the fixture", () => {
+      const content = readFixture("project.assets.json");
+
+      const result = parseProjectAssetsJson(content);
+
+      expect(result).not.toBeNull();
+      expect(packageNamesAndVersions(result!.packages)).toEqual(
+        expect.arrayContaining([
+          { name: "AutoMapper", version: "13.0.1" },
+          { name: "Microsoft.Extensions.Options", version: "6.0.0" },
+          {
+            name: "Microsoft.Extensions.DependencyInjection.Abstractions",
+            version: "6.0.0",
+          },
+        ]),
+      );
+      expect(result!.packages).toHaveLength(3);
+    });
+
+    it("traverses project-type libraries but does not emit them as packages", () => {
+      const content = readFixture("project.assets.json");
+
+      const result = parseProjectAssetsJson(content);
+
+      expect(result).not.toBeNull();
+      expect(result!.rootName).toBe("VulnApp");
+      expect(result!.packages).not.toEqual(
+        expect.arrayContaining([{ name: "VulnApp", version: "1.0.0" }]),
+      );
+      expect(result!.directDependencies).toEqual(
+        expect.arrayContaining(["AutoMapper"]),
+      );
+    });
+
+    it("returns null for malformed or truncated content instead of throwing", () => {
+      expect(() => parseProjectAssetsJson("{")).not.toThrow();
+      expect(parseProjectAssetsJson("{")).toBeNull();
+
+      expect(() => parseProjectAssetsJson("not json")).not.toThrow();
+      expect(parseProjectAssetsJson("not json")).toBeNull();
+
+      expect(() => parseProjectAssetsJson("")).not.toThrow();
+      expect(parseProjectAssetsJson("")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Snyk container test previously only detected .NET/NuGet dependencies from published *.deps.json files, missing the packages.config, PackageReference project (.csproj/.fsproj/.vbproj), packages.lock.json, and obj/project.assets.json formats flagged as gaps in docs/application-ecosystem-coverage.md. Pure parsers for each of these formats live under lib/dotnet-parser/, and the file matcher in lib/inputs/dotnet/static.ts locates them across normalised path separators while excluding the dotnet SDK/shared/pack and NuGet cache directories. lib/analyzer/applications/dotnet.ts dispatches the new formats into the existing nuget-identified dep-graph pipeline alongside the unchanged deps.json handling. For each project root, the richest available resolution wins in the order project.assets.json > packages.lock.json > packages.config > project file, and results are suppressed for roots already covered by a deps.json so a project is never reported twice. docs/application-ecosystem-coverage.md is updated to reflect the closed gaps, leaving paket.lock as the only unmatched NuGet manifest format.

## Acceptance criteria

1. For each NuGet manifest/lockfile format or scenario listed as a gap in the coverage doc (e.g. packages.config, PackageReference-style .csproj/.fsproj/.vbproj entries, obj/project.assets.json, packages.lock.json, or other formats named there), snyk container test detects the format when present in a scanned container image.
2. Dependencies parsed from each newly-covered NuGet format are surfaced in the container test's dependency graph/output with a 'nuget' package-manager identity, consistent with how node/php/pip/poetry dependencies are already surfaced.
3. Once a NuGet dependency is detected via a newly-covered format, it flows through the same existing vulnerability-scanning pipeline as other detected dependencies, without requiring a separate vulnerability-lookup mechanism.
4. Running snyk container test against a container image built with each previously-uncovered NuGet manifest/lockfile produces dependency results equivalent (same packages/versions resolved) to what Snyk Open Source reports for the same manifest.
5. All NuGet detection scenarios that currently pass continue to pass unchanged after this change (no regression).
6. New or updated automated tests exist covering each previously-uncovered NuGet scenario named in the coverage doc.

## Not in this branch

The plan had work this branch does not carry:

- `dotnet-analyzer-dispatch` (done when: `npm run test:unit` passes, including every pre-existing case in test/lib/analyzer/dotnet.spec.ts left unmodified in the diff. dotnetFilesToScannedProjects dispatches on file name, and test/lib/analyzer/dotnet.spec.ts adds: (a) for each of /app/packages.config, /app/App.csproj, /app/packages.lock.json and /app/obj/project.assets.json fed in alone, a result whose identity.type is exactly "nuget", whose identity.targetFile is that file's path, and whose facts include a depGraph fact whose getPkgs() contains the fixture's packages at their pinned versions plus a testedFiles fact naming that file; (b) a precedence case feeding one project root all four new formats and no deps.json, expecting exactly one result, targetFile /app/obj/project.assets.json; (c) a suppression case adding /app/bin/Release/net8.0/App.deps.json to that same root, expecting exactly one result, the deps.json one, with the deps.json graph identical to the existing standalone deps.json case; (d) a grouping case with /app/App.csproj and /app/obj/project.assets.json asserting the obj/ file groups to /app, not /app/obj; (e) malformed content for each new format yields no result and no throw, matching the existing invalid-JSON case.): the builder call itself failed: pipeline: builder:dotnet-analyzer-dispatch:retry: exit: cursor create returned HTTP 400 (validation_error): [invalid_argument] Error

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `coverage-doc-update`: Updated all seven .NET gap anchors in the coverage doc: Detected row now lists packages.config, *.csproj/*.fsproj/*.vbproj, packages.lock.json, and obj/project.assets.json alongside *.deps.json with four path exclusions; partial-gaps row and NuGet manifest-half row name only paket.lock as remaining; Check A/B counts marked historical with new hit sites for lib/inputs/dotnet/static.ts and lib/dotnet-parser/; caveats updated to drop the resolved .csproj example and note NuGet gaps are now fixed except paket.lock. Java, Go, and other Not detected rows left unchanged. npm run test:unit: 940/944 pass; 4 display.spec.ts ANSI-color failures reproduce on the base commit before this docs-only change. | gate "npm run test:unit" passed in 5393ms
- `dotnet-file-matcher`: Widened filePathMatches in lib/inputs/dotnet/static.ts to detect packages.config, .csproj/.fsproj/.vbproj, packages.lock.json, obj/project.assets.json, and existing *.deps.json. Paths are normalised (backslash to slash) before matching; four exclusions (/dotnet/shared/, /dotnet/packs/, /dotnet/sdk/, /.nuget/packages/) apply to every format; project.assets.json requires an /obj/ segment. getDotnetAppFileContentAction still exports actionName dotnet-app-files with streamToString callback. Added test/lib/inputs/dotnet/static.spec.ts with 25 cases covering all acceptance TRUE/FALSE paths plus export assertions — all pass in isolation. Full npm run test:unit reports 4 pre-existing failures in test/lib/display.spec.ts (ANSI colour codes in non-TTY cloud env); same failures on base branch before this change. Pushed to origin/cursor/dotnet-file-matcher-scope-3e61 at dc85c86. | gate "npm run test:unit" passed in 5473ms
- `dotnet-parsers`: Added lib/dotnet-parser/ with four pure-function parsers (no fs or analyzer imports). parsePackagesConfig skips developmentDependency entries; parseProjectFile strips XML comments, ignores Update= references, filters MSBuild/wildcard/range versions, and supports child-element Version; parsePackagesLockJson and parseProjectAssetsJson build graph results with directDependencies, traversing Project/project-type entries without emitting them. All 15 tests in test/unit/dotnet-parsers.spec.ts pass. Pushed to origin/cursor/dotnet-parsers-module-cfbe. | gate "npm run test:unit -- test/unit/dotnet-parsers.spec.ts" passed in 5464ms
- `final:build`: `npm run build` passed in 3791ms
- `final:test_unit`: `npm run test:unit` passed in 3479ms
- `final:lint`: `npm run lint` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch. Anything still failing against the base commit is in the open findings below.

## Open blocking findings

- [plan-conformance/dotnet-parsers-orphaned blocking] lib/dotnet-parser/index.ts: Acceptance criteria 2 and 3 (new-format dependencies surfaced with 'nuget' identity and flowing through the existing vuln-scanning pipeline) are unmet: grepping the repo shows nothing outside lib/dotnet-parser/ and its own spec imports these parser functions, so parsing packages.config/.csproj/.fsproj/.vbproj/packages.lock.json/project.assets.json never reaches a ScannedProject/depGraph despite the widened matcher now extracting those files.

## Decisions taken without asking

- Should the extended NuGet detection aim for exact parity with Snyk Open Source's current NuGet format support, or should it detect additional formats/scenarios beyond what Open Source currently covers if they're technically feasible?
  - took: Match Snyk Open Source's current NuGet support exactly — treat the coverage doc's gap list as the scope boundary, not a floor to exceed.
  - alternative: Build the most comprehensive NuGet detection possible regardless of whether Snyk Open Source currently supports each format.

## Assumptions

- "Matches Snyk Open Source's NuGet support" means detecting the same set of manifest/lockfile formats and producing equivalent resolved-dependency results, not necessarily sharing implementation code with the Open Source scanner.
- The specific list of coverage gaps is defined by an existing coverage doc referenced in the ledger; that doc's contents will be read during planning/routing rather than enumerated here, since intake does not read code or repo artifacts.
- "Partially wired/covered" refers to gaps in format-detection coverage and/or test coverage, not a broken core mechanism, since the 'nuget' identity strings already exist in dotnet.ts.
- "snyk container test" refers to the CLI's container-image static dependency scanning path, not `snyk test` against a source repository.
- Closing detection gaps is sufficient to close vulnerability-scanning gaps too, because container test's existing pipeline already runs vulnerability lookup against any dependency the analyzer emits — no separate vuln-data-source work is implied.

## Run

- Run: `20260810-172202-9ab0`
- Origin: 
- Base: `a378e564a8d39f92a71ea7536abe1f083958d169`
- Head: `c52a50297e66811491cde6dba54a28d6767031b8`

Human review is required. This automation never merges or marks a PR ready.
