### PR TITLE
feat(sbom): wire sbom-format option into scan pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Others:
 - running on Windows (_not_ the same as scanning Windows containers)
 - collecting the `rootFs` hashes for base image detection and recommendation
 
+## SBOM generation
+
+Pass `--sbom-format=cyclonedx1.5+json` when scanning an image to request a
+Software Bill of Materials (SBOM) for the image's dependencies. The only
+supported value is `cyclonedx1.5+json`, which produces a CycloneDX 1.5 JSON
+document.
+
+When the option is supplied, the scan response includes an `sbom` fact on the
+first scan result (the OS dependencies result). The fact's `data` field
+contains the CycloneDX document with `bomFormat: "CycloneDX"`,
+`specVersion: "1.5"`, and `version: 1`. When the option is omitted, no `sbom`
+fact is emitted and scan behavior is unchanged.
+
 ## Tests
 
 Refer to [test/README.md](test/README.md) for running and writing tests.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ contains the CycloneDX document with `bomFormat: "CycloneDX"`,
 `specVersion: "1.5"`, and `version: 1`. When the option is omitted, no `sbom`
 fact is emitted and scan behavior is unchanged.
 
+For example, scanning a `docker-archive` image with the option set:
+
+```js
+const { scan } = require("snyk-docker-plugin");
+
+const result = await scan({
+  path: "docker-archive:./image.tar",
+  "sbom-format": "cyclonedx1.5+json",
+});
+
+const sbomFact = result.scanResults[0].facts.find(
+  (fact) => fact.type === "sbom",
+);
+```
+
+`sbomFact.data` is the CycloneDX document, with these top-level fields:
+
+```json
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "components": [
+    { "type": "library", "name": "...", "version": "...", "bom-ref": "...", "purl": "..." }
+  ]
+}
+```
+
 ## Tests
 
 Refer to [test/README.md](test/README.md) for running and writing tests.

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -1,4 +1,5 @@
 import { DepGraph } from "@snyk/dep-graph";
+import { CycloneDxDocument } from "./sbom/types";
 import { ApplicationFiles } from "./analyzer/applications/types";
 import { ApkPackageOwnership } from "./analyzer/package-managers/apk-ownership";
 import { JarFingerprint } from "./analyzer/types";
@@ -184,4 +185,9 @@ export interface ApkPackageOwnershipFact {
   type: "apkPackageOwnership";
   // Shape owned by the resolver so the contract and the lib stay in lockstep.
   data: ApkPackageOwnership;
+}
+
+export interface SbomFact {
+  type: "sbom";
+  data: CycloneDxDocument;
 }

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -18,6 +18,7 @@ import { OCIDistributionMetadata } from "./extractor/oci-distribution-metadata";
 import { parseProvenanceAttestations } from "./extractor/provenance-parser";
 
 import { computeScanPayloadMetrics } from "./scan-payload-metrics";
+import { depGraphsToCycloneDx, parseSbomFormat } from "./sbom";
 import * as types from "./types";
 import { truncateAdditionalFacts } from "./utils";
 import { PLUGIN_VERSION } from "./version";
@@ -438,6 +439,23 @@ async function buildResponse(
     ...result,
     facts: truncateAdditionalFacts(result.facts || []),
   }));
+
+  const sbomFormat = parseSbomFormat(options?.["sbom-format"]);
+  if (sbomFormat) {
+    const depGraphs = truncatedScanResults
+      .map((result) => result.facts.find((f) => f.type === "depGraph")?.data)
+      .filter(
+        (data): data is NonNullable<typeof data> =>
+          data != null && typeof data.getDepPkgs === "function",
+      );
+
+    const sbomDocument = depGraphsToCycloneDx(depGraphs);
+    const sbomFact: facts.SbomFact = {
+      type: "sbom",
+      data: sbomDocument,
+    };
+    truncatedScanResults[0].facts.push(sbomFact);
+  }
 
   const scanPayloadMetrics = computeScanPayloadMetrics(truncatedScanResults);
 

