### PR TITLE
docs(sbom): document SBOM format rules and limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Each component has a `bom-ref` of the form `pkgManager:name[@version]`. The
 `version` field is omitted when the package has no version. Duplicate
 `bom-ref` values across graphs collapse to a single component. The `purl`
 field is omitted when the package manager has no purl type mapping — in
-practice this applies to pnpm and Go (`gomodules`) components.
+practice this applies to yarn, pnpm, Poetry, and Go (`gomodules`)
+components.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -51,15 +51,25 @@ Others:
 Pass `--sbom-format=cyclonedx1.5+json` when scanning an image to request a
 Software Bill of Materials (SBOM) for the image's dependencies. The only
 supported value is `cyclonedx1.5+json`, which produces a CycloneDX 1.5 JSON
-document.
+document. The value is required — a bare `--sbom-format` flag or a boolean
+`true` is rejected. When the option is omitted, null, or empty, no SBOM is
+generated and scan behavior is unchanged.
+
+The option is validated before the image is read. Unsupported values throw an
+error listing the accepted format.
 
 When the option is supplied, the scan response includes an `sbom` fact on the
 first scan result (the OS dependencies result). The fact's `data` field
 contains the CycloneDX document with `bomFormat: "CycloneDX"`,
-`specVersion: "1.5"`, and `version: 1`. When the option is omitted, no `sbom`
-fact is emitted and scan behavior is unchanged.
+`specVersion: "1.5"`, and `version: 1`.
 
-For example, scanning a `docker-archive` image with the option set:
+For example, with the Snyk CLI flag:
+
+```
+--sbom-format=cyclonedx1.5+json
+```
+
+Or programmatically, scanning a `docker-archive` image:
 
 ```js
 const { scan } = require("snyk-docker-plugin");
@@ -86,6 +96,34 @@ const sbomFact = result.scanResults[0].facts.find(
   ]
 }
 ```
+
+A scan-produced SBOM does not include `serialNumber` or `metadata.timestamp`.
+
+### Limitations
+
+SBOM components come from `depGraph` facts the scan produces. Included
+ecosystems:
+
+- OS packages: deb, apk, rpm
+- Node (npm, yarn, pnpm)
+- Python: pip and Poetry
+- .NET (nuget)
+- Go (gomodules)
+- PHP (composer)
+
+Not included in the SBOM:
+
+- Java JAR dependencies — these yield a `jarFingerprints` fact only, with no
+  dep graph
+- Detect-only package manager manifests surfaced as `imageManifestFiles`
+- Application dependencies when `--exclude-app-vulns` is set
+- Node `node_modules` dependencies when `--exclude-node-modules` is set
+
+Each component has a `bom-ref` of the form `pkgManager:name[@version]`. The
+`version` field is omitted when the package has no version. Duplicate
+`bom-ref` values across graphs collapse to a single component. The `purl`
+field is omitted when the package manager has no purl type mapping — in
+practice this applies to pnpm and Go (`gomodules`) components.
 
 ## Tests
 

--- a/test/lib/sbom/cyclonedx.spec.ts
+++ b/test/lib/sbom/cyclonedx.spec.ts
@@ -87,6 +87,40 @@ describe("depGraphsToCycloneDx", () => {
     ]);
   });
 
