### PR TITLE
feat(swift): detect Swift Package Manager deps in image scans

### DIFF
--- a/lib/analyzer/applications/index.ts
+++ b/lib/analyzer/applications/index.ts
@@ -5,6 +5,7 @@ import {
   pipFilesToScannedProjects,
   poetryFilesToScannedProjects,
 } from "./python";
+import { swiftFilesToScannedProjects } from "./swift";
 
 export {
   dotnetFilesToScannedProjects,
@@ -12,4 +13,5 @@ export {
   phpFilesToScannedProjects,
   poetryFilesToScannedProjects,
   pipFilesToScannedProjects,
+  swiftFilesToScannedProjects,
 };

--- a/lib/analyzer/applications/swift.ts
+++ b/lib/analyzer/applications/swift.ts
@@ -1,0 +1,136 @@
+import { DepGraphBuilder } from "@snyk/dep-graph";
+import * as Debug from "debug";
+import * as path from "path";
+import { getErrorMessage } from "../../error-utils";
+import { DepGraphFact, TestedFilesFact } from "../../facts";
+import { AppDepsScanResultWithoutTarget, FilePathToContent } from "./types";
+
+const debug = Debug("snyk");
+
+interface SwiftPinState {
+  version?: string;
+}
+
+interface SwiftPinV1 {
+  package: string;
+  repositoryURL: string;
+  state?: SwiftPinState;
+}
+
+interface PackageResolvedV1 {
+  version: 1;
+  object?: { pins: SwiftPinV1[] };
+}
+
+interface SwiftPinV2 {
+  identity: string;
+  location: string;
+  state?: SwiftPinState;
+}
+
+interface PackageResolvedV2 {
+  version: 2 | 3;
+  pins: SwiftPinV2[];
+}
+
+type PackageResolved = PackageResolvedV1 | PackageResolvedV2;
+
+interface ResolvedPin {
+  name: string;
+  version?: string;
+}
+
+function nameFromUrl(url: string): string {
+  const base = path.basename(url);
+  const trimmed = base.endsWith(".git") ? base.slice(0, -".git".length) : base;
+  return trimmed.toLowerCase();
+}
+
+function extractPins(parsed: PackageResolved): ResolvedPin[] {
+  if (parsed.version === 1) {
+    const pins = parsed.object?.pins ?? [];
+    return pins.map((pin) => ({
+      name: pin.repositoryURL
+        ? nameFromUrl(pin.repositoryURL)
+        : pin.package,
+      version: pin.state?.version,
+    }));
+  }
+  if (parsed.version === 2 || parsed.version === 3) {
+    const pins = parsed.pins ?? [];
+    return pins.map((pin) => ({
+      name: pin.identity || (pin.location ? nameFromUrl(pin.location) : ""),
+      version: pin.state?.version,
+    }));
+  }
+  throw new Error(
+    `Unrecognised Package.resolved version: ${
+      (parsed as { version?: unknown }).version
+    }`,
+  );
+}
+
+/**
+ * Creates a flat dep graph for every Package.resolved file that was found.
+ * Package.resolved carries no dependency edges between pinned packages, so
+ * every pin is a direct child of the root - see the Swift ecosystem non-goal.
+ */
+export async function swiftFilesToScannedProjects(
+  filePathToContent: FilePathToContent,
+): Promise<AppDepsScanResultWithoutTarget[]> {
+  const scanResults: AppDepsScanResultWithoutTarget[] = [];
+
+  for (const [filePath, content] of Object.entries(filePathToContent)) {
+    try {
+      const parsed: PackageResolved = JSON.parse(content);
+      const pins = extractPins(parsed);
+
+      const builder = new DepGraphBuilder(
+        { name: "swift" },
+        { name: filePath },
+      );
+
+      let pinnedCount = 0;
+      for (const pin of pins) {
+        if (!pin.name || !pin.version) {
+          // A pin with no resolved version is a branch/revision pin; it can't
+          // be matched against advisory data, so it's skipped.
+          continue;
+        }
+        const nodeId = `${pin.name}@${pin.version}`;
+        builder.addPkgNode({ name: pin.name, version: pin.version }, nodeId);
+        builder.connectDep(builder.rootNodeId, nodeId);
+        pinnedCount++;
+      }
+
+      if (pinnedCount === 0) {
+        debug(`No versioned pins found in Package.resolved: ${filePath}`);
+        continue;
+      }
+
+      const depGraphFact: DepGraphFact = {
+        type: "depGraph",
+        data: builder.build(),
+      };
+      const testedFilesFact: TestedFilesFact = {
+        type: "testedFiles",
+        data: [path.basename(filePath)],
+      };
+      scanResults.push({
+        facts: [depGraphFact, testedFilesFact],
+        identity: {
+          type: "swift",
+          targetFile: filePath,
+        },
+      });
+    } catch (err) {
+      debug(
+        `Failed to parse Package.resolved at ${filePath}: ${getErrorMessage(
+          err,
+        )}`,
+      );
+    }
+  }
+
+  return scanResults;
+}

--- a/lib/analyzer/applications/swift.ts
+++ b/lib/analyzer/applications/swift.ts
@@ -50,9 +50,7 @@ function extractPins(parsed: PackageResolved): ResolvedPin[] {
   if (parsed.version === 1) {
     const pins = parsed.object?.pins ?? [];
     return pins.map((pin) => ({
-      name: pin.repositoryURL
-        ? nameFromUrl(pin.repositoryURL)
-        : pin.package,
+      name: pin.repositoryURL ? nameFromUrl(pin.repositoryURL) : pin.package,
       version: pin.state?.version,
     }));
   }

--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -51,6 +51,7 @@ import {
   getRedHatRepositoriesContentAction,
   getRedHatRepositoriesFromExtractedLayers,
 } from "../inputs/redHat/static";
+import { getSwiftAppFileContentAction } from "../inputs/swift/static";
 import {
   getRpmDbFileContent,
   getRpmDbFileContentAction,
@@ -66,6 +67,7 @@ import {
   nodeFilesToScannedProjects,
   phpFilesToScannedProjects,
   poetryFilesToScannedProjects,
+  swiftFilesToScannedProjects,
 } from "./applications";
 import { jarFilesToScannedResults } from "./applications/java";
 import { pipFilesToScannedProjects } from "./applications/python";
@@ -151,6 +153,7 @@ export async function analyze(
         getPoetryAppFileContentAction,
         getPipAppFileContentAction,
         getDotnetAppFileContentAction,
+        getSwiftAppFileContentAction,
         ...jarActions,
         getGoModulesContentAction,
       ],
@@ -357,6 +360,12 @@ export async function analyze(
     timings.dotnetAnalysisMs = Date.now() - phaseStart;
 
     phaseStart = Date.now();
+    const swiftDependenciesScanResults = await swiftFilesToScannedProjects(
+      getFileContent(extractedLayers, getSwiftAppFileContentAction.actionName),
+    );
+    timings.swiftAnalysisMs = Date.now() - phaseStart;
+
+    phaseStart = Date.now();
     const desiredLevelsOfUnpacking = getNestedJarsDesiredDepth(options);
     const jarFingerprintScanResults = await jarFilesToScannedResults(
       getBufferContent(extractedLayers, getJarFileContentAction.actionName),
@@ -379,6 +388,7 @@ export async function analyze(
       ...pipDependenciesScanResults,
       ...pythonApplicationFilesScanResults,
       ...dotnetDependenciesScanResults,
+      ...swiftDependenciesScanResults,
       ...jarFingerprintScanResults,
       ...goModulesScanResult,
     );

--- a/lib/inputs/swift/static.ts
+++ b/lib/inputs/swift/static.ts
@@ -1,0 +1,21 @@
+import { basename } from "path";
+
+import { ExtractAction } from "../../extractor/types";
+import { streamToString } from "../../stream-utils";
+
+const swiftAppFiles = ["Package.resolved"];
+const deletedAppFiles = swiftAppFiles.map((file) => ".wh." + file);
+
+function filePathMatches(filePath: string): boolean {
+  if (filePath.includes("/.build/checkouts/")) {
+    return false;
+  }
+  const fileName = basename(filePath);
+  return swiftAppFiles.includes(fileName) || deletedAppFiles.includes(fileName);
+}
+
+export const getSwiftAppFileContentAction: ExtractAction = {
+  actionName: "swift-app-files",
+  filePathMatches,
+  callback: streamToString,
+};

--- a/test/fixtures/swift/PackageV1.resolved
+++ b/test/fixtures/swift/PackageV1.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+          "version": "1.5.4"
+        }
+      },
+      {
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
+        "state": {
+          "branch": "main",
+          "revision": "abc123",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/test/fixtures/swift/PackageV2.resolved
+++ b/test/fixtures/swift/PackageV2.resolved
@@ -1,0 +1,23 @@
+{
+  "pins": [
+    {
+      "identity": "swift-log",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-log.git",
+      "state": {
+        "revision": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+        "version": "1.5.4"
+      }
+    },
+    {
+      "identity": "swift-algorithms",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-algorithms.git",
+      "state": {
+        "branch": "main",
+        "revision": "def456"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/test/fixtures/swift/PackageV3.resolved
+++ b/test/fixtures/swift/PackageV3.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash": "9f2a5c1e4b6d7a8c9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d",
+  "pins": [
+    {
+      "identity": "swift-log",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-log.git",
+      "state": {
+        "revision": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+        "version": "1.5.4"
+      }
+    }
+  ],
+  "version": 3
+}

--- a/test/lib/analyzer/static-analyzer-swift-wiring.spec.ts
+++ b/test/lib/analyzer/static-analyzer-swift-wiring.spec.ts
@@ -1,0 +1,133 @@
+jest.mock("../../../lib/extractor", () => {
+  const actual = jest.requireActual("../../../lib/extractor");
+  return {
+    ...actual,
+    extractImageContent: jest.fn(),
+  };
+});
+
+import { extractImageContent } from "../../../lib/extractor";
+import { getSwiftAppFileContentAction } from "../../../lib/inputs/swift/static";
+import { ImageType } from "../../../lib/types";
+import { analyze } from "../../../lib/analyzer/static-analyzer";
+
+const mockExtractImageContent = extractImageContent as jest.Mock;
+
+describe("Swift wiring in static-analyzer", () => {
+  afterEach(() => {
+    mockExtractImageContent.mockReset();
+  });
+
+  it("registers the Swift extract action for extraction", async () => {
+    mockExtractImageContent.mockResolvedValue({
+      imageId: "sha256:fake",
+      manifestLayers: [],
+      extractedLayers: {},
+    });
+
+    await analyze(
+      "test-image",
+      undefined,
+      ImageType.DockerArchive,
+      "/fake/path",
+      { include: [], exclude: [] },
+      {},
+    );
+
+    const [, , staticAnalysisActions] = mockExtractImageContent.mock.calls[0];
+    expect(staticAnalysisActions).toContain(getSwiftAppFileContentAction);
+  });
+
+  it("does not register the Swift extract action when app-vuln scanning is excluded", async () => {
+    mockExtractImageContent.mockResolvedValue({
+      imageId: "sha256:fake",
+      manifestLayers: [],
+      extractedLayers: {},
+    });
+
+    await analyze(
+      "test-image",
+      undefined,
+      ImageType.DockerArchive,
+      "/fake/path",
+      { include: [], exclude: [] },
+      { "exclude-app-vulns": true },
+    );
+
+    const [, , staticAnalysisActions] = mockExtractImageContent.mock.calls[0];
+    expect(staticAnalysisActions).not.toContain(getSwiftAppFileContentAction);
+  });
+
+  it("collects a Package.resolved found during extraction into the scan results", async () => {
+    const packageResolved = JSON.stringify({
+      version: 2,
+      pins: [
+        {
+          identity: "swift-log",
+          location: "https://github.com/apple/swift-log.git",
+          state: { version: "1.5.4" },
+        },
+      ],
+    });
+
+    mockExtractImageContent.mockResolvedValue({
+      imageId: "sha256:fake",
+      manifestLayers: [],
+      extractedLayers: {
+        "/app/Package.resolved": {
+          [getSwiftAppFileContentAction.actionName]: packageResolved,
+        },
+      },
+    });
+
+    const result = await analyze(
+      "test-image",
+      undefined,
+      ImageType.DockerArchive,
+      "/fake/path",
+      { include: [], exclude: [] },
+      {},
+    );
+
+    const swiftResult = result.applicationDependenciesScanResults.find(
+      (r) => r.identity.type === "swift",
+    );
+    expect(swiftResult).toBeDefined();
+    expect(swiftResult!.identity.targetFile).toBe("/app/Package.resolved");
+    expect(result.timings.swiftAnalysisMs).toBeDefined();
+  });
+
+  it("does not collect Package.resolved when app-vuln scanning is excluded", async () => {
+    const packageResolved = JSON.stringify({
+      version: 2,
+      pins: [
+        {
+          identity: "swift-log",
+          location: "https://github.com/apple/swift-log.git",
+          state: { version: "1.5.4" },
+        },
+      ],
+    });
+
+    mockExtractImageContent.mockResolvedValue({
+      imageId: "sha256:fake",
+      manifestLayers: [],
+      extractedLayers: {
+        "/app/Package.resolved": {
+          [getSwiftAppFileContentAction.actionName]: packageResolved,
+        },
+      },
+    });
+
+    const result = await analyze(
+      "test-image",
+      undefined,
+      ImageType.DockerArchive,
+      "/fake/path",
+      { include: [], exclude: [] },
+      { "exclude-app-vulns": true },
+    );
+
+    expect(result.applicationDependenciesScanResults).toHaveLength(0);
+  });
+});

--- a/test/lib/analyzer/swift.spec.ts
+++ b/test/lib/analyzer/swift.spec.ts
@@ -1,0 +1,170 @@
+import * as fs from "fs";
+import * as path from "path";
+import { swiftFilesToScannedProjects } from "../../../lib/analyzer/applications/swift";
+
+const fixturesPath = path.join(__dirname, "../../fixtures/swift");
+
+function loadFixture(filename: string): string {
+  return fs.readFileSync(path.join(fixturesPath, filename), "utf-8");
+}
+
+describe("Swift Package.resolved analyzer", () => {
+  describe("v1 lockfile", () => {
+    it("should produce a scan result with a swift identity", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV1.resolved"),
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].identity.type).toBe("swift");
+      expect(results[0].identity.targetFile).toBe("/app/Package.resolved");
+    });
+
+    it("should include the testedFiles fact", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV1.resolved"),
+      });
+
+      const testedFilesFact = results[0].facts.find(
+        (f) => f.type === "testedFiles",
+      );
+      expect(testedFilesFact!.data).toEqual(["Package.resolved"]);
+    });
+
+    it("should include the versioned pin, named from the repository URL", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV1.resolved"),
+      });
+
+      const depGraph = results[0].facts.find(
+        (f) => f.type === "depGraph",
+      )!.data;
+      const pkgs = depGraph.getPkgs();
+      const swiftLog = pkgs.find((p) => p.name === "swift-log");
+      expect(swiftLog).toBeDefined();
+      expect(swiftLog!.version).toBe("1.5.4");
+    });
+
+    it("should skip a pin with no resolved version (branch/revision pin)", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV1.resolved"),
+      });
+
+      const depGraph = results[0].facts.find(
+        (f) => f.type === "depGraph",
+      )!.data;
+      const pkgs = depGraph.getPkgs();
+      expect(pkgs.some((p) => p.name === "swift-nio")).toBe(false);
+    });
+  });
+
+  describe("v2 lockfile", () => {
+    it("should produce a scan result naming pins from identity", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV2.resolved"),
+      });
+
+      expect(results).toHaveLength(1);
+      const depGraph = results[0].facts.find(
+        (f) => f.type === "depGraph",
+      )!.data;
+      const pkgs = depGraph.getPkgs();
+      const swiftLog = pkgs.find((p) => p.name === "swift-log");
+      expect(swiftLog).toBeDefined();
+      expect(swiftLog!.version).toBe("1.5.4");
+    });
+
+    it("should skip a pin with no resolved version", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV2.resolved"),
+      });
+
+      const depGraph = results[0].facts.find(
+        (f) => f.type === "depGraph",
+      )!.data;
+      const pkgs = depGraph.getPkgs();
+      expect(pkgs.some((p) => p.name === "swift-algorithms")).toBe(false);
+    });
+
+    it("should yield the same package name as an equivalent v1 pin for the same repo", async () => {
+      const v1Results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV1.resolved"),
+      });
+      const v2Results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV2.resolved"),
+      });
+
+      const v1Pkgs = v1Results[0].facts
+        .find((f) => f.type === "depGraph")!
+        .data.getPkgs();
+      const v2Pkgs = v2Results[0].facts
+        .find((f) => f.type === "depGraph")!
+        .data.getPkgs();
+
+      expect(v1Pkgs.some((p) => p.name === "swift-log")).toBe(true);
+      expect(v2Pkgs.some((p) => p.name === "swift-log")).toBe(true);
+    });
+  });
+
+  describe("v3 lockfile", () => {
+    it("should parse pins and ignore the top-level originHash", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": loadFixture("PackageV3.resolved"),
+      });
+
+      expect(results).toHaveLength(1);
+      const depGraph = results[0].facts.find(
+        (f) => f.type === "depGraph",
+      )!.data;
+      const pkgs = depGraph.getPkgs();
+      const swiftLog = pkgs.find((p) => p.name === "swift-log");
+      expect(swiftLog).toBeDefined();
+      expect(swiftLog!.version).toBe("1.5.4");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should return empty array for empty input", async () => {
+      const results = await swiftFilesToScannedProjects({});
+      expect(results).toHaveLength(0);
+    });
+
+    it("should handle invalid JSON gracefully", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": "not valid json{{{",
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it("should skip a file with an unrecognised version", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": JSON.stringify({ version: 99, pins: [] }),
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it("should skip a file where every pin lacks a resolved version", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app/Package.resolved": JSON.stringify({
+          version: 2,
+          pins: [
+            {
+              identity: "swift-nio",
+              location: "https://github.com/apple/swift-nio.git",
+              state: { branch: "main", revision: "abc123" },
+            },
+          ],
+        }),
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it("should handle multiple Package.resolved files", async () => {
+      const results = await swiftFilesToScannedProjects({
+        "/app1/Package.resolved": loadFixture("PackageV1.resolved"),
+        "/app2/Package.resolved": loadFixture("PackageV2.resolved"),
+      });
+      expect(results).toHaveLength(2);
+    });
+  });
+});

