### PR TITLE
feat: allow registry provenance fetch for archives

### DIFF
--- a/lib/static.ts
+++ b/lib/static.ts
@@ -67,8 +67,16 @@ export async function analyzeStatically(
     packageFormat: parsedAnalysisResult.packageFormat,
   };
 
+  // Archives pulled from a registry do not contain the attestation manifest --
+  // it is a separate manifest in the image index, so it is never part of the
+  // tarball. Callers that pulled the archive themselves (e.g. DRA) can opt in
+  // to fetching provenance from the registry by reference.
+  const canFetchAttestationsFromRegistry =
+    imageType === ImageType.Identifier ||
+    isTrue(options.fetchProvenanceFromRegistry);
+
   if (
-    imageType === ImageType.Identifier &&
+    canFetchAttestationsFromRegistry &&
     (!analysis.attestations || analysis.attestations.length === 0)
   ) {
     try {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -190,6 +190,23 @@ export interface PluginOptions {
   digests: { manifest?: string; index?: string };
 
   /**
+   * WARNING! This is NOT used by the Snyk CLI!
+   *
+   * Opt in to fetching provenance attestations from the container registry when
+   * scanning an archive. Attestations live in a separate manifest in the image
+   * index, so they are never present in a pulled archive; without this the only
+   * provenance available is whatever the archive itself carries.
+   *
+   * Requires "imageNameAndTag" (to resolve the registry reference) and, for
+   * private registries, "username"/"password". Best-effort: a failed fetch is
+   * logged and never fails the scan.
+   *
+   * Deliberately opt-in rather than the default for archives -- it adds a
+   * network call to a caller-controlled host, which the CLI must not do.
+   */
+  fetchProvenanceFromRegistry: boolean | string;
+
+  /**
    * Provide patterns on which to match for detecting package manager manifest files.
    * Used for the APP+OS deps feature, not by the CLI.
    */

--- a/test/lib/static.spec.ts
+++ b/test/lib/static.spec.ts
@@ -1,0 +1,125 @@
+import { analyzeStatically } from "../../lib/static";
+import { ImageType } from "../../lib/types";
+
+jest.mock("../../lib/analyzer", () => ({
+  analyzeStatically: jest.fn().mockResolvedValue({
+    imageId: "sha256:abc",
+    osRelease: { name: "debian", version: "12", prettyName: "Debian 12" },
+    results: [],
+    binaries: [],
+    imageLayers: [],
+    rootFsLayers: [],
+    autoDetectedUserInstructions: undefined,
+    applicationDependenciesScanResults: [],
+    manifestLayers: [],
+    platform: "linux/amd64",
+  }),
+}));
+
+jest.mock("../../lib/parser", () => ({
+  parseAnalysisResults: jest.fn().mockReturnValue({
+    imageId: "sha256:abc",
+    imageLayers: [],
+    packageFormat: "deb",
+    depInfosList: [],
+    targetOS: { name: "debian", version: "12", prettyName: "Debian 12" },
+  }),
+}));
+
+jest.mock("../../lib/dependency-tree", () => ({
+  buildTree: jest.fn().mockReturnValue({ name: "docker-image", version: "1" }),
+}));
+
+jest.mock("../../lib/response-builder", () => ({
+  buildResponse: jest.fn().mockResolvedValue({ scanResults: [] }),
+}));
+
+jest.mock("../../lib/extractor/fetch-registry-provenance-attestations", () => ({
+  fetchAttestationsFromRegistry: jest.fn().mockResolvedValue([]),
+  parsePlatform: jest.fn().mockReturnValue(undefined),
+}));
+
+const {
+  fetchAttestationsFromRegistry,
+} = require("../../lib/extractor/fetch-registry-provenance-attestations");
+
+describe("analyzeStatically - registry provenance fetching", () => {
+  const globs = { include: [], exclude: [] };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches attestations for an image identifier", async () => {
+    await analyzeStatically(
+      "alpine:3.19",
+      undefined,
+      ImageType.Identifier,
+      "alpine:3.19",
+      globs,
+      {},
+    );
+
+    expect(fetchAttestationsFromRegistry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fetch attestations for an archive by default", async () => {
+    await analyzeStatically(
+      "some/image:tag",
+      undefined,
+      ImageType.DockerArchive,
+      "/tmp/image.tar",
+      globs,
+      { imageNameAndTag: "some/image:tag" },
+    );
+
+    expect(fetchAttestationsFromRegistry).not.toHaveBeenCalled();
+  });
+
+  it("fetches attestations for an archive when the caller opts in", async () => {
+    await analyzeStatically(
+      "registry.example.com/some/image:tag",
+      undefined,
+      ImageType.DockerArchive,
+      "/tmp/image.tar",
+      globs,
+      {
+        imageNameAndTag: "registry.example.com/some/image:tag",
+        fetchProvenanceFromRegistry: true,
+        username: "user",
+        password: "pass",
+      },
+    );
+
+    expect(fetchAttestationsFromRegistry).toHaveBeenCalledTimes(1);
+    expect(fetchAttestationsFromRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registryBase: "registry.example.com",
+        repo: "some/image",
+        imageReference: "tag",
+        username: "user",
+        password: "pass",
+      }),
+    );
+  });
+
+  it("never fails the scan when the attestation fetch throws", async () => {
+    fetchAttestationsFromRegistry.mockRejectedValueOnce(
+      new Error("connection refused"),
+    );
+
+    await expect(
+      analyzeStatically(
+        "registry.example.com/some/image:tag",
+        undefined,
+        ImageType.DockerArchive,
+        "/tmp/image.tar",
+        globs,
+        {
+          imageNameAndTag: "registry.example.com/some/image:tag",
+          fetchProvenanceFromRegistry: true,
+        },
+      ),
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## What this does

Adds an opt-in `fetchProvenanceFromRegistry` plugin option that lets an **archive** scan resolve provenance attestations from the container registry by reference.

Today the registry fetch in `lib/static.ts` is gated on `imageType === ImageType.Identifier`. Attestations live in a *separate* manifest in the image index, so they are never inside a pulled archive — which means any caller that pulls the archive itself (DRA, and potentially kubernetes-monitor) can never obtain provenance at all.

## Notes for the reviewer

- **Deliberately opt-in, not the default for archives.** Broadening the gate unconditionally would give the CLI an unsolicited network call to a caller-controlled host on every `--file=archive` scan — exactly the failure mode behind the `#7047` acceptance-test breakage (a best-effort request being surfaced as a hard error). The CLI never sets this option, so its behaviour is unchanged.
- Requires `imageNameAndTag` to resolve the registry reference. For archive scans `analyzeStatically` already receives that as its `targetImage` (`lib/scan.ts:165-168`), so `extractImageDetails` works without further plumbing.
- The fetch stays best-effort — a failure is logged via `debug` and never fails the scan. There is a test covering that.

## More information

Blocks snyk/docker-registry-agent#PENDING, which sets this option when the `surface-provenance-attestations` release flag is on. Without both changes, container image assets imported through the UI show no `provenance_attestations`, even though every other piece of the pipeline (registry mapping, assets-api persist + read, spec) is already in place.

Draft until the DRA side is reviewed — the two need to land in order (this, then a release, then the DRA bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)