+  it("omits purl for yarn components, which have no purl type mapping", () => {
+    const graph = buildGraph("yarn", "root-app", [
+      { name: "widget", version: "1.0.0" },
+    ]);
+
+    const document = depGraphsToCycloneDx(graph);
+
+    expect(document.components).toEqual([
+      {
+        type: "library",
+        name: "widget",
+        version: "1.0.0",
+        "bom-ref": "yarn:widget@1.0.0",
+      },
+    ]);
+  });
+
+  it("omits purl for poetry components, which have no purl type mapping", () => {
+    const graph = buildGraph("poetry", "root-app", [
+      { name: "widget", version: "1.0.0" },
+    ]);
+
+    const document = depGraphsToCycloneDx(graph);
+
+    expect(document.components).toEqual([
+      {
+        type: "library",
+        name: "widget",
+        version: "1.0.0",
+        "bom-ref": "poetry:widget@1.0.0",
+      },
+    ]);
+  });
+
   it("keeps the verbatim source/binary name on the component while the purl only uses the segment after the last '/'", () => {
     const graph = buildGraph("deb", "os", [
       { name: "glibc/libc-bin", version: "2.31" },


### PR DESCRIPTION
## Summary

The README's SBOM generation section documents the `sbom-format` option in full: `cyclonedx1.5+json` is the only accepted value, and a bare flag or a boolean `true` is rejected. It shows the CLI flag and the programmatic `scan()` call side by side, and notes that SBOM documents produced by a scan never include `serialNumber` or `metadata.timestamp`; those fields only appear when a caller passes options directly to the exported `depGraphsToCycloneDx` function.

A new Limitations subsection covers SBOM output specifically: which ecosystems' dependency graphs become components, which sources are excluded (Java JARs, detect-only manifests, `--exclude-app-vulns`, `--exclude-node-modules`), and which package managers omit `purl` because they have no purl-type mapping. Unit tests cover purl omission for pnpm, yarn, and Poetry components.

## Acceptance criteria

1. Documentation enumerates every SBOM format the plugin's implementation actually supports (e.g. by name/identifier), matching what the code accepts — no formats are invented or omitted.
2. Documentation shows the exact flag/option name and example invocation(s) needed to produce an SBOM, matching the current CLI/plugin argument parsing.
3. Documentation includes a limitations section or note stating which ecosystems' dependencies are included in the generated SBOM and, if applicable, which are excluded.
4. Documentation reflects only behavior that exists in the shipped implementation as of this change — no forward-looking or aspirational claims.
5. Existing documentation content unrelated to SBOM output is left intact (no unrelated rewrites).

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `readme-sbom-docs`: Extended the ## SBOM generation section: documented cyclonedx1.5+json as the sole required format (bare flag/boolean true rejected; omitting leaves scan unchanged), early validation before image read, both --sbom-format=cyclonedx1.5+json and scan({ "sbom-format": ... }) examples, explicit note that scan-produced SBOMs omit serialNumber and metadata.timestamp, and a ### Limitations subsection covering included dep-graph ecosystems (deb/apk/rpm, Node incl. pnpm, pip/Poetry, nuget, gomodules, composer), exclusions (Java JARs, detect-only manifests, --exclude-app-vulns, --exclude-node-modules), and purl omission for pnpm and Go. Lines 1–48 and ## Tests left byte-identical. All 19 SBOM unit tests pass (test/lib/sbom/cyclonedx.spec.ts and test/lib/sbom/format.spec.ts). Pushed to cursor/sbom-generation-documentation-7dbc. | gate "npm run test:unit -- sbom" passed in 5187ms
- `final:build`: `npm run build` passed in 3822ms
- `final:test_unit`: `npm run test:unit` passed in 3306ms
- `final:lint`: `npm run lint` passed in 2657ms
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch, and nothing regressed against the base commit.

## Decisions taken without asking

- Does 'documentation' mean the plugin's markdown docs (README/docs directory) or the CLI's generated --help/usage text?
  - took: Update the plugin's markdown/prose documentation files (README or docs/ directory) that describe usage and features.
  - alternative: Update inline CLI help/usage strings shown by --help output.

## Assumptions

- The SBOM output feature is already implemented and merged (or landing in a paired implementation slice); this slice only documents existing/near-shipped behavior rather than designing it.
- 'The plugin' refers to a single, identifiable plugin within this repository whose docs live in a conventional location (e.g. a README or docs/ directory) discoverable at routing time.
- 'Documentation' means the plugin's prose/markdown documentation (README/docs), not auto-generated CLI --help text or a separate external docs site.
- Supported formats, flag name, and ecosystem coverage should be taken verbatim from the actual implementation/tests rather than assumed from common SBOM conventions (e.g. CycloneDX/SPDX).

## Run

- Run: `20260812-132315-430e`
- Origin: 
- Base: `1abf15802a3fa6d1314543337a7d7e3a1023dec0`
- Head: `82bb0552c17435b799adc679ffbd7b1b3c49e39a`

Human review is required. This automation never merges or marks a PR ready.
