### PR TITLE
fix(security): address Snyk vulnerability alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4739,9 +4739,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "tslib": "^1",
     "varint": "^6.0.0"
   },
+  "overrides": {
+    "brace-expansion@^2": "^2.1.4"
+  },
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",
     "@commitlint/config-conventional": "^17.0.2",


### PR DESCRIPTION
Clears the one high-severity finding `snyk test` reports on main.

`brace-expansion@^2` is pinned to ^2.1.4, which fixes [SNYK-JS-BRACEEXPANSION-18512280](https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-18512280). Version 2.1.3 arrives through `minimatch@9.0.9`.

This adds the repo's first `overrides` block. The entry is scoped to major 2 so the brace-expansion 1.x and 5.x copies elsewhere in the tree keep resolving on their own lines.

The floor lives in `package.json` rather than in a lockfile refresh alone. `minimatch` declares `^2`, which still permits 2.1.3, so anything that regenerates the lockfile could resolve straight back to the affected version and nothing would fail to tell us.

Since npm applies `overrides` only when a package is the root project, this does not change what consumers of the published plugin resolve. It fixes this repo's own tree, which is what the Snyk project scans.

`snyk test --severity-threshold=high` reports 1 finding before this change and 0 after.

### Verification

I regenerated the lockfile with npm 10.9.8, which ships in the `cimg/node:22.22` image CI uses, then validated it with `npm ci` in a clean directory holding only `package.json` and `package-lock.json`.

### Where this came from

The alert landed in [#snyk-vuln-alerts-container](https://snyk.enterprise.slack.com/archives/C08JELSU78W) on Aug 8 against [this Snyk project](https://app.snyk.io/org/infrasec_container/project/e4f0769f-8384-441c-bda6-cfd80f58094e).