### PR TITLE
feat(sbom): add --sbom flag to emit CycloneDX BOM output

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,37 @@ Others:
 - running on Windows (_not_ the same as scanning Windows containers)
 - collecting the `rootFs` hashes for base image detection and recommendation
 
+## SBOM output
+
+When the `sbom` option is truthy (the Snyk CLI's `--sbom` flag), the plugin
+additionally emits a `sbom` fact on the first scan result: a CycloneDX 1.6
+JSON document (`bomFormat`, `specVersion`, `serialNumber`, `metadata`,
+`components`) describing everything found in the scan target, alongside the
+plugin's regular dependency-graph output. Nothing changes when the option is
+absent or falsy.
+
+The document can be assembled from up to three input shapes, and any
+combination of them is folded into a single BOM:
+
+- the image's OS packages (from the dependency tree built while scanning an
+  image or archive)
+- application dependencies (npm, Java, Python, etc., when application
+  scanning is enabled)
+- Dockerfile analysis (the base image and any packages installed by `RUN`
+  instructions), when a Dockerfile is supplied
+
+A package discovered through more than one of these (for example, both
+installed in the image and named in a Dockerfile `RUN` instruction) appears
+as a single component rather than being duplicated.
+
+Two known limits to the enumeration:
+
+- packages detected only through Dockerfile analysis have no version
+  information, since that is not something static Dockerfile parsing can
+  recover
+- jars identified only by content fingerprint, with no resolved Maven
+  coordinates, cannot be named as components and are not listed
+
 ## Tests
 
 Refer to [test/README.md](test/README.md) for running and writing tests.

--- a/lib/facts.ts
+++ b/lib/facts.ts
@@ -5,6 +5,7 @@ import { JarFingerprint } from "./analyzer/types";
 import { DockerFileAnalysis } from "./dockerfile/types";
 import { OCIDistributionMetadata } from "./extractor/oci-distribution-metadata";
 import { ProvenanceMetadata } from "./extractor/provenance-parser";
+import { CycloneDxBom } from "./sbom/cyclonedx";
 import {
   AutoDetectedUserInstructions,
   ImageNameInfo,
@@ -184,4 +185,9 @@ export interface ApkPackageOwnershipFact {
   type: "apkPackageOwnership";
   // Shape owned by the resolver so the contract and the lib stay in lockstep.
   data: ApkPackageOwnership;
+}
+
+export interface SbomFact {
+  type: "sbom";
+  data: CycloneDxBom;
 }

--- a/lib/response-builder.ts
+++ b/lib/response-builder.ts
@@ -1,5 +1,6 @@
 import { legacy } from "@snyk/dep-graph";
 import { buildOwnershipCandidates } from "./analyzer/applications/evidence-paths";
+import { AppDepsScanResultWithoutTarget } from "./analyzer/applications/types";
 import {
   buildApkPathIndex,
   getApkPackagesFromResults,
@@ -16,8 +17,14 @@ import { instructionDigest } from "./dockerfile";
 import { DockerFileAnalysis, DockerFilePackages } from "./dockerfile/types";
 import { OCIDistributionMetadata } from "./extractor/oci-distribution-metadata";
 import { parseProvenanceAttestations } from "./extractor/provenance-parser";
+import { isTrue } from "./option-utils";
 
 import { computeScanPayloadMetrics } from "./scan-payload-metrics";
+import {
+  buildCycloneDxBom,
+  SbomAppComponent,
+  SbomSource,
+} from "./sbom/cyclonedx";
 import * as types from "./types";
 import { truncateAdditionalFacts } from "./utils";
 import { PLUGIN_VERSION } from "./version";
@@ -347,6 +354,23 @@ async function buildResponse(
     };
   });
 
+  if (isTrue(options?.sbom)) {
+    const appComponents = extractSbomAppComponents(
+      depsAnalysis.applicationDependenciesScanResults || [],
+    );
+    const sbomSource: SbomSource = {
+      imageName: depGraph.rootPkg.name,
+      depTree: depsAnalysis.depTree,
+      appComponents,
+      dockerfileAnalysis,
+    };
+    const sbomFact: facts.SbomFact = {
+      type: "sbom",
+      data: buildCycloneDxBom(sbomSource),
+    };
+    additionalFacts.push(sbomFact);
+  }
+
   const args =
     depsAnalysis.platform !== undefined
       ? { platform: depsAnalysis.platform }
@@ -450,6 +474,57 @@ async function buildResponse(
       },
     ],
   };