--- a/test/lib/inputs/swift/static.spec.ts
+++ b/test/lib/inputs/swift/static.spec.ts
@@ -1,0 +1,25 @@
+import { getSwiftAppFileContentAction } from "../../../../lib/inputs/swift/static";
+
+describe("Swift Package.resolved file path matching", () => {
+  const { filePathMatches } = getSwiftAppFileContentAction;
+
+  it("should match Package.resolved files", () => {
+    expect(filePathMatches("/app/Package.resolved")).toBe(true);
+  });
+
+  it("should match whiteout Package.resolved files", () => {
+    expect(filePathMatches("/app/.wh.Package.resolved")).toBe(true);
+  });
+
+  it("should not match non-lockfile Swift or other package manager files", () => {
+    expect(filePathMatches("/app/Package.swift")).toBe(false);
+    expect(filePathMatches("/app/package.json")).toBe(false);
+    expect(filePathMatches("/app/Package.resolved.bak")).toBe(false);
+  });
+
+  it("should exclude vendored lockfiles under .build/checkouts/", () => {
+    expect(
+      filePathMatches("/app/.build/checkouts/swift-nio/Package.resolved"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Swift Package Manager as a supported application ecosystem for container image scanning, following the same extract-action/analyzer/wiring pattern used for PHP and .NET.

- `lib/inputs/swift/static.ts` registers an extract action that matches `Package.resolved` (and its whiteout form), excluding non-lockfile Swift/other manifests and vendored lockfiles under `.build/checkouts/`.
- `lib/analyzer/applications/swift.ts` parses `Package.resolved` in its v1, v2, and v3 forms into a flat dependency graph, since the lockfile doesn't encode edges between pins. Each pin is named from its `identity`/`package` field, or falls back to the repository URL basename so v1 and v2 files for the same repo resolve to the same package name. Pins with no resolved version (branch/revision pins) are skipped, and malformed or unrecognized files are skipped with a debug log rather than failing the scan.
- `lib/analyzer/static-analyzer.ts` wires the new action and analyzer into the existing application-scan pipeline, including timings and the `exclude-app-vulns` opt-out, alongside the other ecosystems.

The scan result shape is unchanged for consumers: `identity.type` is a free-form string, and the response builder already handles application scan results generically, so this is purely additive.

## Acceptance criteria

1. Scanning a container image filesystem that contains one or more Swift Package Manager lockfiles (Package.resolved) causes those files to be located and parsed without executing any code inside the image.
2. Parsed Swift dependencies (name and resolved version) are emitted as part of the plugin's scan result in the same facts/dependency-graph structure used by other ecosystem plugins (e.g. npm, pip, maven), tagged with a package-manager/type identifier for Swift.
3. Each detected dependency result records the in-image file path of the lockfile it came from, consistent with how other ecosystems report their source manifest/lockfile path.
4. If multiple Package.resolved files exist at different paths in the image, each is detected and reported as a separate result, matching existing multi-lockfile behavior for other ecosystems.
5. Scanning an image with no Swift Package Manager files present produces no Swift-related entries in the result and does not error.
6. Existing detection and results for already-supported ecosystems (npm, pip, maven, apk, deb, rpm, etc.) are unchanged by this addition.

## Not in this branch

The plan had work this branch does not carry:

- `swift-analyzer` (done when: `npm run test:unit -- test/lib/analyzer/swift.spec.ts` passes. lib/analyzer/applications/swift.ts exports `swiftFilesToScannedProjects(filePathToContent: FilePathToContent): Promise<AppDepsScanResultWithoutTarget[]>`, and the spec — loading the three new small fixtures the way test/lib/analyzer/dotnet.spec.ts:5-9 loads test/fixtures/dotnet — asserts: the v1 fixture at "/app/Package.resolved" yields exactly one result with `identity.type === "swift"` and `identity.targetFile === "/app/Package.resolved"`; the depGraph fact's `pkgManager.name` is "swift" and `getPkgs()` contains the expected name@version pairs; the v2 and v3 fixtures produce the same package name as v1 for the same repository; a testedFiles fact equal to ["Package.resolved"]; two fixtures at "/a/Package.resolved" and "/b/Package.resolved" yield two results with distinct targetFiles; and `{}`, a file of malformed JSON, and a file whose pins all lack `state.version` each yield `[]` without throwing. The skip-unversioned-pin branch carries a code comment saying a revision/branch pin has no version anything downstream can match.): the builder call itself failed: pipeline: builder:swift-analyzer:retry: exit: cursor create returned HTTP 400 (validation_error): [invalid_argument] Error
- `swift-wiring` (done when: `npm run build` exits 0 and `npm run test:unit` passes with no snapshot writes (no `-u`, no changed files under any `__snapshots__/`), and `git diff` shows lib/inputs/swift/static.ts and lib/analyzer/applications/swift.ts unchanged by this task. The diff shows: lib/analyzer/applications/index.ts importing and re-exporting `swiftFilesToScannedProjects` alongside `dotnetFilesToScannedProjects`; lib/analyzer/static-analyzer.ts importing `getSwiftAppFileContentAction` from "../inputs/swift/static" and `swiftFilesToScannedProjects` from "./applications", pushing `getSwiftAppFileContentAction` into the action list inside the `if (appScan)` block (lines 147-157, next to getPhpAppFileContentAction/getDotnetAppFileContentAction), calling `await swiftFilesToScannedProjects(getFileContent(extractedLayers, getSwiftAppFileContentAction.actionName))` inside the second `if (appScan)` block bracketed by `phaseStart = Date.now()` and `timings.swiftAnalysisMs = Date.now() - phaseStart;` in the style of the dotnet block at lines 353-357, and spreading the results into the `applicationDependenciesScanResults.push(...)` call; and README.md's "Applications" list (lines 36-40) gaining a Swift (SwiftPM, Package.resolved) entry with the existing entries untouched.): not started: chained after task swift-analyzer, which did not land (the builder call itself failed: pipeline: builder:swift-analyzer:retry: exit: cursor create returned HTTP 400 (validation_error): [invalid_argument] Error)

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `swift-input-action`: Added getSwiftAppFileContentAction (actionName: swift-app-files, callback: streamToString) following lib/inputs/php/static.ts. filePathMatches accepts basename Package.resolved and .wh.Package.resolved, rejects paths under /.build/checkouts/, and excludes Package.swift, package.json, and Package.resolved.bak. Unit spec mirrors test/lib/inputs/python/static.spec.ts with four passing assertions. npm run test:unit -- test/lib/inputs/swift/static.spec.ts exits 0 (924 passed); without FORCE_COLOR=1, unrelated test/lib/display.spec.ts chalk ANSI failures also run because Jest does not filter on the positional path alone. | gate "npm run test:unit -- test/lib/inputs/swift/static.spec.ts" passed in 5421ms
- `final:build`: `npm run build` passed in 3788ms
- `final:test_unit`: `npm run test:unit` passed in 3267ms
- `final:lint`: `npm run lint` passed in 2545ms
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch, and nothing regressed against the base commit.

## Decisions taken without asking

- Should Swift dependency detection be based on the Package.resolved lockfile only, or should the plugin also attempt to interpret Package.swift manifests for declared (not just resolved) dependencies?
  - took: Use Package.resolved exclusively, since it is a static, machine-readable lockfile analogous to other lockfiles this plugin already parses (package-lock.json, Gemfile.lock, etc.), and Package.swift requires executing Swift to fully resolve.
  - alternative: Attempt best-effort static parsing of Package.swift to also surface manifest-declared dependencies even when no lockfile is present.

## Assumptions

- Detection is based on the Package.resolved lockfile (a machine-readable JSON pin list), not the Package.swift manifest, since the manifest is executable Swift code and not practical to statically parse — this mirrors how other ecosystems in this plugin prefer lockfiles (e.g. package-lock.json) over manifests.
- The new ecosystem is surfaced as a new package-manager/type value (e.g. 'swift') within the existing facts/depGraph result format, rather than as a wholly new top-level output structure.
- Detection applies to any image containing Package.resolved files (e.g. Linux-based Swift builds), not exclusively iOS/macOS-targeted build artifacts, since the plugin scans generic container filesystems.
- No new dependency edges are inferred beyond what Package.resolved lists; each pinned package is reported as detected without asserting internal dependency relationships if the lockfile format does not expose them.
- No new CLI flag is required — Swift detection runs automatically during a normal scan, consistent with how other ecosystems are already always-on.

## Run

- Run: `event-92fcf8073555ecd32cf4`
- Origin: https://snyk.slack.com/archives/C0BPC0Z2048/p1787329760872889
- Base: `ec433b94c0d3355c58656211265efc156e945717`
- Head: `fadb0bb6c5e1c2240bd0b0ed3a919024e68ceb1f`

Human review is required. This automation never merges or marks a PR ready.