--- a/lib/sbom/format.ts
+++ b/lib/sbom/format.ts
@@ -1,0 +1,27 @@
+export type SbomFormat = "cyclonedx1.5+json";
+
+const SUPPORTED_SBOM_FORMAT = "cyclonedx1.5+json";
+
+/**
+ * Parses and validates the `sbom-format` plugin option.
+ *
+ * @returns the normalized format when SBOM generation is requested, otherwise
+ * `undefined` when the option is absent.
+ * @throws when the value is present but not a supported format.
+ */
+export function parseSbomFormat(
+  value?: boolean | string | null,
+): SbomFormat | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === SUPPORTED_SBOM_FORMAT) {
+    return SUPPORTED_SBOM_FORMAT;
+  }
+
+  throw new Error(
+    `Unsupported SBOM format: ${value}. Supported values: ${SUPPORTED_SBOM_FORMAT}`,
+  );
+}

--- a/lib/sbom/index.ts
+++ b/lib/sbom/index.ts
@@ -1,4 +1,5 @@
 export { depGraphsToCycloneDx } from "./cyclonedx";
+export { parseSbomFormat, SbomFormat } from "./format";
 export {
   CycloneDxComponent,
   CycloneDxDocument,

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -17,6 +17,7 @@ import {
   resolveNestedJarsOption,
 } from "./option-utils";
 import * as staticModule from "./static";
+import { parseSbomFormat } from "./sbom";
 import { ImageType, PluginOptions, PluginResponse } from "./types";
 import { isValidDockerImageReference } from "./utils";
 
@@ -82,6 +83,8 @@ async function getAnalysisParameters(
       "--nested-jars-depth accepts only numbers bigger than or equal to 0",
     );
   }