+}
+
+/**
+ * Turns the per-application-manager scan results collected for this image
+ * into the flat `SbomAppComponent[]` shape `buildCycloneDxBom` expects.
+ *
+ * `depGraph` facts carry an actual `DepGraph` instance (guarded here since
+ * `Fact.data` is typed `any`); `jarFingerprints` facts only contribute a
+ * component when a jar's Maven coordinates were resolved (both `name` and
+ * `version` present) — a fingerprint-only jar has no coordinates to name a
+ * component with.
+ */
+function extractSbomAppComponents(
+  applicationDependenciesScanResults: AppDepsScanResultWithoutTarget[],
+): SbomAppComponent[] {
+  const components: SbomAppComponent[] = [];
+
+  for (const result of applicationDependenciesScanResults) {
+    const targetFile = result.identity?.targetFile;
+
+    const depGraphData = result.facts?.find(
+      (fact) => fact.type === "depGraph",
+    )?.data;
+    if (depGraphData && typeof depGraphData.getDepPkgs === "function") {
+      for (const pkg of depGraphData.getDepPkgs()) {
+        components.push({
+          name: pkg.name,
+          ...(pkg.version ? { version: pkg.version } : {}),
+          ...(pkg.purl ? { purl: pkg.purl } : {}),
+          ...(targetFile ? { targetFile } : {}),
+        });
+      }
+    }
+
+    const jarFingerprintsFacts = (result.facts ?? []).filter(
+      (fact) => fact.type === "jarFingerprints",
+    );
+    for (const jarFingerprintsFact of jarFingerprintsFacts) {
+      for (const fingerprint of jarFingerprintsFact.data?.fingerprints ?? []) {
+        if (fingerprint.name && fingerprint.version) {
+          components.push({
+            name: fingerprint.name,
+            version: fingerprint.version,
+            ...(targetFile ? { targetFile } : {}),
+          });
+        }
+      }
+    }
+  }
+
+  return components;
 }
 
 /**

--- a/lib/sbom/cyclonedx.ts
+++ b/lib/sbom/cyclonedx.ts
@@ -1,0 +1,287 @@
+import { randomUUID } from "crypto";
+
+import { DockerFileAnalysis } from "../dockerfile/types";
+import { DepTree, DepTreeDep } from "../types";
+import { PLUGIN_VERSION } from "../version";
+
+export interface CycloneDxComponent {
+  "bom-ref": string;
+  type: "library" | "container";
+  name: string;
+  version?: string;
+  purl?: string;
+  properties?: Array<{ name: string; value: string }>;
+}
+
+export interface CycloneDxBom {
+  bomFormat: "CycloneDX";
+  specVersion: "1.6";
+  serialNumber: string;
+  version: number;
+  metadata: {
+    timestamp: string;
+    tools: Array<{ vendor: string; name: string; version: string }>;
+    component?: CycloneDxComponent;
+  };
+  components: CycloneDxComponent[];
+}
+
+export interface SbomAppComponent {
+  name: string;
+  version?: string;
+  purl?: string;
+  targetFile?: string;
+}
+
+export interface SbomSource {
+  imageName?: string;
+  depTree?: DepTree;
+  appComponents?: SbomAppComponent[];
+  dockerfileAnalysis?: DockerFileAnalysis;
+}
+
+const SBOM_SOURCE_PROPERTY = "snyk:sbom:source";
+const SBOM_TARGET_FILE_PROPERTY = "snyk:sbom:targetFile";
+
+type SbomComponentSource = "image" | "application" | "dockerfile";
+
+/**
+ * Mutable accumulator for a single CycloneDX component while we merge
+ * evidence from multiple sources (image, application, dockerfile) before
+ * emitting the final read-only CycloneDxComponent objects.
+ */
+interface ComponentAccumulator {
+  type: "library" | "container";
+  name: string;
+  version?: string;
+  purl?: string;
+  sources: Set<SbomComponentSource>;
+  targetFiles: Set<string>;
+}
+
+/**
+ * Builds a CycloneDX 1.6 JSON BOM from whichever inputs were available for
+ * this scan. Any combination of `depTree`, `appComponents` and
+ * `dockerfileAnalysis` may be supplied; callers decide which sources apply.
+ *
+ * Dockerfile-installed packages carry no version (see `DockerFilePackages`),
+ * so a package discovered both in the image and in a `RUN` instruction is
+ * folded into a single component whose `snyk:sbom:source` property lists
+ * both origins, rather than appearing twice.
+ */
+export function buildCycloneDxBom(source: SbomSource): CycloneDxBom {
+  // Keyed by `name@version` for sources that carry a version (image,
+  // application). Also indexed by name alone so that dockerfile packages,
+  // which have no version, can still be matched against an existing
+  // component discovered through another source.
+  const byNameAndVersion = new Map<string, ComponentAccumulator>();
+  const byName = new Map<string, ComponentAccumulator>();
+
+  const upsertComponent = (
+    type: "library" | "container",
+    name: string,
+    version: string | undefined,
+    purl: string | undefined,
+    componentSource: SbomComponentSource,
+    targetFile?: string,
+  ): void => {
+    const versionKey = `${name}@${version ?? ""}`;
+    let existing = byNameAndVersion.get(versionKey);
+
+    // A dockerfile package has no version, so fall back to matching by
+    // name alone against whatever component we already know about.
+    if (!existing && version === undefined) {
+      existing = byName.get(name);
+    }
+
+    if (existing) {
+      existing.sources.add(componentSource);
+      if (targetFile) {
+        existing.targetFiles.add(targetFile);
+      }
+      if (!existing.purl && purl) {
+        existing.purl = purl;
+      }
+      if (!existing.version && version) {
+        existing.version = version;
+      }
+      return;
+    }
+
+    const created: ComponentAccumulator = {
+      type,
+      name,
+      version,
+      purl,
+      sources: new Set([componentSource]),
+      targetFiles: new Set(targetFile ? [targetFile] : []),
+    };
+    byNameAndVersion.set(versionKey, created);
+    if (!byName.has(name)) {
+      byName.set(name, created);
+    }
+  };
+
+  if (source.depTree) {
+    for (const dep of flattenDepTree(source.depTree)) {
+      upsertComponent("library", dep.name, dep.version, dep.purl, "image");
+    }
+  }
+
+  for (const appComponent of source.appComponents ?? []) {
+    upsertComponent(
+      "library",
+      appComponent.name,
+      appComponent.version,
+      appComponent.purl,
+      "application",
+      appComponent.targetFile,
+    );
+  }
+
+  const dockerfilePackages =
+    source.dockerfileAnalysis?.dockerfilePackages ?? {};
+  for (const name of Object.keys(dockerfilePackages)) {
+    upsertComponent("library", name, undefined, undefined, "dockerfile");
+  }
+
+  const orderedComponents = [...byNameAndVersion.values()];
+
+  const usedBomRefs = new Set<string>();
+  const components: CycloneDxComponent[] = orderedComponents.map(
+    (accumulator) => finalizeComponent(accumulator, usedBomRefs),
+  );
+
+  if (source.dockerfileAnalysis?.baseImage) {
+    components.push(
+      finalizeComponent(
+        {
+          type: "container",
+          name: source.dockerfileAnalysis.baseImage,
+          version: undefined,
+          purl: undefined,
+          sources: new Set(["dockerfile"]),
+          targetFiles: new Set(),
+        },
+        usedBomRefs,
+      ),
+    );
+  }
+
+  const metadataComponent: CycloneDxComponent | undefined = source.imageName
+    ? {
+        "bom-ref": makeUniqueBomRef(source.imageName, undefined, usedBomRefs),
+        type: "container",
+        name: source.imageName,
+      }
+    : undefined;
+
+  return {
+    bomFormat: "CycloneDX",
+    specVersion: "1.6",
+    serialNumber: `urn:uuid:${randomUUID()}`,
+    version: 1,
+    metadata: {
+      timestamp: new Date().toISOString(),
+      tools: [
+        {
+          vendor: "Snyk",
+          name: "snyk-docker-plugin",
+          version: PLUGIN_VERSION,
+        },
+      ],
+      ...(metadataComponent ? { component: metadataComponent } : {}),
+    },
+    components,
+  };
+}
+
+function finalizeComponent(
+  accumulator: ComponentAccumulator,
+  usedBomRefs: Set<string>,
+): CycloneDxComponent {
+  const properties = [...accumulator.sources].sort(bySourcePriority).join(",");
+
+  const component: CycloneDxComponent = {
+    "bom-ref": makeUniqueBomRef(
+      accumulator.name,
+      accumulator.version,
+      usedBomRefs,
+    ),
+    type: accumulator.type,
+    name: accumulator.name,
+    ...(accumulator.version ? { version: accumulator.version } : {}),
+    ...(accumulator.purl ? { purl: accumulator.purl } : {}),
+  };
+
+  const propertyList: Array<{ name: string; value: string }> = [];
+  if (properties) {
+    propertyList.push({ name: SBOM_SOURCE_PROPERTY, value: properties });
+  }
+  if (accumulator.targetFiles.size > 0) {
+    propertyList.push({
+      name: SBOM_TARGET_FILE_PROPERTY,
+      value: [...accumulator.targetFiles].join(","),
+    });
+  }
+  if (propertyList.length > 0) {
+    component.properties = propertyList;
+  }
+
+  return component;
+}
+
+// Keeps the "snyk:sbom:source" property value deterministic
+// (e.g. always "image,dockerfile", never "dockerfile,image").
+const SOURCE_PRIORITY: SbomComponentSource[] = [
+  "image",
+  "application",
+  "dockerfile",
+];
+function bySourcePriority(
+  a: SbomComponentSource,
+  b: SbomComponentSource,
+): number {
+  return SOURCE_PRIORITY.indexOf(a) - SOURCE_PRIORITY.indexOf(b);
+}
+
+function makeUniqueBomRef(
+  name: string,
+  version: string | undefined,
+  usedBomRefs: Set<string>,
+): string {
+  const base = version ? `${name}@${version}` : name;
+  let candidate = base;
+  let suffix = 2;
+  while (usedBomRefs.has(candidate)) {
+    candidate = `${base}-${suffix}`;
+    suffix++;
+  }
+  usedBomRefs.add(candidate);
+  return candidate;
+}
+
+/** Walks a (possibly cyclic-by-name) DepTree and yields every dependency node once, keyed by name+version. */
+function flattenDepTree(tree: DepTree): DepTreeDep[] {
+  const seen = new Set<string>();
+  const result: DepTreeDep[] = [];
+
+  const visit = (node: DepTreeDep) => {
+    const key = `${node.name}@${node.version}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    result.push(node);
+
+    for (const childName of Object.keys(node.dependencies ?? {})) {
+      visit(node.dependencies[childName]);
+    }
+  };
+
+  for (const childName of Object.keys(tree.dependencies ?? {})) {
+    visit(tree.dependencies[childName]);
+  }
+
+  return result;
+}

--- a/lib/sbom/dockerfile-only.ts
+++ b/lib/sbom/dockerfile-only.ts
@@ -1,0 +1,47 @@
+import * as path from "path";
+
+import { readDockerfileAndAnalyse } from "../dockerfile";
+import * as facts from "../facts";
+import { PluginResponse } from "../types";
+import { PLUGIN_VERSION } from "../version";
+import { buildCycloneDxBom, SbomSource } from "./cyclonedx";
+
+/**
+ * Handles `--sbom` when only a Dockerfile was supplied (no image identifier
+ * or archive path). Produces a `PluginResponse` with a single scan result
+ * carrying the sbom fact plus dockerfile analysis, and no `depGraph` fact
+ * since there is no image to build a dependency tree from.
+ */
+export async function scanDockerfileOnly(
+  file: string,
+): Promise<PluginResponse> {
+  const dockerfileAnalysis = await readDockerfileAndAnalyse(file);
+
+  const sbomSource: SbomSource = {
+    dockerfileAnalysis,
+  };
+  const sbomFact: facts.SbomFact = {
+    type: "sbom",
+    data: buildCycloneDxBom(sbomSource),
+  };
+  const dockerfileAnalysisFact: facts.DockerfileAnalysisFact = {
+    type: "dockerfileAnalysis",
+    data: dockerfileAnalysis!,
+  };
+  const pluginVersionFact: facts.PluginVersionFact = {
+    type: "pluginVersion",
+    data: PLUGIN_VERSION,
+  };
+
+  const targetImage = dockerfileAnalysis?.baseImage ?? path.basename(file);
+
+  return {
+    scanResults: [
+      {
+        target: { image: targetImage },
+        identity: { type: "dockerfile", targetFile: file },
+        facts: [sbomFact, dockerfileAnalysisFact, pluginVersionFact],
+      },
+    ],
+  };
+}

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -16,6 +16,7 @@ import {
   isTrue,
   resolveNestedJarsOption,
 } from "./option-utils";
+import { scanDockerfileOnly } from "./sbom/dockerfile-only";
 import * as staticModule from "./static";
 import { ImageType, PluginOptions, PluginResponse } from "./types";
 import { isValidDockerImageReference } from "./utils";
@@ -107,6 +108,15 @@ async function getAnalysisParameters(
 export async function scan(
   options?: Partial<PluginOptions>,
 ): Promise<PluginResponse> {
+  if (isTrue(options?.sbom) && !options?.path) {
+    if (!options?.file) {
+      throw new Error(
+        "--sbom requires a scan target: provide an image identifier or archive path, or a Dockerfile via --file",
+      );
+    }
+    return scanDockerfileOnly(options.file);
+  }
+
   const {
     targetImage,
     imageType,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -80,6 +80,9 @@ export type FactType =
   | "pluginVersion"
   | "pluginWarnings"
   | "rootFs"
+  // A CycloneDX Software Bill of Materials for the scan target, emitted
+  // only when the "sbom" option is set.
+  | "sbom"
   // Used for application dependencies scanning; shows which files were used in the analysis of the dependencies.
   | "testedFiles"
   // Application files observed in the image
@@ -252,6 +255,14 @@ export interface PluginOptions {
   "layer-attribution": boolean | string;
 
   "target-reference": string;
+
+  /**
+   * Whether to additionally emit a CycloneDX Software Bill of Materials for
+   * the scan target, as a "sbom" fact on the first scan result. The default
+   * is "false". Requires a scan target: an image identifier/archive path
+   * (via "path"), a Dockerfile (via "file"), or both.
+   */
+  sbom: boolean | string;
 
   parameterWarnings?: string[];
 }

--- a/test/lib/facts.spec.ts
+++ b/test/lib/facts.spec.ts
@@ -98,6 +98,10 @@ describe("Facts", () => {
         truncatedFacts: {},
       },
     };
+    const sbomFact: facts.SbomFact = {
+      type: "sbom",
+      data: {} as any,
+    };
 
     // This would catch compilation errors.
     const allFacts: Fact[] = [
@@ -124,6 +128,7 @@ describe("Facts", () => {
       containerConfigFact,
       historyFact,
       pluginWarningsFact,
+      sbomFact,
     ];
     expect(allFacts).toBeDefined();
 

--- a/test/lib/response-builder-sbom.spec.ts
+++ b/test/lib/response-builder-sbom.spec.ts
@@ -288,6 +288,55 @@ describe("buildResponse sbom wiring", () => {
 
       const git = bom.components.find((c) => c.name === "git");
       expect(findProperty(git!, "snyk:sbom:source")).toBe("dockerfile");
+
+      expect(bom.metadata.component).toBeDefined();
+      expect(bom.metadata.component?.type).toBe("container");
+      expect(bom.metadata.component?.name).toBe("test-image");
+    });
+
+    it("suffixes metadata.component's bom-ref when it collides with a same-named dockerfile base-image component", async () => {
+      const mockAnalysis = createMockAnalysis({
+        depTree: {
+          dependencies: {},
+          // depGraph.rootPkg.name (and thus sbomSource.imageName) is
+          // derived from depTree.name, so this matches the
+          // dockerfileAnalysis.baseImage below.
+          name: "node:18-alpine",
+          version: "1.0.0",
+          packageFormatVersion: "deb:0.0.1",
+          targetOS: { prettyName: "Debian" },
+        },
+        packageFormat: "deb",
+      });
+
+      const dockerfileAnalysis = {
+        baseImage: "node:18-alpine",
+        dockerfilePackages: {},
+        dockerfileLayers: {},
+      };
+
+      const result = await buildResponse(
+        mockAnalysis as any,
+        dockerfileAnalysis as any,
+        false,
+        undefined,
+        undefined,
+        { sbom: true },
+      );
+
+      const bom = getSbomFacts(result.scanResults[0])[0].data;
+
+      const baseImageComponent = bom.components.find(
+        (c) => c.name === "node:18-alpine",
+      );
+      expect(baseImageComponent).toBeDefined();
+
+      const metadataComponent = bom.metadata.component!;
+      expect(metadataComponent).toBeDefined();
+      expect(metadataComponent.name).toBe("node:18-alpine");
+      expect(metadataComponent["bom-ref"]).not.toBe(
+        baseImageComponent!["bom-ref"],
+      );
     });
 
     it('treats the string "true" the same as boolean true', async () => {

--- a/test/lib/response-builder-sbom.spec.ts
+++ b/test/lib/response-builder-sbom.spec.ts
@@ -1,0 +1,353 @@
+import { DepGraphBuilder } from "@snyk/dep-graph";
+import { buildResponse } from "../../lib/response-builder";
+import { CycloneDxBom } from "../../lib/sbom/cyclonedx";
+import { DepTreeDep } from "../../lib/types";
+
+class NodeBuilder {
+  private node: DepTreeDep;
+
+  constructor(name: string, version = "1.0") {
+    this.node = { name, version, dependencies: {} };
+  }
+
+  public withChild(child: NodeBuilder): NodeBuilder {
+    this.node.dependencies[child.node.name] = child.build();
+    return this;
+  }
+
+  public build(): DepTreeDep {
+    return this.node;
+  }
+}
+
+const node = (name: string, version?: string) => new NodeBuilder(name, version);
+
+const createMockAnalysis = (overrides: Record<string, unknown> = {}) => ({
+  depTree: {
+    dependencies: {},
+    name: "test",
+    version: "1.0.0",
+    packageFormatVersion: "1.0.0",
+    targetOS: {
+      prettyName: "Test OS",
+    },
+  },
+  packageFormat: "test",
+  manifestFiles: [],
+  applicationDependenciesScanResults: [],
+  ...overrides,
+});
+
+const getSbomFacts = (scanResult: {
+  facts?: Array<{ type: string; data: any }>;
+}): Array<{ type: string; data: CycloneDxBom }> =>
+  (scanResult.facts ?? []).filter((fact) => fact.type === "sbom") as Array<{
+    type: string;
+    data: CycloneDxBom;
+  }>;
+
+const componentNames = (bom: CycloneDxBom): string[] =>
+  bom.components.map((component) => component.name);
+
+const findProperty = (
+  component: CycloneDxBom["components"][number],
+  name: string,
+): string | undefined =>
+  component.properties?.find((property) => property.name === name)?.value;
+
+function buildDepGraph(pkgs: Array<{ name: string; version: string }>) {
+  const builder = new DepGraphBuilder(
+    { name: "npm" },
+    { name: "root-project", version: "1.0.0" },
+  );
+  for (const pkg of pkgs) {
+    const nodeId = `${pkg.name}@${pkg.version}`;
+    builder.addPkgNode(pkg, nodeId);
+    builder.connectDep(builder.rootNodeId, nodeId);
+  }
+  return builder.build();
+}
+
+describe("buildResponse sbom wiring", () => {
+  describe("with sbom enabled", () => {
+    it("emits exactly one sbom fact naming the depTree packages when there is no dockerfileAnalysis", async () => {
+      const mockAnalysis = createMockAnalysis({
+        depTree: {
+          dependencies: {
+            openssl: node("openssl", "3.0.11-1").build(),
+            curl: node("curl", "8.4.0-1").build(),
+          },
+          name: "test-image",
+          version: "1.0.0",
+          packageFormatVersion: "deb:0.0.1",
+          targetOS: { prettyName: "Debian" },
+        },
+        packageFormat: "deb",
+      });
+
+      const result = await buildResponse(
+        mockAnalysis as any,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        {
+          sbom: true,
+        },
+      );
+
+      const sbomFacts = getSbomFacts(result.scanResults[0]);
+      expect(sbomFacts).toHaveLength(1);
+
+      const bom = sbomFacts[0].data;
+      expect(componentNames(bom)).toEqual(
+        expect.arrayContaining(["openssl", "curl"]),
+      );
+
+      const openssl = bom.components.find((c) => c.name === "openssl");
+      expect(openssl?.purl).toBeUndefined();
+    });
+
+    it("keeps a depTree node's purl on the matching component", async () => {
+      const depWithPurl: DepTreeDep = {
+        name: "openssl",
+        version: "3.0.11-1",
+        purl: "pkg:deb/debian/openssl@3.0.11-1",
+        dependencies: {},
+      };
+
+      const mockAnalysis = createMockAnalysis({
+        depTree: {
+          dependencies: { openssl: depWithPurl },
+          name: "test-image",
+          version: "1.0.0",
+          packageFormatVersion: "deb:0.0.1",
+          targetOS: { prettyName: "Debian" },
+        },
+        packageFormat: "deb",
+      });
+
+      const result = await buildResponse(
+        mockAnalysis as any,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        {
+          sbom: true,
+        },
+      );
+
+      const bom = getSbomFacts(result.scanResults[0])[0].data;
+      const openssl = bom.components.find((c) => c.name === "openssl");
+      expect(openssl?.purl).toBe("pkg:deb/debian/openssl@3.0.11-1");
+    });
+
+    it("includes application dep-graph packages and named jars, tagged with the application source, and omits nameless jars", async () => {
+      const appDepGraph = buildDepGraph([
+        { name: "lodash", version: "4.17.21" },
+        { name: "left-pad", version: "1.3.0" },
+      ]);
+
+      const mockAnalysis = createMockAnalysis({
+        applicationDependenciesScanResults: [
+          {
+            facts: [
+              { type: "depGraph", data: appDepGraph },
+              {
+                type: "jarFingerprints",
+                data: {
+                  fingerprints: [
+                    {
+                      location: "/app/lib/named.jar",
+                      digest: "abc123",
+                      name: "com.example:named",
+                      version: "1.2.3",
+                      dependencies: [],
+                    },
+                    {
+                      location: "/app/lib/unresolved.jar",
+                      digest: "def456",
+                      dependencies: [],
+                    },
+                  ],
+                  origin: "test",
+                  path: "/app/lib",
+                },
+              },
+            ],
+            identity: { type: "npm", targetFile: "/app/package-lock.json" },
+            target: { image: "test-app" },
+          },
+        ],
+      });
+
+      const result = await buildResponse(
+        mockAnalysis as any,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        {
+          sbom: true,
+        },
+      );
+
+      // Exactly one sbom fact overall, and it lives on the first (OS) scan
+      // result — not duplicated onto the application scan result.
+      expect(result.scanResults).toHaveLength(2);
+      expect(getSbomFacts(result.scanResults[0])).toHaveLength(1);
+      expect(getSbomFacts(result.scanResults[1])).toHaveLength(0);
+
+      const bom = getSbomFacts(result.scanResults[0])[0].data;
+      const names = componentNames(bom);
+
+      expect(names).toEqual(
+        expect.arrayContaining(["lodash", "left-pad", "com.example:named"]),
+      );
+      expect(names).not.toContain("unresolved.jar");
+      expect(names.filter((n) => n === "com.example:named")).toHaveLength(1);
+
+      for (const name of ["lodash", "left-pad", "com.example:named"]) {
+        const component = bom.components.find((c) => c.name === name);
+        expect(findProperty(component!, "snyk:sbom:source")).toBe(
+          "application",
+        );
+      }
+    });
+
+    it("merges image, application and dockerfile components into a single sbom fact with no duplicated name@version", async () => {
+      const appDepGraph = buildDepGraph([
+        { name: "lodash", version: "4.17.21" },
+      ]);
+
+      const mockAnalysis = createMockAnalysis({
+        depTree: {
+          dependencies: {
+            curl: node("curl", "8.4.0-1").build(),
+            openssl: node("openssl", "3.0.11-1").build(),
+          },
+          name: "test-image",
+          version: "1.0.0",
+          packageFormatVersion: "deb:0.0.1",
+          targetOS: { prettyName: "Debian" },
+        },
+        packageFormat: "deb",
+        applicationDependenciesScanResults: [
+          {
+            facts: [{ type: "depGraph", data: appDepGraph }],
+            identity: { type: "npm", targetFile: "/app/package-lock.json" },
+            target: { image: "test-app" },
+          },
+        ],
+      });
+
+      const dockerfileAnalysis = {
+        baseImage: "debian:12",
+        dockerfilePackages: {
+          curl: { instruction: "RUN", installCommand: "apt-get install curl" },
+          git: { instruction: "RUN", installCommand: "apt-get install git" },
+        },
+        dockerfileLayers: {},
+      };
+
+      const result = await buildResponse(
+        mockAnalysis as any,
+        dockerfileAnalysis as any,
+        false,
+        undefined,
+        undefined,
+        { sbom: true },
+      );
+
+      const sbomFacts = getSbomFacts(result.scanResults[0]);
+      expect(sbomFacts).toHaveLength(1);
+
+      const bom = sbomFacts[0].data;
+      const names = componentNames(bom);
+      expect(new Set(names).size).toBe(names.length);
+
+      expect(names).toEqual(
+        expect.arrayContaining([
+          "curl",
+          "openssl",
+          "lodash",
+          "git",
+          "debian:12",
+        ]),
+      );
+
+      const curl = bom.components.find((c) => c.name === "curl");
+      expect(findProperty(curl!, "snyk:sbom:source")).toBe("image,dockerfile");
+
+      const openssl = bom.components.find((c) => c.name === "openssl");
+      expect(findProperty(openssl!, "snyk:sbom:source")).toBe("image");
+
+      const lodash = bom.components.find((c) => c.name === "lodash");
+      expect(findProperty(lodash!, "snyk:sbom:source")).toBe("application");
+
+      const git = bom.components.find((c) => c.name === "git");
+      expect(findProperty(git!, "snyk:sbom:source")).toBe("dockerfile");
+    });
+
+    it('treats the string "true" the same as boolean true', async () => {
+      const mockAnalysis = createMockAnalysis({
+        depTree: {
+          dependencies: { openssl: node("openssl", "3.0.11-1").build() },
+          name: "test-image",
+          version: "1.0.0",
+          packageFormatVersion: "deb:0.0.1",
+          targetOS: { prettyName: "Debian" },
+        },
+        packageFormat: "deb",
+      });
+
+      const result = await buildResponse(
+        mockAnalysis as any,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        {
+          sbom: "true",
+        },
+      );
+
+      expect(getSbomFacts(result.scanResults[0])).toHaveLength(1);
+    });
+  });
+
+  describe("with sbom absent", () => {
+    it("emits no sbom fact on any scan result and leaves the OS scan result's fact list unchanged", async () => {
+      const mockAnalysis = createMockAnalysis({
+        depTree: {
+          dependencies: { openssl: node("openssl", "3.0.11-1").build() },
+          name: "test-image",
+          version: "1.0.0",
+          packageFormatVersion: "deb:0.0.1",
+          targetOS: { prettyName: "Debian" },
+        },
+        packageFormat: "deb",
+        applicationDependenciesScanResults: [
+          {
+            facts: [{ type: "depGraph", data: buildDepGraph([]) }],
+            identity: { type: "npm" },
+            target: { image: "test-app" },
+          },
+        ],
+      });
+
+      const result = await buildResponse(mockAnalysis as any, undefined, false);
+
+      for (const scanResult of result.scanResults) {
+        expect(getSbomFacts(scanResult)).toHaveLength(0);
+      }
+
+      expect(result.scanResults[0].facts.map((fact) => fact.type)).toEqual([
+        "depGraph",
+        "imageOsReleasePrettyName",
+        "pluginVersion",
+      ]);
+    });
+  });
+});

--- a/test/lib/scan-sbom.spec.ts
+++ b/test/lib/scan-sbom.spec.ts
@@ -1,0 +1,85 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { scan } from "../../lib/scan";
+import { CycloneDxBom } from "../../lib/sbom/cyclonedx";
+
+const SBOM_TARGET_ERROR =
+  "--sbom requires a scan target: provide an image identifier or archive path, or a Dockerfile via --file";
+
+describe("scan with --sbom", () => {
+  let tmpDir: string;
+  let dockerfilePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "scan-sbom-"));
+    dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      ["FROM debian:12", "RUN apt-get install -y curl git"].join("\n"),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("scans a Dockerfile-only target when no image path is provided", async () => {
+    const response = await scan({ sbom: true, file: dockerfilePath });
+
+    expect(response.scanResults).toHaveLength(1);
+
+    const [scanResult] = response.scanResults;
+    expect(scanResult.identity.type).toBe("dockerfile");
+    expect(scanResult.identity.targetFile).toBe(dockerfilePath);
+    expect(scanResult.target.image).toBe("debian:12");
+
+    const factTypes = scanResult.facts.map((fact) => fact.type);
+    expect(factTypes.filter((type) => type === "sbom")).toHaveLength(1);
+    expect(factTypes).toEqual(
+      expect.arrayContaining(["dockerfileAnalysis", "pluginVersion"]),
+    );
+    expect(factTypes).not.toContain("depGraph");
+
+    const bom = scanResult.facts.find((fact) => fact.type === "sbom")
+      ?.data as CycloneDxBom;
+    const componentNames = bom.components.map((component) => component.name);
+    expect(componentNames).toEqual(
+      expect.arrayContaining(["debian:12", "curl", "git"]),
+    );
+
+    const baseImageComponent = bom.components.find(
+      (component) => component.name === "debian:12",
+    );
+    expect(baseImageComponent?.type).toBe("container");
+  });
+
+  it("rejects with a clear error when neither an image nor a Dockerfile is supplied", async () => {
+    await expect(scan({ sbom: true })).rejects.toThrow(SBOM_TARGET_ERROR);
+
+    let caughtError: unknown;
+    try {
+      await scan({ sbom: true });
+    } catch (error) {
+      caughtError = error;
+    }
+    expect(caughtError).toBeInstanceOf(Error);
+    expect(caughtError).not.toBeInstanceOf(TypeError);
+    expect((caughtError as Error).message).toBe(SBOM_TARGET_ERROR);
+  });
+
+  it("still rejects with the existing message when no options are provided at all", async () => {
+    await expect(scan({})).rejects.toThrow(
+      "No image identifier or path provided",
+    );
+  });
+
+  it("rejects with an error naming the missing Dockerfile path", async () => {
+    const missingPath = path.join(tmpDir, "does-not-exist");
+
+    await expect(scan({ sbom: true, file: missingPath })).rejects.toThrow(
+      new RegExp(missingPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+  });
+});

--- a/test/unit/sbom/cyclonedx.spec.ts
+++ b/test/unit/sbom/cyclonedx.spec.ts
@@ -26,6 +26,14 @@ function assertWellFormed(bom: CycloneDxBom): void {
   expect(bom.metadata.tools[0].version).toBe(PLUGIN_VERSION);
 
   const bomRefs = new Set<string>();
+
+  if (bom.metadata.component) {
+    const metadataComponent = bom.metadata.component;
+    expect(metadataComponent.name.length).toBeGreaterThan(0);
+    expect(["library", "container"]).toContain(metadataComponent.type);
+    bomRefs.add(metadataComponent["bom-ref"]);
+  }
+
   for (const component of bom.components) {
     expect(component.name.length).toBeGreaterThan(0);
     expect(["library", "container"]).toContain(component.type);
@@ -88,6 +96,11 @@ describe("buildCycloneDxBom", () => {
       expect(withPurl?.purl).toBe("pkg:deb/debian/openssl@3.0.11-1");
       expect(withoutPurl).toBeDefined();
       expect(withoutPurl).not.toHaveProperty("purl");
+    });
+
+    it("omits metadata.component when no imageName was supplied", () => {
+      const bom = buildCycloneDxBom(source);
+      expect(bom.metadata.component).toBeUndefined();
     });
   });
 
@@ -241,6 +254,34 @@ describe("buildCycloneDxBom", () => {
       expect(findProperty(openssl!, "snyk:sbom:source")).toBe("image");
       expect(findProperty(lodash!, "snyk:sbom:source")).toBe("application");
       expect(findProperty(git!, "snyk:sbom:source")).toBe("dockerfile");
+    });
+
+    it("emits metadata.component describing the scanned image", () => {
+      const bom = buildCycloneDxBom(source);
+      expect(bom.metadata.component).toBeDefined();
+      expect(bom.metadata.component?.type).toBe("container");
+      expect(bom.metadata.component?.name).toBe("node:18-alpine");
+    });
+
+    it("gives metadata.component a bom-ref distinct from the same-named dockerfile base-image component", () => {
+      // imageName and dockerfileAnalysis.baseImage are both
+      // "node:18-alpine", so both a `components` entry (from the
+      // dockerfile) and `metadata.component` (from imageName) are named
+      // "node:18-alpine". makeUniqueBomRef must suffix one of them so the
+      // two bom-refs don't collide.
+      const bom = buildCycloneDxBom(source);
+
+      const baseImageComponent = bom.components.find(
+        (c) => c.name === "node:18-alpine",
+      );
+      expect(baseImageComponent).toBeDefined();
+      expect(baseImageComponent!["bom-ref"]).toBe("node:18-alpine");
+
+      const metadataComponent = bom.metadata.component!;
+      expect(metadataComponent["bom-ref"]).not.toBe(
+        baseImageComponent!["bom-ref"],
+      );
+      expect(metadataComponent["bom-ref"]).toBe("node:18-alpine-2");
     });
   });
 });

--- a/test/unit/sbom/cyclonedx.spec.ts
+++ b/test/unit/sbom/cyclonedx.spec.ts
@@ -1,0 +1,246 @@
+import {
+  buildCycloneDxBom,
+  CycloneDxBom,
+  SbomSource,
+} from "../../../lib/sbom/cyclonedx";
+import { DepTree } from "../../../lib/types";
+import { PLUGIN_VERSION } from "../../../lib/version";
+
+function findProperty(
+  component: CycloneDxBom["components"][number],
+  name: string,
+): string | undefined {
+  return component.properties?.find((property) => property.name === name)
+    ?.value;
+}
+
+function assertWellFormed(bom: CycloneDxBom): void {
+  expect(JSON.parse(JSON.stringify(bom))).toStrictEqual(bom);
+
+  expect(bom.bomFormat).toBe("CycloneDX");
+  expect(bom.specVersion).toBe("1.6");
+  expect(bom.version).toBe(1);
+  expect(bom.serialNumber).toMatch(/^urn:uuid:[0-9a-f-]{36}$/);
+  expect(Number.isFinite(Date.parse(bom.metadata.timestamp))).toBe(true);
+  expect(bom.metadata.tools[0].name).toBe("snyk-docker-plugin");
+  expect(bom.metadata.tools[0].version).toBe(PLUGIN_VERSION);
+
+  const bomRefs = new Set<string>();
+  for (const component of bom.components) {
+    expect(component.name.length).toBeGreaterThan(0);
+    expect(["library", "container"]).toContain(component.type);
+    expect(bomRefs.has(component["bom-ref"])).toBe(false);
+    bomRefs.add(component["bom-ref"]);
+  }
+}
+
+function buildDepTree(deps: DepTree["dependencies"]): DepTree {
+  return {
+    name: "docker-image|image",
+    version: "latest",
+    packageFormatVersion: "deb:0.0.1",
+    targetOS: { name: "debian", prettyName: "Debian", version: "12" },
+    dependencies: deps,
+  };
+}
+
+describe("buildCycloneDxBom", () => {
+  it("is well-formed with no sources at all", () => {
+    const bom = buildCycloneDxBom({});
+    assertWellFormed(bom);
+    expect(bom.components).toEqual([]);
+  });
+
+  describe("depTree only", () => {
+    const source: SbomSource = {
+      depTree: buildDepTree({
+        openssl: {
+          name: "openssl",
+          version: "3.0.11-1",
+          purl: "pkg:deb/debian/openssl@3.0.11-1",
+          dependencies: {},
+        },
+        "no-purl-pkg": {
+          name: "no-purl-pkg",
+          version: "1.0.0",
+          dependencies: {},
+        },
+      }),
+    };
+
+    it("produces a well-formed BOM", () => {
+      assertWellFormed(buildCycloneDxBom(source));
+    });
+
+    it("marks every component as sourced from the image", () => {
+      const bom = buildCycloneDxBom(source);
+      expect(bom.components).toHaveLength(2);
+      for (const component of bom.components) {
+        expect(findProperty(component, "snyk:sbom:source")).toBe("image");
+      }
+    });
+
+    it("keeps purl when the depTree node had one, and omits it otherwise", () => {
+      const bom = buildCycloneDxBom(source);
+      const withPurl = bom.components.find((c) => c.name === "openssl");
+      const withoutPurl = bom.components.find((c) => c.name === "no-purl-pkg");
+
+      expect(withPurl?.purl).toBe("pkg:deb/debian/openssl@3.0.11-1");
+      expect(withoutPurl).toBeDefined();
+      expect(withoutPurl).not.toHaveProperty("purl");
+    });
+  });
+
+  describe("appComponents only", () => {
+    const source: SbomSource = {
+      appComponents: [
+        {
+          name: "lodash",
+          version: "4.17.21",
+          purl: "pkg:npm/lodash@4.17.21",
+          targetFile: "/app/package-lock.json",
+        },
+        { name: "left-pad", version: "1.3.0" },
+      ],
+    };
+
+    it("produces a well-formed BOM", () => {
+      assertWellFormed(buildCycloneDxBom(source));
+    });
+
+    it("marks every component as sourced from the application", () => {
+      const bom = buildCycloneDxBom(source);
+      expect(bom.components).toHaveLength(2);
+      for (const component of bom.components) {
+        expect(findProperty(component, "snyk:sbom:source")).toBe("application");
+      }
+    });
+
+    it("carries the target file only when it was supplied", () => {
+      const bom = buildCycloneDxBom(source);
+      const withTargetFile = bom.components.find((c) => c.name === "lodash");
+      const withoutTargetFile = bom.components.find(
+        (c) => c.name === "left-pad",
+      );
+
+      expect(findProperty(withTargetFile!, "snyk:sbom:targetFile")).toBe(
+        "/app/package-lock.json",
+      );
+      expect(
+        findProperty(withoutTargetFile!, "snyk:sbom:targetFile"),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("dockerfileAnalysis only", () => {
+    const source: SbomSource = {
+      dockerfileAnalysis: {
+        baseImage: "node:18-alpine",
+        dockerfilePackages: {
+          curl: { instruction: "RUN", installCommand: "apt-get install curl" },
+          git: { instruction: "RUN", installCommand: "apt-get install git" },
+        },
+        dockerfileLayers: {},
+      },
+    };
+
+    it("produces a well-formed BOM", () => {
+      assertWellFormed(buildCycloneDxBom(source));
+    });
+
+    it("marks every package component as sourced from the dockerfile", () => {
+      const bom = buildCycloneDxBom(source);
+      const packageComponents = bom.components.filter(
+        (c) => c.name !== "node:18-alpine",
+      );
+      expect(packageComponents).toHaveLength(2);
+      for (const component of packageComponents) {
+        expect(findProperty(component, "snyk:sbom:source")).toBe("dockerfile");
+      }
+    });
+
+    it("includes the base image as a container component", () => {
+      const bom = buildCycloneDxBom(source);
+      const baseImageComponent = bom.components.find(
+        (c) => c.name === "node:18-alpine",
+      );
+      expect(baseImageComponent).toBeDefined();
+      expect(baseImageComponent?.type).toBe("container");
+    });
+  });
+
+  describe("all three sources together", () => {
+    const source: SbomSource = {
+      imageName: "node:18-alpine",
+      depTree: buildDepTree({
+        curl: {
+          name: "curl",
+          version: "8.4.0-1",
+          purl: "pkg:deb/debian/curl@8.4.0-1",
+          dependencies: {},
+        },
+        openssl: {
+          name: "openssl",
+          version: "3.0.11-1",
+          dependencies: {},
+        },
+      }),
+      appComponents: [{ name: "lodash", version: "4.17.21" }],
+      dockerfileAnalysis: {
+        baseImage: "node:18-alpine",
+        dockerfilePackages: {
+          // Present in both the image scan and the Dockerfile: should
+          // collapse into a single component, not a duplicate.
+          curl: { instruction: "RUN", installCommand: "apt-get install curl" },
+          git: { instruction: "RUN", installCommand: "apt-get install git" },
+        },
+        dockerfileLayers: {},
+      },
+    };
+
+    it("produces a well-formed BOM", () => {
+      assertWellFormed(buildCycloneDxBom(source));
+    });
+
+    it("yields exactly one document with components from all three sources", () => {
+      const bom = buildCycloneDxBom(source);
+
+      const names = bom.components.map((c) => c.name);
+      expect(new Set(names).size).toBe(names.length);
+
+      expect(names).toEqual(
+        expect.arrayContaining([
+          "curl",
+          "openssl",
+          "lodash",
+          "git",
+          "node:18-alpine",
+        ]),
+      );
+    });
+
+    it("does not duplicate a name@version present in multiple sources", () => {
+      const bom = buildCycloneDxBom(source);
+      const curlComponents = bom.components.filter((c) => c.name === "curl");
+      expect(curlComponents).toHaveLength(1);
+    });
+
+    it("merges the source list for a package found via multiple sources", () => {
+      const bom = buildCycloneDxBom(source);
+      const curl = bom.components.find((c) => c.name === "curl");
+      expect(curl?.version).toBe("8.4.0-1");
+      expect(findProperty(curl!, "snyk:sbom:source")).toBe("image,dockerfile");
+    });
+
+    it("keeps single-source components correctly attributed", () => {
+      const bom = buildCycloneDxBom(source);
+      const openssl = bom.components.find((c) => c.name === "openssl");
+      const lodash = bom.components.find((c) => c.name === "lodash");
+      const git = bom.components.find((c) => c.name === "git");
+
+      expect(findProperty(openssl!, "snyk:sbom:source")).toBe("image");
+      expect(findProperty(lodash!, "snyk:sbom:source")).toBe("application");
+      expect(findProperty(git!, "snyk:sbom:source")).toBe("dockerfile");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `sbom` plugin option that produces a CycloneDX 1.6 JSON software bill of materials alongside the plugin's existing scan output, with no change in behavior when the option is unset.

`lib/sbom/cyclonedx.ts` builds a single deduplicated CycloneDX document from the image dependency tree, application dependencies, and Dockerfile analysis, exposed through a new `sbom` fact type and the `PluginOptions.sbom` flag. `buildResponse` assembles that document from the OS dependency tree and any application scan results and attaches it as a fact on the first scan result. `scan()` supports `--sbom` even when only a Dockerfile is supplied, using a Dockerfile-only response path that has no image dependency graph, and returns a clear error when `--sbom` is passed without either an image or a Dockerfile.

Application dependencies are folded into the same document as OS packages rather than scoped out separately, since most scans are not OS-only. Jars identified only by content fingerprint, with no resolved Maven coordinates, and Dockerfile-only packages, which carry no version, are documented in README.md as known enumeration limits rather than being dropped or misrepresented.

## Acceptance criteria

1. Running the CLI with the new flag against an image-only input produces an SBOM output enumerating the packages/components discovered in that image.
2. Running the CLI with the new flag against a Dockerfile-only input (no image) produces an SBOM output enumerating the components discoverable from Dockerfile analysis.
3. Running the CLI with the new flag against both an image and a Dockerfile together produces a single SBOM output that reflects components from both sources.
4. Running the CLI without the new flag leaves existing output and behavior unchanged.
5. If the flag is used but neither an image nor a Dockerfile is supplied, the CLI reports a clear error rather than crashing or emitting an empty/invalid document.
6. The SBOM output emitted is a well-formed, parseable document consistent with whichever SBOM standard is chosen during implementation.

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `sbom-contract`: Implemented the sbom-contract task: lib/sbom/cyclonedx.ts exports buildCycloneDxBom(source: SbomSource): CycloneDxBom with the interfaces pinned verbatim (CycloneDxComponent, CycloneDxBom, SbomAppComponent, SbomSource). No new dependency was needed; serialNumber uses Node's built-in crypto.randomUUID(). lib/facts.ts gained SbomFact{type:"sbom", data: CycloneDxBom}; lib/types.ts gained "sbom" in FactType and a commented `sbom: boolean | string` member on PluginOptions (prettier/eslint --fix stripped the string-literal quotes from the key since it's a valid identifier, matching every other unquoted option key in that interface - the type and doc comment match the pinned spec). test/lib/facts.spec.ts registers an SbomFact in allFacts. test/unit/sbom/cyclonedx.spec.ts covers well-formedness (JSON round-trip, bomFormat/specVersion/version, serialNumber regex, finite timestamp, tools[0] name+version, unique bom-refs, non-empty names, valid types) plus the four cases from the plan: depTree-only (purl kept/omitted correctly), appComponents-only (targetFile present only when supplied), dockerfileAnalysis-only (baseImage as a container component), and all three together (single doc, no duplicate name@version, and a package present in both depTree and dockerfilePackages collapses into one component with snyk:sbom:source="image,dockerfile"). README.md gained an '## SBOM output' section naming --sbom, CycloneDX 1.6 JSON, the three input shapes, and the two enumeration limits. Verified with `npm run build` (tsc, clean) plus `npx jest --selectProjects unit --testPathPattern="test/unit/sbom/cyclonedx.spec.ts|test/lib/facts.spec.ts"` (16/16 passing) and a full `npm run test:unit` run (935 total, only the 4 pre-existing test/lib/display.spec.ts chalk-color failures remain, confirmed present on the unmodified base branch too and unrelated to this change). Also ran `npm run format` and `npx eslint`/`npx prettier --check` (clean) and `npx commitlint --from=HEAD~1` (clean). Used nvm to install and run everything under Node 20 per the pinned .nvmrc, since the base image ships Node 22. Committed as a single feat commit and pushed; `git ls-remote --exit-code origin refs/heads/cursor/sbom-contract-definition-71fd` confirms the branch is on origin. | gate "npm run test:unit" failed exactly as it does on the base commit (exit 1); pre-existing, not chased
- `sbom-response-wiring`: Implemented the sbom-response-wiring task on top of the already-merged sbom-contract commit (lib/sbom/cyclonedx.ts, left byte-identical). In lib/response-builder.ts: added an isTrue(options?.sbom) branch that builds an SbomFact from the final depsAnalysis.depTree, the dockerfileAnalysis argument, depGraph.rootPkg.name as imageName, and appComponents extracted from depsAnalysis.applicationDependenciesScanResults (each result's depGraph fact via a typeof getDepPkgs === 'function' guard, its identity.targetFile, and jarFingerprints entries that carry both name and version), then pushed onto additionalFacts so it lands on the OS scan result. Added test/lib/response-builder-sbom.spec.ts covering all five doneWhen assertions: depTree-only sbom fact with purl survival, application dep-graph+jar merging with named-jar inclusion/nameless-jar omission, three-source merge with no name@version duplicates, sbom-absent leaving the OS fact list unchanged (explicit array, not a snapshot), and the 'true' string behaving like boolean true. Ran on nvm-installed Node 20.20.2 (the environment's default node was v22; /exec-daemon shadowed nvm's PATH entry, so I exported the nvm bin dir explicitly). npm run build && npm run test:unit both pass: 937 passed / 4 failed, all 4 failures pre-existing in test/lib/display.spec.ts (ANSI-color assertions failing under this shell's color settings) and reproduced identically on a stash of my changes, so they predate this task. Zero snapshot files changed. Ran prettier --write and eslint on the touched files; both clean. Verified commitlint passes on the commit message. Pushed cursor/sbom-response-wiring-c2c0 to origin and confirmed with git ls-remote. | gate "npm run test:unit" failed exactly as it does on the base commit (exit 1); pre-existing, not chased
- `sbom-scan-entry`: Implemented sbom-scan-entry on top of the already-landed sbom-contract and sbom-response-wiring commits on this branch. In scan() (lib/scan.ts), added two branches before getAnalysisParameters: throw the pinned '--sbom requires a scan target...' message when isTrue(options?.sbom) and no path/file, or delegate to the new lib/sbom/dockerfile-only.ts (scanDockerfileOnly) when sbom is set, no path, but file is set. lib/sbom/dockerfile-only.ts calls readDockerfileAndAnalyse and returns a single ScanResult with identity.type 'dockerfile', target.image from the base image (falling back to the basename), and facts [sbom, dockerfileAnalysis, pluginVersion] — no depGraph. lib/sbom/cyclonedx.ts was left completely untouched (verified byte-identical via git diff). Added test/lib/scan-sbom.spec.ts covering: dockerfile-only scan producing the expected single scan result and sbom fact with the base image and both RUN-installed packages; the pinned error (asserted as Error, not TypeError) when neither path nor file is given; the pre-existing 'No image identifier or path provided' message when options are empty; and an error mentioning the missing file's path. Ran `npm run build && npm run test:unit -- test/lib/scan-sbom.spec.ts test/lib/scan.spec.ts` (note: this repo's `--selectProjects unit` flag greedily consumes trailing positional args as project names, a pre-existing jest CLI quirk unrelated to my change, so that exact invocation actually runs the whole unit project — I verified this explicitly). The full unit suite passes (945/945) except 4 pre-existing failures in test/lib/display.spec.ts caused by chalk color-code formatting differences in this sandbox, confirmed present on the base commit before any of my changes and outside my file boundary. Also confirmed my two new spec files pass in isolation via an explicit --testPathPattern run, and ran prettier/eslint clean on all touched files. | gate "npm run test:unit" failed exactly as it does on the base commit (exit 1); pre-existing, not chased
- `final:install`: `npm ci` passed in 4134ms
- `final:build`: `npm run build` passed in 4019ms
- `final:test_unit`: `npm run test:unit` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch
- `final:lint`: `npm run lint` passed in 3242ms
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch, and nothing regressed against the base commit.

## Decisions taken without asking

- Does 'for a given image, a Dockerfile, or both' mean the flag must work correctly across whatever input combination the user already supplies, or does the flag itself take a value that selects the scan scope (e.g. --sbom=image|dockerfile|both)?
  - took: The flag is a plain switch that enables SBOM output, and it must produce a correct SBOM for whichever combination of image/Dockerfile the user already passes as scan input via existing arguments.
  - alternative: The flag itself carries an explicit scope value that independently selects which source(s) — image, Dockerfile, or both — to include in the SBOM, separate from the existing scan-target arguments.

## Assumptions

- "SBOM" means a standard machine-readable software bill of materials document (e.g., CycloneDX or SPDX JSON), not a repurposed version of the plugin's existing vulnerability report.
- The flag is additive: it layers onto the plugin's existing image/Dockerfile input arguments rather than introducing a new way to specify scan targets.
- "Dockerfile" refers to the plugin's existing Dockerfile-analysis input mechanism, not a newly introduced file type or parser.
- The flag does not need to take a value; a plain boolean switch is sufficient to trigger SBOM generation, with format/detail choices deferred to implementation.
- Generating an SBOM from a Dockerfile alone (with no image present) is expected to be possible, even though the plugin's existing Dockerfile analysis is normally paired with an image scan.

## Run

- Run: `event-35a9038645ff9e96ce08`
- Origin: https://slack.com/archives/C0BPC0Z2048/p1787066576782339
- Base: `ec433b94c0d3355c58656211265efc156e945717`
- Head: `97a556598be0055ac657fcd92e25612d9da59dee`

Human review is required. This automation never merges or marks a PR ready.
