### PR TITLE
feat(dotnet): detect .NET shared framework key binaries

### DIFF
--- a/lib/analyzer/static-analyzer.ts
+++ b/lib/analyzer/static-analyzer.ts
@@ -19,6 +19,7 @@ import {
 import { getJavaRuntimeReleaseAction } from "../inputs/base-runtimes/static";
 import {
   getBinariesHashes,
+  getDotnetBinariesFileContentAction,
   getNodeBinariesFileContentAction,
   getOpenJDKBinariesFileContentAction,
 } from "../inputs/binaries/static";
@@ -116,6 +117,7 @@ export async function analyze(
     ...getOsReleaseActions,
     getNodeBinariesFileContentAction,
     getOpenJDKBinariesFileContentAction,
+    getDotnetBinariesFileContentAction,
     getJavaRuntimeReleaseAction,
     getDpkgPackageFileContentAction,
     getRedHatRepositoriesContentAction,

--- a/lib/inputs/binaries/static/index.ts
+++ b/lib/inputs/binaries/static/index.ts
@@ -13,9 +13,29 @@ export const getNodeBinariesFileContentAction: ExtractAction = {
   callback: streamToSha256,
 };
 
+const DOTNET_SHARED_FRAMEWORK_PATH = "/dotnet/shared/Microsoft.NETCore.App/";
+const DOTNET_KEY_BINARY_NAMES = new Set([
+  "libcoreclr.so",
+  "System.Private.CoreLib.dll",
+]);
+
+export const getDotnetBinariesFileContentAction: ExtractAction = {
+  actionName: "dotnet",
+  filePathMatches: (filePath) => {
+    const p = filePath.replace(/\\/g, "/");
+    if (!p.includes(DOTNET_SHARED_FRAMEWORK_PATH)) {
+      return false;
+    }
+    const basename = p.split("/").pop();
+    return basename !== undefined && DOTNET_KEY_BINARY_NAMES.has(basename);
+  },
+  callback: streamToSha256,
+};
+
 const binariesExtractActions = [
   getNodeBinariesFileContentAction,
   getOpenJDKBinariesFileContentAction,
+  getDotnetBinariesFileContentAction,
 ];
 
 export function getBinariesHashes(extractedLayers: ExtractedLayers): string[] {

--- a/test/lib/inputs/binaries-static.spec.ts
+++ b/test/lib/inputs/binaries-static.spec.ts
@@ -1,0 +1,125 @@
+import {
+  getBinariesHashes,
+  getDotnetBinariesFileContentAction,
+  getNodeBinariesFileContentAction,
+  getOpenJDKBinariesFileContentAction,
+} from "../../../lib/inputs/binaries/static";
+import { ExtractedLayers } from "../../../lib/extractor/types";
+
+describe("getDotnetBinariesFileContentAction.filePathMatches", () => {
+  const matches = getDotnetBinariesFileContentAction.filePathMatches!;
+
+  it("has the expected action name", () => {
+    expect(getDotnetBinariesFileContentAction.actionName).toBe("dotnet");
+  });
+
+  it("matches libcoreclr.so under the shared framework path", () => {
+    expect(
+      matches(
+        "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.1/libcoreclr.so",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches System.Private.CoreLib.dll under the shared framework path", () => {
+    expect(
+      matches(
+        "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.1/System.Private.CoreLib.dll",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches on win32-style backslash paths", () => {
+    expect(
+      matches(
+        "\\dotnet\\shared\\Microsoft.NETCore.App\\8.0.1\\libcoreclr.so",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a same-named file outside the shared framework path", () => {
+    expect(matches("/app/libcoreclr.so")).toBe(false);
+  });
+
+  it("does not match a same-named file under a self-contained app layout", () => {
+    expect(
+      matches("/app/bin/Release/net8.0/linux-x64/publish/libcoreclr.so"),
+    ).toBe(false);
+  });
+
+  it("does not match Microsoft.AspNetCore.App (no CLR host shipped there)", () => {
+    expect(
+      matches(
+        "/usr/share/dotnet/shared/Microsoft.AspNetCore.App/8.0.1/libcoreclr.so",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match other files under the shared framework path", () => {
+    expect(
+      matches(
+        "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.1/System.Runtime.dll",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match an empty string", () => {
+    expect(matches("")).toBe(false);
+  });
+});
+
+describe("getBinariesHashes", () => {
+  function makeLayer(
+    filePath: string,
+    actionName: string,
+    hash: string,
+  ): ExtractedLayers {
+    return { [filePath]: { [actionName]: hash } };
+  }
+
+  it("includes a dotnet key binary hash in the flat result", () => {
+    const layers = makeLayer(
+      "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.1/libcoreclr.so",
+      "dotnet",
+      "dotnet-hash",
+    );
+    expect(getBinariesHashes(layers)).toEqual(["dotnet-hash"]);
+  });
+
+  it("still includes node key binary hashes (non-regression)", () => {
+    expect(getNodeBinariesFileContentAction.actionName).toBe("node");
+    const layers = makeLayer("/usr/local/bin/node", "node", "node-hash");
+    expect(getBinariesHashes(layers)).toEqual(["node-hash"]);
+  });
+
+  it("still includes java key binary hashes (non-regression)", () => {
+    expect(getOpenJDKBinariesFileContentAction.actionName).toBe("java");
+    const layers = makeLayer(
+      "/usr/lib/jvm/java-17-openjdk-amd64/bin/java",
+      "java",
+      "java-hash",
+    );
+    expect(getBinariesHashes(layers)).toEqual(["java-hash"]);
+  });
+
+  it("dedupes identical hashes across actions", () => {
+    const layers: ExtractedLayers = {
+      "/usr/local/bin/node": { node: "same-hash" },
+      "/usr/lib/jvm/java-17-openjdk-amd64/bin/java": { java: "same-hash" },
+    };
+    expect(getBinariesHashes(layers)).toEqual(["same-hash"]);
+  });
+
+  it("combines node, java, and dotnet hashes from multiple layers", () => {
+    const layers: ExtractedLayers = {
+      "/usr/local/bin/node": { node: "node-hash" },
+      "/usr/lib/jvm/java-17-openjdk-amd64/bin/java": { java: "java-hash" },
+      "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.1/libcoreclr.so": {
+        dotnet: "dotnet-hash",
+      },
+    };
+    expect(getBinariesHashes(layers).sort()).toEqual(
+      ["dotnet-hash", "java-hash", "node-hash"].sort(),
+    );
+  });
+});

--- a/test/lib/inputs/binaries-static.spec.ts
+++ b/test/lib/inputs/binaries-static.spec.ts
@@ -31,9 +31,7 @@ describe("getDotnetBinariesFileContentAction.filePathMatches", () => {
 
   it("matches on win32-style backslash paths", () => {
     expect(
-      matches(
-        "\\dotnet\\shared\\Microsoft.NETCore.App\\8.0.1\\libcoreclr.so",
-      ),
+      matches("\\dotnet\\shared\\Microsoft.NETCore.App\\8.0.1\\libcoreclr.so"),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Extends the unmanaged-binary key-binary fingerprinting mechanism to cover the .NET shared framework runtime, alongside the existing Node.js and OpenJDK support.

A new `getDotnetBinariesFileContentAction` in `lib/inputs/binaries/static/index.ts` is registered in `lib/analyzer/static-analyzer.ts` next to the node and java actions. It reuses the same `streamToSha256` callback the other runtimes use, so .NET hashes flow through the same code path and land in the same `KeyBinariesHashesFact.data: string[]` shape, with no fact, type, or schema changes, preserving compatibility for pinned consumers.

The matcher identifies a file as a .NET key binary when its path contains `/dotnet/shared/Microsoft.NETCore.App/` and its final path segment is `libcoreclr.so` (the CLR host/runtime) or `System.Private.CoreLib.dll` (the core runtime library). Path separators are normalized with a plain backslash-to-forward-slash replace rather than `path`-module helpers, so the check behaves consistently whether the extractor produced a POSIX or Windows-style path. This scoping excludes self-contained/NativeAOT app layouts and `Microsoft.AspNetCore.App` (which ships no CLR host), matching only the shared framework runtime.

Unit tests cover the new matcher directly (shared-framework matches, non-matches for app-local and ASP.NET Core paths, backslash paths, and edge cases) and re-verify `getBinariesHashes` behavior for node, java, and dotnet actions together, including hash deduplication across runtimes.

## Acceptance criteria

1. When a scanned image layer contains a .NET shared framework runtime installation, the plugin identifies the runtime's key binary file(s) using the same detection mechanism (code path/module) that already identifies Node.js and OpenJDK key binaries.
2. For each identified .NET key binary, the plugin computes a scan-time hash using the same hashing algorithm and method already used for Node.js/OpenJDK key binaries.
3. The .NET fingerprint result is emitted in the same output data structure/shape as existing Node.js/OpenJDK key-binary fingerprint entries, distinguished only by a runtime type/name identifier for .NET.
4. The new .NET detection is added as an entry/extension within the existing fingerprinting mechanism rather than as a separate, parallel implementation.
5. Unit tests cover: correct detection and hashing when a .NET shared framework runtime is present in scanned layers, and no .NET fingerprint entries are emitted when no .NET runtime is present.
6. Existing Node.js and OpenJDK fingerprinting output is unchanged by this addition (no regression in existing tests).

## Not in this branch

The plan had work this branch does not carry:

- `t2-dotnet-key-binary-unit-tests` (done when: `npm run test:unit -- test/lib/inputs/binaries/static.spec.ts` passes with a new spec file containing, at minimum: (a) `filePathMatches` positive cases for `/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.10/libcoreclr.so`, the same path's `System.Private.CoreLib.dll`, the Debian layout `/usr/lib/dotnet/shared/Microsoft.NETCore.App/6.0.36/libcoreclr.so`, and the win32 backslash form `\usr\share\dotnet\shared\Microsoft.NETCore.App\8.0.10\libcoreclr.so` (this case must pass on the Linux unit runner, which is why t1 pins the unconditional `replace(/\\/g, "/")` rather than `path.normalize`); (b) negative cases for `/app/MyApp.dll`, self-contained `/app/libcoreclr.so`, `/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.10/System.Text.Json.dll`, `/usr/share/dotnet/host/fxr/8.0.10/libhostfxr.so`, and `""`; (c) a hashing case asserting `getDotnetBinariesFileContentAction.callback` is the very same reference as `getNodeBinariesFileContentAction.callback` and that invoking it on a `Readable.from(<known bytes>)` returns the sha256 hex of those bytes computed in-test via `crypto.createHash("sha256")`; (d) `getBinariesHashes` on a synthetic `ExtractedLayers` of `{ "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.10/libcoreclr.so": { dotnet: "<hash>" } }` returning `["<hash>"]`; (e) `getBinariesHashes` on layers holding only `node`/`java` entries returning exactly those hashes and nothing more, plus `getBinariesHashes({})` returning `[]`, and a layer whose only entry is the unrelated `dotnet-app-files` action producing no hash. The spec is prettier-clean and `lib/inputs/binaries/static/index.ts` is unchanged by this task's diff (it is listed only to sequence this task after t1).): the builder call itself failed: pipeline: builder:t2-dotnet-key-binary-unit-tests:retry: exit: cursor create returned HTTP 400 (validation_error): [invalid_argument] Error

## Tests and gates

What ran: each landed task's own proof command against its own worktree, then the repository's gate set against the branch they were assembled into.

- `t1-dotnet-key-binary-action`: Added getDotnetBinariesFileContentAction (actionName "dotnet", callback streamToSha256 shared with node/java). filePathMatches normalizes backslashes via replace(/\\/g, "/"), requires /dotnet/shared/Microsoft.NETCore.App/ and basename libcoreclr.so or System.Private.CoreLib.dll. Appended to binariesExtractActions and registered in staticAnalysisActions next to node/java. KeyBinariesHashesFact.data unchanged as string[] — AC3 runtime identity is at actionName level only, not in the emitted hash array. npm run build passes; npm run test:unit passes (920/920; cloud VM sets NO_COLOR=1 which breaks display.spec.ts ANSI assertions — pre-existing, unrelated to this change; CI does not set NO_COLOR). Unit coverage for matcher/hash/getBinariesHashes is task t2. Pushed to origin/cursor/dotnet-key-binary-detection-f687. | gate "npm run test:unit" passed in 7006ms
- `final:build`: `npm run build` passed in 4087ms
- `final:test_unit`: `npm run test:unit` passed in 4893ms
- `final:lint`: `npm run lint` failed (exit 1) where the base commit passes; this branch regressed it
- `final:test`: `npm test` failed exactly as it does on the base commit (exit 1); pre-existing, not a regression from this branch

The repository's full gate set ran again on the assembled branch. Anything still failing against the base commit is in the open findings below.

## Open blocking findings

- [test-quality/dotnet-binaries-no-test blocking] lib/inputs/binaries/static/index.ts: getDotnetBinariesFileContentAction (path normalization, DOTNET_SHARED_FRAMEWORK_PATH containment check, and basename lookup against DOTNET_KEY_BINARY_NAMES) has zero test coverage. The repo's established precedent for this exact feature — test/system/key-binaries-hashes/hashes.spec.ts — runs a real fixture image through `scan()` and snapshots the `keyBinariesHashes` fact to pin node's and java's getXBinariesFileContentAction behavior, but no analogous 'should correctly scan dotnet key binaries hashes' test or fixture image was added here. There is also no unit test hitting filePathMatches directly (e.g. verifying it matches '/dotnet/shared/Microsoft.NETCore.App/8.0.1/libcoreclr.so' and rejects a same-named file outside that path, or on Windows-style paths). Reverting the new action back to nothing would not fail any test.
- [gate final:lint] newly failing (exit 1) against a baseline that did not: npm run lint

## Decisions taken without asking

- Which file(s) within a .NET shared framework installation count as the 'key binary' to fingerprint?
  - took: Treat only the primary runtime host/CLR library file(s) (analogous to the single Node.js binary or libjvm.so for Java) as the key binary target(s) for .NET, not every file in the shared framework directory.
  - alternative: Fingerprint every binary file present in the .NET shared framework directory indiscriminately.
- Should .NET key-binary detection cover both Linux and Windows container images, given filenames differ (e.g., libcoreclr.so vs coreclr.dll)?
  - took: Scope detection to Linux container images only, matching the plugin's primary scanning target and the existing Node.js/OpenJDK detection scope.
  - alternative: Support both Linux and Windows container base images with OS-specific key-binary filenames.

## Assumptions

- "Key binaries" for the .NET shared framework runtime means the small set of well-known runtime/host files analogous to the Node.js binary or libjvm.so for OpenJDK (e.g., the CLR host and core runtime library), not every file under the shared framework directory; exact filenames are an implementation detail to be resolved against the existing per-runtime key-binary definitions.
- The existing fingerprinting code exposes a per-runtime configuration/registry of key-binary definitions that can be extended with a new .NET entry, rather than requiring a new standalone code path.
- "Scan-time hashes" means hashes computed live during the scan invocation in this plugin, with no dependency on a pre-populated reference database being available yet — consistent with the reference-data repo being handled in a separate slice.
- Output schema stays structurally identical to existing entries; only a new type/name value is added to represent the .NET runtime, with no breaking schema changes.

## Run

- Team: TeamIDP
- Run: `20260902-144908-95a6`
- Origin: 
- Base: `ec433b94c0d3355c58656211265efc156e945717`
- Head: `3f5d9caf024c2d1a69d70d55051d90439412afb4`

Human review is required. This automation never merges or marks a PR ready.
