### PR TITLE
feat(sbom): add standalone CycloneDX transform for dep graphs

### DIFF
--- a/lib/sbom/cyclonedx.ts
+++ b/lib/sbom/cyclonedx.ts
@@ -1,0 +1,73 @@
+import { DepGraph } from "@snyk/dep-graph";
+import {
+  CycloneDxComponent,
+  CycloneDxDocument,
+  DepGraphsToCycloneDxOptions,
+} from "./types";
+
+function buildBomRef(
+  pkgManagerName: string,
+  name: string,
+  version?: string | null,
+): string {
+  if (version) {
+    return `${pkgManagerName}:${name}@${version}`;
+  }
+
+  return `${pkgManagerName}:${name}`;
+}
+
+function pkgToComponent(
+  graph: DepGraph,
+  pkg: { name: string; version?: string | null },
+): CycloneDxComponent {
+  const bomRef = buildBomRef(graph.pkgManager.name, pkg.name, pkg.version);
+  const component: CycloneDxComponent = {
+    type: "library",
+    name: pkg.name,
+    "bom-ref": bomRef,
+  };
+
+  if (pkg.version) {
+    component.version = pkg.version;
+  }
+
+  return component;
+}
+
+export function depGraphsToCycloneDx(
+  graphs: DepGraph | DepGraph[],
+  options?: DepGraphsToCycloneDxOptions,
+): CycloneDxDocument {
+  const graphList = Array.isArray(graphs) ? graphs : [graphs];
+
+  // Components from all graphs are merged; entries sharing the same bom-ref
+  // (pkgManager.name:name or pkgManager.name:name@version) collapse to one.
+  const componentsByRef = new Map<string, CycloneDxComponent>();
+
+  for (const graph of graphList) {
+    for (const pkg of graph.getDepPkgs()) {
+      const component = pkgToComponent(graph, pkg);
+      if (!componentsByRef.has(component["bom-ref"])) {
+        componentsByRef.set(component["bom-ref"], component);
+      }
+    }
+  }
+
+  const document: CycloneDxDocument = {
+    bomFormat: "CycloneDX",
+    specVersion: "1.5",
+    version: 1,
+    components: Array.from(componentsByRef.values()),
+  };
+
+  if (options?.serialNumber) {
+    document.serialNumber = options.serialNumber;
+  }
+
+  if (options?.timestamp) {
+    document.metadata = { timestamp: options.timestamp };
+  }
+
+  return document;
+}

--- a/lib/sbom/cyclonedx.ts
+++ b/lib/sbom/cyclonedx.ts
@@ -1,9 +1,51 @@
 import { DepGraph } from "@snyk/dep-graph";
+import { PackageURL } from "packageurl-js";
 import {
   CycloneDxComponent,
   CycloneDxDocument,
   DepGraphsToCycloneDxOptions,
 } from "./types";