+
+  parseSbomFormat(options["sbom-format"]);
 
   // TODO temporary solution to avoid double results for PHP if exists in `globsToFind`
   if (options.globsToFind) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,6 +54,7 @@ export interface ImageNameInfo {
 export type FactType =
   | "autoDetectedUserInstructions"
   | "depGraph"
+  | "sbom"
   | "dockerfileAnalysis"
   | "history"
   | "imageCreationTime"
@@ -250,6 +251,13 @@ export interface PluginOptions {
 
   /** Compute and emit per-layer package attribution. The default is "false". */
   "layer-attribution": boolean | string;
+
+  /**
+   * Request SBOM generation for the scanned image. When set, the scan result
+   * includes an `sbom` fact containing a CycloneDX document.
+   * Supported value: `cyclonedx1.5+json`.
+   */
+  "sbom-format": boolean | string;
 
   "target-reference": string;
 

--- a/test/lib/response-builder.spec.ts
+++ b/test/lib/response-builder.spec.ts
@@ -2132,8 +2132,38 @@ describe("buildResponse", () => {
   });
 
   describe("sbom generation", () => {
-    it("emits an sbom fact on the OS scan result when sbom-format is cyclonedx1.5+json", async () => {
-      const analysis = createMockAnalysis({ platform: "linux/amd64" });
+    const depsWithNamedOsPkg = {
+      curl: node("curl").build(),
+    };
+
+    const osDepTreeOverrides = {
+      depTree: {
+        dependencies: structuredClone(depsWithNamedOsPkg),
+        name: "my-image",
+        version: "1.0.0",
+        packageFormatVersion: "apk:0.0.1",
+        targetOS: {
+          name: "alpine",
+          prettyName: "Alpine 3.18",
+          version: "3.18",
+        },
+      },
+      packageFormat: "apk",
+    };
+
+    const expectedOsComponent = {
+      type: "library",
+      name: "curl",
+      version: "1.0",
+      "bom-ref": "apk:curl@1.0",
+      purl: "pkg:apk/curl@1.0",
+    };
+
+    it("emits an sbom fact on the OS scan result with components built from the OS depGraph when sbom-format is cyclonedx1.5+json", async () => {
+      const analysis = createMockAnalysis({
+        platform: "linux/amd64",
+        ...osDepTreeOverrides,
+      });
 
       const result = await buildResponse(
         analysis as any,
@@ -2155,11 +2185,13 @@ describe("buildResponse", () => {
           version: 1,
         }),
       );
+      expect(sbomFact?.data.components).toEqual([expectedOsComponent]);
     });
 
-    it("still emits an sbom fact when an app scan result only has jarFingerprints", async () => {
+    it("filters out an app scan result that only has jarFingerprints, while the OS depGraph's packages still make it into the components", async () => {
       const analysis = createMockAnalysis({
         platform: "linux/amd64",
+        ...osDepTreeOverrides,
         applicationDependenciesScanResults: [
           {
             facts: [
@@ -2191,18 +2223,13 @@ describe("buildResponse", () => {
         (fact) => fact.type === "sbom",
       );
       expect(sbomFact).toBeDefined();
-      expect(sbomFact?.data).toEqual(
-        expect.objectContaining({
-          bomFormat: "CycloneDX",
-          specVersion: "1.5",
-          version: 1,
-        }),
-      );
+      expect(sbomFact?.data.components).toEqual([expectedOsComponent]);
     });
 
-    it("still emits an sbom fact when an app scan result has a placeholder depGraph", async () => {
+    it("filters out an app scan result with a placeholder depGraph, while the OS depGraph's packages still make it into the components", async () => {
       const analysis = createMockAnalysis({
         platform: "linux/amd64",
+        ...osDepTreeOverrides,
         applicationDependenciesScanResults: [
           {
             facts: [{ type: "depGraph" as const, data: {} as any }],
@@ -2225,13 +2252,7 @@ describe("buildResponse", () => {
         (fact) => fact.type === "sbom",
       );
       expect(sbomFact).toBeDefined();
-      expect(sbomFact?.data).toEqual(
-        expect.objectContaining({
-          bomFormat: "CycloneDX",
-          specVersion: "1.5",
-          version: 1,
-        }),
-      );
+      expect(sbomFact?.data.components).toEqual([expectedOsComponent]);
     });
 
     it("does not emit an sbom fact when sbom-format is omitted", async () => {

--- a/test/lib/response-builder.spec.ts
+++ b/test/lib/response-builder.spec.ts
@@ -2130,4 +2130,120 @@ describe("buildResponse", () => {
       expect(pluginWarnings).toBeUndefined();
     });
   });
+
+  describe("sbom generation", () => {
+    it("emits an sbom fact on the OS scan result when sbom-format is cyclonedx1.5+json", async () => {
+      const analysis = createMockAnalysis({ platform: "linux/amd64" });
+
+      const result = await buildResponse(
+        analysis as any,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        { "sbom-format": "cyclonedx1.5+json" },
+      );
+
+      const sbomFact = result.scanResults[0].facts?.find(
+        (fact) => fact.type === "sbom",
+      );
+      expect(sbomFact).toBeDefined();
+      expect(sbomFact?.data).toEqual(
+        expect.objectContaining({
+          bomFormat: "CycloneDX",
+          specVersion: "1.5",
+          version: 1,
+        }),
+      );
+    });
+
+    it("still emits an sbom fact when an app scan result only has jarFingerprints", async () => {
+      const analysis = createMockAnalysis({
+        platform: "linux/amd64",
+        applicationDependenciesScanResults: [
+          {
+            facts: [
+              {
+                type: "jarFingerprints" as const,
+                data: {
+                  fingerprints: [],
+                  origin: "java",
+                  path: "/app/lib/app.jar",
+                },
+              },
+            ],
+            identity: { type: "maven" },
+            target: { image: "test-app" },
+          },
+        ],
+      });
+
+      const result = await buildResponse(
+        analysis as any,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        { "sbom-format": "cyclonedx1.5+json" },
+      );
+
+      const sbomFact = result.scanResults[0].facts?.find(
+        (fact) => fact.type === "sbom",
+      );
+      expect(sbomFact).toBeDefined();
+      expect(sbomFact?.data).toEqual(
+        expect.objectContaining({
+          bomFormat: "CycloneDX",
+          specVersion: "1.5",
+          version: 1,
+        }),
+      );
+    });
+
+    it("still emits an sbom fact when an app scan result has a placeholder depGraph", async () => {
+      const analysis = createMockAnalysis({
+        platform: "linux/amd64",
+        applicationDependenciesScanResults: [
+          {
+            facts: [{ type: "depGraph" as const, data: {} as any }],
+            identity: { type: "npm" },
+            target: { image: "test-app" },
+          },
+        ],
+      });
+
+      const result = await buildResponse(
+        analysis as any,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        { "sbom-format": "cyclonedx1.5+json" },
+      );
+
+      const sbomFact = result.scanResults[0].facts?.find(
+        (fact) => fact.type === "sbom",
+      );
+      expect(sbomFact).toBeDefined();
+      expect(sbomFact?.data).toEqual(
+        expect.objectContaining({
+          bomFormat: "CycloneDX",
+          specVersion: "1.5",
+          version: 1,
+        }),
+      );
+    });
+
+    it("does not emit an sbom fact when sbom-format is omitted", async () => {
+      const analysis = createMockAnalysis({ platform: "linux/amd64" });
+
+      const result = await buildResponse(analysis as any, undefined, false);
+
+      for (const scanResult of result.scanResults) {
+        expect(scanResult.facts?.some((fact) => fact.type === "sbom")).toBe(
+          false,
+        );
+      }
+    });
+  });
 });

--- a/test/lib/sbom/format.spec.ts
+++ b/test/lib/sbom/format.spec.ts
@@ -1,0 +1,25 @@
+import { parseSbomFormat } from "../../../lib/sbom/format";
+
+describe("parseSbomFormat", () => {
+  it.each([
+    ["cyclonedx1.5+json", "cyclonedx1.5+json"],
+    ["  CYCLONEDX1.5+JSON  ", "cyclonedx1.5+json"],
+  ])("accepts %s", (input, expected) => {
+    expect(parseSbomFormat(input)).toBe(expected);
+  });
+
+  it.each([undefined, null, ""])(
+    "returns undefined for absent value %p",
+    (input) => {
+      expect(parseSbomFormat(input)).toBeUndefined();
+    },
+  );
+
+  it.each(["spdx2.3+json", true, "nonsense"])(
+    "rejects unsupported value %p with a message naming the value and cyclonedx1.5+json",
+    (input) => {
+      expect(() => parseSbomFormat(input)).toThrow(String(input));
+      expect(() => parseSbomFormat(input)).toThrow("cyclonedx1.5+json");
+    },
+  );
+});

--- a/test/lib/scan.spec.ts
+++ b/test/lib/scan.spec.ts
@@ -1,6 +1,7 @@
 import {
   appendLatestTagIfMissing,
   mergeEnvVarsIntoCredentials,
+  scan,
 } from "../../lib/scan";
 
 describe("mergeEnvVarsIntoCredentials", () => {
@@ -104,6 +105,26 @@ describe("appendLatestTagIfMissing", () => {
     const imageWithoutTag = "image";
     expect(appendLatestTagIfMissing(imageWithoutTag)).toEqual(
       `${imageWithoutTag}:latest`,
+    );
+  });
+});
+
+describe("scan sbom-format validation", () => {
+  it("rejects unsupported sbom-format before archive access", async () => {
+    await expect(
+      scan({
+        path: "docker-archive:not-here.tar",
+        "sbom-format": "spdx2.3+json",
+      }),
+    ).rejects.toThrow("spdx2.3+json");
+
+    await expect(
+      scan({
+        path: "docker-archive:not-here.tar",
+        "sbom-format": "spdx2.3+json",
+      }),
+    ).rejects.not.toThrow(
+      "The provided archive path does not exist on the filesystem",
     );
   });
 });


### PR DESCRIPTION
## Summary

Connects the CycloneDX generator (lib/sbom/cyclonedx.ts) to the scan pipeline via a new `sbom-format` plugin option. `getAnalysisParameters` validates the option before any image or archive access: the only accepted value is `cyclonedx1.5+json` (case-insensitive, trimmed), and anything else, including the bare boolean a valueless CLI flag would pass, throws immediately. When a valid format is requested, `buildResponse` gathers depGraph data from scan results that expose a callable `getDepPkgs`, skipping app results that carry only `jarFingerprints` or a placeholder `depGraph`, runs the result through `depGraphsToCycloneDx`, and attaches the document as a new `sbom` fact on the OS scan result, after fact truncation and before payload-metrics computation. No `serialNumber` or `timestamp` is passed, so output is deterministic. When the option is omitted, no `sbom` fact appears and scan output is unchanged.

Adds `SbomFact`/`sbom` to the fact and type definitions, with unit tests covering the parser's accept, absent, and reject cases, a scan-level test confirming format validation runs before archive access, and response-builder tests covering the emitted SBOM shape and the two graph-filtering cases. The README documents the new option and its response shape.

The diff also modifies the binary fixture at `test/system/save/image.tar`; reviewers should confirm this is an intended update rather than incidental corruption before merging.

Test coverage is unit-level only. There is no end-to-end system test exercising the option against a docker-archive fixture.

## Acceptance criteria

1. Running `snyk container test IMAGE --sbom-format=<format>` invokes the existing SBOM generator (via the docker-plugin scan pipeline) rather than a new/duplicate implementation.
2. The CLI flag is registered on the container test command surface with a recognizable name (e.g. sbom-format) and documented supported values.
3. When the flag is supplied, the command outputs (to stdout or a file, per existing CLI output conventions) the SBOM document produced by the generator for the scanned image.
4. When the flag is omitted, `snyk container test` behavior and output are unchanged from before this change.
5. Supplying an unsupported/invalid value for the flag produces a clear, non-crashing error message.
6. A new end-to-end/system test exercises the real CLI/plugin pipeline (not a mocked generator) against a docker-archive image fixture and asserts a well-formed, correct SBOM document is produced.
7. The system test's fixture is a docker-archive source (a local tarball), not a live registry pull.

## Not in this branch

The plan had work this branch does not carry:

- `sbom-system-test` (done when: `npm run test:system -- test/system/flags/sbom-format.spec.ts` passes. The new spec sits beside the other flag specs in `test/system/flags/`, imports `scan` from `../../../lib` and `getFixture` from `../../util` exactly as `test/system/flags/include-system-jars.spec.ts:1-2` does, mocks nothing, adds no file under any `__snapshots__/` directory and no new fixture (all three archives already exist), and contains four cases: (1) `scan({ path: `docker-archive:${getFixture("docker-archives/docker-save/nginx.tar")}`, "sbom-format": "cyclonedx1.5+json" })` returns an `sbom` fact on `scanResults[0]` whose document has `bomFormat: "CycloneDX"`, `specVersion: "1.5"`, `version: 1`, a non-empty `components` array where every entry has `type: "library"`, a non-empty `name` and a non-empty `bom-ref`, every present `purl` starts with `pkg:`, and whose set of `bom-ref` values equals the set computed from `getDepPkgs()` over the `depGraph` fact of every scan result that actually has one (skip results with no `depGraph` fact — set equality, not a count, so the generator's cross-graph bom-ref dedupe cannot fail the test); (2) the same call over `npm/multi-project-image.tar` (no `platform`, no `app-vulns`, mirroring `test/system/application-scans/node.spec.ts:212-214`) produces a single document in which every bom-ref derived from the OS `depGraph` on `scanResults[0]` appears in `components` and at least one component `purl` starts with `pkg:npm/` — the merge asserted from the scan's own data, with no hardcoded package names or counts; (3) the same call over `docker-archives/docker-save/java.tar`, whose maven results carry only `jarFingerprints` facts, resolves without throwing and still returns a well-formed `sbom` fact on `scanResults[0]` — this is the regression guard for the filter-then-map collection rule; (4) the same scan with `sbom-format` omitted returns no fact of type `sbom` on any scan result. `README.md` gains, under the SBOM section added by `sbom-option-and-generation`, a short worked example naming the docker-archive form of the flag and the top-level fields of the emitted document.): the builder call itself failed: pipeline: builder:sbom-system-test:retry: exit: cursor create returned HTTP 400 (validation_error): [invalid_argument] Error

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `sbom-option-and-generation`: Implemented sbom-format option end-to-end: parseSbomFormat in lib/sbom/format.ts (re-exported from lib/sbom/index.ts) validates cyclonedx1.5+json case-insensitively and rejects other values early in getAnalysisParameters; PluginOptions and FactType extended; SbomFact added; buildResponse collects depGraphs with callable getDepPkgs, calls depGraphsToCycloneDx without serialNumber/timestamp, and attaches one sbom fact to scanResults[0] after truncation; README documents the option. All new/extended unit tests pass (944/944 with FORCE_COLOR=1; 940/944 without — 4 pre-existing display.spec.ts ANSI failures on base commit, unrelated to this change). Pushed to cursor/sbom-format-option-a007. | gate "npm run test:unit" passed in 5163ms
- `final:build`: `npm run build` passed in 3747ms
- `final:test_unit`: `npm run test:unit` passed in 3342ms
- `final:lint`: `npm run lint` passed in 2529ms
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch. Anything still failing against the base commit is in the open findings below.

## Open blocking findings

- [plan-conformance/dropped-readme-worked-example blocking] README.md: The sbom-system-test task requires README.md to gain, under the SBOM section, a short worked example naming the docker-archive form of the flag and the top-level fields of the emitted document. The diff's README addition (from sbom-option-and-generation) only documents the flag and fact generically; no worked example with a docker-archive invocation was added, because the sbom-system-test task's edits are entirely absent from the diff.

## Decisions taken without asking

- Should the SBOM flag apply only to `snyk container test`, or be wired as a shared flag across all `snyk test` variants?
  - took: Scope strictly to `snyk container test IMAGE` / the docker-plugin scan pipeline, as explicitly stated in the request.
  - alternative: Implement as a cross-cutting flag shared by all `snyk test` subcommands, which would broaden this slice significantly.
- When --sbom-format is passed, does the SBOM output replace the normal vulnerability test report, or is it emitted alongside it?
  - took: The SBOM document becomes the command's primary output when the flag is passed, suppressing the normal vulnerability report, mirroring typical SBOM-flag CLI UX.
  - alternative: Both the vulnerability test report and the SBOM document are produced together in the same invocation.

## Assumptions

- An SBOM generator already exists as a separate, already-implemented component that this slice only needs to invoke, not build.
- The exact flag name and value set (e.g. cyclonedx+json, spdx2.3+json) will follow existing project conventions for similar flags; the request's 'sbom-format' is illustrative, not mandatory.
- 'Returns/writes' means using existing CLI output mechanisms (stdout by default, file if a path/output flag is specified) rather than introducing a new output channel.
- 'End-to-end system test' means a test that runs the actual CLI/plugin code path against a real fixture file, not a unit test with the generator mocked out.
- The docker-archive fixture is a small test image tarball that either already exists in the test fixtures or needs to be added as part of this work.
- Supported SBOM formats are whatever the underlying generator already supports; this slice does not add new format support to the generator.

## Run

- Run: `20260812-125052-68c3`
- Origin: 
- Base: `8335311df103bb9fb1c29e535aa4f4f1555e50b7`
- Head: `1abf15802a3fa6d1314543337a7d7e3a1023dec0`

Human review is required. This automation never merges or marks a PR ready.
