### PR TITLE
chore: retag team ownership to sca-scanners [CMPA-724]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,21 +30,14 @@ windows_defaults: &windows_defaults
 slack-fail-notify: &slack-fail-notify
   slack/notify:
     event: fail
-    channel: team-container-pipeline-info
+    channel: team-sca-scanners-alerts
     branch_pattern: "main"
     template: basic_fail_1
-
-slack-success-notify: &slack-success-notify
-  slack/notify:
-    event: pass
-    channel: team-container-pipeline-info
-    branch_pattern: "main"
-    template: basic_success_1
 
 slack-snapshot-notify: &slack-snapshot-notify
   slack/notify:
     event: always
-    channel: team-container-pipeline-info
+    channel: team-sca-scanners-alerts
     custom: |
       {
         "blocks": [
@@ -479,7 +472,6 @@ workflows:
             - Test Windows no Docker
           post-steps:
             - *slack-fail-notify
-            - *slack-success-notify
   go_regression_test:
     when:
       and:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-* @snyk/container_container
+* @snyk/engines_sca-scanners
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,8 @@ metadata:
   name: snyk-docker-plugin
   annotations:
     github.com/project-slug: snyk/snyk-docker-plugin
-    github.com/team-slug: snyk/infrasec_container
+    github.com/team-slug: snyk/engines_sca-scanners
 spec:
   type: snyk-cli-plugin
   lifecycle: "-"
-  owner: container
+  owner: sca-scanners


### PR DESCRIPTION
### Prerequisites (done)

The Container team's Event Bus resources take `.spec.owner` from the Polaris owner, which ArgoCD
injects from `catalog-info.yaml`, so retagging makes them present as `sca-scanners`. Every
cross-team grant naming `container` now lists the new name alongside it. All six are merged and
deployed: snyk/enso-agent#454, snyk/apprisk-streams#500, snyk/runtime-entities-service#966,
snyk/workspace-service#2805, snyk/test-service#1652, snyk/event-bus#3661.

### What?

Transfers ownership to `@snyk/engines_sca-scanners`:

- `.github/CODEOWNERS` — container team → `@snyk/engines_sca-scanners`
- `catalog-info.yaml` — `owner` → `sca-scanners`, `github.com/team-slug` → `snyk/engines_sca-scanners`
- `helm/**` — `owner` / `snykowner` / `snyk.io/owner` / `team` → `sca-scanners`, wherever they name the container team (including `helm/values/` overrides and `helm/templates/`, which become pod labels and annotations)
- `.circleci/config.yml` — context → `engines_sca-scanners`, unless the repo needs a Circle PAT
- Slack alert destinations → `@slack-team-sca-scanners-alerts`
- drops the `slack-snapshot-notify` job entirely (second commit): it fired on `event: always`,
  so pointing it at the alerts channel would have posted on every snapshot-update run. The
  patches are still downloadable from each job's *Artifacts* tab.
- prunes stale `catalog-info` entries (`snyk.io/jira-prefix` and its doc comment, ask-channel links, Notion links, Datadog links naming a retired team, `pagerduty.com/service-id`)

Note the two naming conventions: only **GitHub and CircleCI** carry the `engines_` prefix, so
Polaris and Backstage values are the bare `sca-scanners` — that is the string FireHydrant's CEL
matches on.

### Why?

Per [#tmp-container-oncall-transition](https://snyk.slack.com/archives/C0BQWGAB2CS), Container's
services are transferring to `@snyk/engines_sca-scanners`, with `container-image-collector` going
to Intelligence Engineering instead (that repo is deliberately excluded from this wave).

**Paging is already safe.** The FireHydrant cutover is live: the OS Managed rule matches
`team == 'container' && service != 'container-image-collector'` **and** `team == 'sca-scanners'`,
so alerts land on the same rota before and after this merge.

### Follow-ups

- Drop the `team == 'container'` clause from the OS Managed CEL once nothing reports as `container`.
- Remove `container` from the Event Bus grant lists at the same point.

---

> [!NOTE]
> **Medium Risk**
> Changes this service's team identity. Paging is unaffected (both names route to the OS Managed
> rota) and the Event Bus grants above are already in place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes team identity and CI alert destinations; snapshot runs lose automated Slack guidance but patches remain in CircleCI artifacts.
> 
> **Overview**
> Transfers **snyk-docker-plugin** from Container to **SCA Scanners** in Backstage (`catalog-info.yaml` owner/`github.com/team-slug`) and GitHub review routing (`CODEOWNERS` → `@snyk/engines_sca-scanners`).
> 
> CircleCI Slack routing moves off Container channels: main-branch **fail** alerts go to `team-sca-scanners-alerts`, prodsec secrets-scan failures to `snyk-vuln-alerts-sca`, and **success** Slack notifications on release are removed.
> 
> The snapshot-update workflow no longer posts a combined Slack message with patch download links—the `notify_snapshots` job, snapshot job URL workspace handoff, and related YAML anchors are deleted. Linux/Windows snapshot jobs still upload `snapshots.patch` / `snapshots-windows.patch` as job artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9dba1ba8a09def35df23b16d941c987a686fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->