+
+// Purl types per https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst,
+// keyed by the pkgManager.name values this repo's dep-graph builders emit. A manager
+// with no entry here omits the purl rather than emit a bogus type.
+const PURL_TYPE_BY_PKG_MANAGER: Record<string, string> = {
+  deb: "deb",
+  apk: "apk",
+  rpm: "rpm",
+  npm: "npm",
+  pip: "pypi",
+  nuget: "nuget",
+  golang: "golang",
+  maven: "maven",
+  composer: "composer",
+  gem: "gem",
+};
+
+function buildPurl(
+  pkgManagerName: string,
+  name: string,
+  version?: string | null,
+): string | undefined {
+  const purlType = PURL_TYPE_BY_PKG_MANAGER[pkgManagerName];
+  if (!purlType) {
+    return undefined;
+  }
+
+  // component.name keeps the dep-graph package name verbatim (e.g. the
+  // `source/binary` form minted by depFullName); the purl only wants the
+  // last segment.
+  const purlName = name.slice(name.lastIndexOf("/") + 1);
+
+  return new PackageURL(
+    purlType,
+    undefined,
+    purlName,
+    version ?? undefined,
+    undefined,
+    undefined,
+  ).toString();
+}
 
 function buildBomRef(
   pkgManagerName: string,
@@ -30,6 +72,11 @@ function pkgToComponent(
 
   if (pkg.version) {
     component.version = pkg.version;
+  }
+
+  const purl = buildPurl(graph.pkgManager.name, pkg.name, pkg.version);
+  if (purl) {
+    component.purl = purl;
   }
 
   return component;

--- a/lib/sbom/index.ts
+++ b/lib/sbom/index.ts
@@ -1,0 +1,6 @@
+export { depGraphsToCycloneDx } from "./cyclonedx";
+export {
+  CycloneDxComponent,
+  CycloneDxDocument,
+  DepGraphsToCycloneDxOptions,
+} from "./types";

--- a/lib/sbom/types.ts
+++ b/lib/sbom/types.ts
@@ -1,0 +1,22 @@
+export interface CycloneDxComponent {
+  type: "library";
+  name: string;
+  version?: string;
+  "bom-ref": string;
+}
+
+export interface CycloneDxDocument {
+  bomFormat: "CycloneDX";
+  specVersion: "1.5";
+  version: 1;
+  components: CycloneDxComponent[];
+  serialNumber?: string;
+  metadata?: {
+    timestamp?: string;
+  };
+}
+
+export interface DepGraphsToCycloneDxOptions {
+  serialNumber?: string;
+  timestamp?: string;
+}

--- a/lib/sbom/types.ts
+++ b/lib/sbom/types.ts
@@ -2,6 +2,7 @@ export interface CycloneDxComponent {
   type: "library";
   name: string;
   version?: string;
+  purl?: string;
   "bom-ref": string;
 }
 

--- a/test/lib/sbom/cyclonedx.spec.ts
+++ b/test/lib/sbom/cyclonedx.spec.ts
@@ -1,0 +1,168 @@
+import { DepGraph, DepGraphBuilder } from "@snyk/dep-graph";
+import { depGraphsToCycloneDx } from "../../../lib/sbom/cyclonedx";
+
+function buildGraph(
+  pkgManagerName: string,
+  rootName: string,
+  deps: Array<{ name: string; version?: string }>,
+): DepGraph {
+  const builder = new DepGraphBuilder(
+    { name: pkgManagerName },
+    { name: rootName, version: "0.0.0" },
+  );
+
+  deps.forEach((dep, index) => {
+    const nodeId = `node-${index}`;
+    builder.addPkgNode({ name: dep.name, version: dep.version }, nodeId);
+    builder.connectDep(builder.rootNodeId, nodeId);
+  });
+
+  return builder.build();
+}
+
+describe("depGraphsToCycloneDx", () => {
+  it("emits the required top-level CycloneDX fields", () => {
+    const graph = buildGraph("npm", "app", []);
+
+    const document = depGraphsToCycloneDx(graph);
+
+    expect(document.bomFormat).toBe("CycloneDX");
+    expect(document.specVersion).toBe("1.5");
+    expect(document.version).toBe(1);
+  });
+
+  it("returns an empty components array when given an empty list of graphs", () => {
+    const document = depGraphsToCycloneDx([]);
+
+    expect(document.components).toEqual([]);
+  });
+
+  it("builds a bom-ref of pkgManager:name@version and includes the purl for a mapped package manager", () => {
+    const graph = buildGraph("npm", "root-app", [
+      { name: "lodash", version: "4.17.21" },
+    ]);
+
+    const document = depGraphsToCycloneDx(graph);
+
+    expect(document.components).toEqual([
+      {
+        type: "library",
+        name: "lodash",
+        version: "4.17.21",
+        purl: "pkg:npm/lodash@4.17.21",
+        "bom-ref": "npm:lodash@4.17.21",
+      },
+    ]);
+  });
+
+  it("omits the version key and the bom-ref version suffix when a package has no version", () => {
+    const graph = buildGraph("pip", "root-app", [{ name: "some-pkg" }]);
+
+    const document = depGraphsToCycloneDx(graph);
+
+    expect(document.components).toEqual([
+      {
+        type: "library",
+        name: "some-pkg",
+        purl: "pkg:pypi/some-pkg",
+        "bom-ref": "pip:some-pkg",
+      },
+    ]);
+  });
+
+  it("omits purl for a package manager with no known purl type mapping", () => {
+    const graph = buildGraph("pnpm", "root-app", [
+      { name: "widget", version: "1.0.0" },
+    ]);
+
+    const document = depGraphsToCycloneDx(graph);
+
+    expect(document.components).toEqual([
+      {
+        type: "library",
+        name: "widget",
+        version: "1.0.0",
+        "bom-ref": "pnpm:widget@1.0.0",
+      },
+    ]);
+  });
+
+  it("keeps the verbatim source/binary name on the component while the purl only uses the segment after the last '/'", () => {
+    const graph = buildGraph("deb", "os", [
+      { name: "glibc/libc-bin", version: "2.31" },
+    ]);
+
+    const document = depGraphsToCycloneDx(graph);
+
+    expect(document.components).toEqual([
+      {
+        type: "library",
+        name: "glibc/libc-bin",
+        version: "2.31",
+        purl: "pkg:deb/libc-bin@2.31",
+        "bom-ref": "deb:glibc/libc-bin@2.31",
+      },
+    ]);
+  });
+
+  it("dedupes components sharing the same bom-ref across multiple graphs", () => {
+    const graphA = buildGraph("npm", "app-a", [
+      { name: "shared-lib", version: "1.0.0" },
+    ]);
+    const graphB = buildGraph("npm", "app-b", [
+      { name: "shared-lib", version: "1.0.0" },
+    ]);
+
+    const document = depGraphsToCycloneDx([graphA, graphB]);
+
+    expect(document.components).toHaveLength(1);
+    expect(document.components[0]["bom-ref"]).toBe("npm:shared-lib@1.0.0");
+  });
+
+  it("keeps components as distinct entries when the same name@version appears under different package managers", () => {
+    const graphA = buildGraph("pip", "app", [
+      { name: "requests", version: "2.31.0" },
+    ]);
+    const graphB = buildGraph("deb", "os", [
+      { name: "requests", version: "2.31.0" },
+    ]);
+
+    const document = depGraphsToCycloneDx([graphA, graphB]);
+
+    expect(document.components.map((c) => c["bom-ref"]).sort()).toEqual([
+      "deb:requests@2.31.0",
+      "pip:requests@2.31.0",
+    ]);
+  });
+
+  it("treats a single DepGraph the same as an array containing only that graph", () => {
+    const graph = buildGraph("npm", "app", [
+      { name: "left-pad", version: "1.3.0" },
+    ]);
+
+    expect(depGraphsToCycloneDx(graph)).toEqual(depGraphsToCycloneDx([graph]));
+  });
+
+  it("omits serialNumber and metadata by default", () => {
+    const graph = buildGraph("npm", "app", []);
+
+    const document = depGraphsToCycloneDx(graph);
+
+    expect(document.serialNumber).toBeUndefined();
+    expect(document.metadata).toBeUndefined();
+  });
+
+  it("includes serialNumber and metadata.timestamp only when provided via options", () => {
+    const graph = buildGraph("npm", "app", []);
+
+    const document = depGraphsToCycloneDx(graph, {
+      serialNumber: "urn:uuid:1234",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+
+    expect(document.serialNumber).toBe("urn:uuid:1234");
+    expect(document.metadata).toEqual({
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

lib/sbom is a new, self-contained module built around a pure depGraphsToCycloneDx(graphs, options?) function that converts @snyk/dep-graph DepGraph instances, the same graphs the OS and application scanners build, into a CycloneDX 1.5 JSON document. Components come from each graph's getDepPkgs(), identified by a bom-ref of pkgManager:name@version (or pkgManager:name when the version is unknown) and deduped by that ref, so a package pulled in by two graphs collapses into one component while the same name@version under a different package manager stays distinct. Purls are attached for a fixed set of known ecosystems (deb, apk, rpm, npm, pip, nuget, golang, maven, composer, gem) and omitted for anything else rather than guessed. The function has no dependency on the clock, randomness, the filesystem, or the network; serialNumber and timestamp appear in the output only when passed in explicitly via options, keeping results deterministic for testing. Unit tests in test/lib/sbom/cyclonedx.spec.ts cover the required document fields, missing-version handling, purl inclusion and omission, cross-graph dedupe, and single-graph-vs-array equivalence. Nothing outside lib/sbom is imported or modified, so this lands as a library building block with no effect on any existing CLI or scan flow. The diff also includes a binary file, test/system/save/image.tar, unrelated to the SBOM work.

## Acceptance criteria

1. A new exported function/module exists that accepts one or more dependency-graph objects (of the type/shape already produced by the existing application and OS package scanners) and returns a CycloneDX JSON SBOM document.
2. The output document is valid CycloneDX JSON: includes required top-level fields (bomFormat, specVersion, version, components) per the CycloneDX schema version targeted.
3. Each package/dependency node in the input graph(s) is represented as a component in the output, preserving at minimum name and version.
4. The function works given only an OS package dependency graph as input (no application graph).
5. The function works given only an application dependency graph as input (no OS graph).
6. The function works given both an OS and an application dependency graph as input, producing a single combined SBOM document.
7. Unit tests exist covering: OS-only input, application-only input, combined input, and at least one edge case (e.g. empty/no-dependency graph).
8. The module is self-contained: it is not called from any existing CLI, plugin entrypoint, or scan orchestration code as part of this change.
9. The module compiles/type-checks and its unit tests pass in isolation.

## Not in this branch

The plan had work this branch does not carry:

- `sbom-cyclonedx-tests` (done when: `npm ci && npm run test:unit -- test/lib/sbom/cyclonedx.spec.ts` passes and its output shows at least five cases, one each for: an OS-only graph (built with `new DepGraphBuilder({ name: "deb" }, ...)` or `legacy.depTreeToGraph` over an OS-shaped dep tree, including one `source/binary`-style name such as `glibc/libc-bin`), an application-only graph (e.g. `{ name: "npm" }` or `{ name: "pip" }`), both graphs passed together, an empty/no-dependency graph, and a package with no version. The spec asserts `bomFormat === "CycloneDX"`, a non-empty `specVersion`, `version === 1` and `Array.isArray(components)` on every case; asserts each expected package appears in `components` with its exact `name` and `version`; asserts the combined case yields one document whose `components` contains packages from both inputs and whose `bom-ref` values are unique (`new Set(refs).size === components.length`), including for a package present in both input graphs; asserts the empty-graph case returns a well-formed document with `components: []` rather than throwing; and asserts the no-version case emits a component with no `version` key at all (`expect(component).not.toHaveProperty("version")`) and a ref that is the bare `manager:name`. Any edit to `lib/sbom/cyclonedx.ts` in this task is a bug fix needed to make those assertions pass — the exported signature and the CycloneDX field set from the previous task stay as they are, `npm ci && npm run build` still exits 0 after the edit, and no import of the module is added outside `lib/sbom/` and this spec (`grep -rn "lib/sbom\|sbom/cyclonedx" lib test --include=*.ts` matches only `lib/sbom/` and `test/lib/sbom/cyclonedx.spec.ts`).): the builder call itself failed: pipeline: builder:sbom-cyclonedx-tests:retry: exit: cursor create returned HTTP 400 (validation_error): [invalid_argument] Error

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `sbom-cyclonedx-module`: Added self-contained lib/sbom module exporting depGraphsToCycloneDx(DepGraph | DepGraph[], options?). Returns CycloneDX 1.5 documents with bomFormat, specVersion, version: 1, and components built from getDepPkgs(). bom-ref is pkgManager.name:name@version (degrades to pkgManager.name:name when version absent); components deduped by bom-ref via Map with an inline comment. Missing versions omit the version key. Optional serialNumber/timestamp pass through options only — no Date.now(), new Date(), randomUUID, fs, or network I/O. npm ci && npm run build exits 0. Manual verification confirms OS-only, app-only, combined (length-2 array), empty-graph, no-version, and cross-graph dedupe cases. Scope checks pass: git status --porcelain lists only lib/sbom/, and grep finds no imports outside lib/sbom/. npm run test:unit reports 4 failures in test/lib/display.spec.ts (chalk color codes without TTY) — pre-existing, unrelated to this diff; 62 other suites pass. | gate "npm run test:unit" passed in 5335ms
- `final:build`: `npm run build` passed in 3793ms
- `final:test_unit`: `npm run test:unit` passed in 3676ms
- `final:lint`: `npm run lint` passed in 2572ms
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch, and nothing regressed against the base commit.

## Decisions taken without asking

- When both an application graph and an OS graph are provided, should the function produce one combined CycloneDX document or two separate documents (one per graph)?
  - took: Produce a single combined CycloneDX document containing components from both graphs, since a container image conceptually has one SBOM covering all its packages.
  - alternative: Produce two independent SBOM documents, mirroring the plugin's existing separation of app-scan and OS-scan results, and leave merging to the caller.

## Assumptions

- The 'dependency graphs already produced by snyk-docker-plugin's application and OS package scanners' refers to existing in-repo data structures (likely the @snyk/dep-graph type or similar) that this task must consume as-is rather than redesign.
- CycloneDX JSON is the target format, per the request's example, rather than SPDX or another SBOM standard.
- 'Self-contained library function' means a pure/stateless transform (input graph(s) in, SBOM document out) with no I/O, file writing, or network calls.
- The module should live within the snyk-docker-plugin repository as a new file/directory rather than a separate package, since no new-repo instruction was given.
- Combining an application graph and an OS graph into one SBOM (rather than producing two separate SBOM documents) is the intended behavior when both are supplied.
- 'Standard SBOM document' means schema-valid CycloneDX output; deep semantic correctness against every optional CycloneDX field is out of scope as long as required fields and component data are present.

## Run

- Run: `20260812-123243-506f`
- Origin: 
- Base: `224d0f11abcb0e726a872f35078ece03a40e98ce`
- Head: `8335311df103bb9fb1c29e535aa4f4f1555e50b7`

Human review is required. This automation never merges or marks a PR ready.
